### PR TITLE
feat: gate relation constraints by inferred belief

### DIFF
--- a/libs/dsl/compiler.py
+++ b/libs/dsl/compiler.py
@@ -28,7 +28,7 @@ class DSLFactorGraph:
     """Factor graph built from DSL package structure.
 
     variables: name -> prior
-    factors: list of {name, premises: [name], conclusions: [name], probability}
+    factors: list of {name, premises: [name], conclusions: [name], probability, gate_var?}
     """
 
     variables: dict[str, float] = field(default_factory=dict)
@@ -169,11 +169,11 @@ def _compile_relation(
     edge_type = f"relation_{rel.type}"
     prob = rel.prior if rel.prior is not None else 0.5
 
-    # Relation variable is NOT included in the constraint factor (no gate variable).
-    # This avoids a feedback loop where the constraint's f2v message to E favors E=0
-    # (unconstrained state is always "cheaper"), pulling Relation belief down.
-    # Constraint strength comes from the Relation's prior via the probability parameter.
-    # The edge_type carries the semantic information for BP potential computation.
+    # Relation variable is NOT included in the constraint factor.
+    # Instead, the factor stores a read-only gate_var reference so BP can use the
+    # Relation's current belief as the effective constraint strength without sending
+    # messages back into the gate.
+    # probability stores the initial / fallback strength (the Relation prior).
 
     if isinstance(rel, Equivalence) and len(related_vars) > 2:
         # Decompose n-ary equivalence into pairwise constraints.
@@ -186,6 +186,7 @@ def _compile_relation(
                     "conclusions": [],
                     "probability": prob,
                     "edge_type": edge_type,
+                    "gate_var": var_name,
                 }
             )
     else:
@@ -196,5 +197,6 @@ def _compile_relation(
                 "conclusions": [],
                 "probability": prob,
                 "edge_type": edge_type,
+                "gate_var": var_name,
             }
         )

--- a/libs/dsl/runtime.py
+++ b/libs/dsl/runtime.py
@@ -69,12 +69,16 @@ class DSLRuntime:
         for j, factor in enumerate(dsl_fg.factors):
             premise_ids = [name_to_id[n] for n in factor["premises"] if n in name_to_id]
             conclusion_ids = [name_to_id[n] for n in factor["conclusions"] if n in name_to_id]
+            gate_var_id = None
+            if factor.get("gate_var") in name_to_id:
+                gate_var_id = name_to_id[factor["gate_var"]]
             bp_fg.add_factor(
                 edge_id=j + 1,
                 premises=premise_ids,
                 conclusions=conclusion_ids,
                 probability=factor["probability"],
                 edge_type=factor.get("edge_type", "deduction"),
+                gate_var=gate_var_id,
             )
 
         # Run BP

--- a/libs/inference/bp.py
+++ b/libs/inference/bp.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 
+from libs.inference.factor_graph import CROMWELL_EPS
+
 if TYPE_CHECKING:
     from libs.inference.factor_graph import FactorGraph
 
@@ -61,12 +63,14 @@ def _evaluate_potential(
 ) -> float:
     """Evaluate factor potential for a full variable assignment.
 
-    **Relation types** (custom gating via conclusion variable E):
+    **Relation types**:
 
-    - **relation_contradiction**: When E=1 (believe the contradiction),
-      penalize A=1 ∧ B=1. When E=0, no constraint.
-    - **relation_equivalence**: When E=1 (believe the equivalence),
-      reward A==B and penalize A≠B. When E=0, no constraint.
+    - **relation_contradiction**: penalize A=1 ∧ B=1.
+    - **relation_equivalence**: reward A==B and penalize A≠B.
+
+    For Relation constraints, any dynamic gating is handled outside this function:
+    `_compute_factor_to_var()` may replace ``prob`` with the current belief of a
+    read-only ``gate_var`` associated with the factor.
 
     **Standard types** (gated on "all premises true"):
 
@@ -90,9 +94,9 @@ def _evaluate_potential(
        premise inhibition and conclusion confirmation share the same
        potential.
     """
