### PR TITLE
docs: add Gaia DSL framework and CLI lifecycle

### DIFF
--- a/docs/foundations/DSL/gaia-dsl-design.md
+++ b/docs/foundations/DSL/gaia-dsl-design.md
@@ -10,6 +10,9 @@ It is the top-level language blueprint. The V1/V2/V3 documents define specific l
 - **V2** — Package management system (Gaia.toml, dependency resolution, registry, publish)
 - **V3** — Probabilistic layer (prior, posterior, belief propagation)
 
+For Gaia DSL's system role, lifecycle stages, and layer boundaries, see
+[gaia-dsl-framework.md](gaia-dsl-framework.md).
+
 ## Design Approach
 
 **Layered language kernel.** Gaia follows the same architecture as Church (extending Scheme) and Pyro (extending Python): a deterministic host language with a probabilistic layer on top. Each version layer adds primitives to the kernel:

--- a/docs/foundations/DSL/gaia-dsl-framework.md
+++ b/docs/foundations/DSL/gaia-dsl-framework.md
@@ -1,0 +1,505 @@
+# Gaia DSL Framework
+
+## Purpose
+
+This document defines the role of Gaia DSL in the overall Gaia system.
+
+It is not the detailed grammar spec. Instead, it answers the higher-level questions that the grammar depends on:
+
+- what Gaia DSL is for
+- which lifecycle stages it must support
+- which responsibilities belong to the DSL, the local runtime, and the server
+- which architectural direction should guide V1
+
+For the detailed language design, see [gaia-dsl-design.md](gaia-dsl-design.md).
+
+## Problem
+
+Gaia DSL is currently being asked to serve several different goals at once:
+
+1. agent-verifiable long-term memory
+2. formalized scientific knowledge representation
+3. a publishable artifact that can replace or complement papers and project summaries
+4. a machine-writable language that AI agents can execute and validate
+5. an input substrate for the global Large Knowledge Model (LKM)
+
+Those goals are related, but they are not the same layer.
+
+If Gaia DSL is treated as only one of the following, the design becomes distorted:
+
+- only a package exchange format
+- only an agent execution script
+- only a graph ingestion schema
+- only a paper-like authoring format
+
+The framework therefore needs explicit layering.
+
+## Design Goals
+
+Gaia DSL should support the following product goals:
+
+### 1. Verifiable Agent Memory
+
+Gaia should let agents externalize reasoning into explicit, reviewable artifacts rather than opaque context-window state.
+
+This requires:
+
+- structured knowledge objects
+- explicit reasoning steps
+- reviewable intermediate conclusions
+- local and global belief updates
+- traceable provenance
+
+### 2. Formalized Scientific Knowledge
+
+Gaia should represent scientific knowledge in a form that is:
+
+- typed
+- modular
+- composable
+- uncertainty-aware
+- stable enough for long-term integration
+
+### 3. Publishable Research Artifact
+
+Gaia packages should be able to act as:
+
+- a research project summary
+- a paper replacement or paper companion
+- a structured note or knowledge bundle
+- a reviewable git artifact
+
+This requires clear package boundaries, stable serialization, and sidecar review artifacts.
+
+### 4. Agent-Friendly Execution
+
+Gaia should be easy for agents to generate, validate, and run locally.
+
+This requires:
+
+- machine-parsable syntax
+- deterministic validation
+- explicit runtime boundaries
+- local execution support for LLM and tool-backed steps
+
+### 5. Clean Path to Global LKM Integration
+
+Gaia packages must eventually map into a global knowledge graph with:
+
+- canonical identity
+- provenance tracking
+- contradiction and retraction handling
+- large-scale belief propagation
+
+## Non-Goals
+
+The DSL framework should explicitly avoid these confusions:
+
+### 1. Gaia is not the agent's entire workspace
+
+Gaia should not try to store every speculative draft or exploratory branch the agent considers before submission.
+
+Local workspace activity is allowed and necessary, but the published package is the stable artifact, not the full private thought process.
+
+### 2. Gaia is not a general-purpose workflow engine
+
+Gaia may need minimal control-flow constructs for execution, but V1 should not attempt to become a full orchestration language.
+
+### 3. Gaia package names are not global identity
+
+Local names exist for authoring convenience. Canonical identity belongs to publish-time or ingest-time integration, not to initial authorship.
+
+### 4. The published package is not the same thing as the server's canonical graph IR
+
+The package is the authoring and exchange artifact. The server may derive a different internal representation for graph integration and inference.
+
+## Lifecycle Model
+
+Gaia should be designed around three distinct lifecycle stages.
+
+### Stage A: Local Workspace
+
+This is where the agent works locally.
+
+Typical activities:
+
+- read existing packages and claims
+- draft new reasoning
+- run local tools
+- execute local LLM-backed inference steps
+- perform dry-run validation
+- inspect local belief updates
+
+This stage is exploratory and may contain transient state.
+
+### Stage B: Published Package
+
+This is the stable artifact that enters git, PR review, and long-term sharing.
+
+It should be:
+
+- serializable
+- diff-friendly
+- reviewable
+- readable by humans and agents
+- stable enough to serve as a research artifact
+
+This is the primary DSL exchange surface.
+
+### Stage C: Canonical LKM Integration
+
+This is where published packages are ingested into the global Large Knowledge Model.
+
+Typical activities:
+
+- canonicalize identities
+- preserve provenance
+- merge equivalent knowledge
+- attach contradiction and retraction structure
+- run larger-scale BP across packages
+
+This stage belongs primarily to the server or registry layer, not to the authoring surface.
+
+## Layer Model
+
+The framework should separate at least five semantic layers.
+
+### 1. Knowledge Layer
+
+Defines what exists as reusable knowledge.
+
+Examples:
+
+- `claim`
+- `question`
+- `setting`
+- `action`
+- `ref`
+
+This layer is the core substrate shared across local runtime and server ingestion.
+
+### 2. Reasoning Layer
+
+Defines how local reasoning is expressed.
+
+Examples:
+
+- `chain_expr`
+- named action application
+- lambda-like inline reasoning steps
+
+This layer describes a reasoning structure, not yet the full execution plan of a package.
+
+### 3. Control Layer
+
+Defines how multiple reasoning units are scheduled and executed.
+
+Examples:
+
+- package entrypoint
+- explicit chain dependencies
+- staged execution
+- optional future guarded execution
+
+This layer should exist primarily for runtime coordination, not as hidden YAML ordering semantics.
+
+### 4. Probabilistic Layer
+
+Defines uncertainty and inference semantics.
+
+Examples:
+
+- `prior`
+- posterior belief
+- dependency strength
+- factor graph compilation
+- belief propagation
+
+### 5. Integration Layer
+
+Defines how a published package enters the global LKM.
+
+Examples:
+
+- canonical identity assignment
+- provenance registration
+- cross-package linking
+- deduplication
+- cross-package BP participation
+
+## Artifact Surfaces
+
+Gaia should distinguish four artifact surfaces.
+
+| Surface | Primary user | Purpose | Stability |
+|---|---|---|---|
+| Local workspace state | agent + local runtime | exploration, dry-run, temporary execution state | low |
+| Published package | author, reviewer, agent, git | stable exchange and review artifact | high |
+| Review sidecars | reviewer, agent, CI/server | external evaluation of package quality | medium |
+| Canonical graph IR | server/LKM runtime | internal integration and large-scale inference | internal |
+
+The published package is the most important author-facing artifact.
+
+## Major Architecture Directions
+
+There are several possible ways to center the Gaia DSL design.
+
+### Option 1: Package-First DSL
+
+The DSL is primarily a stable package and publication format.
+
+Pros:
+
+- best fit for paper replacement and project sharing
+- easiest to review in git and PRs
+- stable exchange format
+- clean separation between package content and review sidecars
+
+Cons:
+
+- runtime semantics can become vague
+- local agent execution may rely on convention rather than explicit control
+- harder to support replay, checkpointing, and local tool orchestration
+
+### Option 2: Runtime-First DSL
+
+The DSL is primarily an executable instruction language for agents.
+
+Pros:
+
+- best fit for local automation
+- execution order is explicit
+- easier checkpointing, retries, and runtime observability
+- natural place for tool calls and LLM-backed steps
+
+Cons:
+
+- publishable artifact becomes process-heavy
+- review target becomes "program plus environment plus run result"
+- weaker fit for paper-like long-term knowledge sharing
+
+### Option 3: Graph-First DSL
+
+The DSL is primarily a direct authoring surface for the global graph model.
+
+Pros:
+
+- easiest path into server ingestion
+- identity and BP semantics are central from the start
+- close to current node/hyperedge infrastructure
+
+Cons:
+
+- poor authoring ergonomics
+- weak narrative structure
+- poor fit for paper replacement
+- local reasoning and package modularity are under-expressed
+
+### Option 4: Layered Split
+
+The DSL framework explicitly separates:
+
+- local runtime execution
+- published package representation
+- global graph integration
+
+Pros:
+
+- best fit for Gaia's combined goals
+- supports agent execution without turning the published artifact into a raw script
+- supports paper-like package structure without losing runtime semantics
+- keeps the LKM ingest layer clean
+
+Cons:
+
+- highest design complexity
+- requires careful boundary definitions
+
+## Recommended Direction
+
+The recommended architecture is Option 4: Layered Split.
+
+The core principle is:
+
+> Gaia's published package is the stable knowledge artifact.
+> Gaia's local runtime is the execution environment that helps agents produce and validate that artifact.
+> Gaia's server or registry is the integration layer that turns packages into global LKM structure.
+
+This gives Gaia a clean separation of concerns:
+
+### Local Runtime Responsibilities
+
+- load and validate packages
+- resolve refs and dependencies
+- schedule local execution
+- call LLM executors for `infer_action`
+- call tool executors for `toolcall_action`
+- run local BP
+- support dry-run and local inspection
+
+### Published Package Responsibilities
+
+- declare knowledge objects
+- declare reasoning structure
+- declare package/module boundaries
+- expose stable exports
+- remain reviewable in git
+- remain understandable as a research artifact
+
+### Server / LKM Responsibilities
+
+- canonicalize and merge packages
+- attach global identity and provenance
+- run large-scale review and inference
+- expose global search and integration services
+
+## Recommended Execution Principle
+
+The control layer should be implemented primarily by interpreter software, not by the LLM itself.
+
+The recommended execution split is:
+
+- interpreter software controls package-level flow
+- LLM executes local cognitive steps
+- tools execute deterministic external actions
+
+In short:
+
+> the LLM should not define the package-level control semantics;
+> the LLM should execute the reasoning steps delegated to it by the runtime.
+
+This improves:
+
+- determinism
+- replayability
+- error handling
+- checkpointing
+- observability
+- cost control
+
+## V1 Scope Recommendation
+
+V1 should stay intentionally narrow.
+
+### What V1 should include
+
+- a stable package artifact
+- typed knowledge objects
+- explicit modules and exports
+- local reasoning via `chain_expr`
+- sidecar review artifacts
+- local and server validation
+- probabilistic annotations and BP compilation
+
+### What V1 should include only in minimal form
+
+- control layer metadata for local execution
+
+Examples of minimal acceptable V1 control:
+
+- `entry`
+- `depends_on`
+- explicit staged execution metadata
+
+### What V1 should defer
+
+- general `if / else`
+- general loops
+- full workflow-engine semantics
+- rich theorem-proving or dependent typing
+- complete cross-package graph canonicalization in author-facing syntax
+
+## Design Rules for the Detailed DSL
+
+The detailed DSL design should follow these rules.
+
+### 1. Keep the published package as the normative author-facing artifact
+
+This is the main object that should be committed, reviewed, shared, and cited.
+
+### 2. Keep local runtime semantics explicit
+
+If execution order matters, it should be modeled explicitly rather than smuggled in through YAML declaration order.
+
+### 3. Keep narrative order separate from execution order
+
+A package may have:
+
+- reading order
+- chain step order
+- chain scheduling order
+- probabilistic dependency order
+
+These should not be collapsed into one notion of "order".
+
+### 4. Keep local names separate from global identity
+
+Package-local and module-local naming are authoring conveniences. Global identity belongs to integration.
+
+### 5. Keep review separate from content
+
+Review reports should remain sidecar artifacts rather than mutating package content files.
+
+### 6. Keep workspace and published knowledge distinct
+
+The local workspace may be richer, messier, and more executable than the published package.
+
+## Relationship to the Current DSL Draft
+
+The current detailed DSL draft already establishes several important pieces correctly:
+
+- Gaia is treated as a language, not merely an API payload
+- the core knowledge object set is small and coherent
+- reasoning structure is represented with `chain_expr`
+- module types can encode editorial intent such as motivation, setting, reasoning, and follow-up
+- probabilistic semantics are recognized as part of the language rather than an afterthought
+
+However, the current draft still needs framework-level clarification in these areas:
+
+### 1. Package artifact vs runtime artifact
+
+The current draft mixes a publishable package surface with an executable local runtime surface, but the boundary is not yet explicit.
+
+### 2. Control layer
+
+The draft defines `chain_expr`, but package-level execution semantics are still underspecified.
+
+### 3. Package-to-LKM integration
+
+The draft defines local names and refs, but not yet the full canonicalization path into the global LKM.
+
+### 4. Review and publish lifecycle
+
+The draft focuses on language structure, but Gaia's product flow also depends on git, PR review, sidecar reports, and publish-time integration.
+
+### 5. Scientific evidence modeling
+
+The current type system is a good kernel, but scientific knowledge may later need richer first-class forms such as observations, experiments, datasets, or protocol-like resources.
+
+## Practical Guidance
+
+When extending Gaia DSL, ask these questions first:
+
+1. Is this feature for local runtime, published package, or global integration?
+2. Does this belong in the normative package surface, or only in the interpreter/runtime?
+3. Is this defining knowledge structure, execution control, or integration semantics?
+4. Does this make the package easier to review and share, or does it merely make local execution easier?
+5. Can this be deferred to a later layer without weakening V1?
+
+If those questions are answered explicitly, the detailed DSL grammar becomes much easier to design coherently.
+
+## Summary
+
+Gaia DSL should be treated as a layered language system with three lifecycle stages:
+
+1. local workspace execution
+2. published package exchange
+3. canonical LKM integration
+
+The published package should remain the central author-facing artifact.
+
+The local runtime should help agents produce and validate that artifact.
+
+The server should integrate that artifact into the global Large Knowledge Model.
+
+That separation is the clearest way to satisfy Gaia's combined goals without forcing one syntax layer to carry every responsibility at once.

