### PR TITLE
docs: Gaia type system direction — Lean structure + Jaynes semantics

### DIFF
--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -34,6 +34,7 @@ The execution plan for that reset lives here:
 - [Gaia Language Spec](language/gaia-language-spec.md)
 - [Gaia Language Design](language/gaia-language-design.md)
 - [Language Design Rationale](language/design-rationale.md)
+- [Type System Direction](language/type-system-direction.md)
 
 **CLI:**
 

--- a/docs/foundations/language/type-system-direction.md
+++ b/docs/foundations/language/type-system-direction.md
@@ -1,0 +1,401 @@
+# Gaia Type System Direction
+
+> Related documents:
+> - [Gaia Language Spec](gaia-language-spec.md)
+> - [Gaia Language Design](gaia-language-design.md)
+> - [Language Design Rationale](design-rationale.md)
+> - [Theoretical Foundation](../theory/theoretical-foundation.md)
+
+## Purpose
+
+This document defines the design direction for Gaia's type system.
+
+It addresses four questions:
+
+1. What is Gaia's type-theoretic identity — how does it relate to Lean?
+2. Which Lean ideas should Gaia borrow, and which should it avoid?
+3. What should the V1 type system look like?
+4. How should the type system expand after V1?
+
+## Foundational Position: Jaynes' Structure + Lean's Architecture
+
+Gaia is a formal language for plausible reasoning. Its type-theoretic foundation derives from a single observation:
+
+**Jaynes' plausible reasoning extends deductive logic — it preserves the logical structure but generalizes truth values from {0, 1} to [0, 1].**
+
+This means the type system's structure can follow established formal language design (borrowing from Lean), while the evaluation semantics follow Jaynes (BP computes beliefs instead of term reduction producing proofs).
+
+In one sentence: **Lean's structure + Jaynes' semantics.**
+
+## Why Not Curry-Howard
+
+Lean's type system is built on the Curry-Howard correspondence: propositions are types, proofs are terms (inhabitants of those types). This does not apply to Gaia, for three reasons.
+
+### 1. Proof irrelevance vs evidence relevance
+
+In Lean, once a proposition `P` has one proof, all proofs of `P` are equal (proof irrelevance). The proposition is simply "true."
+
+In Gaia, different evidence for the same claim has different weight. Multiple pieces of evidence must be aggregated via BP. Evidence is never irrelevant — it is the entire basis for computing belief.
+
+### 2. Binary inhabitation vs continuous belief
+
+In Lean, a proposition is either inhabited (proved) or not. There is no middle ground.
+
+In Gaia, a claim has a degree of belief in [0, 1]. The question is never "is this true?" but "how much should we believe this?"
+
+### 3. Monotonicity vs defeasibility
+
+In Lean, once a theorem is proved, it stays proved forever. New theorems never invalidate old ones.
+
+In Gaia, new evidence can weaken old claims. Retraction and contradiction are first-class operations. Belief revision is the norm, not the exception.
+
+### Consequence: Claims are terms, not types
+
+In Lean:
+```lean
+-- "Earth is round" IS a type
+def EarthIsRound : Prop := ...
+-- A proof is an inhabitant of that type
+def proof : EarthIsRound := ...
+```
+
+In Gaia:
+```yaml
+# "Earth is round" is a term of type Claim
+claim earth_is_round:
+  content: "Earth is round"
+  prior: 0.5
+```
+
+All claims are terms of type `Claim`. Evidence connects to claims via graph edges, not via type inhabitation. BP computes belief on the graph, not via type checking.
+
+## Why Probability Stays at the Value Level
+
+If probability were part of the type system (e.g., `Claim(p=0.8)` is a type distinct from `Claim(p=0.7)`), then type checking itself becomes probabilistic — "do these types match?" becomes "to what degree do they match?"
+
+This is avoided because:
+
+- type checking should be decidable and deterministic
+- no mature theory exists for probabilistic type checking
+- every successful probabilistic language (Church, Pyro, Stan) keeps probability at the value level
+- Jaynes' own framework treats logical structure as deterministic, with probability assigned to propositions within that structure
+
+So Gaia's design is:
+
+| Layer | Deterministic? | Responsible for |
+|---|---|---|
+| Type system | Yes | Structural well-formedness, classification, checking |
+| Values (prior, belief) | N/A — they are data | Carrying probability information |
+| BP evaluator | Deterministic given a graph | Computing posterior beliefs |
+
+## What Gaia Should Borrow From Lean
+
+### 1. Small trusted kernel
+
+Lean's most important design property is not dependent types. It is the existence of a small trusted core with a clear trust boundary.
+
+Gaia's kernel should handle deterministic structural checks:
+
+- declaration formation
+- ref resolution
+- action signature checking
+- chain well-formedness
+- factor-graph compilation validity
+- export and module boundary checks
+
+### 2. Construction and verification separation
+
+In Lean, tactics construct candidate proof terms, but the kernel verifies the result independently.
+
+Gaia preserves this:
+
+- LLMs, tools, and search procedures construct candidate reasoning structures
+- the kernel checks structural validity
+- review checks reasoning quality
+- BP computes posterior beliefs on the resulting structure
+
+### 3. Elaboration
+
+Lean distinguishes surface syntax from core terms.
+
+Gaia should do the same:
+
+- authors and agents write YAML surface form
+- the system elaborates into a typed core IR
+- all kernel checks operate on that core IR
+
+### 4. Judgments and rules
+
+Lean is defined in terms of judgments and inference rules. Gaia should define its kernel the same way, giving precise answers to:
+
+- what does it mean for a `Ref` to be valid?
+- what does it mean for an `Action` signature to be valid?
+- what does it mean for a `ChainExpr` to be well-formed?
+- what does it mean for a chain to compile into a valid factor graph?
+
+Without judgments, the system remains a collection of ad hoc validators.
+
+### 5. Explicit checking environment
+
+Lean checks terms relative to an environment `Γ`. Gaia also needs this:
+
+- a `Ref` is valid relative to a module/package environment
+- an `apply` step is valid relative to the available action signature
+- a `chain_expr` is valid relative to the declarations it mentions
+
+### 6. Goal-state thinking
+
+Lean's tactic engine operates on proof state with open goals.
+
+Gaia borrows this for local reasoning:
+
+- open claims are analogous to goals
+- grounded claims are analogous to discharged goals
+- `InferAction` is analogous to a tactic that fills a hole
+- local progress is observable as state (BeliefState)
+
+### 7. Module and namespace discipline
+
+Lean's environment model is strict about names, scope, and imported context.
+
+Gaia should formalize:
+
+- how local names are introduced
+- how module-local names are resolved
+- how refs preserve type
+- which declarations are visible vs exported into BP
+
+## What Gaia Should Not Borrow From Lean
+
+### 1. Propositions-as-types (Curry-Howard)
+
+As established above, claims are terms, not types. Evidence connects via graph edges, not type inhabitation.
+
+### 2. Full dependent type theory
+
+Gaia does not need universe polymorphism, inductive families, or full dependent typing in V1. The current problem is "how do we deterministically validate reasoning structures?" not "how do we prove value-indexed programs correct?"
+
+### 3. Definitional equality and reduction
+
+Lean depends on normalization and definitional equality. Gaia's evaluation is BP on graphs, not term reduction. Definitional equality has no natural counterpart in plausible reasoning.
+
+### 4. Monotonic proof semantics
+
+Once a Lean theorem is proved, it stays proved. Gaia's beliefs are revised as new evidence arrives. Non-monotonicity is fundamental.
+
+### 5. Aggressive implicit inference
+
+Lean hides substantial complexity behind inference, coercions, and automation. Gaia's users are agents and reviewers who need legible artifacts. V1 should prefer explicitness.
+
+## No LLM In The Kernel
+
+The kernel must not depend on LLM calls.
+
+- LLM outputs are not reliably reproducible
+- kernel failures need crisp, local, explainable errors
+- kernel checks should be cheap enough to run continuously
+- trusted checking must not depend on model temperature or prompt drift
+
+LLMs are appropriate for construction (proposing chains), review (assessing quality), and classification (estimating probabilities). But kernel judgments must be mechanically checkable.
+
+## Formal Checking vs Semantic Review vs BP
+
+Gaia has three validation layers, each with a distinct role:
+
+| Layer | Job | Deterministic? | Uses LLM? |
+|---|---|---|---|
+| **Kernel (formal checking)** | Structural validity: refs resolve, signatures match, chains are well-formed, graph compiles | Yes | No |
+| **Semantic review** | Content quality: reasoning supports conclusion, dependencies are correctly classified, no hallucination | No | Yes |
+| **BP (inference)** | Compute posterior beliefs on a structurally valid graph | Yes (given graph) | No |
+
+These should never be collapsed. A structurally valid chain may contain bad reasoning (review catches this). A well-reviewed chain needs BP to compute its contribution to overall belief.
+
+## V1 Type System
+
+### V1 goals
+
+V1 should make the following explicit:
+
+- a core set of knowledge kinds with formal rules
+- action signatures as first-class checked structure
+- typed chain connectivity
+- the distinction between visible and belief-bearing declarations
+- the boundary between surface syntax and checked core IR
+
+### V1 core categories
+
+The current categories are the right starting point:
+
+| Type | Role | Truth-apt? | Participates in BP? |
+|---|---|---|---|
+| `Claim` | Assertive, revisable | Yes | Yes (variable node) |
+| `Question` | Interrogative | No | No |
+| `Setting` | Contextual (definitions, assumptions) | Yes | Yes (variable node) |
+| `Action` | Procedural (InferAction, ToolCallAction) | No | Via application (factor node) |
+| `Expr` | Compositional (ChainExpr) | No | Via steps |
+| `Ref` | Reference to external knowledge | No | Via resolved target |
+| `Module` | Organizational | No | Via exported declarations |
+
+V1 should strengthen the internal representation of these types — stop treating parameter types and return types as bare strings, use explicit type expressions and signatures.
+
+### V1 judgments
+
+The kernel should establish these judgments:
+
+**Formation:**
+- `Γ ⊢ package ok`
+- `Γ ⊢ module ok`
+- `Γ ⊢ decl ok`
+
+**Resolution:**
+- `Γ ⊢ ref r resolves_to d`
+- `Γ ⊢ ref r preserves_type`
+
+**Action typing:**
+- `Γ ⊢ action a : ActionSig(T₁, ..., Tₙ → Tₒᵤₜ, mode)`
+- `Γ ⊢ apply(a, args) : Tₒᵤₜ`
+
+**Chain well-formedness:**
+- `Γ ⊢ step_i ok`
+- `Γ ⊢ chain ok`
+- `Γ ⊢ chain outputs H from T`
+
+**Graph compilation:**
+- `Γ ⊢ chain lowers_to fg_fragment`
+- `Γ ⊢ fg well_formed`
+
+**Export and belief participation:**
+- `Γ ⊢ x exportable`
+- `Γ ⊢ x belief_bearing`
+
+These are intentionally modest — they define the structural kernel without overcommitting to future machinery.
+
+## After V1: Expansion Path
+
+### Phase 2: BeliefState and hole-driven reasoning
+
+Make local reasoning state explicit:
+
+- open claims (analogous to Lean goals)
+- grounded claims (analogous to discharged goals)
+- chain application against open claims
+- checkpointing and local backtracking
+- explicit progress inspection (`3/5 claims grounded, confidence 0.68`)
+
+This is where the Lean proof-state analogy becomes operational.
+
+### Phase 3: Type classes
+
+Formalize shared behavior interfaces:
+
+```
+class TruthApt (K : Knowledge) where
+  prior : K → Float
+  belief : K → Float?
+
+class BPNode (K : Knowledge) where
+  to_variable : K → VariableNode
+
+instance : TruthApt Claim
+instance : TruthApt Setting
+-- Question has no TruthApt instance → cannot have belief
+```
+
+Type classes replace the current ad-hoc conventions (scattered if-else checks for "is this type truth-apt?") with explicit, checkable declarations. The `belief_bearing` and `exportable` judgments from V1 become derived from type class instances rather than hardcoded rules.
+
+### Phase 4: Inductive type definitions
+
+Allow users to define new knowledge types within the language:
+
+```
+inductive Knowledge where
+  | Claim
+  | Question
+  | Setting
+  | Action
+  | Expr
+  | Ref
+  | Module
+
+inductive Action <: Knowledge where
+  | InferAction
+  | ToolCallAction
+```
+
+Users can extend the hierarchy for domain-specific needs:
+
+```
+inductive MedicalClaim <: Claim where
+  | SideEffect
+  | DrugInteraction
+  | Contraindication
+```
+
+This moves type definitions from the Python implementation layer into the language itself. Combined with type classes, new types automatically inherit or override behavior.
+
+**Important scope limitation:** Inductive types define the **structural** taxonomy of knowledge (what form it takes, what operations are valid). They do not define **content** classification (what topic it covers) — that remains the job of keywords, embeddings, and graph topology.
+
+### Phase 5: Effect and capability typing
+
+Distinguish action kinds more sharply:
+
+- purely inferential steps
+- tool-backed steps (require runtime environment)
+- retrieval steps (require access to knowledge base)
+- proof-producing steps (output formal artifacts)
+- simulation or verification steps
+
+This suggests typing actions by their capabilities and requirements:
+
+```
+action verify_claim : Action[requires=LeanRuntime, produces=Proof]
+action search_literature : Action[requires=VectorDB, produces=List[Ref]]
+```
+
+### Phase 6: Restricted refinement typing
+
+Add expressive types where clearly useful, without full dependent type theory:
+
+```
+-- Edge probability constraint depends on edge type
+induction_edge : Edge where
+  probability : { p : Float | 0 < p ∧ p < 1 }  -- must be < 1
+
+-- Action that returns evidence for a specific claim schema
+verify : Action(claim : Claim) → Evidence(claim)
+```
+
+This gives practical benefits of dependent types (value-level constraints in types) without the full complexity of CIC.
+
+### Phase 7: Formal proof as sublanguage
+
+If Gaia wants genuine formal proof support, add it as a narrower subsystem:
+
+- `Formula` — formal logical statement
+- `Proof` — formal proof artifact
+- `LeanProofAction` — action that calls Lean to produce a proof
+- `SMTCheckAction` — action that calls an SMT solver
+
+Formal proof becomes one high-confidence evidence source among many. Some claims may have formal proofs attached; most will rely on probabilistic evidence and review. Gaia remains a language for defeasible scientific reasoning, with formal proof as an optional upgrade path.
+
+## Summary
+
+Gaia's type system follows one principle: **Lean's structure + Jaynes' semantics.**
+
+From Lean, Gaia borrows architecture: trusted kernel, elaboration, judgments, environments, goal-state reasoning, module discipline.
+
+From Lean, Gaia explicitly declines: Curry-Howard, full dependent types, definitional equality, monotonic proof semantics, aggressive implicit inference.
+
+The expansion path is:
+
+| Phase | Adds | Solves |
+|---|---|---|
+| **V1** | Typed structural kernel with judgments | Ad hoc validation → formal checking |
+| **2** | BeliefState + hole-driven reasoning | Opaque reasoning → observable progress |
+| **3** | Type classes | Implicit conventions → explicit interfaces |
+| **4** | Inductive type definitions | Hardcoded types → user-extensible taxonomy |
+| **5** | Effect and capability typing | Undifferentiated actions → typed capabilities |
+| **6** | Restricted refinement typing | Stringly-typed constraints → value-level type safety |
+| **7** | Formal proof sublanguage | Probabilistic-only → formal proof as evidence source |
+
+Each phase adds the minimum machinery needed for a real problem, without prematurely importing complexity from Lean's full type theory.

