### PR TITLE
test: add regression coverage for relation edge cases

### DIFF
--- a/tests/libs/dsl/test_relation_compiler.py
+++ b/tests/libs/dsl/test_relation_compiler.py
@@ -12,7 +12,6 @@ from libs.dsl.models import (
     StepLambda,
     StepRef,
 )
-from libs.dsl.resolver import resolve_refs
 
 
 def test_contradiction_compiles_to_variable_node():
@@ -178,40 +177,6 @@ def test_non_exported_relation_excluded():
     assert "hidden_contra" not in fg.variables
     # No constraint factor either (relation var not in fg.variables)
     assert len(fg.factors) == 0
-
-
-def test_relation_exported_via_ref_alias_generates_constraint_factor():
-    """Re-exported Relations should keep their constraint factor under the alias name."""
-    base = Module(
-        type="reasoning_module",
-        name="base",
-        declarations=[
-            Claim(name="a0", content="A", prior=0.8),
-            Claim(name="b0", content="B", prior=0.7),
-            Contradiction(name="c0", between=["a0", "b0"], prior=0.9),
-        ],
-        export=[],
-    )
-    alias = Module(
-        type="reasoning_module",
-        name="alias",
-        declarations=[
-            Ref(name="a", target="base.a0"),
-            Ref(name="b", target="base.b0"),
-            Ref(name="c", target="base.c0"),
-        ],
-        export=["a", "b", "c"],
-    )
-    pkg = Package(name="alias_export", modules=["base", "alias"])
-    pkg.loaded_modules = [base, alias]
-
-    fg = compile_factor_graph(resolve_refs(pkg))
-
-    assert fg.variables["c"] == 0.9
-    factor = next(f for f in fg.factors if f["name"] == "c.constraint")
-    assert factor["edge_type"] == "relation_contradiction"
-    assert set(factor["premises"]) == {"a", "b"}
-    assert factor["conclusions"] == ["c"]
 
 
 def test_edge_type_emits_deprecation_warning():

--- a/tests/libs/dsl/test_relation_compiler.py
+++ b/tests/libs/dsl/test_relation_compiler.py
@@ -12,6 +12,7 @@ from libs.dsl.models import (
     StepLambda,
     StepRef,
 )
+from libs.dsl.resolver import resolve_refs
 
 
 def test_contradiction_compiles_to_variable_node():
@@ -177,6 +178,40 @@ def test_non_exported_relation_excluded():
     assert "hidden_contra" not in fg.variables
     # No constraint factor either (relation var not in fg.variables)
     assert len(fg.factors) == 0
+
+
+def test_relation_exported_via_ref_alias_generates_constraint_factor():
+    """Re-exported Relations should keep their constraint factor under the alias name."""
+    base = Module(
+        type="reasoning_module",
+        name="base",
+        declarations=[
+            Claim(name="a0", content="A", prior=0.8),
+            Claim(name="b0", content="B", prior=0.7),
+            Contradiction(name="c0", between=["a0", "b0"], prior=0.9),
+        ],
+        export=[],
+    )
+    alias = Module(
+        type="reasoning_module",
+        name="alias",
+        declarations=[
+            Ref(name="a", target="base.a0"),
+            Ref(name="b", target="base.b0"),
+            Ref(name="c", target="base.c0"),
+        ],
+        export=["a", "b", "c"],
+    )
+    pkg = Package(name="alias_export", modules=["base", "alias"])
+    pkg.loaded_modules = [base, alias]
+
+    fg = compile_factor_graph(resolve_refs(pkg))
+
+    assert fg.variables["c"] == 0.9
+    factor = next(f for f in fg.factors if f["name"] == "c.constraint")
+    assert factor["edge_type"] == "relation_contradiction"
+    assert set(factor["premises"]) == {"a", "b"}
+    assert factor["conclusions"] == ["c"]
 
 
 def test_edge_type_emits_deprecation_warning():