-    # --- Relation types: no gate variable, edge_type carries semantics ---
-    # Constraint strength is encoded in `prob` (from Relation's prior).
-    # Relation variable is excluded from the factor to avoid feedback loops.
+    # --- Relation types: edge_type carries semantics ---
+    # Constraint strength is passed in via `prob`. When a factor has a read-only
+    # gate_var, `_compute_factor_to_var()` substitutes the gate's current belief.
     if edge_type == "relation_contradiction":
         all_claims_true = all(assignment[p] == 1 for p in premise_ids)
         return (1.0 - prob) if all_claims_true else 1.0
@@ -154,6 +158,7 @@ def _compute_factor_to_var(
     target_var: int,
     factor: dict,
     v2f_msgs: dict[tuple[int, int], Msg],
+    gate_beliefs: dict[int, float],
 ) -> Msg:
     """Compute factor→variable message by marginalizing over all other variables.
 
@@ -164,6 +169,15 @@ def _compute_factor_to_var(
     conclusion_ids: list[int] = factor["conclusions"]
     prob: float = factor["probability"]
     edge_type: str = factor.get("edge_type", "deduction")
+    gate_var: int | None = factor.get("gate_var")
+
+    # Optional read-only gate: use the previous iteration's marginal belief for the
+    # Relation variable as the effective constraint strength. The gate variable is
+    # intentionally not part of the factor's participant set, so the factor never
+    # sends messages back into the gate and cannot create a feedback loop.
+    if gate_var is not None:
+        prob = gate_beliefs.get(gate_var, prob)
+        prob = max(CROMWELL_EPS, min(1.0 - CROMWELL_EPS, prob))
 
     all_vars = premise_ids + conclusion_ids
     other_vars = [v for v in all_vars if v != target_var]
@@ -261,7 +275,13 @@ class BeliefPropagation:
             # 2. Compute all factor→var messages
             new_f2v: dict[tuple[int, int], Msg] = {}
             for (fi, vid), _ in f2v_msgs.items():
-                new_f2v[(fi, vid)] = _compute_factor_to_var(fi, vid, graph.factors[fi], new_v2f)
+                new_f2v[(fi, vid)] = _compute_factor_to_var(
+                    fi,
+                    vid,
+                    graph.factors[fi],
+                    new_v2f,
+                    prev_beliefs,
+                )
 
             # 3. Damp and normalize
             for key in f2v_msgs:

--- a/libs/inference/factor_graph.py
+++ b/libs/inference/factor_graph.py
@@ -54,6 +54,7 @@ class FactorGraph:
         conclusions: list[int],
         probability: float,
         edge_type: str = "deduction",
+        gate_var: int | None = None,
     ) -> None:
         """Add a factor (hyperedge) connecting variables.
 
@@ -67,15 +68,16 @@ class FactorGraph:
                 probability,
                 clamped,
             )
-        self.factors.append(
-            {
-                "edge_id": edge_id,
-                "premises": premises,
-                "conclusions": conclusions,
-                "probability": clamped,
-                "edge_type": edge_type,
-            }
-        )
+        factor = {
+            "edge_id": edge_id,
+            "premises": premises,
+            "conclusions": conclusions,
+            "probability": clamped,
+            "edge_type": edge_type,
+        }
+        if gate_var is not None:
+            factor["gate_var"] = gate_var
+        self.factors.append(factor)
 
     @classmethod
     def from_subgraph(cls, nodes: list[Node], edges: list[HyperEdge]) -> FactorGraph:

--- a/tests/libs/dsl/test_relation_compiler.py
+++ b/tests/libs/dsl/test_relation_compiler.py
@@ -13,6 +13,7 @@ from libs.dsl.models import (
     StepRef,
 )
 
+
 def test_contradiction_compiles_to_variable_node():
     claim_a = Claim(name="a", content="A", prior=0.8)
     claim_b = Claim(name="b", content="B", prior=0.7)
