### PR TITLE
docs: add Galileo and Einstein thought experiment fixtures and examples

### DIFF
--- a/docs/examples/einstein_elevator.md
+++ b/docs/examples/einstein_elevator.md
@@ -1,0 +1,192 @@
+# Einstein's Elevator: From Equivalence Principle to General Relativity
+
+## Overview
+
+Einstein's 1907 "happiest thought" -- imagining a person in free fall who feels no gravity -- led him to the equivalence principle: gravitational and inertial effects are locally indistinguishable. This insight ultimately became the foundation of general relativity. This example traces the reasoning chain from Newton through the 1919 solar eclipse, demonstrating how Gaia models theory succession: old theories don't get deleted, their belief simply drops as new evidence accumulates.
+
+The key narrative arc follows a precise quantitative divergence. Newton (via Soldner, 1801) predicted 0.87 arcseconds of light deflection at the solar limb. Einstein initially predicted the same number using only the equivalence principle (1911). Then the full general-relativistic calculation predicted 1.75 arcseconds -- exactly double. Eddington's 1919 eclipse expedition measured approximately 1.7 arcseconds, decisively favoring GR. Five knowledge packages, spanning from Newtonian prior knowledge through Eddington's observation, are committed to the graph in chronological order. Belief propagation automatically tracks how Newton's specific prediction collapses while Newton's gravitational law itself retains moderate belief as a valid approximation.
+
+---
+
+## Package 1: Prior Knowledge Graph (`prior_knowledge`)
+
+The starting state of the graph represents established physics before Einstein: Newtonian mechanics, Newtonian gravity, the corpuscular theory of light, Soldner's calculation, Maxwell's electromagnetism, and the Eotvos experiment.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 6001 | paper-extract | premise | Newton's mechanics: $F = m_i a$. The net force on a body equals the product of its inertial mass and its acceleration. | 0.95 |
+| 6002 | paper-extract | premise | Newton's gravity: $F = GMm_g/r^2$. Every pair of massive bodies attracts with a force proportional to the product of their gravitational masses and inversely proportional to the square of their separation. | 0.95 |
+| 6003 | paper-extract | premise | Corpuscular theory of light: light consists of particles that possess an effective gravitational mass and follow Newtonian trajectories. | 0.5 |
+| 6004 | paper-extract | premise | Soldner's 1801 calculation: a light corpuscle grazing the solar limb is deflected by approximately 0.87 arcseconds ($\alpha = 2GM/rc^2$). | 0.6 |
+| 6005 | paper-extract | premise | Maxwell's electromagnetism: light is an electromagnetic wave propagating at constant speed $c = 1/\sqrt{\mu_0 \epsilon_0}$, independent of the source's motion. | 0.9 |
+| 6006 | paper-extract | premise | Eotvos experiment: inertial mass $m_i$ equals gravitational mass $m_g$ to a precision of 1 part in $10^8$. | 0.95 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 6001 | deduction | [6001, 6002, 6003] | [6004] | 0.6 | Under Newton's mechanics (node 6001) and gravitation (node 6002), the corpuscular theory (node 6003) implies light corpuscles follow hyperbolic orbits around massive bodies. Soldner evaluated the deflection for a ray grazing the Sun and obtained 0.87 arcseconds (node 6004). |
+
+### After propagation
+
+Node 6004 (Soldner's 0.87-arcsecond prediction) receives belief approximately 0.5--0.7. The moderate value reflects that the prediction depends on the corpuscular theory of light (node 6003, prior 0.5), which was already somewhat uncertain by the 19th century. Node 6003's low prior propagates through edge 6001, tempering confidence in the numerical prediction even though the underlying Newtonian mechanics and gravitation are well-established.
+
+---
+
+## Package 2: The Elevator (`einstein1907_equivalence_principle`)
+
+This is Einstein's conceptual breakthrough. A closed elevator in free fall is indistinguishable from one floating in empty space. A closed elevator at rest on Earth is indistinguishable from one accelerating upward in empty space. This operational indistinguishability, combined with the Eotvos experiment's empirical confirmation that inertial and gravitational mass are equal, elevates a numerical coincidence to a fundamental principle of nature.
+
+### Setup
+
+Imagine an observer enclosed in a windowless elevator. If the elevator rests in a uniform gravitational field, the observer feels a downward force $mg$. If the elevator is in free space accelerating upward at $a = g$, the observer feels an identical pseudo-force $ma$. No experiment performed inside the elevator can distinguish the two situations.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 6007 | deduction | -- | Einstein's elevator thought experiment: in a closed elevator, gravitational and inertial effects produce identical observations. No local mechanical experiment can distinguish them. | 1.0 |
+| 6008 | conjecture | -- | The equivalence principle: gravitational and inertial effects are locally indistinguishable. This elevates the Eotvos experiment's empirical mass equality from numerical coincidence to fundamental law. | 0.85 |
+| 6009 | deduction | -- | Corollary: light must bend in a gravitational field. In an accelerating elevator, a horizontal light beam curves downward; by the equivalence principle, the same bending must occur in a gravitational field. | 0.85 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 6002 | deduction | [6006, 6007] | [6008] | 0.85 | The Eotvos experiment (node 6006) provides the empirical foundation: inertial mass equals gravitational mass to extraordinary precision. Einstein's elevator thought experiment (node 6007) provides the conceptual bridge: if all objects fall identically, no local experiment can distinguish gravity from acceleration. Together they yield the equivalence principle (node 6008). |
+| 6003 | deduction | [6008, 6005] | [6009] | 0.85 | By the equivalence principle (node 6008), we can analyze gravity by switching to an equivalent accelerating frame. In an upward-accelerating elevator, a horizontal light beam (an electromagnetic wave per Maxwell, node 6005) enters one wall and hits the opposite wall lower. Since the accelerating frame is indistinguishable from a gravitational field, light must bend in gravity (node 6009). |
+
+### After propagation
+
+Node 6008 (the equivalence principle) receives belief approximately 0.7--0.9. It inherits strong support from the Eotvos experiment (node 6006, prior 0.95) and the elevator thought experiment (node 6007, prior 1.0) through edge 6002. Node 6009 (light bends in gravity) achieves similar belief, supported by the equivalence principle and Maxwell's theory through edge 6003. The thought experiment requires no laboratory -- pure reasoning from established premises generates a new physical prediction.
+
+---
+
+## Package 3: First Light Deflection Prediction (`einstein1911_light_deflection`)
+
+Einstein (1911) published the first quantitative prediction of gravitational light deflection based on the equivalence principle. The result: 0.87 arcseconds at the solar limb -- exactly the same as Soldner's Newtonian calculation. At this point, Newton and Einstein agree. There is no observational way to distinguish the two theories.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 6010 | paper-extract | premise | Einstein's 1911 prediction: 0.87 arcseconds of light deflection at the solar limb, calculated from the equivalence principle in flat spacetime. This captures only the gravitational time dilation (temporal metric component) and does not account for spatial curvature. | 0.8 |
+| 6011 | deduction | -- | The numerical match between Einstein's 1911 prediction and Soldner's 1801 prediction is not a deeper physical equivalence but a mathematical coincidence: both calculations capture only the temporal component ($g_{00}$) of the gravitational effect and miss the spatial curvature contribution. | 0.9 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 6004 | deduction | [6009] | [6010] | 0.8 | Having established that light bends in gravity (node 6009), Einstein calculated the magnitude. Using the equivalence principle in flat spacetime, the deflection angle is $\alpha = 2GM/(rc^2)$. For the Sun: approximately 0.87 arcseconds (node 6010). |
+| 6005 | deduction | [6010, 6004] | [6011] | 0.9 | Einstein's 1911 result (node 6010) and Soldner's 1801 result (node 6004) both yield $\alpha = 2GM/(rc^2) \approx 0.87''$ despite entirely different theoretical foundations. This numerical agreement (node 6011) means the 1911 prediction cannot distinguish Einstein from Newton. |
+
+### After propagation
+
+Both nodes 6004 and 6010 are reinforced: Soldner's prediction gains indirect support from a completely independent theoretical framework (the equivalence principle), and Einstein's prediction is consistent with existing calculations. Node 6010 achieves belief approximately 0.7--0.85, and node 6011 (the significance of the match) achieves approximately 0.8--0.95. Critically, no contradiction edge exists in this package -- the theories are indistinguishable at this stage.
+
+---
+
+## Package 4: General Relativity (`einstein1915_general_relativity`)
+
+This is where the predictions diverge dramatically. Full general relativity (1915) reveals that spacetime curvature has both a temporal component (captured by the equivalence principle) and a spatial component (missed by all previous calculations). Light follows geodesics in curved spacetime, and the spatial curvature contributes an additional deflection equal to the temporal contribution, doubling the predicted angle from 0.87 to 1.75 arcseconds.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 6012 | paper-extract | premise | General relativity: mass-energy curves spacetime via the Einstein field equations $G_{\mu\nu} + \Lambda g_{\mu\nu} = (8\pi G/c^4) T_{\mu\nu}$. Gravity is not a force but a manifestation of spacetime curvature. | 0.85 |
+| 6013 | deduction | -- | Light follows null geodesics in curved spacetime. Near a massive body, the Schwarzschild metric deflects these geodesics, with contributions from both temporal curvature (time dilation) and spatial curvature ($g_{rr}$ component). | 0.85 |
+| 6014 | deduction | -- | GR prediction: $\alpha = 4GM/(rc^2) \approx 1.75''$ at the solar limb -- exactly double the Newtonian/equivalence-principle value. The extra factor of two comes from spatial curvature. | 0.85 |
+| 6015 | paper-extract | premise | GR explains Mercury's anomalous perihelion precession of 43 arcseconds per century with zero free parameters, resolving a 60-year-old anomaly in celestial mechanics. | 0.9 |
+| 6016 | deduction | -- | GR subsumes the equivalence principle as its local (infinitesimal) limit: at any spacetime point, one can choose a freely falling frame where the metric is Minkowskian. | 0.9 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 6006 | deduction | [6012, 6008] | [6013] | 0.85 | The equivalence principle (node 6008) requires freely falling observers to follow the straightest paths through spacetime. In GR (node 6012), spacetime is curved, and these paths are geodesics. For photons, the paths are null geodesics deflected by both temporal and spatial curvature (node 6013). |
+| 6007 | deduction | [6013] | [6014] | 0.85 | Computing null geodesics in the Schwarzschild metric, the total deflection is $\alpha = 4GM/(rc^2)$. For the Sun: 1.75 arcseconds (node 6014), exactly twice the 0.87-arcsecond equivalence-principle-only result. This factor-of-two difference provides a decisive observational test. |
+| 6008 | **contradiction** | [6014, 6004] | [] | -- | GR predicts 1.75 arcseconds (node 6014); Newton/Soldner predicts 0.87 arcseconds (node 6004). These differ by exactly a factor of two and are mutually exclusive within reasonable experimental uncertainty. The disagreement arises because the Newtonian calculation accounts only for the gravitational potential, whereas GR adds an equal contribution from spatial curvature. |
+| 6009 | deduction | [6012] | [6015] | 0.9 | Einstein applied GR to Mercury's orbit (node 6012) and derived an additional precession of $\Delta\phi = 6\pi GM/[a(1-e^2)c^2]$ per orbit, summing to exactly 43 arcseconds per century for Mercury's orbital parameters (node 6015). |
+| 6010 | abstraction | [6008, 6015, 6016] | [6012] | 0.9 | Multiple independent successes strengthen GR (node 6012): Mercury's precession (node 6015), the equivalence principle as local limit (node 6016), and the testable contradiction with Newton (node 6008) provide convergent validation across different physical regimes. |
+
+### After propagation
+
+The contradiction edge (6008) connecting node 6014 (GR's 1.75 arcseconds) and node 6004 (Newton's 0.87 arcseconds) is the critical structure in this package. BP recognizes that these two predictions cannot both be correct. Before observational evidence resolves the conflict, GR's prediction (node 6014) rises to approximately 0.7--0.9 belief, supported by Mercury's perihelion success and theoretical elegance. Soldner's prediction (node 6004) drops to approximately 0.3--0.6 as the contradiction pulls its belief down. The theories now make clearly distinguishable predictions.
+
+This is the key mechanism: **contradiction edges between quantitative predictions create a belief competition that BP resolves based on the relative support for each theory**.
+
+---
+
+## Package 5: Eddington's Eclipse (`eddington1919_solar_eclipse`)
+
+The decisive test. On May 29, 1919, during a total solar eclipse, two expeditions measured the apparent displacement of stars near the Sun. The results -- approximately 1.7 arcseconds -- matched GR and ruled out Newton.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 6017 | paper-extract | premise | Eddington's 1919 eclipse expedition: two teams (Sobral, Brazil and Principe, West Africa) photographed stars near the solar limb during totality, comparing their apparent positions to their known positions when the Sun is elsewhere. | 0.95 |
+| 6018 | paper-extract | premise | Measured deflections: $1.61 \pm 0.30''$ (Sobral) and $1.98 \pm 0.16''$ (Principe). Both consistent with GR's 1.75 arcseconds; both inconsistent with Newton's 0.87 arcseconds. | 0.9 |
+| 6019 | deduction | -- | Observation consistent with GR, inconsistent with Newton: the Sobral result exceeds the Newtonian value by 2.5 standard deviations; the Principe result exceeds it by nearly 7 standard deviations. | 0.9 |
+| 6020 | deduction | -- | GR confirmed as the superior theory of gravity: the eclipse observation adds to Mercury's perihelion success, with two independent quantitative predictions now confirmed. | 0.9 |
+| 6021 | deduction | -- | Newtonian gravity demoted to approximate theory: Newton's $F = GMm/r^2$ remains valid in weak fields at low velocities but fails quantitatively when spatial curvature matters. Not deleted -- just demoted. | 0.9 |
+| 6022 | deduction | -- | Soldner's 1801 prediction and Einstein's 1911 prediction (both 0.87 arcseconds) are definitively ruled out. Both captured only temporal curvature and missed the equal spatial curvature contribution. | 0.9 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 6011 | paper-extract | [6017, 6018] | [6019] | 0.9 | The eclipse expedition (node 6017) measured deflections (node 6018) of $1.61 \pm 0.30''$ and $1.98 \pm 0.16''$. Both measurements are consistent with GR (1.75 arcseconds) and inconsistent with Newton (0.87 arcseconds) at high statistical significance (node 6019). |
+| 6012 | deduction | [6019, 6014] | [6020] | 0.9 | The observations (node 6019) match GR's prediction of 1.75 arcseconds (node 6014). Combined with Mercury's perihelion success, two independent GR predictions are now confirmed, establishing GR as the superior theory (node 6020). |
+| 6013 | deduction | [6019, 6004] | [6021] | 0.9 | The observations (node 6019) are inconsistent with Soldner's Newtonian prediction of 0.87 arcseconds (node 6004). Newtonian gravity is demoted to an approximate limit of GR (node 6021), valid in weak fields but quantitatively wrong when spatial curvature is significant. |
+| 6014 | **contradiction** | [6019, 6004] | [] | -- | Observational refutation: the measured deflections ($\sim$1.7 arcseconds, node 6019) are approximately twice the Newtonian prediction (0.87 arcseconds, node 6004), inconsistent at high statistical significance. This empirical contradiction is decisive. |
+| 6015 | deduction | [6021, 6020] | [6022] | 0.9 | Since GR is confirmed (node 6020) and Newton is demoted (node 6021), the 0.87-arcsecond prediction shared by Soldner and Einstein 1911 is definitively ruled out (node 6022). Both calculations missed the spatial curvature that general relativity reveals. |
+
+### After propagation
+
+Three independent lines of evidence now converge against the Newtonian prediction:
+
+1. **Theoretical contradiction** (Package 4, edge 6008) -- GR's 1.75 arcseconds vs. Newton's 0.87 arcseconds, based on the mathematical structure of spacetime curvature.
+2. **Observational contradiction** (Package 5, edge 6014) -- the measured deflection ($\sim$1.7 arcseconds) vs. Newton's prediction, based on direct observation.
+3. **Mercury's perihelion** (Package 4, edge 6009) -- an independent success of GR in a completely different physical regime.
+
+Each line is independent: the theoretical prediction requires only the Einstein field equations, Mercury's precession involves slow-moving massive bodies rather than light, and the eclipse is a direct measurement. BP naturally assigns high belief to conclusions supported by multiple independent paths.
+
+---
+
+## Final Belief Distribution
+
+After all five packages have been committed and belief propagation has converged, the graph shows the following approximate belief distribution:
+
+| Node | Description | Initial Prior | Final Belief Range |
+|------|-------------|---------------|--------------------|
+| 6004 | Soldner's 0.87-arcsecond prediction | 0.60 | 0.05--0.25 |
+| 6012 | General relativity (Einstein field equations) | 0.85 | 0.85--0.98 |
+| 6014 | GR 1.75-arcsecond prediction | 0.85 | 0.85--0.98 |
+| 6020 | GR confirmed by eclipse observation | 0.90 | 0.85--0.98 |
+| 6002 | Newton's law of gravitation | 0.95 | 0.70--0.90 |
+
+The most striking feature is the collapse of node 6004 from prior 0.60 to final belief 0.05--0.25. This occurs through the cumulative effect of:
+
+- One theoretical contradiction edge within Package 4 (edge 6008): GR's 1.75 arcseconds vs. Newton's 0.87 arcseconds
+- One observational contradiction edge within Package 5 (edge 6014): measured $\sim$1.7 arcseconds vs. Newton's 0.87 arcseconds
+- Multiple independent evidence paths supporting GR (edges 6009, 6010, 6012)
+
+Note that Newton's law of gravitation (node 6002) does not collapse to zero -- it drops from 0.95 to roughly 0.70--0.90 but remains a valid approximation. Only its specific prediction for light deflection (node 6004) is refuted. This is exactly how science works: superseded theories are demoted to approximate limits, not erased from history.
+
+---
+
+## Key Takeaways
+
+1. **Theory succession, not deletion.** Newton's gravity (node 6002) keeps moderate belief even after GR is confirmed. Only the specific prediction (node 6004, 0.87 arcseconds) drops. Gaia naturally captures that old theories remain useful approximations -- Newton's $F = GMm/r^2$ is still the right equation for engineering, planetary orbits, and everyday gravity. The graph records that it is a limiting case of GR, not a discarded falsehood.
+
+2. **Quantitative contradiction.** The contradiction between 1.75 arcseconds and 0.87 arcseconds (edge 6008) is not a qualitative disagreement but a precise numerical one: the predictions differ by exactly a factor of two, traceable to the spatial curvature term in the Schwarzschild metric. Gaia's contradiction edges can represent both qualitative contradictions (as in the Galileo example) and quantitative ones with explicit numerical values.
+
+3. **Predictions that initially agree, then diverge.** Einstein's 1911 prediction matched Newton's -- both gave 0.87 arcseconds from entirely different theoretical foundations. Only in 1915 did the predictions diverge. The graph captures this nuance: the contradiction edge (6008) appears only in Package 4, not Package 3. Packages 1--3 contain no contradiction at all. This models how competing theories can coexist peacefully until a new calculation or observation separates them.
+
+4. **Multiple independent confirmations.** Mercury's perihelion precession (node 6015) and the eclipse observation (node 6018) are independent evidence paths supporting GR. They test the theory in different physical regimes -- slow massive bodies vs. massless relativistic particles -- and both confirm it. BP naturally combines these independent paths, assigning higher belief to conclusions supported by convergent evidence from different sources.
+
+5. **Historical reasoning preserved.** The full chain from Soldner (1801) through Einstein (1907, 1911, 1915) to Eddington (1919) is preserved in the graph, making the evolution of scientific understanding fully traceable. A future query for "why did the prediction of light deflection change?" can trace the path from node 6004 (0.87 arcseconds) through the equivalence principle (node 6008), to the recognition that spatial curvature doubles the effect (node 6013), to the new prediction (node 6014), and finally to its observational confirmation (node 6019). The commit history *is* the history of science.

--- a/docs/examples/galileo_tied_balls.md
+++ b/docs/examples/galileo_tied_balls.md
@@ -1,0 +1,214 @@
+# Galileo's Tied Balls: Overturning Aristotle with a Thought Experiment
+
+## Overview
+
+Galileo's 1638 *Discorsi e dimostrazioni matematiche intorno a due nuove scienze* contains one of history's most elegant thought experiments. By imagining tying a heavy and light ball together, he showed that Aristotle's "heavier falls faster" law leads to a self-contradiction: the combined object must simultaneously fall faster (because it is heavier) and slower (because the light ball drags the heavy one). No laboratory was needed -- pure reasoning exposed a flaw that had survived nearly two millennia.
+
+This example demonstrates how Gaia models the accumulation of evidence against an established theory. Six knowledge packages, spanning from Aristotle's *Physics* (c. 350 BCE) to the Apollo 15 lunar experiment (1971 CE), are committed to the graph in chronological order. Belief propagation automatically tracks how the credibility of Aristotle's law erodes as contradictions, alternative theories, and direct experimental confirmation enter the hypergraph.
+
+---
+
+## Package 1: Prior Knowledge Graph (`aristotle_physics`)
+
+The starting state of the graph represents pre-Galilean accepted wisdom. Aristotle's doctrine of natural motion and everyday empirical observation combine to support a proportionality law: heavier objects fall faster.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 5001 | paper-extract | premise | Aristotle's doctrine of natural motion: every body has a natural place; earthy bodies move downward with a speed determined by their nature (weight). | 0.9 |
+| 5002 | paper-extract | premise | Empirical observation: a stone dropped alongside a leaf reaches the ground first. Heavier objects appear to fall faster in everyday experience. | 0.95 |
+| 5003 | paper-extract | conclusion | Aristotle's law of falling bodies: the speed of a falling body is proportional to its weight (v proportional to W). Heavier objects fall faster than lighter ones. | 0.7 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 5001 | abstraction | [5001, 5002] | [5003] | 0.85 | Aristotle generalizes from the doctrine of natural motion (node 5001) and the everyday observation that stones fall faster than leaves (node 5002) to the universal law that speed of fall is proportional to weight (node 5003). |
+
+### After propagation
+
+Node 5003 (Aristotle's law) receives belief approximately 0.70, reflecting its status as widely accepted but imprecise ancient wisdom. The prior is deliberately set below 1.0 because even within the Aristotelian tradition, the proportionality claim was debated.
+
+---
+
+## Package 2: The Tied Balls Paradox (`galileo1638_tied_balls`)
+
+This is the heart of Galileo's thought experiment. Starting from Aristotle's own premises, Galileo constructs two valid deductive chains that arrive at contradictory conclusions about the same physical setup. The contradiction proves that the shared premise -- Aristotle's law -- must be false.
+
+### Setup
+
+Imagine tying a heavy ball H to a light ball L with a cord. Now drop the combined object HL.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 5004 | conjecture | premise | Setup: Tie a heavy ball H (weight W_H) to a light ball L (weight W_L < W_H) with a cord. Consider the combined object HL. | 0.99 |
+| 5005 | deduction | conclusion | Deduction A: By Aristotle's law, L falls slower than H. When tied together, L acts as a drag on H, retarding its natural motion. Therefore the combined object HL must fall slower than H alone. | 0.9 |
+| 5006 | deduction | conclusion | Deduction B: The combined object HL has total weight W_H + W_L, which is greater than W_H. By Aristotle's law, a heavier body falls faster. Therefore HL must fall faster than H alone. | 0.9 |
+| 5007 | deduction | conclusion | Contradiction: Deductions A and B both follow validly from Aristotle's law applied to the same setup. Yet they yield mutually exclusive predictions -- the combined object HL cannot be both faster and slower than H alone. Therefore Aristotle's law is internally self-contradictory. | 0.95 |
+| 5008 | deduction | conclusion | Galileo's conclusion: since Aristotle's law (v proportional to W) leads to a self-contradiction when applied to composite bodies, the law must be rejected. Speed of fall cannot depend on weight in the way Aristotle claimed. | 0.85 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 5002 | deduction | [5003, 5004] | [5005] | 0.95 | From Aristotle's law (node 5003) and the setup (node 5004): L is lighter than H, so L falls slower. When tied together, L drags on H. Therefore the composite HL is slower than H alone. |
+| 5003 | deduction | [5003, 5004] | [5006] | 0.95 | From Aristotle's law (node 5003) and the setup (node 5004): HL has combined weight W_H + W_L > W_H. By the same law, heavier falls faster. Therefore HL is faster than H alone. |
+| 5004 | contradiction | [5005, 5006] | [] | null | Nodes 5005 and 5006 make mutually exclusive claims about the same object under the same conditions. The combined object HL cannot be simultaneously faster and slower than H alone. This is a logical contradiction. |
+| 5005 | deduction | [5007, 5003] | [5008] | 0.90 | The contradiction (node 5007) arises from valid deductions that share a single premise: Aristotle's law (node 5003). Since the deductions are logically valid, the error must lie in the premise. Therefore Aristotle's law is self-contradictory and must be rejected (node 5008). |
+
+### After propagation
+
+The contradiction edge (5004) connecting nodes 5005 and 5006 is the critical structure. Belief propagation recognizes that these two nodes cannot both be true. Since both are validly derived from the same premise -- Aristotle's law (node 5003) -- BP propagates the inconsistency back to the shared source. The belief in node 5003 drops to roughly 0.20--0.50, depending on edge probabilities and the BP schedule. Meanwhile, node 5008 (Galileo's rejection of Aristotle) rises to approximately 0.75--0.85.
+
+This is the key mechanism: **contradiction edges drive belief revision in shared premises**.
+
+---
+
+## Package 3: Medium Density (`galileo1638_medium_density`)
+
+Galileo did not stop at the thought experiment. He also observed that the medium through which objects fall affects their speed, providing a physical explanation for why Aristotle's everyday observations seemed plausible.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 5009 | paper-extract | premise | Galileo's observation: objects of different densities fall at noticeably different rates in water and viscous media, but the difference diminishes in thinner media such as air. | 0.9 |
+| 5010 | paper-extract | premise | As the density of the medium decreases, the difference in fall rates between heavy and light objects decreases proportionally. | 0.85 |
+| 5011 | deduction | conclusion | Air resistance is a confounding variable: Aristotle's observation (stones fall faster than leaves) is explained by differing air resistance, not by differing intrinsic fall speeds. The medium, not the weight, produces the apparent speed difference. | 0.8 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 5006 | deduction | [5009, 5010] | [5011] | 0.85 | Galileo reasons by extrapolation: if the difference in fall rates diminishes as the medium becomes thinner, then in the limiting case of no medium (vacuum), the difference would vanish entirely. Therefore the observed difference in air is due to the medium, not to any intrinsic property of weight. |
+
+### After propagation
+
+Node 5011 (air resistance as confounding variable) achieves belief approximately 0.75. This provides an alternative explanation for node 5002 (the empirical observation that stones fall faster than leaves), undermining the evidential support that node 5002 previously gave to Aristotle's law (node 5003). The belief in node 5003 drops further.
+
+---
+
+## Package 4: Vacuum Prediction (`galileo1638_vacuum_prediction`)
+
+Galileo makes a testable prediction: in a vacuum, all objects fall at the same rate regardless of weight. He also provides partial experimental confirmation through inclined plane experiments.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 5012 | conjecture | conclusion | Prediction: in a true vacuum (zero air resistance), all objects fall at the same rate regardless of their weight. | 0.85 |
+| 5013 | paper-extract | premise | Inclined plane experiments: Galileo measured that balls of different weights rolling down smooth inclined planes arrive at the bottom at nearly the same time, and that the distance traveled is proportional to the square of the elapsed time. | 0.9 |
+| 5014 | deduction | conclusion | The inclined plane results are consistent with the equal-fall-rate hypothesis and inconsistent with v proportional to W, providing partial experimental support for the vacuum prediction (node 5012). | 0.8 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 5007 | deduction | [5008, 5011] | [5012] | 0.85 | If Aristotle's law is wrong (node 5008) and the observed difference is due to the medium (node 5011), then removing the medium should remove the difference: all objects would fall equally in a vacuum. |
+| 5008 | deduction | [5013, 5012] | [5014] | 0.80 | The inclined plane results (node 5013) match the prediction that fall rate does not depend on weight (node 5012). Friction on the plane acts as a reduced analog of air resistance, and the near-equal arrival times support equal-rate falling. |
+
+### After propagation
+
+The inclined plane evidence (node 5013) strengthens belief in the vacuum prediction (node 5012) to approximately 0.85. Node 5003 (Aristotle's law) continues its decline as more evidence accumulates against it.
+
+---
+
+## Package 5: Newton's Principia (`newton1687_principia`)
+
+Nearly fifty years after Galileo's *Discorsi*, Newton's *Principia Mathematica* (1687) provides a theoretical derivation from first principles that independently confirms Galileo's conclusion and directly contradicts Aristotle's law.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 5015 | paper-extract | premise | Newton's Second Law: F = ma. The net force on a body equals its mass times its acceleration. | 0.95 |
+| 5016 | paper-extract | premise | Newton's Law of Gravitation (near Earth's surface): the gravitational force on a body is F = mg, where g is the gravitational acceleration constant (approximately 9.8 m/s^2) and m is the body's mass. | 0.95 |
+| 5017 | deduction | conclusion | Derivation: setting F = ma equal to F = mg yields a = g. The acceleration due to gravity is independent of mass. All objects in free fall experience the same acceleration regardless of their weight. | 0.95 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 5009 | deduction | [5015, 5016] | [5017] | 0.95 | From F = ma and F = mg, dividing both sides by m gives a = g. The mass cancels, so acceleration is independent of mass. This is a straightforward algebraic derivation from Newton's two laws. |
+| 5010 | deduction | [5017] | [5012] | 0.95 | If a = g for all objects regardless of mass (node 5017), then in a vacuum (no air resistance), all objects fall at the same rate. This independently confirms Galileo's vacuum prediction (node 5012). |
+| 5011 | contradiction | [5003, 5017] | [] | null | Newton's result a = g (acceleration independent of mass, node 5017) directly contradicts Aristotle's law v proportional to W (speed proportional to weight, node 5003). If acceleration is the same for all masses, then speed of fall cannot be proportional to weight. |
+
+### After propagation
+
+Edge 5011 is a contradiction edge linking Newton's derivation (node 5017, high prior 0.95) against Aristotle's law (node 5003, already weakened). This provides a second independent line of attack on Aristotle's law, further driving its belief down. Node 5017 achieves belief approximately 0.90--0.95. Node 5003 drops to roughly 0.05--0.15. The Newtonian derivation also strengthens the vacuum prediction (node 5012) via edge 5010, since it provides a theoretical basis that is independent of Galileo's thought experiment.
+
+---
+
+## Package 6: Apollo 15 (`apollo15_1971_feather_drop`)
+
+On August 2, 1971, astronaut David Scott performed the famous hammer-feather drop on the surface of the Moon during the Apollo 15 mission. In the near-perfect vacuum of the lunar surface, a hammer and a falcon feather were dropped simultaneously and hit the ground at the same time. This was the first direct experimental confirmation of the equal-fall-rate hypothesis in an actual vacuum.
+
+### Nodes
+
+| ID | Type | Subtype | Content | Prior |
+|----|------|---------|---------|-------|
+| 5018 | paper-extract | premise | Apollo 15 experiment conditions: the lunar surface has negligible atmosphere (approximately 3 x 10^-15 atm), providing a near-perfect vacuum environment for free-fall experiments. | 0.99 |
+| 5019 | paper-extract | premise | Observation: astronaut David Scott simultaneously released a 1.32 kg geological hammer and a 0.03 kg falcon feather from the same height. Both objects struck the lunar surface at the same time, as recorded on live television. | 0.99 |
+| 5020 | deduction | conclusion | The Apollo 15 hammer-feather experiment directly confirms that objects of vastly different masses (factor of 44x) fall at the same rate in a vacuum, consistent with Galileo's prediction (node 5012) and Newton's derivation (node 5017). | 0.99 |
+
+### Edges
+
+| ID | Type | Tail | Head | Probability | Reasoning |
+|----|------|------|------|-------------|-----------|
+| 5012 | deduction | [5018, 5019] | [5020] | 0.99 | In a near-perfect vacuum (node 5018), a heavy hammer and a light feather fell at the same rate (node 5019). This directly confirms the equal-fall-rate prediction. The mass ratio of 44:1 makes the result decisive -- under Aristotle's law, the hammer should have fallen 44 times faster. |
+| 5013 | deduction | [5020] | [5012] | 0.99 | The lunar observation (node 5020) provides direct experimental evidence for the vacuum prediction (node 5012), elevating it from theoretical prediction to observed fact. |
+| 5014 | deduction | [5020] | [5017] | 0.95 | The lunar observation (node 5020) is consistent with a = g independent of mass (node 5017), providing direct empirical support for the Newtonian derivation. |
+
+### After propagation
+
+Three independent lines of evidence now converge on the same conclusion:
+
+1. **Galileo's thought experiment** (Package 2) -- logical contradiction in Aristotle's premises
+2. **Newtonian theory** (Package 5) -- theoretical derivation from first principles (a = g)
+3. **Apollo 15 observation** (Package 6) -- direct experimental confirmation in actual vacuum
+
+Each line is independent: the thought experiment requires no empirical data, the Newtonian derivation depends only on F = ma and F = mg, and the lunar observation is a direct measurement. BP naturally assigns high belief to nodes supported by multiple independent paths and low belief to nodes contradicted by them.
+
+---
+
+## Final Belief Distribution
+
+After all six packages have been committed and belief propagation has converged, the graph shows the following approximate belief distribution:
+
+| Node | Description | Initial Prior | Final Belief Range |
+|------|-------------|---------------|--------------------|
+| 5003 | Aristotle's law (v proportional to W) | 0.70 | 0.01--0.15 |
+| 5005 | Deduction A: combined is slower | 0.90 | 0.20--0.40 |
+| 5006 | Deduction B: combined is faster | 0.90 | 0.20--0.40 |
+| 5007 | Contradiction in Aristotle's law | 0.95 | 0.85--0.95 |
+| 5008 | Galileo's rejection of Aristotle | 0.85 | 0.85--0.95 |
+| 5011 | Air resistance as confound | 0.80 | 0.80--0.90 |
+| 5012 | Equal fall rate in vacuum | 0.85 | 0.85--1.00 |
+| 5014 | Inclined plane confirmation | 0.80 | 0.80--0.90 |
+| 5017 | a = g (Newton) | 0.95 | 0.85--1.00 |
+| 5020 | Lunar experiment confirmed | 0.99 | 0.90--1.00 |
+
+The most striking feature is the collapse of node 5003 from prior 0.70 to final belief 0.01--0.15. This occurs through the cumulative effect of:
+
+- One contradiction edge within Aristotle's own framework (edge 5004)
+- One cross-paradigm contradiction edge from Newtonian mechanics (edge 5011)
+- Multiple independent evidence paths supporting the alternative (edges 5007, 5010, 5013, 5014)
+
+Nodes 5005 and 5006 also drop in belief despite being individually valid deductions, because they are linked by a contradiction edge (5004). BP cannot assign high belief to both simultaneously, so it finds the equilibrium by lowering both and propagating the inconsistency back to the shared premise.
+
+---
+
+## Key Takeaways
+
+1. **Thought experiments as nodes and edges.** No special "environment" construct is needed. Galileo's thought experiment is simply new nodes (premises and deductions) and edges (reasoning steps) added to the graph. The setup (node 5004) is a conjecture node; the deductions (nodes 5005, 5006) follow via standard deduction edges; the contradiction (node 5007) is identified by a contradiction edge. The entire argument lives in the same node/edge vocabulary as any empirical observation or theoretical derivation.
+
+2. **Contradiction drives belief revision.** The contradiction edge (5004) between nodes 5005 and 5006 is the structural engine of belief revision. BP detects that these two nodes cannot both be true, and since they share a common premise (Aristotle's law, node 5003), the inconsistency propagates backward to lower belief in that premise. This is precisely how scientific revolutions work: internal contradictions in a theory precede its replacement.
+
+3. **Multiple independent evidence streams converge.** The thought experiment (Package 2), medium-density observations (Package 3), Newtonian theory (Package 5), and lunar experiment (Package 6) are independent paths that all point to the same conclusion. BP naturally assigns higher belief to conclusions supported by multiple independent paths, because the probability of all paths being wrong simultaneously is very low. No special "convergence" logic is needed -- it emerges from the graph topology.
+
+4. **Old theories are not deleted.** Aristotle's law (node 5003) remains in the graph with low belief, preserving the historical record of scientific reasoning. The graph captures not just what we know, but how we came to know it. A future query for "why was Aristotle wrong about falling bodies?" can trace the full chain from node 5003 through the contradiction edges and converging evidence to the current consensus. This is a fundamental advantage over knowledge bases that delete or overwrite superseded theories.
+
+5. **Packages as commit batches.** Each package corresponds to a historical moment when new knowledge entered the graph. This ordering shows how scientific understanding evolved over two millennia: from Aristotle's initial codification of everyday observation (c. 350 BCE), through Galileo's devastating thought experiment and empirical program (1638 CE), to Newton's theoretical unification (1687 CE), and finally to the direct experimental confirmation on the Moon (1971 CE). The commit history *is* the history of science.

--- a/tests/fixtures/examples/einstein_elevator/edges.json
+++ b/tests/fixtures/examples/einstein_elevator/edges.json
@@ -1,0 +1,402 @@
+[
+  {
+    "id": 6001,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6001, 6002, 6003],
+    "head": [6004],
+    "probability": 0.6,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Newtonian framework for light corpuscles",
+        "content": "Under Newton's mechanics ($F = m_i a$, node 6001) and Newton's gravitational law ($F = GMm_g/r^2$, node 6002), any particle with mass follows a trajectory determined by the gravitational field. The corpuscular theory of light (node 6003) assigns an effective gravitational mass to light particles, making them subject to the same laws."
+      },
+      {
+        "title": "Hyperbolic orbit calculation",
+        "content": "Treating a light corpuscle as a particle moving at speed $c$ in the gravitational field of the Sun, the trajectory is a hyperbolic orbit. The deflection angle for a hyperbolic orbit with closest approach $r$ (the solar radius) is $\\alpha = 2GM/(rc^2)$."
+      },
+      {
+        "title": "Soldner's numerical result",
+        "content": "Soldner (1801) evaluated this expression for the Sun's mass and radius, obtaining a deflection of approximately 0.87 arcseconds for a light ray grazing the solar limb. This was the first published prediction of gravitational light bending."
+      }
+    ],
+    "metadata": {
+      "package": "prior_knowledge"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6002,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6006, 6007],
+    "head": [6008],
+    "probability": 0.85,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Empirical foundation from Eotvos",
+        "content": "The Eotvos experiment (node 6006) established that inertial mass equals gravitational mass to extraordinary precision ($1$ part in $10^8$). This empirical equality means that all bodies, regardless of composition, fall identically in a gravitational field."
+      },
+      {
+        "title": "Conceptual leap via the elevator",
+        "content": "Einstein's elevator thought experiment (node 6007) provides the conceptual bridge: if all objects (and the observer) accelerate identically in gravity, then no local experiment can distinguish gravity from acceleration. The universality of free fall (Eotvos) is the empirical fact; the elevator is the thought experiment that reveals its deeper meaning."
+      },
+      {
+        "title": "Elevation to fundamental principle",
+        "content": "Einstein elevated this from empirical coincidence to fundamental principle: gravitational and inertial effects are locally indistinguishable (the equivalence principle, node 6008). This is not merely a statement about mass equality but a constraint on all physics — no local experiment of any kind can distinguish the two situations."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1907_equivalence_principle"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6003,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6008, 6005],
+    "head": [6009],
+    "probability": 0.85,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Light in an accelerating frame",
+        "content": "By the equivalence principle (node 6008), we can analyze gravity by switching to an equivalent accelerating frame. In an upward-accelerating elevator, a horizontal light beam (an electromagnetic wave per Maxwell, node 6005) enters one wall and hits the opposite wall lower, because the elevator has accelerated upward during the light's transit. The observer sees the light path curve downward."
+      },
+      {
+        "title": "Application of the equivalence principle",
+        "content": "Since the equivalence principle asserts that an accelerating frame is locally indistinguishable from a gravitational field, the downward curving of light observed in the accelerating elevator must also occur in a gravitational field. This argument requires no assumption about the mass of light — it applies directly to electromagnetic waves."
+      },
+      {
+        "title": "Conclusion: light bends in gravity",
+        "content": "Therefore, light must bend in a gravitational field (node 6009). This is a direct consequence of combining the equivalence principle with Maxwell's theory of electromagnetic waves, independent of any corpuscular hypothesis."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1907_equivalence_principle"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6004,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6009],
+    "head": [6010],
+    "probability": 0.8,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Quantitative prediction from equivalence principle",
+        "content": "Having established that light bends in a gravitational field (node 6009), Einstein calculated the magnitude of the effect for a light ray passing near the Sun. Using the equivalence principle in flat spacetime (treating gravity as equivalent to uniform acceleration), the deflection angle is $\\alpha = 2GM/(rc^2)$."
+      },
+      {
+        "title": "Numerical evaluation",
+        "content": "Substituting the Sun's mass ($M \\approx 2 \\times 10^{30}$ kg) and radius ($r \\approx 7 \\times 10^8$ m), Einstein obtained $\\alpha \\approx 0.87$ arcseconds for a ray grazing the solar limb. This result was published in his 1911 paper."
+      },
+      {
+        "title": "Limitation of the calculation",
+        "content": "This calculation used only the equivalence principle and did not account for the curvature of space itself. It captured the effect of gravitational time dilation on light propagation but missed the spatial curvature contribution, yielding only half the full general-relativistic result."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1911_light_deflection"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6005,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6010, 6004],
+    "head": [6011],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Two independent calculations",
+        "content": "Soldner (1801) used Newtonian mechanics applied to light corpuscles (node 6004) and obtained 0.87 arcseconds. Einstein (1911) used the equivalence principle applied to electromagnetic waves (node 6010) and obtained 0.87 arcseconds. The two calculations rest on entirely different physical theories."
+      },
+      {
+        "title": "Mathematical equivalence",
+        "content": "Despite the different theoretical foundations, both calculations yield the same formula $\\alpha = 2GM/(rc^2)$ and the same numerical result. The Newtonian calculation treats light as a massive particle in a gravitational potential; the Einstein calculation treats light as a massless wave in an equivalent accelerating frame. Both capture only the temporal component of the gravitational effect."
+      },
+      {
+        "title": "Significance of the coincidence",
+        "content": "The numerical agreement (node 6011) is not a deeper physical equivalence but a mathematical coincidence arising from the fact that both approaches account for the same single component (gravitational time dilation / Newtonian potential) while missing the spatial curvature contribution. This coincidence meant that the 1911 prediction could not distinguish Einstein's new approach from Newtonian physics."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1911_light_deflection"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6006,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6012, 6008],
+    "head": [6013],
+    "probability": 0.85,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "From equivalence to geometry",
+        "content": "The equivalence principle (node 6008) requires that gravity be locally indistinguishable from acceleration, which implies that freely falling observers follow the straightest possible paths through spacetime. In general relativity (node 6012), spacetime is curved by mass-energy, and these straightest paths are geodesics of the curved metric."
+      },
+      {
+        "title": "Light on null geodesics",
+        "content": "For massless particles such as photons, the straightest paths are null geodesics — paths along which the spacetime interval $ds^2 = 0$. In the Schwarzschild metric describing the spacetime around a spherical mass, these null geodesics are deflected by the curvature of spacetime."
+      },
+      {
+        "title": "Both temporal and spatial curvature",
+        "content": "Unlike the equivalence-principle-only calculation (which captures only the $g_{00}$ temporal metric component), the full geodesic equation in GR includes contributions from both the temporal curvature (time dilation) and the spatial curvature ($g_{rr}$ component), yielding a total deflection that differs from the equivalence-principle prediction."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1915_general_relativity"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6007,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6013],
+    "head": [6014],
+    "probability": 0.85,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Solving the geodesic equation",
+        "content": "Computing the null geodesic in the Schwarzschild metric for a light ray passing near a spherical mass at closest approach distance $r$, the total deflection angle is $\\alpha = 4GM/(rc^2)$. The factor of 4 (rather than 2 in the Newtonian/equivalence-principle result) arises from equal contributions of temporal and spatial metric components."
+      },
+      {
+        "title": "Numerical result for the Sun",
+        "content": "For a ray grazing the solar limb ($r = R_{\\odot}$), this yields $\\alpha \\approx 1.75$ arcseconds (node 6014), exactly twice the 0.87 arcseconds predicted by Newton/Soldner and Einstein's 1911 calculation."
+      },
+      {
+        "title": "A genuinely new prediction",
+        "content": "The factor-of-two difference between 1.75 arcseconds (GR) and 0.87 arcseconds (Newton/equivalence principle) provided a clear observational test that could distinguish general relativity from all previous theories of gravity and light."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1915_general_relativity"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6008,
+    "type": "contradiction",
+    "subtype": null,
+    "tail": [6014, 6004],
+    "head": [],
+    "probability": null,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Quantitative contradiction between GR and Newtonian predictions",
+        "content": "General relativity predicts a light deflection of 1.75 arcseconds at the solar limb (node 6014), while the Newtonian corpuscular calculation by Soldner predicts 0.87 arcseconds (node 6004). These predictions differ by exactly a factor of two and are mutually exclusive: if observations match one value, they cannot match the other within reasonable experimental uncertainty. The disagreement arises because the Newtonian calculation accounts only for the gravitational potential (equivalent to time dilation), whereas GR adds an equal contribution from the curvature of space itself."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1915_general_relativity"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6009,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6012],
+    "head": [6015],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Mercury's anomalous precession",
+        "content": "Newtonian celestial mechanics, accounting for perturbations from all known planets, predicted Mercury's orbital precession but left an unexplained residual of approximately 43 arcseconds per century. This anomaly had been known since Le Verrier's analysis in 1859 and resisted all Newtonian explanations."
+      },
+      {
+        "title": "GR calculation",
+        "content": "Einstein applied the general-relativistic equations of motion in the Schwarzschild metric to Mercury's orbit (node 6012). The additional precession due to spacetime curvature is $\\Delta\\phi = 6\\pi GM/(a(1-e^2)c^2)$ per orbit, which sums to approximately 43 arcseconds per century for Mercury's orbital parameters."
+      },
+      {
+        "title": "Resolution without free parameters",
+        "content": "This exact agreement between GR's prediction and the observed anomaly, achieved without any adjustable parameters, provided the first empirical confirmation of general relativity (node 6015). Einstein later described this calculation as giving him heart palpitations."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1915_general_relativity"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6010,
+    "type": "abstraction",
+    "subtype": null,
+    "tail": [6008, 6015, 6016],
+    "head": [6012],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Multiple independent successes strengthen GR",
+        "content": "General relativity (node 6012) is supported by multiple independent lines of evidence: it correctly explains Mercury's anomalous perihelion precession of 43 arcsec/century (node 6015), it subsumes the equivalence principle as a rigorous local limit (node 6016), and the contradiction between its 1.75-arcsecond prediction and the Newtonian 0.87-arcsecond prediction (node 6008) provides a decisive experimental test."
+      },
+      {
+        "title": "Convergent validation",
+        "content": "These successes span different physical regimes: Mercury's precession tests GR in the slow-motion, weak-field orbital regime; light deflection tests it in the massless, relativistic-speed regime; and the equivalence principle correspondence confirms the theory's internal consistency. This convergence across independent phenomena greatly strengthens confidence in the general-relativistic framework."
+      }
+    ],
+    "metadata": {
+      "package": "einstein1915_general_relativity"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6011,
+    "type": "paper-extract",
+    "subtype": null,
+    "tail": [6017, 6018],
+    "head": [6019],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Eclipse observation design",
+        "content": "Eddington's expedition (node 6017) was specifically designed to distinguish between the GR prediction (1.75 arcseconds) and the Newtonian prediction (0.87 arcseconds) by measuring the apparent displacement of stars near the solar limb during totality."
+      },
+      {
+        "title": "Comparison with predictions",
+        "content": "The measured deflections (node 6018) — $1.61 \\pm 0.30''$ at Sobral and $1.98 \\pm 0.16''$ at Principe — were compared against both theoretical predictions. The GR prediction of 1.75 arcseconds lies within the error bars of both measurements. The Newtonian prediction of 0.87 arcseconds lies well outside the error bars of both measurements."
+      },
+      {
+        "title": "Statistical assessment",
+        "content": "The observations are statistically consistent with GR and statistically inconsistent with the Newtonian value (node 6019), providing a clear discriminating test between the two theories."
+      }
+    ],
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6012,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6019, 6014],
+    "head": [6020],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Observation matches GR prediction",
+        "content": "The observed deflection values (node 6019) are consistent with the general-relativistic prediction of 1.75 arcseconds (node 6014). Both independent measurements (Sobral and Principe) agree with the GR value within their stated uncertainties."
+      },
+      {
+        "title": "Combined with prior success",
+        "content": "The eclipse confirmation adds to GR's prior success with Mercury's perihelion precession. Two independent, quantitative predictions of general relativity — in different physical regimes — have now been confirmed observationally."
+      },
+      {
+        "title": "Conclusion: GR confirmed",
+        "content": "The agreement between observation and prediction, combined with the simultaneous falsification of the competing Newtonian prediction, establishes general relativity as the confirmed, superior theory of gravity (node 6020)."
+      }
+    ],
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6013,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6019, 6004],
+    "head": [6021],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Observation contradicts Newtonian prediction",
+        "content": "The observed deflection values (node 6019) are inconsistent with Soldner's Newtonian prediction of 0.87 arcseconds (node 6004). The Sobral measurement exceeds the Newtonian value by 2.5 sigma, and the Principe measurement exceeds it by nearly 7 sigma."
+      },
+      {
+        "title": "Newtonian gravity is incomplete",
+        "content": "The failure of the Newtonian prediction demonstrates that Newton's $F = GMm/r^2$ does not give the correct description of how light propagates in a gravitational field. The missing spatial curvature contribution shows that Newtonian gravity is fundamentally incomplete, even though it remains an excellent approximation in many regimes."
+      },
+      {
+        "title": "Demotion to approximate theory",
+        "content": "Newtonian gravity is thus demoted from a candidate fundamental theory to an approximate limit of general relativity (node 6021), valid in the weak-field, low-velocity regime but quantitatively wrong when spatial curvature effects are significant."
+      }
+    ],
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6014,
+    "type": "contradiction",
+    "subtype": null,
+    "tail": [6019, 6004],
+    "head": [],
+    "probability": null,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Observational refutation of Newtonian prediction",
+        "content": "The 1919 eclipse observations (node 6019) measured deflections of $1.61 \\pm 0.30''$ (Sobral) and $1.98 \\pm 0.16''$ (Principe), while Soldner's Newtonian prediction (node 6004) was 0.87 arcseconds. The observed values are approximately twice the Newtonian prediction and inconsistent with it at high statistical significance. This constitutes an empirical contradiction between observation and the Newtonian theoretical prediction."
+      }
+    ],
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6015,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [6021, 6020],
+    "head": [6022],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Combining the two conclusions",
+        "content": "General relativity has been confirmed as the superior theory of gravity (node 6020), and Newtonian gravity has been demoted to an approximate theory (node 6021). Together, these imply that any prediction based solely on Newtonian mechanics — or on the equivalence principle alone without full spacetime curvature — is inadequate for quantitative predictions of light deflection."
+      },
+      {
+        "title": "Specific invalidation",
+        "content": "The 0.87-arcsecond prediction shared by Soldner (1801) and Einstein (1911) is definitively ruled out by the 1919 observations (node 6022). The Soldner calculation is invalidated because the corpuscular theory gives only half the correct answer; the Einstein 1911 calculation is invalidated because the equivalence principle alone, without spacetime curvature, also gives only half the correct answer."
+      },
+      {
+        "title": "Retrospective significance",
+        "content": "The fact that both the Newtonian and the early Einsteinian calculation gave the same wrong answer (0.87 arcseconds) highlights that only the full general-relativistic framework — incorporating spatial curvature in addition to temporal curvature — yields the correct prediction."
+      }
+    ],
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  }
+]

