### PR TITLE
docs: LKM API v3 设计文档与实现计划

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,54 +4,62 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Gaia is a Large Knowledge Model (LKM) for billion-scale reasoning over academic knowledge. It stores propositions as nodes and reasoning relationships as hyperedges in a hypergraph, with a Git-like commit workflow (submit → review → merge) and probabilistic inference via loopy belief propagation.
+Gaia is a Large Knowledge Model (LKM) — a billion-scale reasoning hypergraph for knowledge representation and inference. It stores propositions as nodes and reasoning relationships as hyperedges, with a Git-like commit workflow (submit → review → merge) and probabilistic inference via loopy belief propagation.
 
-## Commands
+**Stack:** Python 3.12+, FastAPI, Pydantic v2, LanceDB, Neo4j, NumPy/PyArrow
 
-### Install
+## Common Commands
+
 ```bash
+# Install dependencies
 pip install -e ".[dev]"
-```
 
-### Run Tests
-```bash
-pytest tests                                          # all tests
-pytest tests/libs/test_models.py                      # single file
-pytest tests/libs/test_models.py::test_node_defaults  # single test
-pytest -m "not neo4j" tests                           # skip Neo4j tests
-pytest --cov=libs --cov=services tests                # with coverage
-```
+# Run all tests (auto-skips Neo4j tests if unavailable)
+pytest
 
-Neo4j tests are auto-skipped when Neo4j is unavailable (detected in `tests/conftest.py`). All async tests run automatically via `asyncio_mode = "auto"`.
+# Run tests with coverage
+pytest --cov=libs --cov=services tests
 
-### Lint & Format
-```bash
-ruff check .     # lint
-ruff format .    # format
-```
+# Run a single test file / single test
+pytest tests/libs/storage/test_lance_store.py
+pytest tests/libs/test_models.py::test_node_defaults
 
-Style: 100-char line length, Python 3.12 target.
+# Run only non-Neo4j tests
+pytest -m "not neo4j"
 
-### Run Server
-```bash
-uvicorn services.gateway.app:create_app --reload --host 0.0.0.0 --port 8000
-```
+# Lint and format
+ruff check .
+ruff format .
 
-### Seed Database
-```bash
+# Run the API server
+uvicorn services.gateway.app:create_app --factory --reload --host 0.0.0.0 --port 8000
+
+# Seed databases with fixture data
 python scripts/seed_database.py --fixtures-dir tests/fixtures --db-path /data/lancedb/gaia --neo4j-password testpassword
 ```
 
+All async tests run automatically via `asyncio_mode = "auto"`.
+
 ## Architecture
 
-### Two-Package Monorepo
+### Layer Structure
 
-- **`libs/`** — Shared models and storage abstractions (no business logic)
-- **`services/`** — Four service modules, each with its own engine
+```
+services/gateway/        → FastAPI HTTP API (routes, dependency injection)
+    ↓ uses
+services/search_engine/  → Multi-path recall (vector + BM25 + topology) + score merging
+services/commit_engine/  → 3-step commit workflow (submit → review → merge)
+services/inference_engine/→ Loopy belief propagation on factor graphs
+    ↓ uses
+libs/models.py           → Core Pydantic models (Node, HyperEdge, Commit, Operations)
+libs/storage/            → Storage backends (LanceDB, Neo4j, Vector Index)
+```
+
+Dependencies flow downward only. `libs` has no service dependencies. Services depend on `libs` but not on each other (except gateway depends on all services).
 
 ### Storage Layer (`libs/storage/`)
 
-Three complementary backends managed by `StorageManager` (a thin container, no business logic):
+Three complementary backends managed by `StorageManager`:
 
 | Backend | Store Class | Purpose |
 |---------|------------|---------|