@@ -86,6 +87,7 @@ def test_contradiction_generates_constraint_factor():
     assert set(factor["premises"]) == {"a", "b"}
     assert factor["conclusions"] == []  # Relation excluded to avoid feedback loop
     assert factor["probability"] == 0.95  # Uses Relation's prior as strength
+    assert factor["gate_var"] == "a_contradicts_b"
     assert factor["name"] == "a_contradicts_b.constraint"
 
 
@@ -113,6 +115,7 @@ def test_equivalence_generates_constraint_factor():
     assert factor["edge_type"] == "relation_equivalence"
     assert set(factor["premises"]) == {"x", "y"}
     assert factor["conclusions"] == []  # Relation excluded to avoid feedback loop
+    assert factor["gate_var"] == "x_equiv_y"
 
 
 def test_relation_with_chain_produces_both_factors():
@@ -241,6 +244,7 @@ def test_ref_alias_relation_gets_constraint():
     assert factor["edge_type"] == "relation_contradiction"
     assert set(factor["premises"]) == {"a", "b"}
     assert factor["name"] == "c.constraint"
+    assert factor["gate_var"] == "c"
 
 
 def test_equivalence_nary_decomposes_to_pairwise():
@@ -272,6 +276,7 @@ def test_equivalence_nary_decomposes_to_pairwise():
         assert len(f["premises"]) == 2
         assert f["edge_type"] == "relation_equivalence"
         assert f["conclusions"] == []
+        assert f["gate_var"] == "abc_equiv"
     # All pairs covered
     pairs = {tuple(sorted(f["premises"])) for f in constraint_factors}
     assert pairs == {("a", "b"), ("a", "c"), ("b", "c")}
@@ -300,3 +305,4 @@ def test_equivalence_binary_no_decomposition():
     constraint_factors = [f for f in fg.factors if "xy_equiv" in f["name"]]
     assert len(constraint_factors) == 1
     assert constraint_factors[0]["name"] == "xy_equiv.constraint"
+    assert constraint_factors[0]["gate_var"] == "xy_equiv"

--- a/tests/libs/dsl/test_relation_runtime.py
+++ b/tests/libs/dsl/test_relation_runtime.py
@@ -1,12 +1,14 @@
 """Runtime integration tests for Relation types."""
 
 from libs.dsl.models import (
+    Arg,
     ChainExpr,
     Claim,
     Contradiction,
     Equivalence,
     Module,
     Package,
+    StepApply,
     StepLambda,
     StepRef,
 )
@@ -43,7 +45,9 @@ def _build_equivalence_package(
     return pkg, relation
 
 
-def _build_shared_premise_package(include_contradiction: bool) -> tuple[Package, Contradiction | None]:
+def _build_shared_premise_package(
+    include_contradiction: bool,
+) -> tuple[Package, Contradiction | None]:
     premise = Claim(name="premise", content="Shared premise", prior=0.8)
     claim_a = Claim(name="a", content="Prediction A", prior=0.5)
     claim_b = Claim(name="b", content="Prediction B", prior=0.5)
@@ -84,6 +88,47 @@ def _build_shared_premise_package(include_contradiction: bool) -> tuple[Package,
         export=export,
     )
     pkg = Package(name="test_integration", modules=["m"])
+    pkg.loaded_modules = [mod]
+    return pkg, contra
+
+
+def _build_relation_gate_package(include_support_chain: bool) -> tuple[Package, Contradiction]:
+    claim_a = Claim(name="a", content="A", prior=0.8)
+    claim_b = Claim(name="b", content="B", prior=0.7)
+    contra = Contradiction(
+        name="a_vs_b",
+        between=["a", "b"],
+        prior=0.1,
+    )
+
+    declarations = [claim_a, claim_b, contra]
+    if include_support_chain:
+        declarations.append(
+            ChainExpr(
+                name="establish_contradiction",
+                steps=[
+                    StepRef(step=1, ref="a"),
+                    StepApply(
+                        step=2,
+                        apply="support_contradiction",
+                        args=[
+                            Arg(ref="a", dependency="direct"),
+                            Arg(ref="b", dependency="direct"),
+                        ],
+                        prior=0.95,
+                    ),
+                    StepRef(step=3, ref="a_vs_b"),
+                ],
+            )
+        )
+
+    mod = Module(
+        type="reasoning_module",
+        name="m",
+        declarations=declarations,
+        export=["a", "b", "a_vs_b"],
+    )
+    pkg = Package(name="relation_gate_pkg", modules=["m"])
     pkg.loaded_modules = [mod]
     return pkg, contra
 
@@ -190,3 +235,18 @@ async def test_nary_equivalence_pulls_all_members_toward_group():
         control.beliefs[name] for name in ("a", "b", "c")
     )
     assert result_spread < control_spread