--- a/tests/fixtures/examples/einstein_elevator/manifest.json
+++ b/tests/fixtures/examples/einstein_elevator/manifest.json
@@ -1,0 +1,77 @@
+{
+  "name": "einstein_elevator",
+  "title": "Einstein's Elevator Thought Experiment",
+  "description": "Models the reasoning chain from Einstein's 1907 elevator thought experiment through the development of general relativity to its 1919 observational confirmation. The hypergraph traces how established Newtonian physics and the empirical equality of inertial and gravitational mass (Eotvos) led Einstein to the equivalence principle, which predicted light bending in gravitational fields. The chain follows Einstein's initial 1911 prediction (which matched Soldner's earlier Newtonian result), through the full general-relativistic prediction of double the deflection (1.75 vs 0.87 arcseconds), to Eddington's decisive 1919 solar eclipse observations that confirmed GR and demoted Newtonian gravity to an approximate theory. Key features include a quantitative contradiction between GR and Newtonian predictions, an observational contradiction that resolves in GR's favor, and the progressive belief update from prior knowledge through theory development to experimental confirmation.",
+  "packages": [
+    {
+      "name": "prior_knowledge",
+      "order": 1,
+      "description": "Established physics before Einstein: Newton's mechanics and gravitation, the corpuscular theory of light, Soldner's Newtonian light deflection calculation, Maxwell's electromagnetism, and the Eotvos experiment establishing the equality of inertial and gravitational mass.",
+      "node_ids": [6001, 6002, 6003, 6004, 6005, 6006],
+      "edge_ids": [6001],
+      "depends_on": []
+    },
+    {
+      "name": "einstein1907_equivalence_principle",
+      "order": 2,
+      "description": "Einstein's 1907 elevator thought experiment and its consequences: the equivalence principle (gravitational and inertial effects are locally indistinguishable) and the deduction that light must bend in a gravitational field.",
+      "node_ids": [6007, 6008, 6009],
+      "edge_ids": [6002, 6003],
+      "depends_on": ["prior_knowledge"]
+    },
+    {
+      "name": "einstein1911_light_deflection",
+      "order": 3,
+      "description": "Einstein's first quantitative prediction of light deflection (1911): 0.87 arcseconds at the solar limb, derived from the equivalence principle alone. Notable for matching Soldner's 1801 Newtonian result exactly, despite completely different theoretical foundations.",
+      "node_ids": [6010, 6011],
+      "edge_ids": [6004, 6005],
+      "depends_on": ["einstein1907_equivalence_principle"]
+    },
+    {
+      "name": "einstein1915_general_relativity",
+      "order": 4,
+      "description": "Full general relativity (1915) predicts light follows geodesics in curved spacetime, yielding 1.75 arcseconds — exactly double the Newtonian/equivalence-principle value. Introduces a quantitative contradiction between GR and Newton, explains Mercury's perihelion precession, and subsumes the equivalence principle as a local limit.",
+      "node_ids": [6012, 6013, 6014, 6015, 6016],
+      "edge_ids": [6006, 6007, 6008, 6009, 6010],
+      "depends_on": ["einstein1911_light_deflection"]
+    },
+    {
+      "name": "eddington1919_solar_eclipse",
+      "order": 5,
+      "description": "Eddington's 1919 solar eclipse expedition provides the decisive observational test. Measurements of 1.61 and 1.98 arcseconds confirm GR's 1.75-arcsecond prediction, rule out the Newtonian 0.87-arcsecond prediction, and establish general relativity as the superior theory of gravity.",
+      "node_ids": [6017, 6018, 6019, 6020, 6021, 6022],
+      "edge_ids": [6011, 6012, 6013, 6014, 6015],
+      "depends_on": ["einstein1915_general_relativity"]
+    }
+  ],
+  "expected_beliefs": {
+    "after_package": {
+      "prior_knowledge": {
+        "6004": [0.5, 0.7]
+      },
+      "einstein1907_equivalence_principle": {
+        "6008": [0.7, 0.9]
+      },
+      "einstein1911_light_deflection": {
+        "6010": [0.7, 0.85],
+        "6011": [0.8, 0.95]
+      },
+      "einstein1915_general_relativity": {
+        "6014": [0.7, 0.9],
+        "6004": [0.3, 0.6]
+      },
+      "eddington1919_solar_eclipse": {
+        "6020": [0.85, 0.98],
+        "6004": [0.05, 0.25],
+        "6014": [0.85, 0.98]
+      }
+    },
+    "final": {
+      "6004": [0.05, 0.25],
+      "6012": [0.85, 0.98],
+      "6014": [0.85, 0.98],
+      "6020": [0.85, 0.98],
+      "6002": [0.7, 0.9]
+    }
+  }
+}