--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -21,10 +21,12 @@ The execution plan for that reset lives here:
 - [System Overview](system-overview.md)
 - [Product Scope](product-scope.md)
 - [Domain Model](domain-model.md)
+- [Gaia DSL Framework](DSL/gaia-dsl-framework.md)
 - [Shared Knowledge Package V1 Static](shared/knowledge-package-static.md)
 - [Shared Knowledge Package V1 File Formats](shared/knowledge-package-file-formats.md)
 - [V3 Probabilistic Semantics](shared/probabilistic-semantics.md)
 - [Gaia CLI Runtime Boundaries](cli/boundaries.md)
+- [Gaia CLI Command Lifecycle](cli/command-lifecycle.md)
 
 ## Intended outputs
 
@@ -54,6 +56,7 @@ Reasoning design is now intentionally split by layer:
 
 ## Folder Layout
 
+- `DSL/`: Gaia DSL framework and detailed language design docs
 - `shared/`: contracts intended to be shared by Gaia local/CLI and Gaia server
 - `cli/`: Gaia CLI runtime boundaries and future CLI-specific docs
 

--- a/docs/foundations/cli/README.md
+++ b/docs/foundations/cli/README.md
@@ -5,5 +5,6 @@ This directory contains Gaia CLI-specific architectural notes that sit on top of
 Current docs:
 
 - [Gaia CLI Runtime Boundaries](boundaries.md)