--- a/docs/foundations/language/type-system-direction.md
+++ b/docs/foundations/language/type-system-direction.md
@@ -264,9 +264,13 @@ The kernel should establish these judgments:
 - `Γ ⊢ chain lowers_to fg_fragment`
 - `Γ ⊢ fg well_formed`
 
-**Export and belief participation:**
-- `Γ ⊢ x exportable`
+**Belief participation (type-level):**
 - `Γ ⊢ x belief_bearing`
+
+**Export (module-level):**
+- `Γ, M ⊢ x exportable`
+
+Note the distinction: `belief_bearing` is an intrinsic property of a declaration's type (Claim and Setting are belief-bearing, Question is not). `exportable` is a module boundary property — it depends on whether `x` appears in module `M`'s export list, not on `x`'s type. Any declaration type can be exported or not.
 
 These are intentionally modest — they define the structural kernel without overcommitting to future machinery.
 
@@ -301,39 +305,34 @@ instance : TruthApt Setting
 -- Question has no TruthApt instance → cannot have belief
 ```
 
-Type classes replace the current ad-hoc conventions (scattered if-else checks for "is this type truth-apt?") with explicit, checkable declarations. The `belief_bearing` and `exportable` judgments from V1 become derived from type class instances rather than hardcoded rules.
+Type classes replace the current ad-hoc conventions (scattered if-else checks for "is this type truth-apt?") with explicit, checkable declarations. The `belief_bearing` judgment from V1 becomes derived from type class instances rather than hardcoded rules. Note that `exportable` remains a module-level judgment — it depends on the module's export list, not on type class membership.
 
-### Phase 4: Inductive type definitions
+### Phase 4: User-extensible knowledge types
 
-Allow users to define new knowledge types within the language:
+Move type definitions from the Python implementation layer into the language itself, with a clear distinction between closed and open layers.
 
-```
-inductive Knowledge where
-  | Claim
-  | Question
-  | Setting
-  | Action
-  | Expr
-  | Ref
-  | Module
+**Root types are closed.** The base knowledge categories (Claim, Question, Setting, Action, Expr, Ref, Module) define the grammar of the language. They determine what kernel judgments apply, how declarations participate in BP, and what structural rules hold. These are fixed by the language definition, just as Lean's core type formers (inductive, structure, class) are fixed.
 