--- a/tests/fixtures/examples/einstein_elevator/nodes.json
+++ b/tests/fixtures/examples/einstein_elevator/nodes.json
@@ -1,0 +1,369 @@
+[
+  {
+    "id": 6001,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Newton's second law of motion",
+    "content": "Newton's mechanics: the net force acting on a body equals the product of its inertial mass and its acceleration, $F = m_i a$. This law governs all motion in classical mechanics and defines inertial mass $m_i$ as the measure of a body's resistance to acceleration.",
+    "keywords": ["Newton", "classical mechanics", "F=ma", "inertial mass", "second law"],
+    "prior": 0.95,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "prior_knowledge",
+      "source": "Newton, Principia Mathematica, 1687"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6002,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Newton's law of universal gravitation",
+    "content": "Newton's gravity: every pair of massive bodies attracts each other with a force $F = G M m_g / r^2$, where $G$ is the gravitational constant, $M$ and $m_g$ are the gravitational masses of the two bodies, and $r$ is the distance between their centers of mass. Gravitational mass $m_g$ determines the strength of a body's gravitational interaction.",
+    "keywords": ["Newton", "gravity", "universal gravitation", "inverse square law", "gravitational mass"],
+    "prior": 0.95,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "prior_knowledge",
+      "source": "Newton, Principia Mathematica, 1687"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6003,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Corpuscular theory of light",
+    "content": "Corpuscular theory of light: light consists of particles (corpuscles) that possess an effective gravitational mass. Under this hypothesis, light particles follow trajectories governed by Newton's laws and are deflected by gravitational fields just as material bodies are, with the deflection angle depending on the ratio of gravitational acceleration to the speed of light.",
+    "keywords": ["corpuscular theory", "light", "Newton", "particle theory", "gravitational deflection"],
+    "prior": 0.5,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "prior_knowledge",
+      "source": "Newton, Opticks, 1704"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6004,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Soldner's Newtonian light deflection prediction",
+    "content": "Johann Georg von Soldner (1801) calculated the deflection of a light ray passing near a massive body using Newtonian mechanics applied to a corpuscle of light. For a ray grazing the solar limb, Soldner obtained a deflection angle of approximately 0.87 arcseconds ($\\alpha = 2GM / (rc^2) \\approx 0.87''$), treating the light corpuscle as a particle moving at speed $c$ in a hyperbolic orbit around the Sun.",
+    "keywords": ["Soldner", "Newtonian deflection", "light bending", "0.87 arcseconds", "solar limb", "corpuscular"],
+    "prior": 0.6,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "prior_knowledge",
+      "source": "Soldner, Berliner Astronomisches Jahrbuch, 1804 (written 1801)"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6005,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Maxwell's electromagnetic theory of light",
+    "content": "Maxwell's electromagnetism: light is an electromagnetic wave propagating at speed $c = 1/\\sqrt{\\mu_0 \\epsilon_0}$, a universal constant independent of the motion of the source or the observer. The speed of light $c$ is determined solely by the permittivity and permeability of free space, and electromagnetic waves carry energy and momentum but have zero rest mass.",
+    "keywords": ["Maxwell", "electromagnetism", "speed of light", "electromagnetic wave", "constant c"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "prior_knowledge",
+      "source": "Maxwell, A Treatise on Electricity and Magnetism, 1873"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6006,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Eotvos experiment: equivalence of inertial and gravitational mass",
+    "content": "The Eotvos experiment (1885, refined through 1922) demonstrated that inertial mass $m_i$ and gravitational mass $m_g$ are equal to a precision of 1 part in $10^8$. Using a torsion balance, Eotvos compared the ratio $m_g / m_i$ for different materials and found no detectable difference, establishing the empirical foundation for the equivalence of inertial and gravitational mass.",
+    "keywords": ["Eotvos", "torsion balance", "inertial mass", "gravitational mass", "equivalence", "precision measurement"],
+    "prior": 0.95,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "prior_knowledge",
+      "source": "Eotvos, Mathematische und Naturwissenschaftliche Berichte aus Ungarn, 1890"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6007,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Einstein's elevator thought experiment",
+    "content": "Thought experiment (Einstein, 1907): consider an observer enclosed in a windowless elevator. If the elevator is at rest in a uniform gravitational field $g$, the observer feels a downward force $mg$. If the elevator is in free space (no gravity) but accelerating upward at rate $a = g$, the observer feels an identical downward pseudo-force $ma$. No mechanical experiment performed inside the closed elevator can distinguish between these two situations. This operational indistinguishability of gravitational and inertial effects is the conceptual core of what became the equivalence principle.",
+    "keywords": ["Einstein", "elevator", "thought experiment", "gravity", "acceleration", "indistinguishable", "equivalence principle"],
+    "prior": 1.0,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1907_equivalence_principle",
+      "source": "Einstein, Jahrbuch der Radioaktivitat und Elektronik, 1907"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6008,
+    "type": "conjecture",
+    "subtype": null,
+    "title": "The equivalence principle",
+    "content": "Equivalence principle (Einstein, 1907): gravitational and inertial effects are locally indistinguishable. In any sufficiently small region of spacetime, the effects of a gravitational field are identical to the effects of an accelerated reference frame. No local experiment can distinguish between a uniform gravitational field and a uniformly accelerated frame. This principle elevates the empirical equality of inertial and gravitational mass (Eotvos) from a numerical coincidence to a fundamental law of nature.",
+    "keywords": ["equivalence principle", "Einstein", "gravity", "acceleration", "local indistinguishability", "fundamental principle"],
+    "prior": 0.85,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1907_equivalence_principle",
+      "source": "Einstein, Jahrbuch der Radioaktivitat und Elektronik, 1907"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6009,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Light must bend in a gravitational field",
+    "content": "Corollary of the equivalence principle: in an elevator accelerating upward, a horizontal beam of light enters one wall and, because the elevator has moved upward during the light's transit, strikes the opposite wall at a lower point. The observer inside sees the light path curve downward. By the equivalence principle, the same bending must occur in a gravitational field. Therefore, light must follow a curved path in the presence of gravity, regardless of whether light has rest mass. This argument applies to electromagnetic waves (Maxwell's theory) and does not require the corpuscular hypothesis.",
+    "keywords": ["light bending", "equivalence principle", "gravitational deflection", "electromagnetic wave", "curved path"],
+    "prior": 0.85,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1907_equivalence_principle",
+      "source": "Einstein, Jahrbuch der Radioaktivitat und Elektronik, 1907"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6010,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Einstein's 1911 light deflection prediction",
+    "content": "Einstein (1911) published the first quantitative prediction of gravitational light deflection based on the equivalence principle. For a light ray grazing the solar limb, he calculated a deflection of approximately 0.87 arcseconds. This calculation used only the equivalence principle in flat (Minkowski) spacetime and did not account for spacetime curvature; it treated the gravitational field as equivalent to an accelerating frame but did not incorporate the full geometric effects of curved spacetime.",
+    "keywords": ["Einstein", "1911", "light deflection", "0.87 arcseconds", "equivalence principle", "solar limb"],
+    "prior": 0.8,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1911_light_deflection",
+      "source": "Einstein, Annalen der Physik, 1911, 'On the Influence of Gravitation on the Propagation of Light'"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6011,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Einstein 1911 prediction matches Soldner's Newtonian result",
+    "content": "Einstein's 1911 equivalence-principle-based prediction of 0.87 arcseconds for light deflection at the solar limb is numerically identical to Soldner's 1801 Newtonian corpuscular calculation. Despite arising from completely different theoretical frameworks (Newtonian corpuscular mechanics vs. the equivalence principle applied to electromagnetic waves), both approaches yield the same deflection angle $\\alpha = 2GM/(rc^2)$. This coincidence occurs because both calculations account only for the gravitational time dilation (or equivalently, the Newtonian potential) and miss the spatial curvature contribution that would later emerge from full general relativity.",
+    "keywords": ["Einstein", "Soldner", "0.87 arcseconds", "numerical coincidence", "equivalence principle", "Newtonian", "partial calculation"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1911_light_deflection"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6012,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "General relativity: Einstein field equations",
+    "content": "General relativity (Einstein, 1915): mass-energy curves spacetime, and the geometry of spacetime is described by the Einstein field equations $G_{\\mu\\nu} + \\Lambda g_{\\mu\\nu} = (8\\pi G / c^4) T_{\\mu\\nu}$, where $G_{\\mu\\nu}$ is the Einstein tensor encoding spacetime curvature, $g_{\\mu\\nu}$ is the metric tensor, $T_{\\mu\\nu}$ is the stress-energy tensor describing matter and energy content, $\\Lambda$ is the cosmological constant, $G$ is Newton's gravitational constant, and $c$ is the speed of light. Gravity is not a force but a manifestation of spacetime curvature caused by mass-energy.",
+    "keywords": ["general relativity", "Einstein field equations", "spacetime curvature", "metric tensor", "stress-energy tensor", "gravity as geometry"],
+    "prior": 0.85,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1915_general_relativity",
+      "source": "Einstein, Sitzungsberichte der Preussischen Akademie der Wissenschaften, 1915"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6013,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Light follows geodesics in curved spacetime",
+    "content": "In general relativity, light (and all massless particles) travels along null geodesics — the straightest possible paths through curved spacetime. Near a massive body such as the Sun, spacetime curvature deflects these geodesics, causing light rays to bend. The geodesic equation in the Schwarzschild metric yields both the temporal component (gravitational time dilation, equivalent to the equivalence principle prediction) and the spatial component (curvature of space itself), producing a total deflection that is exactly twice the equivalence-principle-only result.",
+    "keywords": ["geodesics", "null geodesics", "curved spacetime", "light propagation", "Schwarzschild metric", "spatial curvature"],
+    "prior": 0.85,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1915_general_relativity"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6014,
+    "type": "deduction",
+    "subtype": null,
+    "title": "GR prediction: 1.75 arcseconds deflection at solar limb",
+    "content": "The full general-relativistic calculation of light deflection near the Sun yields a deflection angle of $\\alpha = 4GM/(rc^2) \\approx 1.75$ arcseconds for a ray grazing the solar limb. This is exactly double the Newtonian/equivalence-principle prediction of 0.87 arcseconds. The additional factor of two arises from the contribution of spatial curvature: the equivalence principle captures only the effect of gravitational time dilation (the $g_{00}$ component of the metric), while general relativity adds an equal contribution from the curvature of space (the $g_{rr}$ component).",
+    "keywords": ["1.75 arcseconds", "light deflection", "general relativity", "double deflection", "spatial curvature", "Schwarzschild"],
+    "prior": 0.85,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1915_general_relativity",
+      "source": "Einstein, Sitzungsberichte der Preussischen Akademie der Wissenschaften, 1915"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6015,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "GR explains Mercury's perihelion precession",
+    "content": "General relativity explains the anomalous precession of Mercury's perihelion. Newtonian gravity predicts a precession due to perturbations from other planets, but observations show an excess precession of approximately 43 arcseconds per century that cannot be accounted for by Newtonian mechanics. Einstein's field equations applied to Mercury's orbit in the Schwarzschild metric yield an additional precession of exactly 43 arcseconds per century, resolving a 60-year-old anomaly in celestial mechanics without any free parameters.",
+    "keywords": ["Mercury", "perihelion precession", "43 arcseconds", "anomaly", "general relativity", "Schwarzschild"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1915_general_relativity",
+      "source": "Einstein, Sitzungsberichte der Preussischen Akademie der Wissenschaften, 1915"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6016,
+    "type": "deduction",
+    "subtype": null,
+    "title": "GR subsumes the equivalence principle as a local limit",
+    "content": "General relativity subsumes the equivalence principle as its local (infinitesimal) limit. In GR, at any point in spacetime one can choose a locally inertial (freely falling) reference frame in which the metric is Minkowskian and the Christoffel symbols vanish — reproducing the equivalence principle's assertion that gravity is locally indistinguishable from acceleration. The equivalence principle is thus not abandoned but incorporated as the foundational local constraint from which the global geometric theory is constructed.",
+    "keywords": ["equivalence principle", "local limit", "general relativity", "freely falling frame", "Minkowski", "Christoffel symbols"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "einstein1915_general_relativity"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6017,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Eddington's 1919 solar eclipse expedition",
+    "content": "Arthur Eddington organized two expeditions to observe the total solar eclipse of May 29, 1919, with the specific goal of measuring the gravitational deflection of starlight passing near the Sun. One team traveled to Sobral, Brazil, and another to the island of Principe off the west coast of Africa. The eclipse provided the opportunity to photograph stars near the solar limb, whose apparent positions could be compared with their known positions when the Sun is elsewhere in the sky.",
+    "keywords": ["Eddington", "solar eclipse", "1919", "Sobral", "Principe", "light deflection", "expedition"],
+    "prior": 0.95,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "eddington1919_solar_eclipse",
+      "source": "Dyson, Eddington, Davidson, Phil. Trans. Royal Society A, 1920"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6018,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Measured light deflection from 1919 eclipse",
+    "content": "The 1919 eclipse observations yielded two independent measurements of the gravitational deflection of starlight at the solar limb: the Sobral station measured a deflection of $1.61 \\pm 0.30$ arcseconds, and the Principe station measured $1.98 \\pm 0.16$ arcseconds (after correction for systematic effects). Both measurements are consistent with the general-relativistic prediction of 1.75 arcseconds and inconsistent with the Newtonian prediction of 0.87 arcseconds at the reported confidence levels.",
+    "keywords": ["1919 eclipse", "measured deflection", "1.61 arcseconds", "1.98 arcseconds", "Sobral", "Principe", "observation"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "eddington1919_solar_eclipse",
+      "source": "Dyson, Eddington, Davidson, Phil. Trans. Royal Society A, 1920"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6019,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Observation consistent with GR, inconsistent with Newton",
+    "content": "The observed deflection values ($1.61 \\pm 0.30''$ from Sobral and $1.98 \\pm 0.16''$ from Principe) are consistent with the general-relativistic prediction of 1.75 arcseconds: both measurements fall within their respective error bars of the GR value. Simultaneously, both measurements are inconsistent with the Newtonian/equivalence-principle prediction of 0.87 arcseconds: the Sobral result exceeds the Newtonian value by 2.5 standard deviations, and the Principe result exceeds it by nearly 7 standard deviations.",
+    "keywords": ["observation", "GR prediction", "Newtonian prediction", "consistency", "statistical significance", "light deflection"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6020,
+    "type": "deduction",
+    "subtype": null,
+    "title": "General relativity confirmed as superior theory of gravity",
+    "content": "The 1919 eclipse observations confirmed general relativity as the superior theory of gravity over Newtonian mechanics. GR's prediction of 1.75 arcseconds matched the observations, while Newton's prediction of 0.87 arcseconds was ruled out. Combined with GR's prior success in explaining Mercury's perihelion precession (43 arcsec/century) without free parameters, the eclipse results established general relativity as the correct description of gravitation, instantly making Einstein world-famous and fundamentally changing physics.",
+    "keywords": ["general relativity", "confirmed", "superior theory", "gravity", "eclipse", "Einstein"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6021,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Newtonian gravity demoted to approximate theory",
+    "content": "The 1919 eclipse observations, by ruling out the Newtonian deflection prediction of 0.87 arcseconds in favor of the general-relativistic 1.75 arcseconds, demonstrated that Newtonian gravity is fundamentally incomplete. Newton's $F = GMm/r^2$ remains an excellent approximation in weak gravitational fields and at low velocities (the Newtonian limit of GR), but it fails quantitatively when spatial curvature contributes significantly, as in light deflection near massive bodies. Newtonian gravity is thus demoted from a fundamental theory to an approximate limit of general relativity.",
+    "keywords": ["Newtonian gravity", "demoted", "approximate", "incomplete", "Newtonian limit", "light deflection"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 6022,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Soldner/Einstein 1911 prediction ruled out by observation",
+    "content": "The 1919 eclipse measurements definitively ruled out the 0.87-arcsecond deflection prediction shared by Soldner's Newtonian corpuscular calculation (1801) and Einstein's equivalence-principle-only calculation (1911). Both predictions captured only the gravitational time dilation contribution to light bending and missed the equal contribution from spatial curvature. The observational refutation of the 0.87-arcsecond value simultaneously invalidated the corpuscular approach to light deflection and demonstrated the insufficiency of the equivalence principle alone (without full spacetime curvature) for quantitative predictions.",
+    "keywords": ["Soldner", "Einstein 1911", "0.87 arcseconds", "ruled out", "refuted", "observation", "spatial curvature"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "eddington1919_solar_eclipse"
+    },
+    "extra": {},
+    "created_at": null
+  }
+]

--- a/tests/fixtures/examples/galileo_tied_balls/edges.json
+++ b/tests/fixtures/examples/galileo_tied_balls/edges.json
@@ -1,0 +1,355 @@
+[
+  {
+    "id": 5001,
+    "type": "abstraction",
+    "subtype": null,
+    "tail": [5001, 5002],
+    "head": [5003],
+    "probability": 0.7,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Aristotle's qualitative doctrine",
+        "content": "Aristotle's natural motion doctrine (node 5001) asserts that heavier bodies fall faster because they have a greater tendency toward their natural place. This is a qualitative claim: weight determines fall speed."
+      },
+      {
+        "title": "Supporting empirical evidence",
+        "content": "Everyday observations (node 5002) appear to confirm this: stones fall faster than leaves, cannonballs faster than feathers. These observations provide empirical grounding for the qualitative doctrine."
+      },
+      {
+        "title": "Abstraction to quantitative law",
+        "content": "Generalizing from the qualitative doctrine and the supporting observations, we extract the specific quantitative claim: the speed of fall v is directly proportional to the weight W of the falling body (v = k * W). This is Aristotle's law of falling bodies in its strongest, most falsifiable form."
+      }
+    ],
+    "metadata": {
+      "package": "aristotle_physics"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5002,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [5003, 5004],
+    "head": [5005],
+    "probability": 1.0,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Setup: two bodies tied together",
+        "content": "Consider Galileo's thought experiment (node 5004): a heavy cannonball (weight W_H, speed v_H) is tied to a light musket ball (weight W_L, speed v_L), with v_H > v_L by Aristotle's law (node 5003)."
+      },
+      {
+        "title": "Apply the retardation argument",
+        "content": "The light ball, whose natural speed is v_L < v_H, acts as a drag on the heavy ball. It tries to fall at its own slower speed, pulling back on the heavy ball. Conversely, the heavy ball tries to speed up the light ball. The result is that the combined system falls at some intermediate speed v_combined, where v_L < v_combined < v_H."
+      },
+      {
+        "title": "Conclusion: combined system is slower",
+        "content": "Therefore v_combined < v_H: the combined system falls SLOWER than the heavy ball alone. This follows deductively from Aristotle's law applied to interacting bodies of different natural speeds."
+      }
+    ],
+    "metadata": {
+      "package": "galileo1638_tied_balls"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5003,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [5003, 5004],
+    "head": [5006],
+    "probability": 1.0,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Setup: combined weight of tied system",
+        "content": "The same thought experiment (node 5004): the heavy ball (W_H) and light ball (W_L) are tied together. The total weight of the combined system is W_total = W_H + W_L."
+      },
+      {
+        "title": "Apply Aristotle's law to total weight",
+        "content": "By Aristotle's law (node 5003), speed is proportional to weight: v = k * W. Therefore the combined system's speed is v(W_total) = k * (W_H + W_L) = k * W_H + k * W_L = v_H + v_L."
+      },
+      {
+        "title": "Conclusion: combined system is faster",
+        "content": "Since W_total = W_H + W_L > W_H, it follows that v(W_total) > v(W_H) = v_H: the combined system falls FASTER than the heavy ball alone. This follows deductively from Aristotle's law applied to the combined system treated as a single body."
+      }
+    ],
+    "metadata": {
+      "package": "galileo1638_tied_balls"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5004,
+    "type": "contradiction",
+    "subtype": null,
+    "tail": [5005, 5006],
+    "head": [],
+    "probability": null,
+    "verified": false,
+    "reasoning": [
+      "Deduction A (node 5005) concludes v_combined < v_H (the tied system falls slower than the heavy ball alone). Deduction B (node 5006) concludes v_combined > v_H (the tied system falls faster than the heavy ball alone). These two conclusions are mutually exclusive: the same physical system cannot simultaneously fall both faster and slower than the heavy ball. Both deductions follow validly from the same premise (Aristotle's law, node 5003) applied to the same physical setup (Galileo's tied balls, node 5004). This constitutes a formal contradiction within the Aristotelian framework."
+    ],
+    "metadata": {
+      "package": "galileo1638_tied_balls",
+      "source": "reductio_ad_absurdum",
+      "contradicts_premise": 5003
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5005,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [5007],
+    "head": [5008],
+    "probability": 1.0,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Contradiction identified",
+        "content": "Node 5007 establishes that Aristotle's law leads to a logical contradiction: the same tied-ball system must fall both faster and slower than the heavy ball alone."
+      },
+      {
+        "title": "Reductio ad absurdum",
+        "content": "By the principle of reductio ad absurdum, if an assumption leads to a contradiction, the assumption must be false. The only assumption employed in both deductions is Aristotle's law (v proportional to W)."
+      },
+      {
+        "title": "Conclusion: the law is self-contradictory",
+        "content": "Therefore Aristotle's law is self-contradictory and must be rejected. This is a purely logical refutation that requires no experimental evidence whatsoever — the law fails on its own internal terms."
+      }
+    ],
+    "metadata": {
+      "package": "galileo1638_tied_balls"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5006,
+    "type": "induction",
+    "subtype": null,
+    "tail": [5009, 5010],
+    "head": [5011],
+    "probability": 0.8,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Pattern in dense media",
+        "content": "Node 5009 reports that fall speed differences between heavy and light objects are much more pronounced in dense media (water, honey) than in thin media (air)."
+      },
+      {
+        "title": "Trend toward convergence",
+        "content": "Node 5010 notes that as medium density decreases, the speed difference systematically decreases. Extrapolating: in a medium of zero density (vacuum), the difference should vanish entirely."
+      },
+      {
+        "title": "Inductive conclusion",
+        "content": "The most parsimonious explanation is that the medium's resistance is the confounding variable. Heavy objects have a more favorable weight-to-drag ratio, giving them a speed advantage that shrinks as drag diminishes. If drag is removed entirely (vacuum), the advantage disappears. Therefore weight alone does not determine fall speed — air resistance is the true cause of the observed differences."
+      }
+    ],
+    "metadata": {
+      "package": "galileo1638_medium_density"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5007,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [5011, 5008],
+    "head": [5012],
+    "probability": 0.85,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Logical refutation of Aristotle",
+        "content": "Node 5008 establishes that Aristotle's law (v proportional to W) is self-contradictory and therefore false."
+      },
+      {
+        "title": "Air resistance as confound",
+        "content": "Node 5011 provides the explanation: observed speed differences between heavy and light objects are caused by medium resistance, not by intrinsic weight-speed proportionality."
+      },
+      {
+        "title": "Vacuum prediction",
+        "content": "Combining both results: since (a) Aristotle's law is logically false, and (b) the observed speed differences are entirely attributable to medium resistance, it follows that in a vacuum (zero medium resistance) all objects must fall at the same rate regardless of weight. This is a deductive prediction that can in principle be tested experimentally."
+      }
+    ],
+    "metadata": {
+      "package": "galileo1638_vacuum_prediction"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5008,
+    "type": "paper-extract",
+    "subtype": null,
+    "tail": [5013],
+    "head": [5014],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Inclined plane methodology",
+        "content": "Galileo's inclined plane experiments (node 5013) use smooth planes to slow effective gravitational acceleration, making precise timing possible with period water clocks."
+      },
+      {
+        "title": "Experimental result",
+        "content": "Bronze balls of different weights released simultaneously from the top of the same inclined plane arrive at the bottom at the same time. The distance-time relationship d proportional to t^2 holds independent of ball weight."
+      },
+      {
+        "title": "Interpretation",
+        "content": "Since the inclined plane reduces air resistance effects (dense bronze balls, moderate speeds) while preserving the gravitational-to-inertial mass ratio, these experiments confirm that acceleration is independent of weight. This provides direct experimental evidence supporting the equal-fall-rate prediction for vacuum conditions."
+      }
+    ],
+    "metadata": {
+      "package": "galileo1638_vacuum_prediction"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5009,
+    "type": "abstraction",
+    "subtype": null,
+    "tail": [5012, 5014],
+    "head": [5012],
+    "probability": 0.9,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Theoretical prediction",
+        "content": "Node 5012 predicts that in vacuum all objects fall at the same rate, derived from the logical refutation of Aristotle's law and the air-resistance hypothesis."
+      },
+      {
+        "title": "Experimental confirmation",
+        "content": "Node 5014 reports that inclined plane experiments confirm weight-independent acceleration under conditions that minimize air resistance."
+      },
+      {
+        "title": "Reinforcement",
+        "content": "The experimental confirmation (node 5014) strengthens the vacuum prediction (node 5012) by providing independent empirical evidence for the same conclusion reached by logical argument. This is a self-reinforcing edge: evidence converges on and increases confidence in the prediction."
+      }
+    ],
+    "metadata": {
+      "package": "galileo1638_vacuum_prediction",
+      "self_reinforcing": true
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5010,
+    "type": "deduction",
+    "subtype": null,
+    "tail": [5015, 5016],
+    "head": [5017],
+    "probability": 0.95,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Newton's second law",
+        "content": "From node 5015: F = ma relates force, mass, and acceleration for any body."
+      },
+      {
+        "title": "Gravitational force law",
+        "content": "From node 5016: the gravitational force on a body of mass m near Earth's surface is F = mg, where g is the local gravitational acceleration constant."
+      },
+      {
+        "title": "Algebraic derivation",
+        "content": "Setting the gravitational force equal to mass times acceleration: mg = ma. Dividing both sides by m (valid for any m > 0): g = a. Therefore a = g: the acceleration of any freely falling body equals g, completely independent of the body's mass. The mass cancels algebraically, providing a rigorous theoretical foundation for Galileo's empirical finding."
+      }
+    ],
+    "metadata": {
+      "package": "newton1687_principia"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5011,
+    "type": "contradiction",
+    "subtype": null,
+    "tail": [5003, 5017],
+    "head": [],
+    "probability": null,
+    "verified": false,
+    "reasoning": [
+      "Aristotle's law (node 5003) asserts v proportional to W: heavier bodies fall faster in direct proportion to their weight. Newton's derivation (node 5017) proves a = g: all bodies experience the same gravitational acceleration regardless of mass. These two claims are logically incompatible. If a = g is constant for all masses, then speed of fall (in vacuum) is identical for all objects, directly contradicting v proportional to W. Newton's framework, grounded in the equivalence of inertial and gravitational mass, provides a rigorous theoretical basis for rejecting Aristotle's proportionality law."
+    ],
+    "metadata": {
+      "package": "newton1687_principia",
+      "source": "theoretical_derivation",
+      "contradicts_premise": 5003
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5012,
+    "type": "paper-extract",
+    "subtype": null,
+    "tail": [5018, 5019],
+    "head": [5020],
+    "probability": 0.99,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Experimental setup",
+        "content": "On the lunar surface (node 5018), astronaut David Scott held a 1.32 kg hammer and a 0.03 kg feather at the same height — a mass ratio of 44:1. The Moon's surface is a natural vacuum (pressure < 3 x 10^-15 atm), eliminating the air resistance confound entirely."
+      },
+      {
+        "title": "Observation",
+        "content": "Upon simultaneous release (node 5019), both objects fell side by side and struck the lunar soil at the same instant. This was recorded on television and witnessed worldwide."
+      },
+      {
+        "title": "Conclusion",
+        "content": "The hammer and feather, despite a 44-fold mass difference, experienced identical gravitational acceleration in the lunar vacuum. This directly confirms that fall rate in vacuum is independent of mass, as predicted by Galileo (1638) and derived by Newton (1687)."
+      }
+    ],
+    "metadata": {
+      "package": "apollo15_1971_feather_drop"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5013,
+    "type": "abstraction",
+    "subtype": null,
+    "tail": [5020, 5017, 5012],
+    "head": [5020],
+    "probability": 0.99,
+    "verified": false,
+    "reasoning": [
+      {
+        "title": "Line 1: Apollo 15 experiment",
+        "content": "Node 5020 reports the direct experimental observation: a hammer and feather fall at the same rate in the lunar vacuum, confirming mass-independent free fall."
+      },
+      {
+        "title": "Line 2: Newtonian derivation",
+        "content": "Node 5017 provides the theoretical derivation: from F = ma and F = mg, mass cancels to yield a = g, proving that gravitational acceleration is mass-independent."
+      },
+      {
+        "title": "Line 3: Galileo's prediction",
+        "content": "Node 5012 records Galileo's 1638 prediction, derived from the tied-balls paradox and medium-density observations, that all objects fall at the same rate in vacuum."
+      },
+      {
+        "title": "Convergence of evidence",
+        "content": "Three independent lines of evidence — logical argument (Galileo, 1638), theoretical derivation (Newton, 1687), and direct experimental confirmation (Apollo 15, 1971) — all converge on the same conclusion: free fall acceleration is independent of mass. This convergence from different epistemic methods (logic, theory, experiment) spanning 333 years provides overwhelming support for the universality of free fall."
+      }
+    ],
+    "metadata": {
+      "package": "apollo15_1971_feather_drop",
+      "convergence": true,
+      "lines_of_evidence": 3
+    },
+    "extra": {},
+    "created_at": null
+  }
+]