--- a/tests/libs/dsl/test_relation_runtime.py
+++ b/tests/libs/dsl/test_relation_runtime.py
@@ -13,6 +13,81 @@ from libs.dsl.models import (
 from libs.dsl.runtime import DSLRuntime, RuntimeResult
 
 
+def _build_equivalence_package(
+    *,
+    member_names: tuple[str, ...],
+    priors: tuple[float, ...],
+    include_equivalence: bool,
+    relation_name: str,
+) -> tuple[Package, Equivalence | None]:
+    claims = [
+        Claim(name=name, content=name.upper(), prior=prior)
+        for name, prior in zip(member_names, priors, strict=True)
+    ]
+    relation = None
+    declarations = list(claims)
+    export = list(member_names)
+    if include_equivalence:
+        relation = Equivalence(name=relation_name, between=list(member_names), prior=0.85)
+        declarations.append(relation)
+        export.append(relation_name)
+
+    mod = Module(
+        type="reasoning_module",
+        name="m",
+        declarations=declarations,
+        export=export,
+    )
+    pkg = Package(name=f"{relation_name}_pkg", modules=["m"])
+    pkg.loaded_modules = [mod]
+    return pkg, relation
+
+
+def _build_shared_premise_package(include_contradiction: bool) -> tuple[Package, Contradiction | None]:
+    premise = Claim(name="premise", content="Shared premise", prior=0.8)
+    claim_a = Claim(name="a", content="Prediction A", prior=0.5)
+    claim_b = Claim(name="b", content="Prediction B", prior=0.5)
+
+    chain_a = ChainExpr(
+        name="chain_a",
+        steps=[
+            StepRef(step=1, ref="premise"),
+            StepLambda(step=2, **{"lambda": "derive A"}, prior=0.9),
+            StepRef(step=3, ref="a"),
+        ],
+    )
+    chain_b = ChainExpr(
+        name="chain_b",
+        steps=[
+            StepRef(step=1, ref="premise"),
+            StepLambda(step=2, **{"lambda": "derive B"}, prior=0.9),
+            StepRef(step=3, ref="b"),
+        ],
+    )
+
+    declarations = [premise, claim_a, claim_b, chain_a, chain_b]
+    export = ["premise", "a", "b"]
+    contra = None
+    if include_contradiction:
+        contra = Contradiction(
+            name="a_vs_b",
+            between=["a", "b"],
+            prior=0.95,
+        )
+        declarations.append(contra)
+        export.append("a_vs_b")
+
+    mod = Module(
+        type="reasoning_module",
+        name="m",
+        declarations=declarations,
+        export=export,
+    )
+    pkg = Package(name="test_integration", modules=["m"])
+    pkg.loaded_modules = [mod]
+    return pkg, contra
+
+
 async def test_contradiction_gets_belief_after_inference():
     """Relation declarations should have .belief set after BP."""
     claim_a = Claim(name="a", content="A", prior=0.8)
@@ -42,85 +117,76 @@ async def test_contradiction_gets_belief_after_inference():
 
 
 async def test_equivalence_gets_belief_after_inference():
-    """Equivalence relation should also get belief."""
-    claim_x = Claim(name="x", content="X", prior=0.6)
-    claim_y = Claim(name="y", content="Y", prior=0.9)
-    equiv = Equivalence(
-        name="x_equiv_y",
-        between=["x", "y"],
-        prior=0.85,
+    """Equivalence should change beliefs relative to the no-relation control graph."""
+    pkg, equiv = _build_equivalence_package(
+        member_names=("x", "y"),
+        priors=(0.6, 0.9),
+        include_equivalence=True,
+        relation_name="x_equiv_y",
     )
-    mod = Module(
-        type="reasoning_module",
-        name="m",
-        declarations=[claim_x, claim_y, equiv],
-        export=["x", "y", "x_equiv_y"],
+    control_pkg, _ = _build_equivalence_package(
+        member_names=("x", "y"),
+        priors=(0.6, 0.9),
+        include_equivalence=False,
+        relation_name="x_equiv_y",
     )
-    pkg = Package(name="test_equiv_bp", modules=["m"])
-    pkg.loaded_modules = [mod]
-
     runtime = DSLRuntime()
-    result = RuntimeResult(package=pkg)
-    result = await runtime.infer(result)
+    result = await runtime.infer(RuntimeResult(package=pkg))
+    control = await runtime.infer(RuntimeResult(package=control_pkg))
 
+    assert equiv is not None
     assert equiv.belief is not None
-    # Equivalence should pull beliefs together
-    prior_gap = abs(0.9 - 0.6)
-    posterior_gap = abs(result.beliefs["y"] - result.beliefs["x"])
-    assert posterior_gap < prior_gap
+    # Equivalence should pull both claims toward each other compared with the control graph.
+    result_gap = abs(result.beliefs["y"] - result.beliefs["x"])
+    control_gap = abs(control.beliefs["y"] - control.beliefs["x"])
+    assert result_gap < control_gap
+    assert result.beliefs["x"] > control.beliefs["x"]
+    assert result.beliefs["y"] < control.beliefs["y"]
 
 
 async def test_contradiction_weakens_shared_premises():
-    """Full pipeline: Contradiction relation should weaken beliefs of claims
-    that are premises of both contradicting claims."""
-    # Setup: shared premise -> two contradicting conclusions
-    premise = Claim(name="premise", content="Shared premise", prior=0.8)
-    claim_a = Claim(name="a", content="Prediction A", prior=0.5)
-    claim_b = Claim(name="b", content="Prediction B", prior=0.5)
-
-    chain_a = ChainExpr(
-        name="chain_a",
-        steps=[
-            StepRef(step=1, ref="premise"),
-            StepLambda(step=2, **{"lambda": "derive A"}, prior=0.9),
-            StepRef(step=3, ref="a"),
-        ],
-    )
-    chain_b = ChainExpr(
-        name="chain_b",
-        steps=[
-            StepRef(step=1, ref="premise"),
-            StepLambda(step=2, **{"lambda": "derive B"}, prior=0.9),
-            StepRef(step=3, ref="b"),
-        ],
-    )
-    contra = Contradiction(
-        name="a_vs_b",
-        between=["a", "b"],
-        prior=0.95,
-    )
-
-    mod = Module(
-        type="reasoning_module",
-        name="m",
-        declarations=[premise, claim_a, claim_b, chain_a, chain_b, contra],
-        export=["premise", "a", "b", "a_vs_b"],
-    )
-    pkg = Package(name="test_integration", modules=["m"])
-    pkg.loaded_modules = [mod]
-
+    """Contradiction should lower the shared premise and both branches vs control."""
+    pkg, contra = _build_shared_premise_package(include_contradiction=True)
+    control_pkg, _ = _build_shared_premise_package(include_contradiction=False)
     runtime = DSLRuntime()
-    result = RuntimeResult(package=pkg)
-    result = await runtime.infer(result)
+    result = await runtime.infer(RuntimeResult(package=pkg))
+    control = await runtime.infer(RuntimeResult(package=control_pkg))
 
-    # Both claims should be lower than without contradiction
-    # Without contradiction, chains would push a and b above 0.5
-    # With contradiction, they can't both be true -> both drop
-    assert result.beliefs["a"] < 0.8  # limited by contradiction
-    assert result.beliefs["b"] < 0.8
-
-    # Shared premise should also be weakened (indirect BP propagation)
-    assert result.beliefs["premise"] < 0.8
-
-    # Contradiction belief should stay high
+    assert result.beliefs["a"] < control.beliefs["a"]
+    assert result.beliefs["b"] < control.beliefs["b"]
+    assert result.beliefs["premise"] < control.beliefs["premise"]
+    assert contra is not None
     assert result.beliefs["a_vs_b"] > 0.8
+
+
+async def test_nary_equivalence_pulls_all_members_toward_group():
+    """A 3-way equivalence should affect every member, not just the first two."""
+    pkg, equiv = _build_equivalence_package(
+        member_names=("a", "b", "c"),
+        priors=(0.9, 0.1, 0.9),
+        include_equivalence=True,
+        relation_name="abc_equiv",
+    )
+    control_pkg, _ = _build_equivalence_package(
+        member_names=("a", "b", "c"),
+        priors=(0.9, 0.1, 0.9),
+        include_equivalence=False,
+        relation_name="abc_equiv",
+    )
+    runtime = DSLRuntime()
+    result = await runtime.infer(RuntimeResult(package=pkg))
+    control = await runtime.infer(RuntimeResult(package=control_pkg))
+
+    assert equiv is not None
+    assert equiv.belief is not None
+    assert result.beliefs["b"] > control.beliefs["b"]
+    assert result.beliefs["a"] < control.beliefs["a"]
+    assert result.beliefs["c"] < control.beliefs["c"]
+
+    result_spread = max(result.beliefs[name] for name in ("a", "b", "c")) - min(
+        result.beliefs[name] for name in ("a", "b", "c")
+    )
+    control_spread = max(control.beliefs[name] for name in ("a", "b", "c")) - min(
+        control.beliefs[name] for name in ("a", "b", "c")
+    )
+    assert result_spread < control_spread

--- a/tests/libs/dsl/test_runtime.py
+++ b/tests/libs/dsl/test_runtime.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from libs.dsl.models import RetractAction
 from libs.dsl.runtime import DSLRuntime, RuntimeResult
 
 from .conftest import MockExecutor
@@ -64,6 +65,23 @@ async def test_runtime_beliefs_written_back_to_declarations():
     thought_env = next(d for d in setting_mod.declarations if d.name == "thought_experiment_env")
     assert thought_env.belief is not None
     assert thought_env.belief == result.beliefs["thought_experiment_env"]
+
+
+async def test_runtime_preserves_retract_action_provenance_contract():
+    """RetractAction should remain provenance-only while pointing to belief-bearing nodes."""
+    runtime = DSLRuntime(executor=MockExecutor())
+    result = await runtime.run(FIXTURE_DIR)
+
+    reasoning = next(m for m in result.package.loaded_modules if m.name == "reasoning")
+    retract = next(d for d in reasoning.declarations if d.name == "retract_aristotle")
+
+    assert isinstance(retract, RetractAction)
+    assert retract.target == "heavier_falls_faster"
+    assert retract.reason == "tied_balls_contradiction"
+    assert retract.name not in result.beliefs
+    assert retract.target in result.beliefs
+    assert retract.reason in result.beliefs
+    assert not any(f["name"].startswith("retract_aristotle") for f in result.factor_graph.factors)
 
 
 async def test_runtime_execute_only():


### PR DESCRIPTION
## Summary
- add compiler coverage for Relations exported through `Ref` aliases
- strengthen runtime Relation tests with control-vs-experiment assertions
- add a 3-member Equivalence regression test so every member must participate
- add an end-to-end RetractAction provenance contract test in the Galileo runtime suite

## Notes
- test-only PR; no implementation changes
- I did not run tests in this branch per request