-inductive Action <: Knowledge where
-  | InferAction
-  | ToolCallAction
-```
-
-Users can extend the hierarchy for domain-specific needs:
+**Subtypes are open.** Users can extend any root type with domain-specific subtypes without modifying the root definition:
 
 ```
-inductive MedicalClaim <: Claim where
-  | SideEffect
-  | DrugInteraction
-  | Contraindication
+-- User-defined subtypes of Claim
+extend Claim where
+  | Observation      -- direct empirical data
+  | Conjecture       -- unverified hypothesis
+  | Theorem          -- highly verified
+
+-- User-defined subtypes of Action
+extend Action where
+  | PythonAction     -- executes Python code
+  | LeanProofAction  -- calls Lean prover
 ```
 
-This moves type definitions from the Python implementation layer into the language itself. Combined with type classes, new types automatically inherit or override behavior.
+New subtypes inherit the kernel rules of their parent (a `Conjecture` is a `Claim`, so it is `belief_bearing` and participates in BP). Type class instances can be overridden for subtypes where needed (e.g., `Observation` might have a higher default prior than `Conjecture`).
 
-**Important scope limitation:** Inductive types define the **structural** taxonomy of knowledge (what form it takes, what operations are valid). They do not define **content** classification (what topic it covers) — that remains the job of keywords, embeddings, and graph topology.
+The exact syntax (`extend`, `open inductive`, or another mechanism) is deferred. The design commitment is: **closed root types for language integrity, open subtypes for domain extensibility.**
+
+**Important scope limitation:** This extensibility defines the **structural** taxonomy of knowledge (what form it takes, what operations are valid). It does not define **content** classification (what topic it covers) — that remains the job of keywords, embeddings, and graph topology.
 
 ### Phase 5: Effect and capability typing
 
@@ -393,7 +392,7 @@ The expansion path is:
 | **V1** | Typed structural kernel with judgments | Ad hoc validation → formal checking |
 | **2** | BeliefState + hole-driven reasoning | Opaque reasoning → observable progress |
 | **3** | Type classes | Implicit conventions → explicit interfaces |
-| **4** | Inductive type definitions | Hardcoded types → user-extensible taxonomy |
+| **4** | User-extensible knowledge types | Hardcoded types → open subtype taxonomy |
 | **5** | Effect and capability typing | Undifferentiated actions → typed capabilities |
 | **6** | Restricted refinement typing | Stringly-typed constraints → value-level type safety |
 | **7** | Formal proof sublanguage | Probabilistic-only → formal proof as evidence source |


### PR DESCRIPTION
## Summary

- Replaces PR #74 with a more complete type system direction document
- Synthesizes our brainstorming discussion with Codex's kernel-first approach
- Establishes the foundational principle: **Lean's structure + Jaynes' semantics**

## Key differences from PR #74

| Topic | PR #74 | This PR |
|---|---|---|
| **Curry-Howard** | Says "avoid" but doesn't explain why | Explains the 3 reasons (proof irrelevance, binary inhabitation, monotonicity) with concrete examples |
| **Probability placement** | Implicit | Explicit section: probability at value level, type system deterministic |
| **Type classes** | Not mentioned | Phase 3 in roadmap — formalizes TruthApt, BPNode interfaces |
| **Inductive types** | Not mentioned | Phase 4 in roadmap — user-definable knowledge types |
| **Phasing** | 6 phases focused on kernel + knowledge sorts | 7 phases: kernel → BeliefState → type classes → inductive types → effects → refinement → formal proof |
| **Length** | 617 lines | ~400 lines (more concise, same coverage) |

## What's preserved from PR #74

- Kernel-first V1 approach with judgments (`Γ ⊢ chain ok`, etc.)
- No LLM in the kernel principle
- Construction/verification separation
- Elaboration pipeline
- Formal checking vs semantic review vs BP distinction

## What's added from brainstorming

- Why claims must be terms, not types (Curry-Howard analysis)
- Why probability cannot be in the type system
- Type classes as Phase 3 (replaces ad-hoc if-else conventions)
- Inductive types as Phase 4 (user-extensible taxonomy)
- Formal proof as Phase 7 sublanguage (not the whole language)

Supersedes #74.

## Test plan

- [ ] Review document for logical consistency with existing foundation docs
- [ ] Verify alignment with design-rationale.md (Lean analogy section)
- [ ] Confirm no contradictions with gaia-language-spec.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)