+
+
+async def test_relation_support_chain_strengthens_constraint_via_gate_belief():
+    """Supporting evidence for a Relation should increase its constraint effect."""
+    pkg, contra = _build_relation_gate_package(include_support_chain=True)
+    control_pkg, _ = _build_relation_gate_package(include_support_chain=False)
+
+    runtime = DSLRuntime()
+    result = await runtime.infer(RuntimeResult(package=pkg))
+    control = await runtime.infer(RuntimeResult(package=control_pkg))
+
+    assert contra.belief is not None
+    assert result.beliefs["a_vs_b"] > control.beliefs["a_vs_b"]
+    assert result.beliefs["a"] < control.beliefs["a"]
+    assert result.beliefs["b"] < control.beliefs["b"]

--- a/tests/libs/test_inference/test_factor_graph.py
+++ b/tests/libs/test_inference/test_factor_graph.py
@@ -24,6 +24,19 @@ def test_add_factor():
     assert fg.factors[0]["edge_type"] == "induction"
 
 
+def test_add_factor_with_gate_var():
+    fg = FactorGraph()
+    fg.add_factor(
+        edge_id=100,
+        premises=[1, 2],
+        conclusions=[],
+        probability=0.8,
+        edge_type="relation_contradiction",
+        gate_var=3,
+    )
+    assert fg.factors[0]["gate_var"] == 3
+
+
 def test_from_subgraph():
     nodes = [
         Node(id=1, type="paper-extract", content="p1", prior=0.9),

--- a/tests/services/test_inference_engine/test_bp.py
+++ b/tests/services/test_inference_engine/test_bp.py
@@ -885,6 +885,50 @@ class TestRelationContradiction:
         # Stronger prob should cause more drop
         assert beliefs_strong[1] < beliefs_weak[1]
 
+    def test_gate_var_strengthens_constraint_when_relation_belief_rises(self):
+        """A supported Relation belief should dynamically strengthen the constraint."""
+        fg = FactorGraph()
+        fg.add_variable(1, 0.8)  # Claim A
+        fg.add_variable(2, 0.7)  # Claim B
+        fg.add_variable(3, 0.1)  # Relation node E starts weak
+        fg.add_variable(4, 0.95)  # Support for the Relation
+        fg.add_factor(
+            edge_id=1,
+            premises=[4],
+            conclusions=[3],
+            probability=0.99,
+            edge_type="deduction",
+        )
+        fg.add_factor(
+            edge_id=2,
+            premises=[1, 2],
+            conclusions=[],
+            probability=0.1,  # fallback if gate belief is unavailable
+            edge_type="relation_contradiction",
+            gate_var=3,
+        )
+
+        control = FactorGraph()
+        control.add_variable(1, 0.8)
+        control.add_variable(2, 0.7)
+        control.add_variable(3, 0.1)
+        control.add_factor(
+            edge_id=1,
+            premises=[1, 2],
+            conclusions=[],
+            probability=0.1,
+            edge_type="relation_contradiction",
+            gate_var=3,
+        )
+
+        bp = BeliefPropagation(damping=1.0, max_iterations=50)
+        beliefs = bp.run(fg)
+        control_beliefs = bp.run(control)
+
+        assert beliefs[3] > control_beliefs[3]
+        assert beliefs[1] < control_beliefs[1]
+        assert beliefs[2] < control_beliefs[2]
+
 
 class TestRelationEquivalence:
     """Tests for the relation_equivalence factor (no gate variable)."""

--- a/tests/services/test_inference_engine/test_factor_graph.py
+++ b/tests/services/test_inference_engine/test_factor_graph.py
@@ -24,6 +24,19 @@ def test_add_factor():
     assert fg.factors[0]["edge_type"] == "induction"
 
 
+def test_add_factor_with_gate_var():
+    fg = FactorGraph()
+    fg.add_factor(
+        edge_id=100,
+        premises=[1, 2],
+        conclusions=[],
+        probability=0.8,
+        edge_type="relation_contradiction",
+        gate_var=3,
+    )
+    assert fg.factors[0]["gate_var"] == 3
+
+
 def test_from_subgraph():
     nodes = [
         Node(id=1, type="paper-extract", content="p1", prior=0.9),


### PR DESCRIPTION
## Background
PR 79 introduces relation nodes such as `Contradiction` and `Equivalence`, but after the latest compiler/runtime shape the constraint factors themselves are still driven by the relation declaration's compiled `prior`. In practice that means the relation node can accumulate evidence and get a higher posterior belief, while the contradiction/equivalence strength applied to the connected claims remains fixed.

This PR restores a coupling between the inferred relation belief and the effective constraint strength used during BP.

## What This Changes
- Add an optional `gate_var` field to relation constraint factors emitted by the DSL compiler
- Thread that metadata through runtime graph construction into the inference `FactorGraph`
- In BP, use the previous iteration belief of `gate_var` as the effective probability for `relation_contradiction` and `relation_equivalence`
- Keep the relation variable out of the constraint factor's participants, so the factor still constrains only the related claims/premises while using the relation belief as a read-only gate signal

## Implementation Notes
### Compiler / Runtime
For contradiction and equivalence factors, the compiler now emits both:
- the existing fallback `probability`
- a `gate_var` pointing at the relation variable name

Runtime resolves that name to the concrete graph node id and passes it into `FactorGraph.add_factor(...)`.

### Belief Propagation
When BP computes a factor-to-variable message for a factor with `gate_var`:
- it looks up the previous iteration belief of the gate node
- it uses that belief as the factor's effective `prob`
- it clamps with the existing Cromwell epsilon guardrails

If no `gate_var` is present, behavior stays the same as before and the factor uses its static `probability`.

## Why Previous-Iteration Belief
This keeps the implementation simple and avoids making the factor potential directly depend on its own current-step messages. The resulting update rule is a fixed-point style approximation rather than a pure static-factor BP model, but it matches the intended product behavior here: evidence that raises belief in the relation should strengthen the relation's constraint in subsequent iterations.

## Scope
This PR only changes the gating behavior for relation constraint factors:
- `relation_contradiction`
- `relation_equivalence`

It does not change:
- claim priors
- deduction / support semantics
- non-relation factors

## Tests Added
### Compiler coverage
- relation constraint factors include `gate_var`
- alias-exported relation declarations still preserve the gate metadata
- decomposed n-ary equivalence factors all point back to the same relation gate

### Runtime coverage
- control vs experiment test showing that supporting evidence for a weak contradiction relation raises the relation belief and suppresses the connected claims more strongly

### Inference-layer coverage
- direct BP test for gated contradiction strength
- factor graph tests that `gate_var` metadata is stored correctly

## Testing
```bash
.venv/bin/python -m pytest tests/libs/dsl/test_relation_compiler.py tests/libs/dsl/test_relation_runtime.py tests/libs/dsl/test_runtime.py tests/libs/test_inference/test_factor_graph.py tests/services/test_inference_engine/test_bp.py tests/services/test_inference_engine/test_factor_graph.py -q
```

Result:
- `116 passed in 0.23s`

## Tradeoffs / Follow-ups
This is an intentionally pragmatic implementation. It restores the missing coupling between relation posterior and constraint strength without reworking the whole model as a fully explicit latent-variable joint factorization.

If we later want a more principled formulation, the next step would be to model that dependency directly in the graph rather than reading the previous iteration marginal as a gate signal.