+- [Gaia CLI Command Lifecycle](command-lifecycle.md)
 
 These docs describe CLI runtime responsibilities and should not redefine shared artifact schemas.

--- a/docs/foundations/cli/boundaries.md
+++ b/docs/foundations/cli/boundaries.md
@@ -137,5 +137,6 @@ The orchestrator manages when those services are applied and how their outputs a
 
 - [../shared/knowledge-package-static.md](../shared/knowledge-package-static.md) defines the shared V1 static package schema consumed by the CLI
 - [../shared/knowledge-package-file-formats.md](../shared/knowledge-package-file-formats.md) defines the shared V1 package file formats and review-report format consumed by CLI formalization services
+- [command-lifecycle.md](command-lifecycle.md) defines the intended semantics of the core CLI commands: build, review, verify, and publish
 
 Gaia server architecture remains intentionally undefined here and should be designed separately later.

--- a/docs/foundations/cli/command-lifecycle.md
+++ b/docs/foundations/cli/command-lifecycle.md
@@ -1,0 +1,416 @@
+# Gaia CLI Command Lifecycle
+
+## Purpose
+
+This document defines the intended semantic boundary of the four core Gaia CLI commands:
+
+- `gaia build`
+- `gaia review`
+- `gaia verify`
+- `gaia publish`
+
+It answers a product question rather than a grammar question:
+
+> What is the lifecycle of a Gaia package from local research snapshot to published knowledge integrated into the Large Knowledge Model?
+
+This document assumes the higher-level DSL framework from
+[../DSL/gaia-dsl-framework.md](../DSL/gaia-dsl-framework.md)
+and the CLI layering from
+[boundaries.md](boundaries.md).
+
+## Core Judgment
+
+Gaia's primary local workflow should be:
+
+```text
+workspace -> build -> review -> verify -> publish
+```
+
+Not:
+
+```text
+workspace -> build -> run -> review -> publish
+```
+
+The reason is architectural:
+
+- Gaia's primary artifact is a reviewable knowledge package, not an executable script
+- LLMs should primarily audit and critique reasoning, not define the package-level control semantics
+- local execution that exists should serve validation and reproducibility, not become the central user model
+
+Therefore the core command set should be:
+
+1. build the package into a grounded, auditable form
+2. review the reasoning quality
+3. verify reproducible or executable claims
+4. publish the stable package for independent server review and integration
+
+## The Lifecycle
+
+### Stage 0: Private Workspace
+
+Before Gaia CLI commands act on a package, the agent works in a private local workspace.
+
+Typical workspace activity:
+
+- reading papers
+- collecting notes
+- running exploratory tools
+- testing hypotheses
+- drafting candidate claims
+- writing package snapshots or reports
+
+This workspace is intentionally broader and messier than the published Gaia artifact.
+
+It is not the shared truth surface.
+
+### Stage 1: Draft Package Snapshot
+
+At some point the agent materializes a structured package snapshot.
+
+That snapshot should already contain explicit package content:
+
+- claims
+- settings
+- questions
+- actions
+- refs
+- reasoning structure
+- provenance or resource references
+
+This draft package is the input to `gaia build`.
+
+### Stage 2: Built Package
+
+`gaia build` turns the draft package into a grounded, validated, auditable local artifact.
+
+This is the first stage where Gaia CLI should treat the package as structurally meaningful rather than as raw authoring material.
+
+### Stage 3: Reviewed Package
+
+`gaia review` performs model-based critique of the built package.
+
+This stage adds assessment artifacts rather than redefining the package's normative content.
+
+Its outputs should be review sidecars and local audit results.
+
+### Stage 4: Verified Package
+
+`gaia verify` checks reproducible or executable claims whose truth depends on external execution rather than purely textual reasoning review.
+
+This stage adds verification evidence and execution reports.
+
+### Stage 5: Published Package
+
+`gaia publish` sends the stable package to the shared collaboration path:
+
+- git / GitHub
+- server-side review
+- later ingestion into the LKM
+
+## The Four Commands
+
+## 1. `gaia build`
+
+### Role
+
+`build` is the deterministic normalization boundary.
+
+Its job is to take a package in authoring form and produce a grounded core form suitable for:
+
+- structural inspection
+- local BP compilation
+- later review
+- later publish
+
+### Responsibilities
+
+- schema validation
+- local reference resolution
+- package consistency checks
+- instantiation of statically known parameters
+- elaboration of templates or meta-level authoring sugar
+- explicit lowering into a grounded local core
+- factor graph compilation
+- optional local BP precomputation
+
+### What `build` should not do
+
+- perform open-ended LLM reasoning generation
+- assign final reasoning quality scores
+- replace independent review
+- perform authoritative server-side integration
+- silently rewrite scientific meaning
+
+### Build output
+
+The result of `build` should be a deterministic artifact or cacheable internal form with these properties:
+
+- no unresolved refs
+- no unbound parameters
+- no hidden template expansion left unresolved
+- explicit reasoning structure
+- explicit BP inputs
+
+In effect:
+
+> `build` turns package source into grounded local core.
+
+### Programming language analogy
+
+`gaia build` is closest to:
+
+- elaboration
+- grounding
+- partial evaluation of statically known structure
+
+It is not primarily analogous to "run the program".
+
+## 2. `gaia review`
+
+### Role
+
+`review` is the model-based audit boundary.
+
+Its job is to critique reasoning quality after the package has already been built into explicit form.
+
+### Responsibilities
+
+- review reasoning edges or chains step by step
+- estimate edge reliability or conditional probability
+- validate premise/context assignment
+- identify hidden premises
+- identify weak or invalid reasoning jumps
+- produce review reports as sidecar artifacts
+- optionally feed local BP with review-derived edge scores
+
+### What `review` should not do
+
+- redefine the package schema
+- silently mutate the normative package contents
+- act as the final server-controlled publish gate
+- replace reproducibility checks for tool-backed claims
+
+### Review output
+
+Review should produce sidecar artifacts such as:
+
+- reasoning scores
+- issues
+- suggested premise/context adjustments
+- abstraction warnings
+- local verdict summaries
+
+Review output is an audit of the package, not the package itself.
+
+### Abstraction and review
+
+Abstraction analysis belongs more naturally inside `review` than inside `build`.
+
+Reason:
+
+- abstraction is not purely structural normalization
+- abstraction can introduce semantic weakening or generalization
+- abstraction therefore requires quality judgment, not just deterministic expansion
+
+Typical review-time abstraction questions:
+
+- are two claims equivalent?
+- is one claim a special case of another?
+- does a proposed summary over-generalize?
+- does a parent claim contain union error?
+
+So the correct relationship is:
+
+> `build` normalizes explicit structure.
+> `review` critiques reasoning and abstraction.
+
+## 3. `gaia verify`
+
+### Role
+
+`verify` is the reproducibility and execution boundary.
+
+Its job is to check claims whose trust depends on external execution, replay, or reproducible evidence rather than purely textual reasoning audit.
+
+### Responsibilities
+
+- execute `toolcall_action`-like steps when supported
+- replay computational derivations
+- rerun scripts, proofs, or deterministic procedures
+- check that claimed outputs match observed outputs
+- attach verification evidence to the package as sidecars or local reports
+
+### What `verify` should not do
+
+- act as a generic workflow runner
+- replace review of natural-language reasoning
+- replace publish-time independent server review
+
+### Verification output
+
+Verification should produce explicit evidence artifacts such as:
+
+- pass/fail execution results
+- captured outputs
+- hashes, metrics, or checkpoints
+- environment metadata
+- reproducibility notes
+
+### Why `verify` is separate from `review`
+
+Review asks:
+
+- "Is this reasoning step credible?"
+
+Verify asks:
+
+- "If we actually execute or replay this step, does it hold?"
+
+They are complementary but not the same.
+
+## 4. `gaia publish`
+
+### Role
+
+`publish` is the handoff boundary from local package lifecycle to shared package lifecycle.
+
+Its job is to submit a stable package for independent server-side evaluation and possible integration into the LKM.
+
+### Responsibilities
+
+- package the stable local artifact
+- push or submit through the supported collaboration path
+- preserve sidecar review and verification artifacts as appropriate
+- trigger server-side review
+- expose publish status to the user or agent
+
+### What `publish` should not do
+
+- trust local review as authoritative
+- bypass server-controlled review policy
+- directly mutate the global LKM without review
+
+### Server-side follow-up
+
+After publish, the server may:
+
+- rerun review using server-controlled models and prompts
+- perform integration-time abstraction analysis
+- canonicalize identities
+- merge into the global LKM
+- run larger-scale BP
+
+That work is downstream of publish, not part of local CLI authority.
+
+## Why There Is No Core `gaia run`
+
+Gaia may still have internal execution steps, but `run` should not be the primary conceptual command.
+
+### Why not
+
+- the package is not primarily an executable script
+- the package should be reviewable before any open-ended model execution
+- "run" suggests program execution semantics, which is not the main Gaia product surface
+- the most important user-visible lifecycle is audit and publication, not free-form execution
+
+### What would be misleading about `run`
+
+If a user sees:
+
+```text
+gaia build
+gaia run
+gaia review
+```
+
+the implied model is:
+
+- build the program
+- execute the program
+- inspect the result
+
+That is too close to notebook or agent-script semantics.
+
+Gaia's intended model is instead:
+
+- structure the knowledge package
+- audit the package
+- verify reproducible parts
+- publish the package
+
+## The Command Contract Table
+
+| Command | Main mode | Determinism | Primary output | Primary question |
+|---|---|---|---|---|
+| `build` | normalization | deterministic | grounded local core | "Is the package structurally valid and explicit?" |
+| `review` | audit | model-dependent | review sidecars and scores | "How credible is the reasoning?" |
+| `verify` | reproduction | execution-dependent | verification evidence | "Does the executable/reproducible claim actually hold?" |
+| `publish` | handoff | protocol-driven | shared package submission | "Is this package ready for independent shared review?" |
+
+## Recommended Agent Workflow
+
+For the target agentic research use case, the intended flow is:
+
+1. work privately in local workspace
+2. periodically write a draft package snapshot or report
+3. run `gaia build`
+4. run `gaia review`
+5. run `gaia verify` for executable or reproducible claims when needed
+6. revise the package based on the results
+7. repeat until stable
+8. run `gaia publish`
+9. let server-side review decide whether the package enters the LKM
+
+This preserves the critical boundary:
+
+> Local Gaia helps the agent produce a better package.
+> Shared Gaia decides whether that package becomes part of the shared knowledge model.
+
+## Design Implications
+
+The four-command model implies several design rules.
+
+### 1. Package content must be explicit before review
+
+Review should critique an explicit package, not fill in most of its content from scratch.
+
+### 2. Build must be strong enough to remove structural ambiguity
+
+If package meaning depends on unresolved templates, hidden refs, or implicit local ordering, `build` is too weak.
+
+### 3. Review output must remain a sidecar
+
+Review may influence local BP and agent iteration, but it should not silently overwrite package truth.
+
+### 4. Verification must be evidence-producing
+
+`verify` is not just another score. It should leave a reproducible trail.
+
+### 5. Publish must not trust local results blindly
+
+Local build, review, and verify are preparation steps. The shared system still needs independent review authority.
+
+## Relationship to Other Docs
+
+- [boundaries.md](boundaries.md) defines the CLI architectural layering
+- [../DSL/gaia-dsl-framework.md](../DSL/gaia-dsl-framework.md) defines Gaia DSL's lifecycle and layer model
+- [../shared/knowledge-package-file-formats.md](../shared/knowledge-package-file-formats.md) defines package and review sidecar exchange formats
+
+## Summary
+
+Gaia CLI should center on four commands:
+
+- `build`
+- `review`
+- `verify`
+- `publish`
+
+Together they define a package lifecycle oriented around:
+
+- normalization
+- audit
+- reproducibility
+- shared publication
+
+That lifecycle matches Gaia's role as a system for verifiable research packages and long-term knowledge integration better than a script-first `run` model.


### PR DESCRIPTION
## Summary
- add a Gaia DSL framework doc covering lifecycle stages, layer boundaries, and recommended architecture
- add a CLI command lifecycle doc defining build/review/verify/publish semantics and why run is not a core command
- link the new docs from the foundations and CLI indexes, plus the detailed DSL design doc

## Testing
- not run (docs only)