@@ -59,22 +67,22 @@ Three complementary backends managed by `StorageManager` (a thin container, no b
 | **Neo4j** | `Neo4jGraphStore` | Graph topology, hyperedge relationships (`:TAIL`/`:HEAD`) |
 | **Vector** | `VectorSearchClient` (ABC) | Embedding similarity search; local impl uses LanceDB |
 
-Neo4j is optional — the system degrades gracefully without it. Configuration lives in `libs/storage/config.py` (`StorageConfig`).
-
-### Service Engines (`services/`)
-
-| Engine | Path | Responsibility |
-|--------|------|----------------|
-| **CommitEngine** | `services/commit_engine/` | 3-step workflow: validate → LLM review (stub in Phase 1) → merge to storage |
-| **SearchEngine** | `services/search_engine/` | Multi-path recall (vector + BM25 + topology) with score normalization and merging |
-| **InferenceEngine** | `services/inference_engine/` | Loopy belief propagation on factor graphs extracted from Neo4j |
-| **Gateway** | `services/gateway/` | FastAPI app factory, dependency injection (`deps.py`), route handlers |
+Neo4j is optional — the system degrades gracefully without it. All writes go through triple-write in the commit engine merger: LanceDB nodes → Neo4j edges → Vector embeddings.
 
 ### Core Data Models (`libs/models.py`)
 
 - **Node** — A proposition with `content`, `prior`, `belief`, `keywords`, `type` (paper-extract, join, deduction, conjecture)
 - **HyperEdge** — A reasoning link with `tail[]` → `head[]`, `probability`, `reasoning` steps, `type` (paper-extract, join, meet, contradiction, retraction)
 - **Commit** — A batch of operations with status state machine: `pending_review` → `reviewed` → `merged` (or `rejected`)
+
+### Key Patterns
+
+- **Fully async** — all I/O is `async def`, tests use `asyncio_mode = "auto"`
+- **Dependency injection** — `services/gateway/deps.py` holds a global `Dependencies` singleton initialized at startup; tests inject custom instances via `create_app(dependencies=...)`
+- **Graceful degradation** — Neo4j, vector search, and LLM review are all optional; topology recall is skipped when graph is unavailable
+- **Commit workflow** — operations (AddEdge, ModifyNode, ModifyEdge) are validated, reviewed (stub LLM auto-approves in Phase 1), then merged to all backends
+- **Search merging** — three recall paths run in parallel, scores are min-max normalized, weighted (vector=0.5, bm25=0.3, topology=0.2), deduped, and top-k filtered
+- **ID generation** — file-based with asyncio lock (`libs/storage/id_generator.py`), single-process safe
 
 ### API Routes (`services/gateway/routes/`)
 
@@ -85,6 +93,20 @@ Neo4j is optional — the system degrades gracefully without it. Configuration l
 ### Dependency Injection
 
 `services/gateway/deps.py` holds a global `Dependencies` singleton initialized during FastAPI startup. All engines receive `StorageManager` and are wired together there.
+
+## Testing
+
+- Tests live in `tests/` mirroring the source structure
+- Neo4j tests are marked `@pytest.mark.neo4j` and auto-skipped if Neo4j is unreachable (checked in `conftest.py`)
+- E2E integration tests (`tests/integration/test_e2e.py`) run without Neo4j using `tmp_path` for ephemeral LanceDB
+- Test fixtures in `tests/fixtures/` — note `embeddings.json` is git-ignored (large file)
+
+## Code Style
+
+- Ruff for linting/formatting, line length 100, target Python 3.12
+- Type hints use PEP 604 union syntax (`X | None` not `Optional[X]`)
+- Google-style docstrings
+- Pydantic v2 API: `.model_dump()`, `.model_validate()`, `.model_validate_json()`
 
 ## Design Documents
 

--- a/docs/plans/2026-03-03-lkm-api-design-v3.md
+++ b/docs/plans/2026-03-03-lkm-api-design-v3.md
@@ -1,0 +1,1124 @@
+# LKM API 设计 v3
+
+| 文档属性 | 值 |
+|---------|---|
+| 版本 | 3.0 |
+| 日期 | 2026-03-03 |
+| 状态 | 草稿 |
+| 前置文档 | `docs/plans/2026-03-02-lkm-api-design-v2.md` (v2.4, 已被本文档取代) |
+| 变更记录 | v3.0: review 重构为异步 pipeline (embedding→NN search→CC/CP join→verify→BP)；所有 API 新增 batch 异步模式；重新定义 Gaia 仓库 scope——内部集成 embedding/join/verify/BP 算子 |
+
+---
+
+## 1. 设计原则
+
+### 1.1 超边是原子单元 (继承 v2)
+
+LKM 是知识库（Large Knowledge Model）。所有知识以**超边**（hyperedge）的形式存在：
+
+```
+超边 = {tail: [前提命题...], head: [结论命题...], type, reasoning}
+```
+
+- 命题不独立存在，命题永远是超边的一部分
+- 论文提取：`[论文上下文] ──paper-extract──→ [命题]`
+- Agent 推导：`[已有命题A, B] ──meet/deduction──→ [新命题C]`
+- 没有思维链的命题不允许进入图
+
+### 1.2 超边类型 (继承 v2)
+
+| 类型 | 说明 |
+|------|------|
+| `paper-extract` | 从论文中提取的推理链 |
+| `join` | 发现已有命题之间的关系（等价、包含、部分重叠） |
+| `meet` | 从已有关系推导新知识（子类型见下） |
+| `contradiction` | 发现矛盾 |
+| `retraction` | 撤回已有知识 |
+
+**Meet 子类型**：
+
+| 子类型 | 说明 |
+|--------|------|
+| `reasoning` | 逻辑推理 |
+| `deduction` | 严格演绎 |
+| `conjecture` | 合理猜测（附 probability） |
+| `contradiction` | 发现矛盾 |
+
+### 1.3 Git-like 写入模型 (v3 更新)
+
+写入操作统一为 commit → review → merge 三步，**review 为异步长链路 pipeline**：
+
+```
+Git                    LKM
+────                   ────
+git push + create PR   POST /commits               提交变更 + 轻量检查（同步）
+CI pipeline            POST /commits/{id}/review    提交异步 review job
+                       GET  /commits/{id}/review    查看 review 进度
+                       → Embedding → NN Search      自动计算向量 + 搜索近邻
+                         → CC/CP Join → Verify      发现关系 + 验证推理
+                         → BP                       信念传播
+code review result     GET  /commits/{id}/review/result  获取审核结果
+merge PR               POST /commits/{id}/merge     入图（同步）
+```
+
+### 1.4 单条同步 / 批量异步
+
+| 模式 | 行为 |
+|------|------|
+| 单条请求 | 同步返回结果（review 除外，review 始终异步） |
+| 批量请求 | 全部异步执行，返回 job_id，通过 Job API 查询 |
+
+### 1.5 Review Pipeline 内部算子化
+
+Review 不再是单次 LLM 调用，而是**多步 pipeline**，每步为独立可复用算子：
+
+```
+① Embedding       为新节点生成向量
+      │
+② NN Search       每个新节点搜索 20 个最近邻
+      │
+      ├────────────────────────┐
+      ▼ (parallel)             ▼ (parallel)
+③a CC Join                ③b CP Join
+  conclusion↔conclusion     conclusion↔premise
+      │                        │
+  Join Tree Verify         Join Tree Verify
+      │                        │
+  Refine                   Refine
+      │                        │
+  Verify Again             Verify Again
+      │                        │
+      └───────────┬────────────┘
+                  ▼
+④ Belief Propagation
+      │
+⑤ Return verified trees + review result
+```
+
+### 1.6 两层 API 架构 (继承 v2)
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Layer 2: Research API  (上层 — 面向研究问题)           │
+│  novelty / reliability / contradiction / provenance   │
+│  （需求清单见第 8 节，详细设计待后续文档）               │
+├──────────────────────────────────────────────────────┤
+│  Layer 1: Knowledge Graph API  (底层 — 面向图操作)      │
+│  commits / review pipeline / nodes / edges / search   │
+│  （本文档详细设计的主体）                                │
+└──────────────────────────────────────────────────────┘
+                        │
+                   共享存储层
+           LanceDB (local/TOS) + Neo4j + ByteHouse (未来)
+```
+
+### 1.7 Gaia 仓库 Scope
+
+**Gaia 负责**：
+
+| 能力 | 说明 |
+|------|------|
+| Commit + Review + Merge | 写入流程，review 内含完整推理 pipeline |
+| 内部算子 | embedding, nn_search, join, verify, refine, bp |
+| 搜索与读取 | 多路搜索、精确读取、子图查询 |
+| 存储层 | LanceDB (三模式) + Neo4j + Vector Index |
+| 异步 Job 管理 | review pipeline 和所有 batch 操作的 job 调度 |
+
+**Gaia 不负责**：
+
+| 不做 | 说明 |
+|------|------|
+| OCR / PDF 解析 | 外部服务 |
+| 论文结构化提取 | 外部 pipeline，产出 nodes + edges 后调用 Gaia API |
+
+### 1.8 Metadata 约定
+
+Node 和 HyperEdge 的 `metadata` 字段需遵循以下约定，以支持按论文过滤等功能：
+
+| 字段 | 类型 | 说明 | 示例 |
+|------|------|------|------|
+| `paper_id` | string | 论文唯一标识 | `"arxiv:2301.12345"` |
+| `location` | string | 论文内的位置标识 | `"10.1021ja800073m_2008_J.__1"` |
+| `premise_id` | string | 命题在论文内的编号 | `"1"` |
+
+> **注**：`paper_id` 是 search filter 中 `paper_id` 过滤条件的数据来源。提交 commit 时，外部 pipeline 应在 metadata 中填入 `paper_id`。
+
+---
+
+## 2. API 总览
+
+### 2.1 完整 API 列表
+
+| API | 方法 | 模式 | 功能 |
+|-----|------|------|------|
+| **写入** | | | |
+| `/commits` | POST | 同步 | 提交变更 + 轻量检查 |
+| `/commits/{id}` | GET | 同步 | 查看 commit 状态 |
+| `/commits/{id}/review` | POST | 异步 | 提交 review job |
+| `/commits/{id}/review` | GET | 同步 | 查看 review 进度 |
+| `/commits/{id}/review` | DELETE | 同步 | 取消 review job |
+| `/commits/{id}/review/result` | GET | 同步 | 获取 review 结果 |
+| `/commits/{id}/merge` | POST | 同步 | 入图 |
+| **批量写入** | | | |
+| `/commits/batch` | POST | 异步 | 批量提交 + 自动 review + merge |
+| `/commits/batch/{batch_id}` | GET | 同步 | 查看批量进度 |
+| `/commits/batch/{batch_id}` | DELETE | 同步 | 取消批量 job |
+| **精确读取** | | | |
+| `/nodes/{id}` | GET | 同步 | 读取节点 |
+| `/hyperedges/{id}` | GET | 同步 | 读取超边 |
+| `/nodes/{id}/subgraph` | GET | 同步 | 节点邻居子图 |
+| **批量读取** | | | |
+| `/nodes/batch` | POST | 异步 | 批量读取节点 |
+| `/hyperedges/batch` | POST | 异步 | 批量读取超边 |
+| `/nodes/subgraph/batch` | POST | 异步 | 批量子图查询 |
+| **检索** | | | |
+| `/search/nodes` | POST | 同步 | 搜索节点 |
+| `/search/hyperedges` | POST | 同步 | 搜索超边 |
+| **批量检索** | | | |
+| `/search/nodes/batch` | POST | 异步 | 批量搜索节点 |
+| `/search/hyperedges/batch` | POST | 异步 | 批量搜索超边 |
+| **Job 管理 (通用)** | | | |
+| `/jobs/{job_id}` | GET | 同步 | 查看 job 状态 |
+| `/jobs/{job_id}` | DELETE | 同步 | 取消 job |
+| `/jobs/{job_id}/result` | GET | 同步 | 获取 job 结果 |
+
+### 2.2 vs v2 变更摘要
+
+| 变更 | 说明 |
+|------|------|
+| review 重构为异步 pipeline | 不再是单次 LLM 调用，包含 embedding/search/join/verify/BP |
+| review API 扩展 | 新增 GET (status), DELETE (cancel), GET /result |
+| 所有 API 新增 batch 模式 | batch 请求异步执行，通过 Job API 查询 |
+| 通用 Job 管理 API | `/jobs/{job_id}` 统一管理所有异步任务 |
+| Gaia 内部集成算子 | embedding, join, verify, bp 不再依赖外部 |
+| search 不再要求外部传入 embedding | Gaia 内部生成 embedding |
+
+---
+
+## 3. 写入 API 详细设计
+
+### 3.1 Commit 生命周期
+
+```
+                         ┌────────────────────┐
+    POST /commits ──────►│  pending_review     │
+    (同步，秒回)          └────────┬───────────┘
+                                  │
+                   POST /commits/{id}/review (异步 job)
+                                  │
+                         ┌────────▼───────────┐
+                         │  reviewing          │ ← 新状态: pipeline 执行中
+                         │  (异步 pipeline)     │
+                         └────────┬───────────┘
+                                  │
+                      Pipeline 完成 (自动更新)
+                                  │
+                    ┌─────────────┼─────────────┐
+                    ▼                            ▼
+           ┌────────────────┐          ┌────────────────┐
+           │  reviewed       │          │  rejected       │
+           │  (verdict:pass) │          │  (verdict:fail  │
+           └───────┬────────┘          │   或 has_overlap)│
+                   │                    └────────────────┘
+        POST /commits/{id}/merge
+              (同步)
+                   │
+          ┌────────▼───────────┐
+          │     merged          │
+          └────────────────────┘
+```
+
+### 3.2 POST /commits — 提交变更 (同步)
+
+提交一个或多个操作，系统自动执行轻量检查。
+
+**请求**：
+
+```json
+{
+  "message": "Add YH10 superconductivity findings from arxiv:2301.xxx",
+  "operations": [
+    {
+      "op": "add_edge",
+      "tail": [
+        {"title": "DFT 预测 fcc YH10 相稳定", "content": "...", "keywords": [], "extra": {}},
+        {"title": "声子谱无虚频", "content": "...", "keywords": [], "extra": {}}
+      ],
+      "head": [
+        {"title": "YH10 高压超导 Tc≈303K", "content": "...", "keywords": [], "extra": {}}
+      ],
+      "type": "paper-extract",
+      "reasoning": [{"title": "DFT+Eliashberg", "content": "基于 DFT 和 Eliashberg 方程的理论预测"}]
+    },
+    {
+      "op": "modify_edge",
+      "edge_id": 456,
+      "changes": {"status": "retracted", "reason": "原始数据有误"}
+    },
+    {
+      "op": "modify_node",
+      "node_id": 789,
+      "changes": {"content": "修正后的命题文本"}
+    }
+  ]
+}
+```
+
+**支持的操作类型**：
+
+| op | 说明 | 必填字段 |
+|----|------|---------|
+| `add_edge` | 新增超边（含新/旧命题） | tail, head, type, reasoning |
+| `modify_edge` | 修改已有超边 | edge_id, changes |
+| `modify_node` | 修改已有节点 | node_id, changes |
+
+**轻量检查（同步，不涉及 LLM）**：
+
+| 检查项 | 说明 |
+|--------|------|
+| 结构校验 | tail/head 非空、type 合法 |
+| 引用校验 | modify 操作引用的 edge_id / node_id 是否存在 |
+
+**响应**：
+
+```json
+{
+  "commit_id": "abc123",
+  "status": "pending_review",
+  "check_results": {
+    "operations": [
+      {
+        "index": 0,
+        "op": "add_edge",
+        "structural_valid": true
+      },
+      {
+        "index": 1,
+        "op": "modify_edge",
+        "edge_exists": true
+      }
+    ]
+  }
+}
+```
+
+### 3.3 POST /commits/{id}/review — 提交 Review Job (异步)
+
+触发异步 review pipeline。返回 job_id，通过 Job API 查询进度。
+
+**请求**：
+
+```json
+{
+  "depth": "standard"
+}
+```
+
+| depth | 说明 |
+|-------|------|
+| `standard` | 完整 pipeline: embedding → NN search → CC/CP join → verify → BP |
+| `quick` | 仅 embedding → NN search → 基础去重检测 (跳过 join/verify/BP) |
+
+**响应**：
+
+```json
+{
+  "job_id": "job_review_abc123",
+  "status": "running",
+  "pipeline_steps": [
+    {"step": "embedding", "status": "pending"},
+    {"step": "nn_search", "status": "pending"},
+    {"step": "cc_join", "status": "pending"},
+    {"step": "cp_join", "status": "pending"},
+    {"step": "verify", "status": "pending"},
+    {"step": "bp", "status": "pending"}
+  ]
+}
+```
+
+### 3.4 GET /commits/{id}/review — 查看 Review 进度
+
+**响应**：
+
+```json
+{
+  "job_id": "job_review_abc123",
+  "status": "running",
+  "progress": {
+    "current_step": "cc_join",
+    "steps_completed": 2,
+    "steps_total": 6
+  },
+  "pipeline_steps": [
+    {"step": "embedding", "status": "completed", "duration_ms": 1200},
+    {"step": "nn_search", "status": "completed", "duration_ms": 800},
+    {"step": "cc_join", "status": "running"},
+    {"step": "cp_join", "status": "running"},
+    {"step": "verify", "status": "pending"},
+    {"step": "bp", "status": "pending"}
+  ]
+}
+```
+
+### 3.5 DELETE /commits/{id}/review — 取消 Review Job
+
+**响应**：
+
+```json
+{
+  "job_id": "job_review_abc123",
+  "status": "cancelled"
+}
+```
+
+### 3.6 GET /commits/{id}/review/result — 获取 Review 结果
+
+仅在 review job 完成后可用。
+
+**响应 (通过, 无重合)**：
+
+```json
+{
+  "job_id": "job_review_abc123",
+  "status": "completed",
+  "review_results": {
+    "operations": [
+      {
+        "index": 0,
+        "op": "add_edge",
+        "verdict": "pass",
+        "embedding_generated": true,
+        "nn_candidates": [
+          {"node_id": 102, "similarity": 0.97, "content": "fcc YH10 的声子谱..."}
+        ],
+        "quality": {
+          "reasoning_valid": true,
+          "tightness": 4,
+          "substantiveness": 3,
+          "novelty": 0.72
+        },
+        "join_trees": {
+          "cc": [
+            {
+              "source_node": 5002,
+              "target_node": 251,
+              "relation": "partial_overlap",
+              "verified": true,
+              "edge_id_created": null
+            }
+          ],
+          "cp": []
+        },
+        "contradictions_confirmed": [
+          {
+            "node_id": 269,
+            "is_real_contradiction": true,
+            "reason": "理论预测 vs 实验结果"
+          }
+        ],
+        "overlaps": []
+      }
+    ],
+    "overall_verdict": "pass",
+    "bp_results": {
+      "belief_updates": {
+        "5002": 0.65,
+        "269": 0.71,
+        "102": 0.88
+      },
+      "iterations": 8,
+      "converged": true,
+      "affected_nodes": 12,
+      "explanation": "有一篇实验论文矛盾，head node belief 未达到高置信"
+    }
+  }
+}
+```
+
+**响应 (有重合，merge 将拒绝)**：
+
+```json
+{
+  "review_results": {
+    "operations": [
+      {
+        "index": 0,
+        "op": "add_edge",
+        "verdict": "has_overlap",
+        "overlaps": [
+          {
+            "position": "tail[1]",
+            "submitted_content": "声子谱无虚频",
+            "matched_node_id": 102,
+            "matched_content": "fcc YH10 的声子谱计算显示无虚频模",
+            "judgment": "semantically_equivalent",
+            "similarity": 0.97
+          }
+        ]
+      }
+    ],
+    "overall_verdict": "has_overlap"
+  }
+}
+```
+
+### 3.7 POST /commits/{id}/merge — 入图 (同步)
+
+将已通过 review 的 commit 应用到图中。
+
+**前置条件**：commit status 必须为 `reviewed` (verdict=pass)。
+
+**请求**：
+
+```json
+{
+  "force": false
+}
+```
+
+| 参数 | 说明 |
+|------|------|
+| `force: false` | 默认：review 必须 pass |
+| `force: true` | 跳过 verdict 检查 |
+
+**处理**：
+
+1. 对每条 `add_edge`：创建新节点 → 创建超边 → 写入 LanceDB + Neo4j
+2. 对每条 `modify_edge` / `modify_node`：更新对应存储
+3. 将 review pipeline 中已计算的 embedding 写入向量索引
+4. 将 review pipeline 中 join/verify 产生的新边写入存储
+5. 将 review pipeline 中 BP 计算的 belief 值写入 LanceDB
+
+> **注**：belief 计算在 review pipeline 中完成，merge 只负责将结果持久化。belief_updates 在 review result 中返回给调用者。
+
+**响应**：
+
+```json
+{
+  "commit_id": "abc123",
+  "status": "merged",
+  "results": {
+    "operations": [
+      {
+        "index": 0,
+        "op": "add_edge",
+        "edge_id": 1234,
+        "tail_node_ids": [102, 5001],
+        "head_node_ids": [5002],
+        "nodes_created": [5001, 5002],
+        "nodes_reused": [102]
+      }
+    ],
+    "join_edges_created": [1235, 1236],
+    "beliefs_persisted": true,
+    "index_status": "indexed"
+  }
+}
+```
+
+### 3.8 POST /commits/batch — 批量提交 (异步)
+
+批量提交多个 commit，异步执行 commit → review → merge 全流程。
+
+**请求**：
+
+```json
+{
+  "commits": [
+    {
+      "message": "arxiv:2301.12345 - YH10 超导研究",
+      "operations": [{"op": "add_edge", "...": "..."}]
+    },
+    {
+      "message": "arxiv:2301.67890 - LaH10 高压实验",
+      "operations": [{"op": "add_edge", "...": "..."}]
+    }
+  ],
+  "auto_review": true,
+  "auto_merge": true,
+  "review_depth": "standard"
+}
+```
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `auto_review` | 自动触发 review | `true` |
+| `auto_merge` | review 通过后自动 merge | `true` |
+| `review_depth` | review 深度 | `"standard"` |
+
+**响应**：
+
+```json
+{
+  "job_id": "job_batch_001",
+  "total_commits": 2,
+  "status": "running"
+}
+```
+
+### 3.9 GET /commits/batch/{batch_id} — 批量进度查询
+
+```json
+{
+  "job_id": "job_batch_001",
+  "status": "running",
+  "total_commits": 100,
+  "progress": {
+    "pending_review": 3,
+    "reviewing": 12,
+    "reviewed": 0,
+    "merged": 82,
+    "rejected": 3
+  },
+  "commits": [
+    {"commit_id": "abc123", "message": "arxiv:2301.12345...", "status": "merged"},
+    {"commit_id": "abc124", "message": "arxiv:2301.67890...", "status": "rejected"}
+  ]
+}
+```
+
+---
+
+## 4. 精确读取 API 详细设计
+
+### 4.1 GET /nodes/{id} (同步)
+
+```json
+{
+  "id": 251,
+  "type": "paper-extract",
+  "subtype": "premise",
+  "title": "YH10 高压超导 Tc≈303K",
+  "content": "fcc YH10 相在 400GPa 下超导，Tc≈303K",
+  "keywords": ["YH10", "超导", "高压氢化物"],
+  "prior": 1.0,
+  "belief": 0.65,
+  "status": "active",
+  "metadata": {},
+  "extra": {"notations": "T_c \\approx 303\\,K"},
+  "created_at": "2026-03-01T..."
+}
+```
+
+### 4.2 GET /hyperedges/{id} (同步)
+
+```json
+{
+  "id": 1234,
+  "type": "paper-extract",
+  "subtype": null,
+  "tail": [102, 5001],
+  "head": [5002],
+  "reasoning": [{"title": "DFT+Eliashberg", "content": "基于 DFT 和 Eliashberg 方程的理论预测"}],
+  "probability": null,
+  "verified": true,
+  "metadata": {},
+  "extra": {},
+  "created_at": "2026-03-01T..."
+}
+```
+
+### 4.3 GET /nodes/{id}/subgraph (同步)
+
+**参数**：
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `hops` | 跳数 | 3 |
+| `direction` | `upstream` \| `downstream` \| `both` | `both` |
+| `max_nodes` | 最大节点数 | 500 |
+| `edge_types` | 过滤超边类型 | 全部 |
+
+**响应**：
+
+```json
+{
+  "center_node_id": 251,
+  "nodes": [
+    {"id": 251, "title": "...", "content": "...", "belief": 0.65, "type": "paper-extract"}
+  ],
+  "edges": [
+    {"id": 1234, "type": "paper-extract", "tail": [102, 5001], "head": [251]}
+  ]
+}
+```
+
+### 4.4 批量读取 (异步)
+
+#### POST /nodes/batch
+
+**请求**：
+
+```json
+{
+  "node_ids": [251, 269, 300, 5001, 5002]
+}
+```
+
+**响应**：
+
+```json
+{
+  "job_id": "job_read_nodes_001",
+  "status": "running"
+}
+```
+
+通过 `GET /jobs/{job_id}/result` 获取结果。
+
+#### POST /hyperedges/batch
+
+**请求**：
+
+```json
+{
+  "edge_ids": [1234, 1235, 1567]
+}
+```
+
+#### POST /nodes/subgraph/batch
+
+**请求**：
+
+```json
+{
+  "queries": [
+    {"node_id": 251, "hops": 3, "direction": "both"},
+    {"node_id": 269, "hops": 2, "direction": "upstream"}
+  ]
+}
+```
+
+---
+
+## 5. 检索 API 详细设计
+
+### 5.1 POST /search/nodes (同步)
+
+**请求**：
+
+```json
+{
+  "text": "高压下氢化物的超导转变温度",
+  "top_k": 20,
+  "filters": {
+    "status": "active",
+    "type": ["paper-extract", "deduction"],
+    "min_belief": 0.5,
+    "paper_id": "arxiv:2301.12345",
+    "min_quality": 3
+  }
+}
+```
+
+> **v3 变化**：不再需要调用者传入 `embedding`，Gaia 内部生成。
+
+**支持的 filters**：
+
+| filter | 类型 | 说明 |
+|--------|------|------|
+| `status` | string | 节点状态 |
+| `type` | string[] | 节点类型 |
+| `min_belief` | float | 最低 belief 阈值 |
+| `paper_id` | string | 按论文 ID 过滤 |
+| `min_quality` | int | 最低质量评分 |
+| `edge_type` | string[] | 按关联超边类型过滤 |
+| `keywords` | string[] | 关键词过滤 |
+
+**处理**：text → 内部 embedding → 多路召回 (vector + BM25 + topology) → 融合排序。
+
+**响应**：
+
+```json
+{
+  "results": [
+    {
+      "node_id": 251,
+      "title": "YH10 高压超导 Tc≈303K",
+      "content": "fcc YH10 相在 400GPa 下超导，Tc≈303K",
+      "similarity": 0.89,
+      "belief": 0.65,
+      "source": "vector",
+      "type": "paper-extract"
+    }
+  ],
+  "total": 20,
+  "recall_sources": {"vector": 12, "bm25": 6, "topology": 2}
+}
+```
+
+### 5.2 POST /search/hyperedges (同步)
+
+**请求**：
+
+```json
+{
+  "text": "DFT 理论预测氢化物超导温度",
+  "top_k": 10,
+  "filters": {
+    "edge_type": ["paper-extract", "deduction"],
+    "min_quality": 3
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "results": [
+    {
+      "edge_id": 1234,
+      "type": "paper-extract",
+      "reasoning": [{"title": "DFT+Eliashberg", "content": "..."}],
+      "tail_summary": ["DFT 计算", "晶格动力学"],
+      "head_summary": ["YH10 Tc≈303K"],
+      "similarity": 0.87
+    }
+  ]
+}
+```
+
+### 5.3 批量检索 (异步)
+
+#### POST /search/nodes/batch
+
+**请求**：
+
+```json
+{
+  "queries": [
+    {"text": "高压氢化物超导", "top_k": 20},
+    {"text": "铜氧化物配对机制", "top_k": 10},
+    {"text": "拓扑超导体", "top_k": 15}
+  ],
+  "filters": {
+    "status": "active"
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "job_id": "job_search_batch_001",
+  "status": "running"
+}
+```
+
+#### POST /search/hyperedges/batch
+
+同上模式。
+
+---
+
+## 6. Job 管理 API
+
+所有异步操作（review、batch 操作）共享统一的 Job 管理接口。
+
+### 6.1 GET /jobs/{job_id} — 查看 Job 状态
+
+```json
+{
+  "job_id": "job_review_abc123",
+  "type": "review",
+  "status": "running",
+  "created_at": "2026-03-03T10:00:00Z",
+  "updated_at": "2026-03-03T10:00:05Z",
+  "progress": {
+    "current_step": "cc_join",
+    "steps_completed": 2,
+    "steps_total": 6
+  }
+}
+```
+
+**Job 状态**：
+
+| status | 说明 |
+|--------|------|
+| `pending` | 等待执行 |
+| `running` | 执行中 |
+| `completed` | 执行完成 |
+| `failed` | 执行失败 |
+| `cancelled` | 已取消 |
+
+### 6.2 DELETE /jobs/{job_id} — 取消 Job
+
+```json
+{
+  "job_id": "job_review_abc123",
+  "status": "cancelled"
+}
+```
+
+### 6.3 GET /jobs/{job_id}/result — 获取 Job 结果
+
+仅在 status=completed 时可用。结果格式取决于 job type。
+
+---
+
+## 7. Review Pipeline 算子设计
+
+每个算子为独立模块，可单独测试、替换、组合。
+
+### 7.1 算子列表
+
+| 算子 | 输入 | 输出 | 说明 |
+|------|------|------|------|
+| `EmbeddingOperator` | node content (text) | embedding vector (float[]) | 调用 embedding model |
+| `NNSearchOperator` | embedding vector | list of (node_id, similarity) | 搜索 k 个最近邻 |
+| `CCJoinOperator` | conclusion nodes + NN candidates | join trees | conclusion↔conclusion 关系发现 |
+| `CPJoinOperator` | conclusion nodes + NN candidates | join trees | conclusion↔premise 关系发现 |
+| `JoinTreeVerifyOperator` | join trees | verified trees | 验证 join tree 的有效性 |
+| `RefineOperator` | verified trees | refined trees | 精炼 join tree |
+| `VerifyAgainOperator` | refined trees | final verified trees | 二次验证 |
+| `BPOperator` | affected node ids + graph | belief updates | 局部信念传播 |
+
+### 7.2 算子接口
+
+每个算子实现统一接口：
+
+```python
+class Operator(ABC):
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        """执行算子逻辑，读取并更新 context。"""
+        ...
+
+    async def cancel(self) -> None:
+        """取消正在执行的操作。"""
+        ...
+```
+
+### 7.3 Pipeline 编排
+
+Pipeline 根据 commit 中的**操作类型**自动选择算子子集：
+
+| 操作类型 | 执行的算子 | 说明 |
+|---------|-----------|------|
+| `add_edge` | 全部 (①→②→③→④→⑤) | 新节点需要 embedding、join 发现、verify、BP |
+| `modify_node` (content 变更) | ① Embedding → ② NN Search → ⑤ BP | 内容变更需重新计算 embedding 和影响评估 |
+| `modify_node` (非 content) | ⑤ BP | 仅影响评估 |
+| `modify_edge` (retraction) | ⑤ BP | 撤回影响评估，计算下游节点 belief 变化 |
+| `modify_edge` (其他) | ⑤ BP | 仅影响评估 |
+
+一个 commit 包含混合操作时，取所有操作所需算子的**并集**。
+
+```python
+# add_edge 操作: 完整 pipeline
+pipeline_full = Pipeline(steps=[
+    EmbeddingOperator(model=embedding_model),
+    NNSearchOperator(k=20),
+    ParallelStep(
+        CCJoinOperator(),
+        CPJoinOperator(),
+    ),
+    JoinTreeVerifyOperator(),
+    RefineOperator(),
+    VerifyAgainOperator(),
+    BPOperator(),
+])
+
+# modify 操作: 仅 BP 影响评估
+pipeline_modify = Pipeline(steps=[
+    BPOperator(),
+])
+```
+
+---
+
+## 8. 典型使用场景
+
+### 8.1 Research Agent 推导新知识
+
+```
+1. POST /search/nodes                    → 了解已有知识 (同步)
+   {text: "YH10 高压超导"}
+
+2. (Agent 自己推理，产出新的超边)
+
+3. POST /commits                         → 提交推导结果 (同步，秒回)
+   {operations: [{op: "add_edge", type: "deduction", ...}]}
+   ← commit_id, status: "pending_review"
+
+4. POST /commits/{id}/review             → 提交 review job (异步)
+   {depth: "standard"}
+   ← job_id, status: "running"
+
+5. GET /commits/{id}/review              → 轮询 review 进度
+   ← pipeline_steps: embedding ✓, nn_search ✓, cc_join running...
+
+6. GET /commits/{id}/review/result       → 获取审核结果
+   ├─ verdict: pass              → 继续 merge
+   ├─ verdict: has_overlap       → 修改后重新提交新 commit
+   └─ verdict: rejected          → 推理链不合格
+
+7. POST /commits/{id}/merge              → 入图 (同步)
+   ← join_edges_created, beliefs_persisted, index_status
+   (belief_updates 已在 step 6 review result 中返回)
+```
+
+### 8.2 批量论文注入 (Paper Ingest Agent)
+
+```
+1. 外部系统将论文解析为超边
+
+2. POST /commits/batch                   → 批量提交 (异步)
+   {commits: [
+     {message: "arxiv:2301.12345", operations: [...]},
+     {message: "arxiv:2301.67890", operations: [...]},
+     ...100 篇论文
+   ], auto_review: true, auto_merge: true}
+   ← job_id: "job_batch_001"
+
+3. GET /commits/batch/{batch_id}         → 轮询进度
+   ← 82 merged, 15 reviewing, 3 rejected
+
+4. 对 rejected 的 commit:
+   修改后 POST /commits → review → merge (逐条处理)
+```
+
+### 8.3 撤回已有知识
+
+```
+1. POST /commits                         → 提交撤回操作 (同步)
+   {operations: [{
+     op: "modify_edge",
+     edge_id: 456,
+     changes: {status: "retracted", reason: "论文撤稿"}
+   }]}
+
+2. POST /commits/{id}/review             → review (异步)
+   ← pipeline 评估影响范围，受影响节点 BP 重算
+
+3. GET /commits/{id}/review/result       → 查看影响分析
+   ← affected_downstream_nodes: 12, belief_updates preview
+
+4. POST /commits/{id}/merge              → 入图 (同步)
+   ← review 中计算的 BP 结果持久化，受影响节点 belief 降低
+```
+
+### 8.4 批量撤回某篇论文的所有命题
+
+```
+1. POST /search/nodes                    → 按论文查询所有节点 (同步)
+   {filters: {paper_id: "arxiv:retracted-paper"}}
+   ← 返回该论文的所有节点
+
+2. POST /search/hyperedges               → 查找关联超边 (同步)
+   {filters: {edge_type: ["paper-extract"]}}
+
+3. POST /commits                         → 批量撤回 (同步)
+   {operations: [
+     {op: "modify_edge", edge_id: 101, changes: {status: "retracted"}},
+     {op: "modify_edge", edge_id: 102, changes: {status: "retracted"}},
+     ...
+   ]}
+
+4. POST /commits/{id}/review → merge     → 异步 review + 同步 merge
+```
+
+### 8.5 文献综述 (Human Researcher)
+
+```
+1. POST /search/nodes                    → 搜索相关命题 (同步)
+   {text: "铜氧化物高温超导机理", top_k: 50}
+
+2. POST /search/hyperedges               → 搜索推理链 (同步)
+   {text: "超导配对机制的理论解释", top_k: 20}
+
+3. GET /nodes/{id}/subgraph              → 探索某个命题的上下游 (同步)
+   ?hops=3&direction=both
+
+4. (如果需要批量探索多个命题)
+   POST /nodes/subgraph/batch            → 批量子图查询 (异步)
+   {queries: [
+     {node_id: 251, hops: 3},
+     {node_id: 300, hops: 3},
+     ...
+   ]}
+   ← job_id → GET /jobs/{job_id}/result
+```
+
+### 8.6 检查"我的想法新不新"
+
+```
+1. POST /search/nodes                    → 搜索相似命题 (同步)
+   {text: "我的新想法...", top_k: 5}
+   ← top-1 similarity < 0.5 → 很新颖
+   ← top-1 similarity > 0.9 → 已有人提出
+
+2. (可选) 提交到知识图谱验证
+   POST /commits → review
+   ← review result 中的 novelty 评分给出量化新颖度
+```
+
+---
+
+## 9. 用户角色与 API 覆盖矩阵
+
+### 9.1 角色定义 (继承 v2)
+
+| 角色 | 谁 | 与 LKM 的关系 |
+|------|-----|---------------|
+| **Research Agent** | 自动化 AI Agent | 检索知识 → 推理 → 提交新发现 |
+| **Paper Ingest Agent** | 自动化 Agent | 批量注入论文到知识图谱 |
+| **Human Researcher** | 人类科学家 | 查询、浏览、验证假设、写综述 |
+| **Reviewer** | 人类/AI 审稿人 | 评估论文/命题的质量 |
+| **Knowledge Curator** | 人类/AI 维护者 | 纠错、撤回、标注 |
+| **System Admin** | 运维人员 | 监控、Job 管理 |
+
+### 9.2 覆盖矩阵
+
+| 操作 | 角色 | API | 状态 |
+|------|------|-----|------|
+| 搜索已有知识 | Agent, Researcher | `POST /search/nodes` | ✅ |
+| 批量搜索 | Agent | `POST /search/nodes/batch` | ✅ 新增 |
+| 搜索超边 | Agent, Researcher | `POST /search/hyperedges` | ✅ |
+| 查看节点详情 | 所有 | `GET /nodes/{id}` | ✅ |
+| 批量读取节点 | Agent | `POST /nodes/batch` | ✅ 新增 |
+| 查看超边详情 | 所有 | `GET /hyperedges/{id}` | ✅ |
+| 查看节点邻居 | 所有 | `GET /nodes/{id}/subgraph` | ✅ |
+| 提交新超边 | Agent | `POST /commits` | ✅ |
+| 异步 review | Agent | `POST /commits/{id}/review` | ✅ 重构 |
+| 查看 review 进度 | Agent | `GET /commits/{id}/review` | ✅ 新增 |
+| 取消 review | Agent | `DELETE /commits/{id}/review` | ✅ 新增 |
+| 入图 | Agent | `POST /commits/{id}/merge` | ✅ |
+| 批量提交 | Ingest Agent | `POST /commits/batch` | ✅ |
+| 撤回知识 | Curator | `POST /commits` (modify_edge) | ✅ |
+| 管理 Job | Admin | `GET/DELETE /jobs/{job_id}` | ✅ 新增 |
+| 新颖度评估 | Researcher | Layer 2 API | ⏳ 待设计 |
+| 可信度 + 证据链 | Researcher | Layer 2 API | ⏳ 待设计 |
+| 矛盾分析 | Researcher | Layer 2 API | ⏳ 待设计 |
+
+---
+
+## 10. Layer 2 Research API 需求清单 (继承 v2)
+
+| 端点 | 功能 | 内部编排 |
+|------|------|---------|
+| `POST /research/novelty` | 新颖度评分 | 多路召回 + BP + score 聚合 |
+| `POST /research/reliability` | 可信度评分 | 子图提取 + BP + 证据分类 |
+| `POST /research/contradictions` | 矛盾列表 | 子图过滤 + BP |
+| `GET /research/provenance/{id}` | 论文溯源树 | 递归上游追溯 |
+| `POST /research/overview` | 领域知识结构 | 多路召回 + 聚类 + 子图合并 |
+| `POST /research/compare` | 证据强度比较 | 双方子图 + BP + LLM |
+| `POST /review/paper` | 论文审阅报告 | 命题遍历 + novelty + reliability |
+
+---
+
+## 附录 A：vs v2 变更总结
+
+| 项目 | v2 | v3 |
+|------|-----|-----|
+| review | 单次 LLM 调用 (同步) | 多步 pipeline (异步 job) |
+| review 内容 | LLM 审核推理链 + 重合检测 | embedding → NN search → CC/CP join → verify → BP |
+| embedding | 调用者外部提供 | Gaia 内部生成 |
+| join/verify | 不在 Gaia 内 | Gaia 内部算子 |
+| BP 触发 | merge 时同步 | review pipeline 内完成，belief_updates 作为 review result 返回，merge 仅持久化 |
+| batch API | 仅 /commits/batch | 所有 API 都支持 batch |
+| batch 模式 | 异步 | 异步，统一 Job 管理 |
+| Job 管理 | 无 | 通用 /jobs API |
+| commit 轻量检查 | 去重 + 矛盾候选 + 引用校验 | 结构校验 + 引用校验 (去重移入 review pipeline) |
+| search 输入 | text + embedding | 仅 text (内部生成 embedding) |

--- a/docs/plans/2026-03-03-plan1-operator-layer.md
+++ b/docs/plans/2026-03-03-plan1-operator-layer.md
@@ -1,0 +1,1242 @@
+# Plan 1: Review Pipeline Operator Layer
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the review pipeline framework and all operators (embedding, NN search, CC/CP join, verify, refine, BP) as independent, testable modules.
+
+**Architecture:** A `Pipeline` orchestrator executes a chain of `Operator` instances, passing a shared `PipelineContext` between them. Each operator reads from and writes to the context. `ParallelStep` runs multiple operators concurrently. LLM-dependent operators (join, verify, refine) use a pluggable interface with stubs for Phase 1.
+
+**Tech Stack:** Python 3.12+, Pydantic v2, asyncio, existing inference_engine/bp.py, existing search_engine
+
+---
+
+### Task 1: PipelineContext Data Model
+
+**Files:**
+- Create: `services/review_pipeline/__init__.py`
+- Create: `services/review_pipeline/context.py`
+- Test: `tests/services/test_review_pipeline/__init__.py`
+- Test: `tests/services/test_review_pipeline/test_context.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_context.py
+from services.review_pipeline.context import PipelineContext, NewNodeInfo, JoinTree
+
+
+def test_context_init_from_add_edge_ops():
+    """Context extracts new node info from add_edge operations."""
+    from libs.models import CommitRequest, AddEdgeOp, NewNode, NodeRef
+
+    request = CommitRequest(
+        message="test",
+        operations=[
+            AddEdgeOp(
+                tail=[NewNode(content="premise A"), NodeRef(node_id=100)],
+                head=[NewNode(content="conclusion B")],
+                type="paper-extract",
+                reasoning=[{"title": "step1", "content": "because"}],
+            )
+        ],
+    )
+    ctx = PipelineContext.from_commit_request(request)
+    assert len(ctx.new_nodes) == 2
+    assert ctx.new_nodes[0].content == "premise A"
+    assert ctx.new_nodes[0].op_index == 0
+    assert ctx.new_nodes[0].position == "tail[0]"
+    assert ctx.new_nodes[1].content == "conclusion B"
+    assert ctx.new_nodes[1].position == "head[0]"
+    assert ctx.cancelled is False
+
+
+def test_context_init_from_modify_ops():
+    """Context with only modify ops has no new nodes."""
+    from libs.models import CommitRequest, ModifyNodeOp
+
+    request = CommitRequest(
+        message="test",
+        operations=[ModifyNodeOp(node_id=1, changes={"status": "deleted"})],
+    )
+    ctx = PipelineContext.from_commit_request(request)
+    assert len(ctx.new_nodes) == 0
+    assert ctx.affected_node_ids == [1]
+
+
+def test_join_tree_model():
+    tree = JoinTree(
+        source_node_index=0,
+        target_node_id=251,
+        relation="partial_overlap",
+        verified=False,
+    )
+    assert tree.source_node_index == 0
+    assert tree.verified is False
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_context.py -v`
+Expected: FAIL — module not found
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/__init__.py
+"""Review pipeline — async operator-based review for commits."""
+
+# services/review_pipeline/context.py
+"""PipelineContext — shared state passed between pipeline operators."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from libs.models import (
+    AddEdgeOp,
+    CommitRequest,
+    ModifyEdgeOp,
+    ModifyNodeOp,
+    NewNode,
+)
+
+
+class NewNodeInfo(BaseModel):
+    """Metadata about a new node extracted from a commit operation."""
+    content: str
+    keywords: list[str] = []
+    extra: dict = {}
+    op_index: int
+    position: str  # e.g. "tail[0]", "head[1]"
+
+
+class JoinTree(BaseModel):
+    """A discovered relationship between a new node and an existing node."""
+    source_node_index: int  # index into PipelineContext.new_nodes
+    target_node_id: int
+    relation: str  # "equivalent", "partial_overlap", "subsumes", "subsumed_by"
+    verified: bool = False
+    reasoning: str = ""
+
+
+class PipelineContext:
+    """Shared mutable state flowing through the review pipeline."""
+
+    def __init__(self) -> None:
+        self.request: CommitRequest | None = None
+        self.new_nodes: list[NewNodeInfo] = []
+        self.affected_node_ids: list[int] = []
+        self.embeddings: dict[int, list[float]] = {}  # new_node index -> vector
+        self.nn_results: dict[int, list[tuple[int, float]]] = {}  # index -> [(node_id, sim)]
+        self.cc_join_trees: list[JoinTree] = []
+        self.cp_join_trees: list[JoinTree] = []
+        self.verified_trees: list[JoinTree] = []
+        self.bp_results: dict[int, float] = {}  # node_id -> belief
+        self.cancelled: bool = False
+        self.step_results: dict[str, dict] = {}  # step_name -> metadata
+
+    @classmethod
+    def from_commit_request(cls, request: CommitRequest) -> PipelineContext:
+        ctx = cls()
+        ctx.request = request
+        for op_idx, op in enumerate(request.operations):
+            if isinstance(op, AddEdgeOp):
+                for i, item in enumerate(op.tail):
+                    if isinstance(item, NewNode):
+                        ctx.new_nodes.append(
+                            NewNodeInfo(
+                                content=item.content if isinstance(item.content, str) else str(item.content),
+                                keywords=item.keywords,
+                                extra=item.extra,
+                                op_index=op_idx,
+                                position=f"tail[{i}]",
+                            )
+                        )
+                for i, item in enumerate(op.head):
+                    if isinstance(item, NewNode):
+                        ctx.new_nodes.append(
+                            NewNodeInfo(
+                                content=item.content if isinstance(item.content, str) else str(item.content),
+                                keywords=item.keywords,
+                                extra=item.extra,
+                                op_index=op_idx,
+                                position=f"head[{i}]",
+                            )
+                        )
+            elif isinstance(op, ModifyNodeOp):
+                ctx.affected_node_ids.append(op.node_id)
+            elif isinstance(op, ModifyEdgeOp):
+                ctx.affected_node_ids.append(op.edge_id)
+        return ctx
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_context.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/review_pipeline/ tests/services/test_review_pipeline/
+git commit -m "feat: add PipelineContext data model for review pipeline"
+```
+
+---
+
+### Task 2: Pipeline Framework (Operator ABC, Pipeline, ParallelStep)
+
+**Files:**
+- Create: `services/review_pipeline/base.py`
+- Test: `tests/services/test_review_pipeline/test_base.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_base.py
+import pytest
+from services.review_pipeline.base import Operator, Pipeline, ParallelStep
+from services.review_pipeline.context import PipelineContext
+from libs.models import CommitRequest, ModifyNodeOp
+
+
+class IncrementOperator(Operator):
+    """Test operator that appends its name to step_results."""
+    def __init__(self, name: str):
+        self.name = name
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        context.step_results[self.name] = {"done": True}
+        return context
+
+
+class FailingOperator(Operator):
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        raise ValueError("operator failed")
+
+
+@pytest.fixture
+def empty_context():
+    req = CommitRequest(
+        message="test",
+        operations=[ModifyNodeOp(node_id=1, changes={"status": "deleted"})],
+    )
+    return PipelineContext.from_commit_request(req)
+
+
+async def test_pipeline_sequential(empty_context):
+    pipeline = Pipeline(steps=[IncrementOperator("a"), IncrementOperator("b")])
+    result = await pipeline.execute(empty_context)
+    assert "a" in result.step_results
+    assert "b" in result.step_results
+
+
+async def test_pipeline_parallel_step(empty_context):
+    pipeline = Pipeline(steps=[
+        ParallelStep(IncrementOperator("x"), IncrementOperator("y")),
+    ])
+    result = await pipeline.execute(empty_context)
+    assert "x" in result.step_results
+    assert "y" in result.step_results
+
+
+async def test_pipeline_skips_after_cancel(empty_context):
+    empty_context.cancelled = True
+    pipeline = Pipeline(steps=[IncrementOperator("a")])
+    result = await pipeline.execute(empty_context)
+    assert "a" not in result.step_results
+
+
+async def test_pipeline_cancel_propagates(empty_context):
+    pipeline = Pipeline(steps=[IncrementOperator("a"), IncrementOperator("b")])
+    await pipeline.cancel()
+    result = await pipeline.execute(empty_context)
+    assert "a" not in result.step_results
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_base.py -v`
+Expected: FAIL — module not found
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/base.py
+"""Pipeline framework — Operator ABC, Pipeline orchestrator, ParallelStep."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+
+from services.review_pipeline.context import PipelineContext
+
+
+class Operator(ABC):
+    """Base class for all pipeline operators."""
+
+    @abstractmethod
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        """Execute operator logic, reading from and writing to context."""
+        ...
+
+    async def cancel(self) -> None:
+        """Cancel a running operation. Override if cleanup is needed."""
+        pass
+
+
+class ParallelStep:
+    """Run multiple operators concurrently on the same context."""
+
+    def __init__(self, *operators: Operator) -> None:
+        self._operators = list(operators)
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        if context.cancelled:
+            return context
+        await asyncio.gather(*(op.execute(context) for op in self._operators))
+        return context
+
+    async def cancel(self) -> None:
+        await asyncio.gather(*(op.cancel() for op in self._operators))
+
+
+class Pipeline:
+    """Sequential pipeline that passes context through each step."""
+
+    def __init__(self, steps: list[Operator | ParallelStep]) -> None:
+        self._steps = steps
+        self._cancelled = False
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        if self._cancelled:
+            context.cancelled = True
+        for step in self._steps:
+            if context.cancelled:
+                break
+            context = await step.execute(context)
+        return context
+
+    async def cancel(self) -> None:
+        self._cancelled = True
+        for step in self._steps:
+            await step.cancel()
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_base.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/review_pipeline/base.py tests/services/test_review_pipeline/test_base.py
+git commit -m "feat: add Pipeline framework with Operator ABC and ParallelStep"
+```
+
+---
+
+### Task 3: EmbeddingOperator
+
+**Files:**
+- Create: `services/review_pipeline/operators/__init__.py`
+- Create: `services/review_pipeline/operators/embedding.py`
+- Test: `tests/services/test_review_pipeline/test_embedding_op.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_embedding_op.py
+import pytest
+from services.review_pipeline.operators.embedding import (
+    EmbeddingModel,
+    EmbeddingOperator,
+    StubEmbeddingModel,
+)
+from services.review_pipeline.context import PipelineContext
+from libs.models import CommitRequest, AddEdgeOp, NewNode, NodeRef
+
+
+@pytest.fixture
+def context_with_new_nodes():
+    req = CommitRequest(
+        message="test",
+        operations=[
+            AddEdgeOp(
+                tail=[NewNode(content="premise A")],
+                head=[NewNode(content="conclusion B")],
+                type="paper-extract",
+                reasoning=[{"title": "r", "content": "because"}],
+            )
+        ],
+    )
+    return PipelineContext.from_commit_request(req)
+
+
+async def test_stub_embedding_model():
+    model = StubEmbeddingModel(dim=128)
+    vecs = await model.embed(["hello", "world"])
+    assert len(vecs) == 2
+    assert len(vecs[0]) == 128
+    assert all(isinstance(v, float) for v in vecs[0])
+
+
+async def test_embedding_operator_generates_vectors(context_with_new_nodes):
+    op = EmbeddingOperator(model=StubEmbeddingModel(dim=128))
+    result = await op.execute(context_with_new_nodes)
+    assert 0 in result.embeddings
+    assert 1 in result.embeddings
+    assert len(result.embeddings[0]) == 128
+
+
+async def test_embedding_operator_skips_if_no_new_nodes():
+    from libs.models import ModifyNodeOp
+    req = CommitRequest(
+        message="test",
+        operations=[ModifyNodeOp(node_id=1, changes={"status": "deleted"})],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    op = EmbeddingOperator(model=StubEmbeddingModel(dim=128))
+    result = await op.execute(ctx)
+    assert len(result.embeddings) == 0
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_embedding_op.py -v`
+Expected: FAIL — module not found
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/operators/__init__.py
+"""Review pipeline operators."""
+
+# services/review_pipeline/operators/embedding.py
+"""EmbeddingOperator — generate embeddings for new nodes."""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from abc import ABC, abstractmethod
+
+from services.review_pipeline.base import Operator
+from services.review_pipeline.context import PipelineContext
+
+
+class EmbeddingModel(ABC):
+    """Abstract embedding model interface."""
+
+    @abstractmethod
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for a batch of texts."""
+        ...
+
+
+class StubEmbeddingModel(EmbeddingModel):
+    """Deterministic stub: hashes text to produce reproducible vectors."""
+
+    def __init__(self, dim: int = 1024) -> None:
+        self._dim = dim
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        results = []
+        for text in texts:
+            digest = hashlib.sha256(text.encode()).digest()
+            # Repeat digest bytes to fill dim floats
+            raw = digest * ((self._dim * 4 // len(digest)) + 1)
+            floats = list(struct.unpack(f"<{self._dim}f", raw[: self._dim * 4]))
+            # Normalize to reasonable range
+            mag = max(abs(f) for f in floats) or 1.0
+            results.append([f / mag for f in floats])
+        return results
+
+
+class EmbeddingOperator(Operator):
+    """Generate embeddings for all new nodes in the context."""
+
+    def __init__(self, model: EmbeddingModel) -> None:
+        self._model = model
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        if not context.new_nodes:
+            return context
+        texts = [node.content for node in context.new_nodes]
+        vectors = await self._model.embed(texts)
+        for i, vec in enumerate(vectors):
+            context.embeddings[i] = vec
+        return context
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_embedding_op.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/review_pipeline/operators/ tests/services/test_review_pipeline/test_embedding_op.py
+git commit -m "feat: add EmbeddingOperator with pluggable model interface"
+```
+
+---
+
+### Task 4: NNSearchOperator
+
+**Files:**
+- Create: `services/review_pipeline/operators/nn_search.py`
+- Test: `tests/services/test_review_pipeline/test_nn_search_op.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_nn_search_op.py
+import pytest
+from unittest.mock import AsyncMock
+from services.review_pipeline.operators.nn_search import NNSearchOperator
+from services.review_pipeline.context import PipelineContext
+from libs.models import CommitRequest, AddEdgeOp, NewNode
+from libs.storage.vector_search.base import VectorSearchClient
+
+
+@pytest.fixture
+def context_with_embeddings():
+    req = CommitRequest(
+        message="test",
+        operations=[
+            AddEdgeOp(
+                tail=[NewNode(content="premise")],
+                head=[NewNode(content="conclusion")],
+                type="paper-extract",
+                reasoning=[{"title": "r", "content": "because"}],
+            )
+        ],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    ctx.embeddings = {0: [0.1] * 128, 1: [0.2] * 128}
+    return ctx
+
+
+async def test_nn_search_returns_neighbors(context_with_embeddings):
+    mock_client = AsyncMock(spec=VectorSearchClient)
+    mock_client.search.return_value = [(100, 0.1), (200, 0.2), (300, 0.3)]
+
+    op = NNSearchOperator(vector_client=mock_client, k=20)
+    result = await op.execute(context_with_embeddings)
+
+    assert 0 in result.nn_results
+    assert 1 in result.nn_results
+    assert len(result.nn_results[0]) == 3
+    assert result.nn_results[0][0] == (100, 0.1)
+    assert mock_client.search.call_count == 2
+
+
+async def test_nn_search_skips_if_no_embeddings():
+    from libs.models import ModifyNodeOp
+    req = CommitRequest(
+        message="t",
+        operations=[ModifyNodeOp(node_id=1, changes={"x": 1})],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    mock_client = AsyncMock(spec=VectorSearchClient)
+    op = NNSearchOperator(vector_client=mock_client, k=20)
+    result = await op.execute(ctx)
+    assert len(result.nn_results) == 0
+    mock_client.search.assert_not_called()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_nn_search_op.py -v`
+Expected: FAIL — module not found
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/operators/nn_search.py
+"""NNSearchOperator — find nearest neighbors for each new node embedding."""
+
+from __future__ import annotations
+
+from libs.storage.vector_search.base import VectorSearchClient
+from services.review_pipeline.base import Operator
+from services.review_pipeline.context import PipelineContext
+
+
+class NNSearchOperator(Operator):
+    """Search k nearest neighbors for each new node's embedding."""
+
+    def __init__(self, vector_client: VectorSearchClient, k: int = 20) -> None:
+        self._client = vector_client
+        self._k = k
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        if not context.embeddings:
+            return context
+        for idx, embedding in context.embeddings.items():
+            results = await self._client.search(embedding, k=self._k)
+            context.nn_results[idx] = results
+        return context
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_nn_search_op.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/review_pipeline/operators/nn_search.py tests/services/test_review_pipeline/test_nn_search_op.py
+git commit -m "feat: add NNSearchOperator wrapping vector search client"
+```
+
+---
+
+### Task 5: CC/CP Join Operators (stub)
+
+**Files:**
+- Create: `services/review_pipeline/operators/join.py`
+- Test: `tests/services/test_review_pipeline/test_join_op.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_join_op.py
+import pytest
+from services.review_pipeline.operators.join import (
+    CCJoinOperator,
+    CPJoinOperator,
+    JoinLLM,
+    StubJoinLLM,
+)
+from services.review_pipeline.context import PipelineContext
+from libs.models import CommitRequest, AddEdgeOp, NewNode
+
+
+@pytest.fixture
+def context_with_nn():
+    req = CommitRequest(
+        message="test",
+        operations=[
+            AddEdgeOp(
+                tail=[NewNode(content="premise")],
+                head=[NewNode(content="conclusion")],
+                type="paper-extract",
+                reasoning=[{"title": "r", "content": "because"}],
+            )
+        ],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    ctx.embeddings = {0: [0.1] * 128, 1: [0.2] * 128}
+    ctx.nn_results = {
+        0: [(100, 0.05), (200, 0.1)],
+        1: [(300, 0.02), (400, 0.15)],
+    }
+    return ctx
+
+
+async def test_stub_join_llm():
+    llm = StubJoinLLM()
+    trees = await llm.find_joins("new content", [(100, "existing content")])
+    assert isinstance(trees, list)
+
+
+async def test_cc_join_produces_trees(context_with_nn):
+    op = CCJoinOperator(join_llm=StubJoinLLM())
+    result = await op.execute(context_with_nn)
+    assert isinstance(result.cc_join_trees, list)
+
+
+async def test_cp_join_produces_trees(context_with_nn):
+    op = CPJoinOperator(join_llm=StubJoinLLM())
+    result = await op.execute(context_with_nn)
+    assert isinstance(result.cp_join_trees, list)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_join_op.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/operators/join.py
+"""CC/CP Join Operators — discover relationships between new and existing nodes.
+
+Phase 1: StubJoinLLM returns empty results. Future phases plug in real LLM.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from services.review_pipeline.base import Operator
+from services.review_pipeline.context import JoinTree, PipelineContext
+
+
+class JoinLLM(ABC):
+    """Abstract interface for LLM-based join discovery."""
+
+    @abstractmethod
+    async def find_joins(
+        self,
+        new_content: str,
+        candidates: list[tuple[int, str]],
+    ) -> list[JoinTree]:
+        """Find relationships between new content and candidate nodes.
+
+        Args:
+            new_content: Content of the new node.
+            candidates: List of (node_id, content) pairs to compare against.
+
+        Returns:
+            List of discovered join trees.
+        """
+        ...
+
+
+class StubJoinLLM(JoinLLM):
+    """Always returns empty results. For testing and Phase 1."""
+
+    async def find_joins(
+        self,
+        new_content: str,
+        candidates: list[tuple[int, str]],
+    ) -> list[JoinTree]:
+        return []
+
+
+class CCJoinOperator(Operator):
+    """Discover conclusion-conclusion relationships."""
+
+    def __init__(self, join_llm: JoinLLM | None = None) -> None:
+        self._llm = join_llm or StubJoinLLM()
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        if not context.nn_results:
+            return context
+        # In future: load candidate node contents, call LLM to find CC joins
+        # Phase 1: stub returns empty
+        for idx in context.nn_results:
+            candidates = [(nid, "") for nid, _ in context.nn_results[idx]]
+            trees = await self._llm.find_joins(
+                context.new_nodes[idx].content if idx < len(context.new_nodes) else "",
+                candidates,
+            )
+            for tree in trees:
+                tree.source_node_index = idx
+            context.cc_join_trees.extend(trees)
+        return context
+
+
+class CPJoinOperator(Operator):
+    """Discover conclusion-premise relationships."""
+
+    def __init__(self, join_llm: JoinLLM | None = None) -> None:
+        self._llm = join_llm or StubJoinLLM()
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        if not context.nn_results:
+            return context
+        for idx in context.nn_results:
+            candidates = [(nid, "") for nid, _ in context.nn_results[idx]]
+            trees = await self._llm.find_joins(
+                context.new_nodes[idx].content if idx < len(context.new_nodes) else "",
+                candidates,
+            )
+            for tree in trees:
+                tree.source_node_index = idx
+            context.cp_join_trees.extend(trees)
+        return context
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_join_op.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/review_pipeline/operators/join.py tests/services/test_review_pipeline/test_join_op.py
+git commit -m "feat: add CC/CP JoinOperators with pluggable LLM interface"
+```
+
+---
+
+### Task 6: Verify + Refine Operators (stub)
+
+**Files:**
+- Create: `services/review_pipeline/operators/verify.py`
+- Test: `tests/services/test_review_pipeline/test_verify_op.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_verify_op.py
+import pytest
+from services.review_pipeline.operators.verify import (
+    JoinTreeVerifyOperator,
+    RefineOperator,
+    VerifyAgainOperator,
+    VerifyLLM,
+    StubVerifyLLM,
+)
+from services.review_pipeline.context import JoinTree, PipelineContext
+from libs.models import CommitRequest, ModifyNodeOp
+
+
+@pytest.fixture
+def context_with_trees():
+    req = CommitRequest(
+        message="t",
+        operations=[ModifyNodeOp(node_id=1, changes={"x": 1})],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    ctx.cc_join_trees = [
+        JoinTree(source_node_index=0, target_node_id=100, relation="partial_overlap"),
+        JoinTree(source_node_index=0, target_node_id=200, relation="equivalent"),
+    ]
+    ctx.cp_join_trees = [
+        JoinTree(source_node_index=1, target_node_id=300, relation="subsumes"),
+    ]
+    return ctx
+
+
+async def test_verify_marks_trees(context_with_trees):
+    op = JoinTreeVerifyOperator(verify_llm=StubVerifyLLM())
+    result = await op.execute(context_with_trees)
+    # Stub auto-verifies all trees
+    all_trees = result.cc_join_trees + result.cp_join_trees
+    assert all(t.verified for t in all_trees)
+
+
+async def test_refine_passes_through(context_with_trees):
+    op = RefineOperator()
+    result = await op.execute(context_with_trees)
+    assert len(result.cc_join_trees) == 2
+
+
+async def test_verify_again_filters(context_with_trees):
+    # Mark one as verified, one not
+    context_with_trees.cc_join_trees[0].verified = True
+    context_with_trees.cc_join_trees[1].verified = False
+    context_with_trees.cp_join_trees[0].verified = True
+
+    op = VerifyAgainOperator(verify_llm=StubVerifyLLM())
+    result = await op.execute(context_with_trees)
+    assert len(result.verified_trees) == 3  # stub verifies all
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_verify_op.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/operators/verify.py
+"""Verify and Refine operators for join trees.
+
+Phase 1: StubVerifyLLM auto-verifies all trees.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from services.review_pipeline.base import Operator
+from services.review_pipeline.context import JoinTree, PipelineContext
+
+
+class VerifyLLM(ABC):
+    @abstractmethod
+    async def verify(self, trees: list[JoinTree]) -> list[JoinTree]:
+        """Verify join trees, setting verified=True/False on each."""
+        ...
+
+
+class StubVerifyLLM(VerifyLLM):
+    """Auto-verifies all trees. For testing and Phase 1."""
+
+    async def verify(self, trees: list[JoinTree]) -> list[JoinTree]:
+        for tree in trees:
+            tree.verified = True
+        return trees
+
+
+class JoinTreeVerifyOperator(Operator):
+    """First-pass verification of discovered join trees."""
+
+    def __init__(self, verify_llm: VerifyLLM | None = None) -> None:
+        self._llm = verify_llm or StubVerifyLLM()
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        all_trees = context.cc_join_trees + context.cp_join_trees
+        if all_trees:
+            await self._llm.verify(all_trees)
+        return context
+
+
+class RefineOperator(Operator):
+    """Refine join trees — Phase 1: pass-through."""
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        return context
+
+
+class VerifyAgainOperator(Operator):
+    """Second verification pass. Collects all verified trees into verified_trees."""
+
+    def __init__(self, verify_llm: VerifyLLM | None = None) -> None:
+        self._llm = verify_llm or StubVerifyLLM()
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        all_trees = context.cc_join_trees + context.cp_join_trees
+        if all_trees:
+            await self._llm.verify(all_trees)
+        context.verified_trees = [t for t in all_trees if t.verified]
+        return context
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_verify_op.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/review_pipeline/operators/verify.py tests/services/test_review_pipeline/test_verify_op.py
+git commit -m "feat: add Verify/Refine operators with pluggable LLM interface"
+```
+
+---
+
+### Task 7: BPOperator
+
+**Files:**
+- Create: `services/review_pipeline/operators/bp.py`
+- Test: `tests/services/test_review_pipeline/test_bp_op.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_bp_op.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from services.review_pipeline.operators.bp import BPOperator
+from services.review_pipeline.context import PipelineContext
+from libs.models import CommitRequest, AddEdgeOp, NewNode, Node, HyperEdge
+
+
+@pytest.fixture
+def mock_storage():
+    storage = MagicMock()
+    storage.graph = MagicMock()
+    storage.graph.get_subgraph = AsyncMock(return_value=({1, 2, 3}, {10}))
+    storage.graph.get_hyperedge = AsyncMock(
+        return_value=HyperEdge(id=10, type="paper-extract", tail=[1, 2], head=[3])
+    )
+    storage.lance = MagicMock()
+    storage.lance.load_nodes_bulk = AsyncMock(
+        return_value=[
+            Node(id=1, type="paper-extract", content="a", prior=0.9),
+            Node(id=2, type="paper-extract", content="b", prior=0.8),
+            Node(id=3, type="paper-extract", content="c", prior=0.5),
+        ]
+    )
+    return storage
+
+
+@pytest.fixture
+def context_with_affected_nodes():
+    req = CommitRequest(
+        message="test",
+        operations=[
+            AddEdgeOp(
+                tail=[NewNode(content="p")],
+                head=[NewNode(content="c")],
+                type="paper-extract",
+                reasoning=[{"title": "r", "content": "x"}],
+            )
+        ],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    ctx.affected_node_ids = [1, 2, 3]
+    return ctx
+
+
+async def test_bp_operator_computes_beliefs(mock_storage, context_with_affected_nodes):
+    op = BPOperator(storage=mock_storage)
+    result = await op.execute(context_with_affected_nodes)
+    assert len(result.bp_results) > 0
+    assert all(0 <= v <= 1 for v in result.bp_results.values())
+
+
+async def test_bp_operator_skips_without_graph():
+    storage = MagicMock()
+    storage.graph = None
+    req = CommitRequest(
+        message="t",
+        operations=[],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    ctx.affected_node_ids = [1]
+    op = BPOperator(storage=storage)
+    result = await op.execute(ctx)
+    assert len(result.bp_results) == 0
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_bp_op.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/operators/bp.py
+"""BPOperator — run belief propagation on affected subgraph."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from services.inference_engine.bp import BeliefPropagation
+from services.inference_engine.factor_graph import FactorGraph
+from services.review_pipeline.base import Operator
+from services.review_pipeline.context import PipelineContext
+
+if TYPE_CHECKING:
+    from libs.storage.manager import StorageManager
+
+
+class BPOperator(Operator):
+    """Run local belief propagation on the subgraph around affected nodes."""
+
+    def __init__(self, storage: StorageManager, hops: int = 3) -> None:
+        self._storage = storage
+        self._hops = hops
+        self._bp = BeliefPropagation()
+
+    async def execute(self, context: PipelineContext) -> PipelineContext:
+        if not self._storage.graph:
+            return context
+
+        seed_ids = context.affected_node_ids
+        if not seed_ids:
+            return context
+
+        node_ids, edge_ids = await self._storage.graph.get_subgraph(
+            seed_ids, hops=self._hops
+        )
+        if not edge_ids:
+            return context
+
+        edges = []
+        for eid in edge_ids:
+            edge = await self._storage.graph.get_hyperedge(eid)
+            if edge:
+                edges.append(edge)
+
+        nodes = await self._storage.lance.load_nodes_bulk(list(node_ids))
+        fg = FactorGraph.from_subgraph(nodes, edges)
+        beliefs = self._bp.run(fg)
+        context.bp_results = beliefs
+        return context
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_bp_op.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/review_pipeline/operators/bp.py tests/services/test_review_pipeline/test_bp_op.py
+git commit -m "feat: add BPOperator wrapping belief propagation engine"
+```
+
+---
+
+### Task 8: Full Pipeline Assembly + Integration Test
+
+**Files:**
+- Create: `services/review_pipeline/pipeline.py`
+- Test: `tests/services/test_review_pipeline/test_pipeline_integration.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_review_pipeline/test_pipeline_integration.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from services.review_pipeline.pipeline import build_review_pipeline, ReviewPipelineConfig
+from services.review_pipeline.context import PipelineContext
+from services.review_pipeline.operators.embedding import StubEmbeddingModel
+from services.review_pipeline.operators.join import StubJoinLLM
+from services.review_pipeline.operators.verify import StubVerifyLLM
+from libs.models import (
+    CommitRequest, AddEdgeOp, ModifyNodeOp, NewNode, Node, HyperEdge,
+)
+
+
+@pytest.fixture
+def mock_storage():
+    storage = MagicMock()
+    storage.graph = MagicMock()
+    storage.graph.get_subgraph = AsyncMock(return_value=({1, 2}, {10}))
+    storage.graph.get_hyperedge = AsyncMock(
+        return_value=HyperEdge(id=10, type="paper-extract", tail=[1], head=[2])
+    )
+    storage.lance = MagicMock()
+    storage.lance.load_nodes_bulk = AsyncMock(
+        return_value=[
+            Node(id=1, type="paper-extract", content="a", prior=0.9),
+            Node(id=2, type="paper-extract", content="b", prior=0.8),
+        ]
+    )
+    storage.vector = AsyncMock()
+    storage.vector.search = AsyncMock(return_value=[(1, 0.1), (2, 0.2)])
+    return storage
+
+
+async def test_full_pipeline_add_edge(mock_storage):
+    """Full pipeline runs all steps for add_edge operations."""
+    config = ReviewPipelineConfig(
+        embedding_model=StubEmbeddingModel(dim=128),
+        join_llm=StubJoinLLM(),
+        verify_llm=StubVerifyLLM(),
+    )
+    pipeline = build_review_pipeline(config, mock_storage)
+
+    req = CommitRequest(
+        message="test",
+        operations=[
+            AddEdgeOp(
+                tail=[NewNode(content="premise")],
+                head=[NewNode(content="conclusion")],
+                type="paper-extract",
+                reasoning=[{"title": "r", "content": "x"}],
+            )
+        ],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    result = await pipeline.execute(ctx)
+
+    assert len(result.embeddings) == 2
+    assert len(result.nn_results) == 2
+    assert not result.cancelled
+
+
+async def test_pipeline_modify_only_runs_bp(mock_storage):
+    """Modify-only commits skip embedding/join, only run BP."""
+    config = ReviewPipelineConfig(
+        embedding_model=StubEmbeddingModel(dim=128),
+        join_llm=StubJoinLLM(),
+        verify_llm=StubVerifyLLM(),
+    )
+    pipeline = build_review_pipeline(config, mock_storage)
+
+    req = CommitRequest(
+        message="test",
+        operations=[ModifyNodeOp(node_id=1, changes={"status": "deleted"})],
+    )
+    ctx = PipelineContext.from_commit_request(req)
+    result = await pipeline.execute(ctx)
+
+    assert len(result.embeddings) == 0
+    assert len(result.nn_results) == 0
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_review_pipeline/test_pipeline_integration.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/review_pipeline/pipeline.py
+"""Build configured review pipelines from components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from services.review_pipeline.base import Operator, ParallelStep, Pipeline
+from services.review_pipeline.operators.bp import BPOperator
+from services.review_pipeline.operators.embedding import EmbeddingModel, EmbeddingOperator
+from services.review_pipeline.operators.join import CCJoinOperator, CPJoinOperator, JoinLLM
+from services.review_pipeline.operators.nn_search import NNSearchOperator
+from services.review_pipeline.operators.verify import (
+    JoinTreeVerifyOperator,
+    RefineOperator,
+    VerifyAgainOperator,
+    VerifyLLM,
+)
+
+if TYPE_CHECKING:
+    from libs.storage.manager import StorageManager
+
+
+@dataclass
+class ReviewPipelineConfig:
+    embedding_model: EmbeddingModel
+    join_llm: JoinLLM | None = None
+    verify_llm: VerifyLLM | None = None
+    nn_k: int = 20
+    bp_hops: int = 3
+
+
+def build_review_pipeline(
+    config: ReviewPipelineConfig,
+    storage: StorageManager,
+) -> Pipeline:
+    """Build the full review pipeline.
+
+    The pipeline is: Embedding → NN Search → CC/CP Join (parallel) →
+    Verify → Refine → Verify Again → BP.
+
+    Operators that find no input data (e.g. no new_nodes) are no-ops.
+    """
+    return Pipeline(steps=[
+        EmbeddingOperator(model=config.embedding_model),
+        NNSearchOperator(vector_client=storage.vector, k=config.nn_k),
+        ParallelStep(
+            CCJoinOperator(join_llm=config.join_llm),
+            CPJoinOperator(join_llm=config.join_llm),
+        ),
+        JoinTreeVerifyOperator(verify_llm=config.verify_llm),
+        RefineOperator(),
+        VerifyAgainOperator(verify_llm=config.verify_llm),
+        BPOperator(storage=storage, hops=config.bp_hops),
+    ])
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_review_pipeline/test_pipeline_integration.py -v`
+Expected: PASS
+
+**Step 5: Run all pipeline tests**
+
+Run: `pytest tests/services/test_review_pipeline/ -v`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add services/review_pipeline/pipeline.py tests/services/test_review_pipeline/test_pipeline_integration.py
+git commit -m "feat: add review pipeline assembly with full operator chain"
+```

--- a/docs/plans/2026-03-03-plan2-single-input-apis.md
+++ b/docs/plans/2026-03-03-plan2-single-input-apis.md
@@ -1,0 +1,959 @@
+# Plan 2: Single-Input API Layer
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement the v3 single-input APIs: async review with job management, updated commit/merge, search without external embedding, and enhanced read routes.
+
+**Architecture:** A `JobManager` handles async job lifecycle (submit/cancel/status/result). Review route submits a background pipeline job. Search generates embeddings internally via the same `EmbeddingModel`. Merge persists review pipeline results (embeddings, beliefs, join edges).
+
+**Tech Stack:** Python 3.12+, FastAPI, Pydantic v2, asyncio, review_pipeline from Plan 1
+
+**Depends on:** Plan 1 (Operator Layer) must be completed first.
+
+---
+
+### Task 1: Job Manager — Model + Store
+
+**Files:**
+- Create: `services/job_manager/__init__.py`
+- Create: `services/job_manager/models.py`
+- Create: `services/job_manager/store.py`
+- Test: `tests/services/test_job_manager/__init__.py`
+- Test: `tests/services/test_job_manager/test_models.py`
+- Test: `tests/services/test_job_manager/test_store.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_job_manager/test_models.py
+from services.job_manager.models import Job, JobStatus, JobType
+
+
+def test_job_creation():
+    job = Job(job_type=JobType.REVIEW, reference_id="commit_abc123")
+    assert job.status == JobStatus.PENDING
+    assert job.job_id.startswith("job_")
+    assert job.reference_id == "commit_abc123"
+    assert job.progress == {}
+    assert job.result is None
+
+
+def test_job_status_transitions():
+    job = Job(job_type=JobType.REVIEW, reference_id="x")
+    job.status = JobStatus.RUNNING
+    assert job.status == JobStatus.RUNNING
+    job.status = JobStatus.COMPLETED
+    assert job.status == JobStatus.COMPLETED
+```
+
+```python
+# tests/services/test_job_manager/test_store.py
+import pytest
+from services.job_manager.models import Job, JobType
+from services.job_manager.store import InMemoryJobStore
+
+
+@pytest.fixture
+def store():
+    return InMemoryJobStore()
+
+
+async def test_save_and_get(store):
+    job = Job(job_type=JobType.REVIEW, reference_id="c1")
+    await store.save(job)
+    loaded = await store.get(job.job_id)
+    assert loaded is not None
+    assert loaded.job_id == job.job_id
+
+
+async def test_get_missing_returns_none(store):
+    assert await store.get("nonexistent") is None
+
+
+async def test_update(store):
+    job = Job(job_type=JobType.REVIEW, reference_id="c1")
+    await store.save(job)
+    job.status = "running"
+    await store.update(job)
+    loaded = await store.get(job.job_id)
+    assert loaded.status == "running"
+
+
+async def test_get_by_reference(store):
+    job = Job(job_type=JobType.REVIEW, reference_id="commit_abc")
+    await store.save(job)
+    loaded = await store.get_by_reference("commit_abc", JobType.REVIEW)
+    assert loaded is not None
+    assert loaded.job_id == job.job_id
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_job_manager/ -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/job_manager/__init__.py
+"""Job management for async operations."""
+
+# services/job_manager/models.py
+"""Job data models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class JobStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class JobType(StrEnum):
+    REVIEW = "review"
+    BATCH_COMMIT = "batch_commit"
+    BATCH_SEARCH = "batch_search"
+    BATCH_READ = "batch_read"
+
+
+class Job(BaseModel):
+    job_id: str = Field(default_factory=lambda: f"job_{uuid.uuid4().hex[:12]}")
+    job_type: JobType
+    reference_id: str  # e.g. commit_id for review jobs
+    status: JobStatus = JobStatus.PENDING
+    progress: dict = {}
+    result: dict | None = None
+    error: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# services/job_manager/store.py
+"""Job persistence — in-memory for Phase 1."""
+
+from __future__ import annotations
+
+from services.job_manager.models import Job, JobType
+
+
+class InMemoryJobStore:
+    """Thread-safe in-memory job store."""
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, Job] = {}
+
+    async def save(self, job: Job) -> None:
+        self._jobs[job.job_id] = job
+
+    async def get(self, job_id: str) -> Job | None:
+        return self._jobs.get(job_id)
+
+    async def update(self, job: Job) -> None:
+        self._jobs[job.job_id] = job
+
+    async def get_by_reference(
+        self, reference_id: str, job_type: JobType
+    ) -> Job | None:
+        for job in self._jobs.values():
+            if job.reference_id == reference_id and job.job_type == job_type:
+                return job
+        return None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_job_manager/ -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/job_manager/ tests/services/test_job_manager/
+git commit -m "feat: add Job model and InMemoryJobStore"
+```
+
+---
+
+### Task 2: JobManager — Orchestrator
+
+**Files:**
+- Create: `services/job_manager/manager.py`
+- Test: `tests/services/test_job_manager/test_manager.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_job_manager/test_manager.py
+import pytest
+import asyncio
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from services.job_manager.models import JobStatus, JobType
+
+
+@pytest.fixture
+def manager():
+    return JobManager(store=InMemoryJobStore())
+
+
+async def test_submit_job(manager):
+    async def work(job_id: str):
+        return {"answer": 42}
+
+    job = await manager.submit(
+        job_type=JobType.REVIEW,
+        reference_id="commit_1",
+        work_fn=work,
+    )
+    assert job.status == JobStatus.RUNNING
+    # Wait for background task
+    await asyncio.sleep(0.1)
+    result = await manager.get_result(job.job_id)
+    assert result == {"answer": 42}
+
+
+async def test_cancel_job(manager):
+    async def slow_work(job_id: str):
+        await asyncio.sleep(10)
+        return {}
+
+    job = await manager.submit(
+        job_type=JobType.REVIEW,
+        reference_id="commit_2",
+        work_fn=slow_work,
+    )
+    cancelled = await manager.cancel(job.job_id)
+    assert cancelled is True
+    loaded = await manager.get_status(job.job_id)
+    assert loaded.status == JobStatus.CANCELLED
+
+
+async def test_get_status(manager):
+    async def work(job_id: str):
+        return {"done": True}
+
+    job = await manager.submit(
+        job_type=JobType.REVIEW,
+        reference_id="c3",
+        work_fn=work,
+    )
+    status = await manager.get_status(job.job_id)
+    assert status is not None
+
+
+async def test_failed_job(manager):
+    async def failing_work(job_id: str):
+        raise ValueError("something broke")
+
+    job = await manager.submit(
+        job_type=JobType.REVIEW,
+        reference_id="c4",
+        work_fn=failing_work,
+    )
+    await asyncio.sleep(0.1)
+    loaded = await manager.get_status(job.job_id)
+    assert loaded.status == JobStatus.FAILED
+    assert "something broke" in loaded.error
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_job_manager/test_manager.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# services/job_manager/manager.py
+"""JobManager — submit, cancel, and track async jobs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from datetime import datetime, timezone
+from typing import Any
+
+from services.job_manager.models import Job, JobStatus, JobType
+from services.job_manager.store import InMemoryJobStore
+
+
+class JobManager:
+    """Manages async job lifecycle."""
+
+    def __init__(self, store: InMemoryJobStore | None = None) -> None:
+        self._store = store or InMemoryJobStore()
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    async def submit(
+        self,
+        job_type: JobType,
+        reference_id: str,
+        work_fn: Callable[[str], Coroutine[Any, Any, dict]],
+    ) -> Job:
+        """Submit an async job. work_fn receives job_id and returns result dict."""
+        job = Job(job_type=job_type, reference_id=reference_id)
+        job.status = JobStatus.RUNNING
+        await self._store.save(job)
+
+        task = asyncio.create_task(self._run(job.job_id, work_fn))
+        self._tasks[job.job_id] = task
+        return job
+
+    async def _run(
+        self,
+        job_id: str,
+        work_fn: Callable[[str], Coroutine[Any, Any, dict]],
+    ) -> None:
+        job = await self._store.get(job_id)
+        if not job:
+            return
+        try:
+            result = await work_fn(job_id)
+            job.status = JobStatus.COMPLETED
+            job.result = result
+        except asyncio.CancelledError:
+            job.status = JobStatus.CANCELLED
+        except Exception as e:
+            job.status = JobStatus.FAILED
+            job.error = str(e)
+        job.updated_at = datetime.now(timezone.utc)
+        await self._store.update(job)
+        self._tasks.pop(job_id, None)
+
+    async def cancel(self, job_id: str) -> bool:
+        task = self._tasks.get(job_id)
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            job = await self._store.get(job_id)
+            if job:
+                job.status = JobStatus.CANCELLED
+                job.updated_at = datetime.now(timezone.utc)
+                await self._store.update(job)
+            return True
+        return False
+
+    async def get_status(self, job_id: str) -> Job | None:
+        return await self._store.get(job_id)
+
+    async def get_result(self, job_id: str) -> dict | None:
+        job = await self._store.get(job_id)
+        if job and job.status == JobStatus.COMPLETED:
+            return job.result
+        return None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_job_manager/test_manager.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/job_manager/manager.py tests/services/test_job_manager/test_manager.py
+git commit -m "feat: add JobManager for async job lifecycle"
+```
+
+---
+
+### Task 3: Refactor Review Route to Async Job
+
+**Files:**
+- Modify: `services/gateway/routes/commits.py`
+- Modify: `services/gateway/deps.py`
+- Test: `tests/services/test_gateway/test_commits.py` (update existing)
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_gateway/test_review_async.py
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock, AsyncMock
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from libs.models import Commit
+
+
+@pytest.fixture
+def test_deps():
+    deps = Dependencies()
+    deps.storage = MagicMock()
+    deps.storage.graph = None
+    deps.storage.vector = AsyncMock()
+    deps.search_engine = MagicMock()
+    deps.commit_engine = MagicMock()
+    deps.commit_engine.get_commit = AsyncMock(
+        return_value=Commit(
+            commit_id="test123",
+            message="test",
+            operations=[],
+            status="pending_review",
+        )
+    )
+    deps.job_manager = JobManager(store=InMemoryJobStore())
+    deps.review_pipeline_config = MagicMock()
+    return deps
+
+
+@pytest.fixture
+async def client(test_deps):
+    app = create_app(dependencies=test_deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_submit_review_returns_job_id(client):
+    resp = await client.post("/commits/test123/review", json={"depth": "standard"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "job_id" in data
+    assert data["status"] == "running"
+
+
+async def test_get_review_status(client):
+    # Submit first
+    resp = await client.post("/commits/test123/review", json={"depth": "standard"})
+    job_id = resp.json()["job_id"]
+    # Check status
+    resp = await client.get("/commits/test123/review")
+    assert resp.status_code == 200
+    assert "status" in resp.json()
+
+
+async def test_delete_review_cancels(client):
+    resp = await client.post("/commits/test123/review", json={"depth": "standard"})
+    resp = await client.delete("/commits/test123/review")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cancelled"
+
+
+async def test_review_not_found(client):
+    deps = client._transport.app  # noqa
+    # Override to return None
+    from services.gateway.deps import deps as global_deps
+    global_deps.commit_engine.get_commit = AsyncMock(return_value=None)
+    resp = await client.post("/commits/nonexistent/review", json={})
+    assert resp.status_code == 404
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_gateway/test_review_async.py -v`
+Expected: FAIL
+
+**Step 3: Update deps.py to include JobManager and ReviewPipelineConfig**
+
+```python
+# services/gateway/deps.py — updated
+"""Dependency injection — singleton services created at startup."""
+
+from __future__ import annotations
+
+from libs.storage import StorageConfig, StorageManager
+from services.search_engine.engine import SearchEngine
+from services.commit_engine.engine import CommitEngine
+from services.commit_engine.store import CommitStore
+from services.inference_engine.engine import InferenceEngine
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from services.review_pipeline.operators.embedding import StubEmbeddingModel
+from services.review_pipeline.pipeline import ReviewPipelineConfig
+
+
+class Dependencies:
+    """Holds all service singletons."""
+
+    def __init__(self, config: StorageConfig | None = None):
+        self.config = config or StorageConfig()
+        self.storage: StorageManager | None = None
+        self.search_engine: SearchEngine | None = None
+        self.commit_engine: CommitEngine | None = None
+        self.inference_engine: InferenceEngine | None = None
+        self.job_manager: JobManager | None = None
+        self.review_pipeline_config: ReviewPipelineConfig | None = None
+
+    def initialize(self, storage_config: StorageConfig | None = None):
+        """Create all services. Call once at startup."""
+        config = storage_config or self.config
+        self.storage = StorageManager(config)
+        self.search_engine = SearchEngine(self.storage)
+        commit_store = CommitStore(storage_path=config.lancedb_path + "/commits")
+        self.commit_engine = CommitEngine(
+            storage=self.storage,
+            commit_store=commit_store,
+            search_engine=self.search_engine,
+        )
+        self.inference_engine = InferenceEngine(self.storage)
+        self.job_manager = JobManager(store=InMemoryJobStore())
+        self.review_pipeline_config = ReviewPipelineConfig(
+            embedding_model=StubEmbeddingModel(dim=1024),
+        )
+
+    async def cleanup(self):
+        """Shut down services gracefully."""
+        if self.storage:
+            await self.storage.close()
+
+
+# Global instance
+deps = Dependencies()
+```
+
+**Step 4: Update commits route**
+
+```python
+# services/gateway/routes/commits.py — updated
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from libs.models import CommitRequest, CommitResponse, MergeResult
+from services.gateway.deps import deps
+from services.job_manager.models import JobType
+from services.review_pipeline.context import PipelineContext
+from services.review_pipeline.pipeline import build_review_pipeline
+
+router = APIRouter(prefix="/commits", tags=["commits"])
+
+
+class ReviewRequest(BaseModel):
+    depth: str = "standard"
+
+
+class MergeRequest(BaseModel):
+    force: bool = False
+
+
+@router.post("", response_model=CommitResponse)
+async def submit_commit(request: CommitRequest):
+    return await deps.commit_engine.submit(request)
+
+
+@router.get("/{commit_id}")
+async def get_commit(commit_id: str):
+    commit = await deps.commit_engine.get_commit(commit_id)
+    if not commit:
+        raise HTTPException(status_code=404, detail="Commit not found")
+    return commit.model_dump()
+
+
+@router.post("/{commit_id}/review")
+async def submit_review(commit_id: str, request: ReviewRequest = ReviewRequest()):
+    commit = await deps.commit_engine.get_commit(commit_id)
+    if not commit:
+        raise HTTPException(status_code=404, detail="Commit not found")
+
+    async def run_review(job_id: str) -> dict:
+        pipeline = build_review_pipeline(deps.review_pipeline_config, deps.storage)
+        ctx = PipelineContext.from_commit_request(
+            CommitRequest(message=commit.message, operations=commit.operations)
+        )
+        result = await pipeline.execute(ctx)
+        return {
+            "bp_results": result.bp_results,
+            "verified_trees": [t.model_dump() for t in result.verified_trees],
+            "embeddings_count": len(result.embeddings),
+        }
+
+    job = await deps.job_manager.submit(
+        job_type=JobType.REVIEW,
+        reference_id=commit_id,
+        work_fn=run_review,
+    )
+    return {"job_id": job.job_id, "status": job.status}
+
+
+@router.get("/{commit_id}/review")
+async def get_review_status(commit_id: str):
+    job = await deps.job_manager._store.get_by_reference(commit_id, JobType.REVIEW)
+    if not job:
+        raise HTTPException(status_code=404, detail="No review job for this commit")
+    return {"job_id": job.job_id, "status": job.status, "progress": job.progress}
+
+
+@router.delete("/{commit_id}/review")
+async def cancel_review(commit_id: str):
+    job = await deps.job_manager._store.get_by_reference(commit_id, JobType.REVIEW)
+    if not job:
+        raise HTTPException(status_code=404, detail="No review job for this commit")
+    await deps.job_manager.cancel(job.job_id)
+    return {"job_id": job.job_id, "status": "cancelled"}
+
+
+@router.get("/{commit_id}/review/result")
+async def get_review_result(commit_id: str):
+    job = await deps.job_manager._store.get_by_reference(commit_id, JobType.REVIEW)
+    if not job:
+        raise HTTPException(status_code=404, detail="No review job for this commit")
+    if job.status != "completed":
+        raise HTTPException(status_code=409, detail=f"Review status is {job.status}")
+    return {"job_id": job.job_id, "status": job.status, "review_results": job.result}
+
+
+@router.post("/{commit_id}/merge", response_model=MergeResult)
+async def merge_commit(commit_id: str, request: MergeRequest = MergeRequest()):
+    commit = await deps.commit_engine.get_commit(commit_id)
+    if not commit:
+        raise HTTPException(status_code=404, detail="Commit not found")
+    return await deps.commit_engine.merge(commit_id, force=request.force)
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `pytest tests/services/test_gateway/test_review_async.py -v`
+Expected: PASS
+
+**Step 6: Run existing tests to ensure no regression**
+
+Run: `pytest tests/ -v --ignore=tests/services/test_gateway/test_review_async.py`
+Expected: existing tests still PASS (may need minor fixture updates)
+
+**Step 7: Commit**
+
+```bash
+git add services/gateway/routes/commits.py services/gateway/deps.py tests/services/test_gateway/test_review_async.py
+git commit -m "feat: refactor review to async job with pipeline execution"
+```
+
+---
+
+### Task 4: Update Search to Generate Embeddings Internally
+
+**Files:**
+- Modify: `services/search_engine/engine.py`
+- Modify: `services/gateway/routes/search.py`
+- Test: `tests/services/test_gateway/test_search_v3.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_gateway/test_search_v3.py
+import pytest
+from services.search_engine.engine import SearchEngine
+from services.review_pipeline.operators.embedding import EmbeddingModel
+
+
+async def test_search_engine_accepts_text_only():
+    """SearchEngine.search_nodes should work with text only (no embedding param)."""
+    from unittest.mock import MagicMock, AsyncMock
+    from services.review_pipeline.operators.embedding import StubEmbeddingModel
+
+    storage = MagicMock()
+    storage.vector = AsyncMock()
+    storage.vector.search = AsyncMock(return_value=[])
+    storage.lance = MagicMock()
+    storage.lance.fts_search = AsyncMock(return_value=[])
+    storage.graph = None
+
+    engine = SearchEngine(storage, embedding_model=StubEmbeddingModel(dim=128))
+    results = await engine.search_nodes(query="test query", k=10)
+    assert isinstance(results, list)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_gateway/test_search_v3.py -v`
+Expected: FAIL — SearchEngine doesn't accept embedding_model
+
+**Step 3: Update SearchEngine**
+
+Add `embedding_model` parameter to `SearchEngine.__init__`. When `embedding` is not provided to `search_nodes`, generate it internally.
+
+Modify `services/search_engine/engine.py`:
+- Add `embedding_model: EmbeddingModel | None = None` to `__init__`
+- In `search_nodes`, make `embedding` optional — if not provided, generate via model
+- Same for `search_edges`
+
+Modify `services/gateway/routes/search.py`:
+- Change `SearchNodesRequest.embedding` from required to optional
+- Change request field `embedding: list[float]` to `embedding: list[float] | None = None`
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_gateway/test_search_v3.py -v`
+Expected: PASS
+
+**Step 5: Run all tests**
+
+Run: `pytest tests/ -v`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add services/search_engine/engine.py services/gateway/routes/search.py tests/services/test_gateway/test_search_v3.py
+git commit -m "feat: search generates embeddings internally, external embedding optional"
+```
+
+---
+
+### Task 5: Job Management Routes
+
+**Files:**
+- Create: `services/gateway/routes/jobs.py`
+- Modify: `services/gateway/app.py` (register new router)
+- Test: `tests/services/test_gateway/test_jobs.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_gateway/test_jobs.py
+import pytest
+import asyncio
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock, AsyncMock
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from services.job_manager.models import JobType
+
+
+@pytest.fixture
+def test_deps():
+    deps = Dependencies()
+    deps.storage = MagicMock()
+    deps.storage.graph = None
+    deps.storage.vector = AsyncMock()
+    deps.search_engine = MagicMock()
+    deps.commit_engine = MagicMock()
+    deps.job_manager = JobManager(store=InMemoryJobStore())
+    deps.review_pipeline_config = MagicMock()
+    return deps
+
+
+@pytest.fixture
+async def client(test_deps):
+    app = create_app(dependencies=test_deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_get_job_status(client, test_deps):
+    async def work(job_id):
+        return {"done": True}
+
+    job = await test_deps.job_manager.submit(
+        JobType.REVIEW, "ref1", work
+    )
+    await asyncio.sleep(0.1)
+    resp = await client.get(f"/jobs/{job.job_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "completed"
+
+
+async def test_get_job_result(client, test_deps):
+    async def work(job_id):
+        return {"answer": 42}
+
+    job = await test_deps.job_manager.submit(
+        JobType.REVIEW, "ref2", work
+    )
+    await asyncio.sleep(0.1)
+    resp = await client.get(f"/jobs/{job.job_id}/result")
+    assert resp.status_code == 200
+    assert resp.json()["result"] == {"answer": 42}
+
+
+async def test_delete_job(client, test_deps):
+    async def slow(job_id):
+        await asyncio.sleep(10)
+
+    job = await test_deps.job_manager.submit(
+        JobType.REVIEW, "ref3", slow
+    )
+    resp = await client.delete(f"/jobs/{job.job_id}")
+    assert resp.status_code == 200
+
+
+async def test_get_nonexistent_job(client):
+    resp = await client.get("/jobs/nonexistent")
+    assert resp.status_code == 404
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_gateway/test_jobs.py -v`
+Expected: FAIL
+
+**Step 3: Write implementation**
+
+```python
+# services/gateway/routes/jobs.py
+"""Job management routes — GET/DELETE /jobs/{job_id}."""
+
+from fastapi import APIRouter, HTTPException
+from services.gateway.deps import deps
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+@router.get("/{job_id}")
+async def get_job_status(job_id: str):
+    job = await deps.job_manager.get_status(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return {
+        "job_id": job.job_id,
+        "type": job.job_type,
+        "status": job.status,
+        "progress": job.progress,
+        "created_at": job.created_at.isoformat(),
+        "updated_at": job.updated_at.isoformat(),
+    }
+
+
+@router.get("/{job_id}/result")
+async def get_job_result(job_id: str):
+    job = await deps.job_manager.get_status(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.status != "completed":
+        raise HTTPException(
+            status_code=409, detail=f"Job status is {job.status}, not completed"
+        )
+    return {"job_id": job.job_id, "status": job.status, "result": job.result}
+
+
+@router.delete("/{job_id}")
+async def cancel_job(job_id: str):
+    job = await deps.job_manager.get_status(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    await deps.job_manager.cancel(job_id)
+    return {"job_id": job.job_id, "status": "cancelled"}
+```
+
+Register in app.py — add `from .routes.jobs import router as jobs_router` and `app.include_router(jobs_router)`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_gateway/test_jobs.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/gateway/routes/jobs.py services/gateway/app.py tests/services/test_gateway/test_jobs.py
+git commit -m "feat: add /jobs API routes for job status, result, and cancellation"
+```
+
+---
+
+### Task 6: Enhanced Read Routes (subgraph params)
+
+**Files:**
+- Modify: `services/gateway/routes/read.py`
+- Test: `tests/services/test_gateway/test_read_v3.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_gateway/test_read_v3.py
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock, AsyncMock
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from libs.models import Node
+
+
+@pytest.fixture
+def test_deps():
+    deps = Dependencies()
+    deps.storage = MagicMock()
+    deps.storage.lance = MagicMock()
+    deps.storage.lance.load_node = AsyncMock(
+        return_value=Node(id=1, type="paper-extract", content="test")
+    )
+    deps.storage.graph = MagicMock()
+    deps.storage.graph.get_subgraph = AsyncMock(return_value=({1, 2}, {10}))
+    deps.storage.graph.get_hyperedge = AsyncMock(return_value=None)
+    deps.storage.lance.load_nodes_bulk = AsyncMock(
+        return_value=[Node(id=1, type="paper-extract", content="a")]
+    )
+    deps.search_engine = MagicMock()
+    deps.commit_engine = MagicMock()
+    deps.job_manager = MagicMock()
+    deps.review_pipeline_config = MagicMock()
+    return deps
+
+
+@pytest.fixture
+async def client(test_deps):
+    app = create_app(dependencies=test_deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_subgraph_with_direction(client):
+    resp = await client.get("/nodes/1/subgraph?hops=2&direction=upstream&max_nodes=100")
+    assert resp.status_code == 200
+
+
+async def test_subgraph_with_edge_types(client):
+    resp = await client.get("/nodes/1/subgraph?hops=1&edge_types=paper-extract,join")
+    assert resp.status_code == 200
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_gateway/test_read_v3.py -v`
+Expected: FAIL — new params not supported
+
+**Step 3: Update read route**
+
+Add `direction`, `max_nodes`, `edge_types` query params to `/nodes/{id}/subgraph`. Pass `edge_types` to `get_subgraph()`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_gateway/test_read_v3.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/gateway/routes/read.py tests/services/test_gateway/test_read_v3.py
+git commit -m "feat: add direction, max_nodes, edge_types params to subgraph route"
+```
+
+---
+
+### Task 7: Update app.py Dependencies Wiring
+
+**Files:**
+- Modify: `services/gateway/app.py`
+
+**Step 1: Verify app.py includes all new routers and deps**
+
+Ensure `create_app` propagates `job_manager` and `review_pipeline_config` when custom dependencies are injected.
+
+**Step 2: Run full test suite**
+
+Run: `pytest tests/ -v`
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+git add services/gateway/app.py services/gateway/deps.py
+git commit -m "feat: wire JobManager and ReviewPipelineConfig into app dependencies"
+```

--- a/docs/plans/2026-03-03-plan3-batch-processing.md
+++ b/docs/plans/2026-03-03-plan3-batch-processing.md
@@ -1,0 +1,754 @@
+# Plan 3: Batch Processing APIs
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add batch (async) variants for all APIs: batch commit (with auto review/merge), batch search, batch read.
+
+**Architecture:** All batch endpoints return a `job_id` immediately. The `JobManager` from Plan 2 runs the work in the background. Each batch endpoint wraps the corresponding single-input logic in a loop, collecting results into the job's result dict.
+
+**Tech Stack:** Python 3.12+, FastAPI, Pydantic v2, JobManager from Plan 2
+
+**Depends on:** Plan 1 (Operator Layer) + Plan 2 (Single-Input APIs) must be completed first.
+
+---
+
+### Task 1: Batch Commit API
+
+**Files:**
+- Create: `services/gateway/routes/batch.py`
+- Modify: `services/gateway/app.py` (register router)
+- Test: `tests/services/test_gateway/test_batch_commit.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_gateway/test_batch_commit.py
+import pytest
+import asyncio
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock, AsyncMock
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from libs.models import CommitResponse, MergeResult, ReviewResult
+
+
+@pytest.fixture
+def test_deps():
+    deps = Dependencies()
+    deps.storage = MagicMock()
+    deps.storage.graph = None
+    deps.storage.vector = AsyncMock()
+    deps.search_engine = MagicMock()
+    deps.commit_engine = MagicMock()
+    deps.commit_engine.submit = AsyncMock(
+        return_value=CommitResponse(commit_id="c1", status="pending_review")
+    )
+    deps.commit_engine.review = AsyncMock(
+        return_value=ReviewResult(approved=True).model_dump()
+    )
+    deps.commit_engine.merge = AsyncMock(
+        return_value=MergeResult(success=True, new_node_ids=[1], new_edge_ids=[2])
+    )
+    deps.job_manager = JobManager(store=InMemoryJobStore())
+    deps.review_pipeline_config = MagicMock()
+    deps.inference_engine = MagicMock()
+    return deps
+
+
+@pytest.fixture
+async def client(test_deps):
+    app = create_app(dependencies=test_deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_batch_commit_returns_job(client):
+    resp = await client.post("/commits/batch", json={
+        "commits": [
+            {"message": "paper 1", "operations": []},
+            {"message": "paper 2", "operations": []},
+        ],
+        "auto_review": True,
+        "auto_merge": True,
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "job_id" in data
+    assert data["total_commits"] == 2
+    assert data["status"] == "running"
+
+
+async def test_batch_commit_progress(client, test_deps):
+    resp = await client.post("/commits/batch", json={
+        "commits": [
+            {"message": "paper 1", "operations": []},
+        ],
+        "auto_review": True,
+        "auto_merge": True,
+    })
+    job_id = resp.json()["job_id"]
+    await asyncio.sleep(0.2)
+
+    resp = await client.get(f"/jobs/{job_id}/result")
+    assert resp.status_code == 200
+    result = resp.json()["result"]
+    assert "commits" in result
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_gateway/test_batch_commit.py -v`
+Expected: FAIL
+
+**Step 3: Write implementation**
+
+```python
+# services/gateway/routes/batch.py
+"""Batch API routes — all async via JobManager."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from libs.models import CommitRequest
+from services.gateway.deps import deps
+from services.job_manager.models import JobType
+
+router = APIRouter(tags=["batch"])
+
+
+# ── Batch Commit ──────────────────────────────────────────────────────
+
+
+class BatchCommitRequest(BaseModel):
+    commits: list[CommitRequest]
+    auto_review: bool = True
+    auto_merge: bool = True
+    review_depth: str = "standard"
+
+
+@router.post("/commits/batch")
+async def batch_commit(request: BatchCommitRequest):
+    async def work(job_id: str) -> dict:
+        results = []
+        for req in request.commits:
+            commit_resp = await deps.commit_engine.submit(req)
+            entry = {
+                "commit_id": commit_resp.commit_id,
+                "message": req.message,
+                "status": commit_resp.status,
+            }
+            if commit_resp.status == "rejected":
+                results.append(entry)
+                continue
+
+            if request.auto_review:
+                review_result = await deps.commit_engine.review(
+                    commit_resp.commit_id, depth=request.review_depth
+                )
+                reviewed = review_result.get("approved", False) if isinstance(review_result, dict) else False
+                entry["status"] = "reviewed" if reviewed else "rejected"
+
+                if reviewed and request.auto_merge:
+                    merge_result = await deps.commit_engine.merge(
+                        commit_resp.commit_id, force=False
+                    )
+                    entry["status"] = "merged" if merge_result.success else "merge_failed"
+                    entry["merge_result"] = merge_result.model_dump()
+
+            results.append(entry)
+
+        return {"commits": results, "total": len(results)}
+
+    job = await deps.job_manager.submit(
+        job_type=JobType.BATCH_COMMIT,
+        reference_id=f"batch_{len(request.commits)}",
+        work_fn=work,
+    )
+    return {
+        "job_id": job.job_id,
+        "total_commits": len(request.commits),
+        "status": job.status,
+    }
+
+
+# ── Batch Search Nodes ────────────────────────────────────────────────
+
+
+class BatchSearchQuery(BaseModel):
+    text: str
+    top_k: int = 50
+
+
+class BatchSearchNodesRequest(BaseModel):
+    queries: list[BatchSearchQuery]
+    filters: dict | None = None
+
+
+@router.post("/search/nodes/batch")
+async def batch_search_nodes(request: BatchSearchNodesRequest):
+    async def work(job_id: str) -> dict:
+        results = []
+        for q in request.queries:
+            scored = await deps.search_engine.search_nodes(
+                query=q.text, k=q.top_k,
+            )
+            results.append([s.model_dump() for s in scored])
+        return {"results": results, "total_queries": len(results)}
+
+    job = await deps.job_manager.submit(
+        job_type=JobType.BATCH_SEARCH,
+        reference_id=f"search_batch_{len(request.queries)}",
+        work_fn=work,
+    )
+    return {"job_id": job.job_id, "status": job.status}
+
+
+# ── Batch Search Hyperedges ───────────────────────────────────────────
+
+
+class BatchSearchEdgesRequest(BaseModel):
+    queries: list[BatchSearchQuery]
+    filters: dict | None = None
+
+
+@router.post("/search/hyperedges/batch")
+async def batch_search_edges(request: BatchSearchEdgesRequest):
+    async def work(job_id: str) -> dict:
+        results = []
+        for q in request.queries:
+            scored = await deps.search_engine.search_edges(
+                query=q.text, k=q.top_k,
+            )
+            results.append([s.model_dump() for s in scored])
+        return {"results": results, "total_queries": len(results)}
+
+    job = await deps.job_manager.submit(
+        job_type=JobType.BATCH_SEARCH,
+        reference_id=f"edge_search_batch_{len(request.queries)}",
+        work_fn=work,
+    )
+    return {"job_id": job.job_id, "status": job.status}
+
+
+# ── Batch Read Nodes ──────────────────────────────────────────────────
+
+
+class BatchReadNodesRequest(BaseModel):
+    node_ids: list[int]
+
+
+@router.post("/nodes/batch")
+async def batch_read_nodes(request: BatchReadNodesRequest):
+    async def work(job_id: str) -> dict:
+        nodes = await deps.storage.lance.load_nodes_bulk(request.node_ids)
+        return {"nodes": [n.model_dump() for n in nodes]}
+
+    job = await deps.job_manager.submit(
+        job_type=JobType.BATCH_READ,
+        reference_id=f"read_nodes_{len(request.node_ids)}",
+        work_fn=work,
+    )
+    return {"job_id": job.job_id, "status": job.status}
+
+
+# ── Batch Read Hyperedges ─────────────────────────────────────────────
+
+
+class BatchReadEdgesRequest(BaseModel):
+    edge_ids: list[int]
+
+
+@router.post("/hyperedges/batch")
+async def batch_read_edges(request: BatchReadEdgesRequest):
+    async def work(job_id: str) -> dict:
+        if not deps.storage.graph:
+            return {"edges": [], "error": "Graph store not available"}
+        edges = []
+        for eid in request.edge_ids:
+            edge = await deps.storage.graph.get_hyperedge(eid)
+            if edge:
+                edges.append(edge.model_dump())
+        return {"edges": edges}
+
+    job = await deps.job_manager.submit(
+        job_type=JobType.BATCH_READ,
+        reference_id=f"read_edges_{len(request.edge_ids)}",
+        work_fn=work,
+    )
+    return {"job_id": job.job_id, "status": job.status}
+
+
+# ── Batch Subgraph ────────────────────────────────────────────────────
+
+
+class SubgraphQuery(BaseModel):
+    node_id: int
+    hops: int = 3
+    direction: str = "both"
+
+
+class BatchSubgraphRequest(BaseModel):
+    queries: list[SubgraphQuery]
+
+
+@router.post("/nodes/subgraph/batch")
+async def batch_subgraph(request: BatchSubgraphRequest):
+    async def work(job_id: str) -> dict:
+        if not deps.storage.graph:
+            return {"subgraphs": [], "error": "Graph store not available"}
+        results = []
+        for q in request.queries:
+            node_ids, edge_ids = await deps.storage.graph.get_subgraph(
+                [q.node_id], hops=q.hops
+            )
+            results.append({
+                "center_node_id": q.node_id,
+                "node_ids": list(node_ids),
+                "edge_ids": list(edge_ids),
+            })
+        return {"subgraphs": results}
+
+    job = await deps.job_manager.submit(
+        job_type=JobType.BATCH_READ,
+        reference_id=f"subgraph_batch_{len(request.queries)}",
+        work_fn=work,
+    )
+    return {"job_id": job.job_id, "status": job.status}
+```
+
+Register in `services/gateway/app.py`:
+
+```python
+from .routes.batch import router as batch_router
+# ...
+app.include_router(batch_router)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_gateway/test_batch_commit.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/gateway/routes/batch.py services/gateway/app.py tests/services/test_gateway/test_batch_commit.py
+git commit -m "feat: add batch commit API with auto review/merge"
+```
+
+---
+
+### Task 2: Batch Search + Read Tests
+
+**Files:**
+- Test: `tests/services/test_gateway/test_batch_search.py`
+- Test: `tests/services/test_gateway/test_batch_read.py`
+
+**Step 1: Write the failing tests**
+
+```python
+# tests/services/test_gateway/test_batch_search.py
+import pytest
+import asyncio
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock, AsyncMock
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+
+
+@pytest.fixture
+def test_deps():
+    deps = Dependencies()
+    deps.storage = MagicMock()
+    deps.storage.graph = None
+    deps.storage.vector = AsyncMock()
+    deps.search_engine = MagicMock()
+    deps.search_engine.search_nodes = AsyncMock(return_value=[])
+    deps.search_engine.search_edges = AsyncMock(return_value=[])
+    deps.commit_engine = MagicMock()
+    deps.job_manager = JobManager(store=InMemoryJobStore())
+    deps.review_pipeline_config = MagicMock()
+    deps.inference_engine = MagicMock()
+    return deps
+
+
+@pytest.fixture
+async def client(test_deps):
+    app = create_app(dependencies=test_deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_batch_search_nodes(client):
+    resp = await client.post("/search/nodes/batch", json={
+        "queries": [
+            {"text": "query 1", "top_k": 10},
+            {"text": "query 2", "top_k": 5},
+        ]
+    })
+    assert resp.status_code == 200
+    assert "job_id" in resp.json()
+
+
+async def test_batch_search_edges(client):
+    resp = await client.post("/search/hyperedges/batch", json={
+        "queries": [{"text": "query 1"}]
+    })
+    assert resp.status_code == 200
+    assert "job_id" in resp.json()
+
+
+async def test_batch_search_result(client):
+    resp = await client.post("/search/nodes/batch", json={
+        "queries": [{"text": "q1"}]
+    })
+    job_id = resp.json()["job_id"]
+    await asyncio.sleep(0.2)
+    resp = await client.get(f"/jobs/{job_id}/result")
+    assert resp.status_code == 200
+    assert "results" in resp.json()["result"]
+```
+
+```python
+# tests/services/test_gateway/test_batch_read.py
+import pytest
+import asyncio
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock, AsyncMock
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from libs.models import Node
+
+
+@pytest.fixture
+def test_deps():
+    deps = Dependencies()
+    deps.storage = MagicMock()
+    deps.storage.lance = MagicMock()
+    deps.storage.lance.load_nodes_bulk = AsyncMock(
+        return_value=[Node(id=1, type="paper-extract", content="a")]
+    )
+    deps.storage.graph = MagicMock()
+    deps.storage.graph.get_hyperedge = AsyncMock(return_value=None)
+    deps.storage.graph.get_subgraph = AsyncMock(return_value=({1}, {10}))
+    deps.search_engine = MagicMock()
+    deps.commit_engine = MagicMock()
+    deps.job_manager = JobManager(store=InMemoryJobStore())
+    deps.review_pipeline_config = MagicMock()
+    deps.inference_engine = MagicMock()
+    return deps
+
+
+@pytest.fixture
+async def client(test_deps):
+    app = create_app(dependencies=test_deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_batch_read_nodes(client):
+    resp = await client.post("/nodes/batch", json={"node_ids": [1, 2, 3]})
+    assert resp.status_code == 200
+    assert "job_id" in resp.json()
+
+
+async def test_batch_read_edges(client):
+    resp = await client.post("/hyperedges/batch", json={"edge_ids": [10, 20]})
+    assert resp.status_code == 200
+    assert "job_id" in resp.json()
+
+
+async def test_batch_subgraph(client):
+    resp = await client.post("/nodes/subgraph/batch", json={
+        "queries": [
+            {"node_id": 1, "hops": 2},
+            {"node_id": 2, "hops": 3, "direction": "upstream"},
+        ]
+    })
+    assert resp.status_code == 200
+    assert "job_id" in resp.json()
+
+
+async def test_batch_read_nodes_result(client):
+    resp = await client.post("/nodes/batch", json={"node_ids": [1]})
+    job_id = resp.json()["job_id"]
+    await asyncio.sleep(0.2)
+    resp = await client.get(f"/jobs/{job_id}/result")
+    assert resp.status_code == 200
+    assert "nodes" in resp.json()["result"]
+```
+
+**Step 2: Run tests to verify they pass** (implementation already done in Task 1)
+
+Run: `pytest tests/services/test_gateway/test_batch_search.py tests/services/test_gateway/test_batch_read.py -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/services/test_gateway/test_batch_search.py tests/services/test_gateway/test_batch_read.py
+git commit -m "test: add batch search and batch read API tests"
+```
+
+---
+
+### Task 3: Batch Commit Progress Endpoint
+
+**Files:**
+- Modify: `services/gateway/routes/batch.py` (add GET /commits/batch/{batch_id})
+- Test: `tests/services/test_gateway/test_batch_progress.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tests/services/test_gateway/test_batch_progress.py
+import pytest
+import asyncio
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import MagicMock, AsyncMock
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from libs.models import CommitResponse, MergeResult, ReviewResult
+
+
+@pytest.fixture
+def test_deps():
+    deps = Dependencies()
+    deps.storage = MagicMock()
+    deps.storage.graph = None
+    deps.storage.vector = AsyncMock()
+    deps.search_engine = MagicMock()
+    deps.commit_engine = MagicMock()
+    deps.commit_engine.submit = AsyncMock(
+        return_value=CommitResponse(commit_id="c1", status="pending_review")
+    )
+    deps.commit_engine.review = AsyncMock(
+        return_value=ReviewResult(approved=True).model_dump()
+    )
+    deps.commit_engine.merge = AsyncMock(
+        return_value=MergeResult(success=True)
+    )
+    deps.job_manager = JobManager(store=InMemoryJobStore())
+    deps.review_pipeline_config = MagicMock()
+    deps.inference_engine = MagicMock()
+    return deps
+
+
+@pytest.fixture
+async def client(test_deps):
+    app = create_app(dependencies=test_deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_get_batch_progress(client):
+    resp = await client.post("/commits/batch", json={
+        "commits": [
+            {"message": "p1", "operations": []},
+            {"message": "p2", "operations": []},
+        ],
+        "auto_review": True,
+        "auto_merge": True,
+    })
+    job_id = resp.json()["job_id"]
+    await asyncio.sleep(0.3)
+
+    resp = await client.get(f"/commits/batch/{job_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "status" in data
+    assert "total_commits" in data
+
+
+async def test_cancel_batch(client):
+    resp = await client.post("/commits/batch", json={
+        "commits": [{"message": "p1", "operations": []}],
+    })
+    job_id = resp.json()["job_id"]
+    resp = await client.delete(f"/commits/batch/{job_id}")
+    assert resp.status_code == 200
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/test_gateway/test_batch_progress.py -v`
+Expected: FAIL
+
+**Step 3: Add batch progress routes**
+
+Add to `services/gateway/routes/batch.py`:
+
+```python
+@router.get("/commits/batch/{batch_id}")
+async def get_batch_progress(batch_id: str):
+    job = await deps.job_manager.get_status(batch_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Batch job not found")
+    result = job.result or {}
+    commits = result.get("commits", [])
+    progress = {}
+    for c in commits:
+        s = c.get("status", "unknown")
+        progress[s] = progress.get(s, 0) + 1
+    return {
+        "job_id": job.job_id,
+        "status": job.status,
+        "total_commits": result.get("total", 0),
+        "progress": progress,
+        "commits": commits,
+    }
+
+
+@router.delete("/commits/batch/{batch_id}")
+async def cancel_batch(batch_id: str):
+    job = await deps.job_manager.get_status(batch_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Batch job not found")
+    await deps.job_manager.cancel(batch_id)
+    return {"job_id": job.job_id, "status": "cancelled"}
+```
+
+Add `from fastapi import HTTPException` import.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/test_gateway/test_batch_progress.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add services/gateway/routes/batch.py tests/services/test_gateway/test_batch_progress.py
+git commit -m "feat: add batch commit progress and cancel endpoints"
+```
+
+---
+
+### Task 4: Full Integration Test
+
+**Files:**
+- Test: `tests/integration/test_batch_e2e.py`
+
+**Step 1: Write the integration test**
+
+```python
+# tests/integration/test_batch_e2e.py
+"""End-to-end test for batch APIs using real LanceDB (no Neo4j)."""
+
+import pytest
+import asyncio
+from pathlib import Path
+from httpx import AsyncClient, ASGITransport
+
+from libs.storage import StorageConfig, StorageManager
+from services.gateway.app import create_app
+from services.gateway.deps import Dependencies
+from services.search_engine.engine import SearchEngine
+from services.commit_engine.engine import CommitEngine
+from services.commit_engine.store import CommitStore
+from services.job_manager.manager import JobManager
+from services.job_manager.store import InMemoryJobStore
+from services.review_pipeline.operators.embedding import StubEmbeddingModel
+from services.review_pipeline.pipeline import ReviewPipelineConfig
+
+
+@pytest.fixture
+async def e2e_client(tmp_path: Path):
+    config = StorageConfig(
+        deployment_mode="local",
+        lancedb_path=str(tmp_path / "lance"),
+        neo4j_password="",
+    )
+    storage = StorageManager(config)
+    deps = Dependencies(config=config)
+    deps.storage = storage
+    deps.search_engine = SearchEngine(storage)
+    deps.commit_engine = CommitEngine(
+        storage=storage,
+        commit_store=CommitStore(str(tmp_path / "commits")),
+        search_engine=deps.search_engine,
+    )
+    deps.job_manager = JobManager(store=InMemoryJobStore())
+    deps.review_pipeline_config = ReviewPipelineConfig(
+        embedding_model=StubEmbeddingModel(dim=128),
+    )
+
+    app = create_app(dependencies=deps)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+    await storage.close()
+
+
+async def test_batch_commit_e2e(e2e_client):
+    """Submit batch → auto review/merge → check results."""
+    resp = await e2e_client.post("/commits/batch", json={
+        "commits": [
+            {
+                "message": "paper 1",
+                "operations": [{
+                    "op": "add_edge",
+                    "tail": [{"content": "premise A"}],
+                    "head": [{"content": "conclusion B"}],
+                    "type": "paper-extract",
+                    "reasoning": [{"title": "r", "content": "because"}],
+                }],
+            },
+        ],
+        "auto_review": True,
+        "auto_merge": True,
+    })
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+
+    # Wait for completion
+    for _ in range(20):
+        await asyncio.sleep(0.1)
+        status = await e2e_client.get(f"/jobs/{job_id}")
+        if status.json()["status"] in ("completed", "failed"):
+            break
+
+    result = await e2e_client.get(f"/jobs/{job_id}/result")
+    assert result.status_code == 200
+
+
+async def test_batch_read_nodes_e2e(e2e_client):
+    resp = await e2e_client.post("/nodes/batch", json={"node_ids": [1, 2]})
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+    await asyncio.sleep(0.2)
+    result = await e2e_client.get(f"/jobs/{job_id}/result")
+    assert result.status_code == 200
+```
+
+**Step 2: Run integration test**
+
+Run: `pytest tests/integration/test_batch_e2e.py -v`
+Expected: PASS
+
+**Step 3: Run full test suite**
+
+Run: `pytest tests/ -v`
+Expected: ALL PASS
+
+**Step 4: Commit**
+
+```bash
+git add tests/integration/test_batch_e2e.py
+git commit -m "test: add batch API end-to-end integration tests"
+```


### PR DESCRIPTION
## Summary

- 新增 v3 API 设计文档，取代 v2，核心变更：review 改为异步 pipeline、所有 API 支持 single + batch 输入、BP 结果作为 review 返回值
- 新增 3 个实现计划：算子层 (Plan 1)、单输入 API (Plan 2)、批量处理 (Plan 3)
- 新增 CLAUDE.md 项目指引

## 文件清单

| 文件 | 说明 |
|------|------|
| `docs/plans/2026-03-03-lkm-api-design-v3.md` | v3 API 设计文档（21 个端点、review pipeline、6 个使用场景） |
| `docs/plans/2026-03-03-plan1-operator-layer.md` | Plan 1：Pipeline 框架 + 7 个算子（Embedding/NNSearch/Join/Verify/BP） |
| `docs/plans/2026-03-03-plan2-single-input-apis.md` | Plan 2：Job 系统 + 异步 review + search 内置 embedding |
| `docs/plans/2026-03-03-plan3-batch-processing.md` | Plan 3：batch commit/search/read + 进度追踪 |
| `CLAUDE.md` | Claude Code 项目指引 |

## Test plan

- [x] 设计文档 review：确认 6 个使用场景链路覆盖完整
- [x] 实现计划 review：确认任务拆分粒度合适、TDD 步骤可执行
- [x] 确认 v3 设计向后兼容现有 commit/search/read API

🤖 Generated with [Claude Code](https://claude.com/claude-code)