--- a/tests/fixtures/examples/galileo_tied_balls/manifest.json
+++ b/tests/fixtures/examples/galileo_tied_balls/manifest.json
@@ -1,0 +1,86 @@
+{
+  "name": "galileo_tied_balls",
+  "title": "Galileo's Tied Balls Thought Experiment",
+  "description": "Models the complete epistemic arc from Aristotle's 'heavier falls faster' doctrine through Galileo's 1638 tied-balls reductio ad absurdum, medium-density observations, vacuum prediction, Newton's 1687 theoretical derivation (a = g), to the definitive Apollo 15 hammer-and-feather experiment (1971). Demonstrates how a knowledge hypergraph represents logical refutation (contradiction edges), inductive reasoning, deductive derivation, self-reinforcing evidence loops, and multi-line convergence across 2300 years of physics.",
+  "packages": [
+    {
+      "name": "aristotle_physics",
+      "order": 1,
+      "description": "Aristotle's natural motion doctrine and the everyday observations that supported it for nearly two millennia. Establishes the prior knowledge: heavier objects fall faster, formalized as v proportional to W.",
+      "node_ids": [5001, 5002, 5003],
+      "edge_ids": [5001],
+      "depends_on": []
+    },
+    {
+      "name": "galileo1638_tied_balls",
+      "order": 2,
+      "description": "Galileo's tied-balls thought experiment from Discorsi (1638). By tying a heavy and light ball together, Aristotle's law generates two contradictory predictions (the combined system falls both faster and slower), proving the law self-contradictory by reductio ad absurdum.",
+      "node_ids": [5004, 5005, 5006, 5007, 5008],
+      "edge_ids": [5002, 5003, 5004, 5005],
+      "depends_on": ["aristotle_physics"]
+    },
+    {
+      "name": "galileo1638_medium_density",
+      "order": 3,
+      "description": "Galileo's observations that fall-speed differences diminish in less dense media, leading to the hypothesis that air resistance — not weight — is the true cause of observed speed differences between heavy and light objects.",
+      "node_ids": [5009, 5010, 5011],
+      "edge_ids": [5006],
+      "depends_on": ["aristotle_physics"]
+    },
+    {
+      "name": "galileo1638_vacuum_prediction",
+      "order": 4,
+      "description": "Combining the logical refutation of Aristotle (tied-balls paradox) with the air-resistance hypothesis yields Galileo's prediction: in vacuum, all objects fall at the same rate. Confirmed partially by inclined-plane experiments.",
+      "node_ids": [5012, 5013, 5014],
+      "edge_ids": [5007, 5008, 5009],
+      "depends_on": ["galileo1638_tied_balls", "galileo1638_medium_density"]
+    },
+    {
+      "name": "newton1687_principia",
+      "order": 5,
+      "description": "Newton's theoretical derivation from F = ma and F = mg yields a = g: gravitational acceleration is independent of mass. This provides rigorous theoretical grounding for Galileo's empirical finding and directly contradicts Aristotle's law.",
+      "node_ids": [5015, 5016, 5017],
+      "edge_ids": [5010, 5011],
+      "depends_on": ["aristotle_physics"]
+    },
+    {
+      "name": "apollo15_1971_feather_drop",
+      "order": 6,
+      "description": "The Apollo 15 hammer-and-feather experiment (1971) provides definitive experimental confirmation in a true vacuum. Three independent lines of evidence — Galileo's logic, Newton's theory, and Apollo's experiment — converge on the universality of free fall.",
+      "node_ids": [5018, 5019, 5020],
+      "edge_ids": [5012, 5013],
+      "depends_on": ["galileo1638_vacuum_prediction", "newton1687_principia"]
+    }
+  ],
+  "expected_beliefs": {
+    "after_package": {
+      "aristotle_physics": {
+        "5003": [0.6, 0.8]
+      },
+      "galileo1638_tied_balls": {
+        "5003": [0.2, 0.5],
+        "5008": [0.7, 1.0]
+      },
+      "galileo1638_medium_density": {
+        "5011": [0.6, 0.85]
+      },
+      "galileo1638_vacuum_prediction": {
+        "5012": [0.7, 0.9]
+      },
+      "newton1687_principia": {
+        "5017": [0.85, 0.98],
+        "5003": [0.05, 0.25]
+      },
+      "apollo15_1971_feather_drop": {
+        "5020": [0.9, 1.0],
+        "5003": [0.01, 0.15]
+      }
+    },
+    "final": {
+      "5003": [0.01, 0.15],
+      "5012": [0.85, 1.0],
+      "5017": [0.85, 1.0],
+      "5020": [0.9, 1.0]
+    }
+  }
+}

--- a/tests/fixtures/examples/galileo_tied_balls/nodes.json
+++ b/tests/fixtures/examples/galileo_tied_balls/nodes.json
@@ -1,0 +1,342 @@
+[
+  {
+    "id": 5001,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Aristotle's natural motion doctrine",
+    "content": "In Aristotle's physics (De Caelo, Book I; Physics, Book IV), every terrestrial body possesses a natural tendency to seek its natural place. Heavy bodies (those dominated by the element earth) move downward more vigorously than light ones. Aristotle holds that the speed of natural downward motion is directly related to the body's weight (or more precisely, its heaviness): a body twice as heavy will fall twice as fast through the same medium. This doctrine stood essentially unchallenged for nearly two millennia in Western natural philosophy.",
+    "keywords": ["Aristotle", "natural motion", "De Caelo", "Physics", "heaviness", "fall speed", "natural place", "terrestrial mechanics"],
+    "prior": 0.7,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "aristotle_physics",
+      "source": "Aristotle, De Caelo (~350 BCE); Physics IV.8, 215a-216a"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5002,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Empirical observation: stones fall faster than leaves",
+    "content": "Everyday experience appears to confirm Aristotle's doctrine: a heavy stone dropped from a height reaches the ground noticeably sooner than a light leaf or feather released from the same height at the same instant. Similarly, a cannonball falls much faster than a sheet of paper, and a gold coin falls faster than a wood chip. These commonplace observations provided the empirical foundation that sustained belief in Aristotle's weight-speed proportionality for nearly two thousand years.",
+    "keywords": ["empirical observation", "stone", "leaf", "feather", "fall speed", "everyday experience", "Aristotelian evidence"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "aristotle_physics",
+      "source": "common empirical observation cited in Aristotelian tradition"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5003,
+    "type": "abstraction",
+    "subtype": null,
+    "title": "Aristotle's law: fall speed proportional to weight",
+    "content": "Aristotle's law of falling bodies asserts that the natural speed of fall v of a body is directly proportional to its weight W: v = k * W (for some constant k depending on the medium). Equivalently, if body A weighs twice as much as body B, then A falls twice as fast as B through the same medium. This is a specific quantitative claim extracted from Aristotle's qualitative doctrine and the supporting empirical observations.",
+    "keywords": ["Aristotle's law", "speed proportional to weight", "v proportional to W", "quantitative claim", "falling bodies"],
+    "prior": 0.7,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "aristotle_physics",
+      "source": "abstraction from Aristotle's Physics IV.8"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5004,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Thought experiment: tie a heavy ball to a light ball",
+    "content": "Galileo (Discorsi e Dimostrazioni Matematiche, 1638) proposes the following thought experiment: take a heavy cannonball (weight W_H) and a light musket ball (weight W_L, where W_L < W_H). Now tie them together with a cord to form a single combined system. Assume Aristotle's law holds: the heavy ball falls at speed v_H and the light ball at speed v_L, with v_H > v_L because W_H > W_L. What happens when we drop the combined system?",
+    "keywords": ["Galileo", "thought experiment", "tied balls", "cannonball", "musket ball", "Discorsi", "1638", "reductio ad absurdum"],
+    "prior": 1.0,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_tied_balls",
+      "source": "Galileo Galilei, Discorsi e Dimostrazioni Matematiche, First Day (1638)"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5005,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Deduction A: light ball should slow heavy ball, so combined falls SLOWER",
+    "content": "If Aristotle's law holds, the light ball (natural speed v_L) acts as a drag on the heavy ball (natural speed v_H). Since the light ball 'wants' to fall more slowly, it retards the heavy ball when they are tied together. Therefore the combined system should fall at some intermediate speed v_combined, where v_L < v_combined < v_H. In particular, the combined system falls SLOWER than the heavy ball alone.",
+    "keywords": ["deduction", "retardation", "drag", "slower", "combined system", "intermediate speed", "Aristotle's law applied"],
+    "prior": 1.0,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_tied_balls",
+      "source": "Galileo, Discorsi (1638), First Day — Salviati's first deduction"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5006,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Deduction B: combined system is heavier, so combined falls FASTER",
+    "content": "If Aristotle's law holds, the combined weight of the tied system is W_H + W_L, which is strictly greater than W_H alone. Since speed is proportional to weight, the combined system should fall at speed v(W_H + W_L) > v(W_H) = v_H. Therefore the combined system falls FASTER than the heavy ball alone.",
+    "keywords": ["deduction", "combined weight", "faster", "weight addition", "Aristotle's law applied", "heavier system"],
+    "prior": 1.0,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_tied_balls",
+      "source": "Galileo, Discorsi (1638), First Day — Salviati's second deduction"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5007,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Contradiction: same system cannot fall both faster and slower",
+    "content": "Deductions A and B, both derived from Aristotle's law applied to the same physical setup, yield mutually exclusive predictions. Deduction A concludes: v_combined < v_H (the tied system falls slower than the heavy ball). Deduction B concludes: v_combined > v_H (the tied system falls faster than the heavy ball). Both v_combined < v_H and v_combined > v_H cannot hold simultaneously. This is a logical contradiction derived purely from the assumption that Aristotle's law is correct.",
+    "keywords": ["contradiction", "paradox", "reductio ad absurdum", "mutual exclusion", "logical inconsistency", "Galileo's paradox"],
+    "prior": 1.0,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_tied_balls",
+      "source": "Galileo, Discorsi (1638), First Day — the central paradox"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5008,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Therefore Aristotle's law is self-contradictory",
+    "content": "Since Aristotle's law (v proportional to W) leads to a logical contradiction when applied to the simple case of two bodies tied together, the law must be false by reductio ad absurdum. The only assumption that can be dropped to resolve the paradox is the proportionality v = k * W itself. Galileo concludes that the premise 'heavier bodies fall faster in proportion to their weight' is internally inconsistent and must be rejected on purely logical grounds, independent of any experiment.",
+    "keywords": ["reductio ad absurdum", "Aristotle refuted", "self-contradictory", "logical refutation", "Galileo's conclusion", "law falsified"],
+    "prior": 1.0,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_tied_balls",
+      "source": "Galileo, Discorsi (1638), First Day — Salviati's conclusion"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5009,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Observation: objects fall at different speeds in water vs air",
+    "content": "Galileo observes that the difference in fall speeds between heavy and light objects is much more pronounced in dense media (such as water or honey) than in thin media (such as air). A gold ball and a lead ball released in water show a noticeable speed difference, but the same pair released in air shows a much smaller difference. Furthermore, a gold ball and an inflated bladder differ enormously in water but only moderately in air.",
+    "keywords": ["medium density", "water", "air", "fall speed difference", "dense media", "thin media", "Galileo observation"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_medium_density",
+      "source": "Galileo, Discorsi (1638), First Day — discussion of media effects"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5010,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Observation: speed difference decreases in less dense media",
+    "content": "As the density of the medium decreases, the difference in fall speeds between heavy and light objects of similar size systematically diminishes. Galileo notes that a lead ball and a wooden ball show a larger speed difference in water than in air. Extrapolating this trend to its logical limit, in a medium of zero density (i.e., a vacuum), the speed difference should vanish entirely. This is a crucial empirical pattern that Aristotle's theory cannot explain, since Aristotle's law predicts the same speed ratio regardless of the medium.",
+    "keywords": ["medium density", "extrapolation", "vacuum", "speed convergence", "decreasing difference", "Galileo observation", "trend"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_medium_density",
+      "source": "Galileo, Discorsi (1638), First Day — extrapolation to void"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5011,
+    "type": "conjecture",
+    "subtype": null,
+    "title": "Hypothesis: air resistance is the confounding variable, not weight",
+    "content": "The observed differences in fall speed between objects of different weight are caused primarily by the resistance of the medium (air, water, etc.) rather than by any intrinsic relationship between weight and natural speed. In a vacuum, where medium resistance is absent, all objects would fall at the same speed regardless of weight. The medium acts as the confounding variable that produces the illusion of weight-dependent fall speed: denser objects have a more favorable ratio of gravitational pull to drag, giving them a speed advantage that disappears as medium density approaches zero.",
+    "keywords": ["air resistance", "confounding variable", "medium resistance", "drag", "buoyancy", "vacuum hypothesis", "Galileo conjecture"],
+    "prior": 0.8,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_medium_density",
+      "source": "Galileo, Discorsi (1638), First Day — Salviati's hypothesis"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5012,
+    "type": "conjecture",
+    "subtype": null,
+    "title": "Prediction: in vacuum, all objects fall at the same rate",
+    "content": "Combining the logical refutation of Aristotle's law (from the tied balls paradox) with the hypothesis that air resistance is the confounding variable, Galileo arrives at a specific prediction: in a true vacuum, all objects regardless of their weight, size, shape, or material composition will fall with exactly the same acceleration and reach the ground at the same time when dropped from the same height. This is the universality of free fall.",
+    "keywords": ["vacuum", "equal fall rate", "universality of free fall", "prediction", "Galileo", "weight-independent acceleration"],
+    "prior": 0.85,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_vacuum_prediction",
+      "source": "Galileo, Discorsi (1638), First Day — the vacuum prediction"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5013,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Inclined plane experiments: different weights arrive at same time",
+    "content": "Galileo reports experiments using inclined planes (which slow down the effective acceleration, making timing feasible with water clocks). Bronze balls of different weights are rolled down smooth inclined planes of various angles. The key finding: balls of different weight released simultaneously from the top of the same inclined plane consistently arrive at the bottom at the same time, within experimental precision. The ratio of distances traversed follows the square of the ratio of elapsed times (d proportional to t^2), independent of the ball's weight.",
+    "keywords": ["inclined plane", "experiment", "bronze balls", "equal arrival time", "d proportional to t squared", "Galileo experiment", "weight-independent"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_vacuum_prediction",
+      "source": "Galileo, Discorsi (1638), Third Day — inclined plane experiments"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5014,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Equal fall rate (in vacuum) confirmed by inclined plane",
+    "content": "The inclined plane experiments demonstrate that different weights traverse the same distance in the same time when air resistance is minimized (dense bronze balls on smooth planes). Since an inclined plane is geometrically equivalent to reducing the effective gravitational component while preserving the ratio of gravitational to inertial effects, these results provide direct experimental evidence that the acceleration of falling bodies is independent of their weight. This confirms Galileo's vacuum prediction within the experimental limits imposed by residual air resistance and friction.",
+    "keywords": ["inclined plane", "experimental confirmation", "equal acceleration", "weight-independent", "Galileo confirmed", "residual friction"],
+    "prior": 0.9,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "galileo1638_vacuum_prediction",
+      "source": "Galileo, Discorsi (1638), Third Day — interpretation of inclined plane results"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5015,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Newton's 2nd law: F = ma",
+    "content": "Newton's second law of motion (Principia Mathematica, 1687) states that the net force F acting on a body equals the product of its inertial mass m and its acceleration a: F = ma. This law is universal and applies to all bodies regardless of their composition, weight, or size. It establishes the concept of inertial mass as the quantity that resists changes in motion, fundamentally distinct from weight (which is a force).",
+    "keywords": ["Newton", "second law", "F = ma", "inertial mass", "acceleration", "Principia", "1687", "force"],
+    "prior": 0.95,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "newton1687_principia",
+      "source": "Isaac Newton, Philosophiae Naturalis Principia Mathematica (1687), Book I, Axioms"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5016,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Gravitational force: F = mg",
+    "content": "Near the surface of a massive body (such as Earth), the gravitational force on an object of mass m is F = mg, where g is the local gravitational acceleration (approximately 9.8 m/s^2 on Earth's surface). Crucially, the same quantity m that appears in F = ma (inertial mass) also appears in F = mg (gravitational mass). This equivalence of inertial and gravitational mass was noted by Newton and later elevated to a fundamental principle by Einstein in the equivalence principle of general relativity.",
+    "keywords": ["gravitational force", "F = mg", "gravitational mass", "inertial mass equivalence", "g", "weight", "Newton", "equivalence principle"],
+    "prior": 0.95,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "newton1687_principia",
+      "source": "Newton, Principia (1687), Book III; confirmed by Eotvos experiments"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5017,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Derivation: a = g (acceleration independent of mass)",
+    "content": "From Newton's second law F = ma and the gravitational force law F = mg, we can derive the acceleration of a freely falling body: ma = mg, therefore a = g. The mass m cancels completely from both sides. This means every object in free fall (ignoring air resistance) accelerates at exactly the same rate g, regardless of its mass, weight, composition, or any other property. This is a rigorous theoretical derivation of Galileo's empirical observation, grounded in the equivalence of inertial and gravitational mass.",
+    "keywords": ["derivation", "a = g", "mass cancellation", "universal free fall", "Newton derivation", "mass-independent acceleration", "equivalence principle"],
+    "prior": 0.95,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "newton1687_principia",
+      "source": "derived from Newton's Principia (1687), combining Laws II and III with universal gravitation"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5018,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Apollo 15: hammer and feather dropped on Moon (vacuum)",
+    "content": "On August 2, 1971, during the Apollo 15 mission, astronaut David Scott performed a live televised experiment on the lunar surface. Standing at the Hadley-Apennine landing site, he held a 1.32 kg aluminum geological hammer in one hand and a 0.03 kg falcon feather in the other, both at the same height (approximately 1.6 m above the lunar surface). He released them simultaneously. The Moon has no atmosphere (surface pressure < 3 x 10^-15 atm), providing a natural vacuum environment.",
+    "keywords": ["Apollo 15", "David Scott", "hammer", "feather", "Moon", "lunar surface", "vacuum", "1971", "Hadley-Apennine"],
+    "prior": 0.99,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "apollo15_1971_feather_drop",
+      "source": "NASA Apollo 15 mission, EVA-3, August 2, 1971; televised broadcast"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5019,
+    "type": "paper-extract",
+    "subtype": "premise",
+    "title": "Observation: hammer and feather hit lunar surface simultaneously",
+    "content": "When David Scott simultaneously released the 1.32 kg hammer and the 0.03 kg feather on the lunar surface (a factor of 44 difference in mass), both objects were observed to fall side by side and strike the lunar soil at the same instant. Scott declared: 'How about that! ... This proves that Mr. Galileo was correct in his findings.' The experiment was recorded on the rover's television camera and witnessed live by a worldwide audience, providing unambiguous visual confirmation.",
+    "keywords": ["simultaneous impact", "hammer and feather", "Apollo 15", "visual confirmation", "David Scott", "Galileo confirmed", "lunar experiment"],
+    "prior": 0.99,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "apollo15_1971_feather_drop",
+      "source": "NASA Apollo 15 mission, EVA-3 transcript and television footage, August 2, 1971"
+    },
+    "extra": {},
+    "created_at": null
+  },
+  {
+    "id": 5020,
+    "type": "deduction",
+    "subtype": null,
+    "title": "Equal fall rate in vacuum confirmed experimentally",
+    "content": "The Apollo 15 hammer-and-feather experiment provides definitive experimental confirmation that objects of vastly different masses (44:1 ratio) fall at exactly the same rate in a true vacuum. Unlike Galileo's inclined plane experiments, which could only approximate vacuum conditions, the lunar experiment was conducted in a natural near-perfect vacuum. This result simultaneously confirms Galileo's 1638 prediction, Newton's 1687 derivation (a = g, independent of mass), and the equivalence of inertial and gravitational mass to high precision.",
+    "keywords": ["experimental confirmation", "vacuum", "equal fall rate", "Apollo 15", "Galileo confirmed", "Newton confirmed", "equivalence principle confirmed", "definitive test"],
+    "prior": 0.99,
+    "belief": null,
+    "status": "active",
+    "metadata": {
+      "package": "apollo15_1971_feather_drop",
+      "source": "confirmed by Apollo 15 lunar experiment (1971)"
+    },
+    "extra": {},
+    "created_at": null
+  }
+]


### PR DESCRIPTION
## Summary

Two complete worked examples showing how Gaia models theory succession through thought experiments, contradictions, and multi-source evidence convergence.

- **Galileo's Tied Balls** — 从亚里士多德 "越重越快" 到阿波罗15号月球锤子羽毛实验，跨越 2300 年
- **Einstein's Elevator** — 从牛顿 0.87″ 到 GR 1.75″ 再到 Eddington 1919 日食观测

### Key demonstrations:
- 思想实验 = 添加新 node 和 edge（不需要 overlay 或特殊机制）
- 矛盾通过 contradiction edge 建模，BP 自动量化 belief 变化
- 多源独立证据汇聚自然提升 belief
- 旧理论不被删除，belief 下降但保留在图中

### Files

**Test fixtures** (`tests/fixtures/examples/`):

| Example | Nodes | Edges | Contradictions | Packages |
|---------|-------|-------|----------------|----------|
| `galileo_tied_balls/` | 20 (5001–5020) | 13 (5001–5013) | 2 | 6: Aristotle → tied balls → air resistance → vacuum prediction → Newton a=g → Apollo 15 |
| `einstein_elevator/` | 22 (6001–6022) | 15 (6001–6015) | 2 | 5: Newton/Soldner → equivalence principle → 1911 prediction → GR 1.75″ → Eddington 1919 |

Each directory contains `nodes.json`, `edges.json`, `manifest.json` (package ordering + expected belief ranges).

**Documentation** (`docs/examples/`):
- `galileo_tied_balls.md` — per-package walkthrough with node/edge tables and BP analysis
- `einstein_elevator.md` — same structure, covering the Einstein reasoning chain

### Related
- Issue #40 — wishlist integration test (once BP engine is ready)

## Test plan

- [x] All fixture JSON valid
- [x] All nodes/edges pass Pydantic model validation (`Node`, `HyperEdge`)
- [x] All edge tail/head IDs reference existing nodes
- [x] Contradiction edges: `head: []`, `probability: null` (matches edge 734 format)
- [x] Manifest node/edge IDs match actual data
- [x] All nodes/edges have `metadata.package` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)