### PR TITLE
refactor: make knowledge the canonical module surface

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -448,7 +448,7 @@ def init_cmd(
     mod_data = {
         "type": "motivation_module",
         "name": "motivation",
-        "declarations": [
+        "knowledge": [
             {
                 "type": "question",
                 "name": "main_question",

--- a/docs/foundations/cli/command-lifecycle.md
+++ b/docs/foundations/cli/command-lifecycle.md
@@ -102,7 +102,7 @@ Its outputs should be review sidecars and local audit results.
 
 ### Stage 3.5: Inferred Package
 
-`gaia infer` compiles the factor graph from build/review outputs and runs local belief propagation to compute self-consistent belief scores across all declarations.
+`gaia infer` compiles the factor graph from build/review outputs and runs local belief propagation to compute self-consistent belief scores across all knowledge objects.
 
 This stage is shipped. It sits between review and verify in the lifecycle.
 
@@ -358,7 +358,7 @@ Gaia's intended model is instead:
 |---|---|---|---|---|---|
 | `build` | normalization | deterministic | grounded local core | "Is the package structurally valid and explicit?" | shipped |
 | `review` | audit | model-dependent | review sidecars and scores | "How credible is the reasoning?" | shipped |
-| `infer` | belief propagation | deterministic | belief scores on declarations | "What should we believe given the reasoning structure?" | shipped |
+| `infer` | belief propagation | deterministic | belief scores on knowledge objects | "What should we believe given the reasoning structure?" | shipped |
 | `verify` | reproduction | execution-dependent | verification evidence | "Does the executable/reproducible claim actually hold?" | future |
 | `publish` | handoff | protocol-driven | shared package submission | "Is this package ready for independent shared review?" | shipped |
 
@@ -367,7 +367,7 @@ Gaia's intended model is instead:
 For the target agentic research use case, the current shipped flow is:
 
 1. work privately in local workspace
-2. author YAML modules (declarations + chains)
+2. author YAML modules (knowledge objects + chains)
 3. run `gaia build` — structural validation, ref resolution, per-module Markdown
 4. run `gaia review` — LLM critique of reasoning chains
 5. run `gaia infer` — local belief propagation over the factor graph

--- a/docs/foundations/language/gaia-language-design.md
+++ b/docs/foundations/language/gaia-language-design.md
@@ -86,9 +86,9 @@ Knowledge                              (root type)
 - **ChainExpr**: linear pipeline connected by `=>`. The simplest form of composition.
 - Future subtypes may include BranchExpr, DAGExpr, etc. for more complex reasoning structures.
 
-**Ref** — a reference to knowledge declared in another module. Replaces the traditional `import` statement. Since Ref is a Knowledge type, imports are just declarations like any other knowledge object.
+**Ref** — a reference to knowledge declared in another module. Replaces the traditional `import` statement. Since Ref is a Knowledge type, imports are just knowledge objects like any other entry.
 
-**Module** — a composite knowledge unit that groups declarations and exports. Modules have a type describing their purpose (ReasoningModule, SettingModule, etc.) rather than a separate "role" field.
+**Module** — a composite knowledge unit that groups knowledge objects and exports. Modules have a type describing their purpose (ReasoningModule, SettingModule, etc.) rather than a separate "role" field.
 
 ### Key type distinctions
 
@@ -97,7 +97,7 @@ Knowledge                              (root type)
 | Truth-apt? | Yes | **No** | Yes | No | No | No | No |
 | Participates in BP? | Yes | No | Yes | Via application | Via steps | Via dependency | Via exports |
 | Can be "called"? | No | No | No | **Yes** | **Yes** | No | Deferred |
-| Has internal structure? | No | No | No | No | **Yes** (steps) | No | **Yes** (declarations) |
+| Has internal structure? | No | No | No | No | **Yes** (steps) | No | **Yes** (knowledge objects) |
 
 ### Subtyping rules
 
@@ -134,7 +134,7 @@ chain_expr main_derivation := premise => contrastive_analysis(premise) => conclu
 
 ref premise := env_module.premise
 
-reasoning_module main := <declarations...> export conclusion
+reasoning_module main := <knowledge...> export conclusion
 ```
 
 ### Immutability
@@ -276,7 +276,7 @@ Future Expr subtypes (BranchExpr, DAGExpr) may provide explicit branching syntax
 
 ### Definition
 
-A Module is a Knowledge type (subtype of Knowledge) that groups declarations, manages references, and provides scoping. Its "type" describes its purpose (replacing the earlier "role" concept):
+A Module is a Knowledge type (subtype of Knowledge) that groups knowledge objects, manages references, and provides scoping. Its "type" describes its purpose (replacing the earlier "role" concept):
 
 ```
 reasoning_module main:
@@ -291,9 +291,9 @@ reasoning_module main:
   export conclusion
 ```
 
-### Imports as Ref declarations
+### Imports as Ref knowledge objects
 
-There is no separate import syntax. Imports are `ref` type declarations within a module:
+There is no separate import syntax. Imports are `ref` knowledge objects within a module:
 
 ```
 ref premise := env_module.premise           -- reference to external knowledge
@@ -475,7 +475,7 @@ dependencies:
 type: reasoning_module
 name: reasoning
 
-declarations:
+knowledge:
   # Ref — reference to external knowledge
   - type: ref
     name: premise
@@ -550,7 +550,7 @@ steps:
 
 | Abstract Syntax | YAML representation |
 |----------------|---------------------|
-| `Type Name Body` | `type: xxx`, `name: xxx`, `content/steps/target/declarations: ...` |
+| `Type Name Body` | `type: xxx`, `name: xxx`, `content/steps/target/knowledge: ...` |
 | `KnowledgeRef` | `ref: name` |
 | `Application` | `apply: name`, `args: [...]` |
 | `Lambda` | `lambda: "text"` |
@@ -636,7 +636,7 @@ The following questions have been resolved:
 2. **Declaration unified or split?** -> Unified. One Knowledge form, Body distinguishes types.
 3. **Module role or type?** -> Type. Module is a Knowledge type (ReasoningModule, SettingModule, etc.).
 4. **Expression: structural element or type?** -> Type. Expr is a Knowledge base type, ChainExpr is a subtype of Expr under Action's sibling.
-5. **Import: separate syntax or Ref type?** -> Ref type. Imports are `ref` declarations, not a separate syntactic construct.
+5. **Import: separate syntax or Ref type?** -> Ref type. Imports are `ref` knowledge objects, not a separate syntactic construct.
 6. **Lambda: traditional or pipe-implicit?** -> Pipe-implicit single-parameter anonymous function.
 7. **Strong/weak: on Ref or on usage?** -> On usage. `dependency: direct/indirect` annotated at the point of use (in Application args).
 8. **Strong/weak naming?** -> `direct` / `indirect`. More descriptive than strong/weak.

--- a/docs/foundations/language/gaia-language-spec.md
+++ b/docs/foundations/language/gaia-language-spec.md
@@ -298,16 +298,16 @@ Each module file is a YAML document with:
 
 - required `type`
 - required `name`
-- optional `declarations` (defaults to empty; a module with no declarations is structurally valid)
+- optional `knowledge` (defaults to empty; a module with no knowledge objects is structurally valid)
 - optional `export`
 
-Reasoning is expressed inside `declarations` via `chain_expr`.
+Reasoning is expressed inside `knowledge` via `chain_expr`.
 
 Gaia Language does not currently use a top-level module `chains:` key. Any simplified example that suggests otherwise should be treated as explanatory shorthand rather than normative syntax.
 
-### Declaration surface
+### Knowledge surface
 
-The current declaration kinds on `main` are:
+The current knowledge kinds on `main` are:
 
 - `claim`
 - `question`
@@ -323,11 +323,11 @@ The current declaration kinds on `main` are:
 - `apply`
 - `lambda`
 
-These are the shapes consumed by the current loader and runtime. The loader also accepts declaration types not in this list — unknown types are loaded as generic `Knowledge` objects so the LLM runtime can interpret their semantics during build and review.
+These are the shapes consumed by the current loader and runtime. The loader also accepts knowledge types not in this list — unknown types are loaded as generic `Knowledge` objects so the LLM runtime can interpret their semantics during build and review.
 
 ## Conformance and Well-Formedness
 
-Gaia uses an LLM as its runtime CPU. This means conformance should be **structurally strict but semantically permissive**: the loader enforces file-level and graph-compilation constraints that an LLM cannot self-heal, while semantic interpretation of declaration content and unknown types is intentionally left to the LLM runtime.
+Gaia uses an LLM as its runtime CPU. This means conformance should be **structurally strict but semantically permissive**: the loader enforces file-level and graph-compilation constraints that an LLM cannot self-heal, while semantic interpretation of knowledge content and unknown types is intentionally left to the LLM runtime.
 
 ### Runtime-enforced conformance on current `main`
 
@@ -336,7 +336,7 @@ A package is ill-formed for the current runtime if any of the following hold:
 - `package.yaml` is missing
 - a module listed in `package.yaml.modules` does not have a matching `<module>.yaml` file
 - a `chain_expr` step is not one of `ref`, `apply`, or `lambda` (these are compiled into a factor graph for BP)
-- a `ref.target` cannot be resolved to a non-`ref` declaration using `module_name.declaration_name`
+- a `ref.target` cannot be resolved to a non-`ref` knowledge object using `module_name.knowledge_name`
 
 These are structural constraints — they block loading or factor-graph compilation and cannot be recovered by LLM interpretation.
 
@@ -344,9 +344,9 @@ These are structural constraints — they block loading or factor-graph compilat
 
 The following are intentionally accepted by the current runtime:
 
-- declaration types not in `KNOWLEDGE_TYPE_MAP` — loaded as generic `Knowledge` objects and interpreted by the LLM during build/review
+- knowledge types not in `KNOWLEDGE_TYPE_MAP` — loaded as generic `Knowledge` objects and interpreted by the LLM during build/review
 - packages with an empty `modules` list
-- modules with an empty `declarations` list
+- modules with an empty `knowledge` list
 
 This permissiveness is a design choice: since the LLM runtime can understand author intent from content and context, the loader should not reject valid-looking YAML that simply uses unfamiliar type names.
 
@@ -354,11 +354,11 @@ This permissiveness is a design choice: since the LLM runtime can understand aut
 
 The following should be treated as language-level quality rules even where the current runtime does not reject them:
 
-- declaration names should be unique within a module
-- exported names should refer to declarations that actually exist in the package
+- knowledge object names should be unique within a module
+- exported names should refer to knowledge objects that actually exist in the package
 - package/module naming should avoid ambiguity between local aliases and resolved targets
 - package examples in docs should use the same surface as the real loader
-- unknown declaration types should be documented in the module or package manifest when used intentionally
+- unknown knowledge types should be documented in the module or package manifest when used intentionally
 
 ## Operational Semantics Boundary
 
@@ -420,9 +420,9 @@ Gaia's goals require traceability even before first-class evidence/object kinds 
 
 Current rule:
 
-- authored knowledge lives in declarations and `chain_expr`
+- authored knowledge lives in `knowledge` and `chain_expr`
 - review and belief outputs stay in sidecars or runtime outputs
-- provenance, citations, and external resources may be attached via declaration `metadata`
+- provenance, citations, and external resources may be attached via knowledge-object `metadata`
 
 Deferred for later language versions:
 

--- a/docs/foundations/language/type-system-direction.md
+++ b/docs/foundations/language/type-system-direction.md
@@ -141,7 +141,7 @@ Lean checks terms relative to an environment `Γ`. Gaia also needs this:
 
 - a `Ref` is valid relative to a module/package environment
 - an `apply` step is valid relative to the available action signature
-- a `chain_expr` is valid relative to the declarations it mentions
+- a `chain_expr` is valid relative to the knowledge objects it mentions
 
 ### 6. Goal-state thinking
 
@@ -163,7 +163,7 @@ Gaia should formalize:
 - how local names are introduced
 - how module-local names are resolved
 - how refs preserve type
-- which declarations are visible vs exported into BP
+- which knowledge objects are visible vs exported into BP
 
 ## What Gaia Should Not Borrow From Lean
 
@@ -219,7 +219,7 @@ V1 should make the following explicit:
 - a core set of knowledge kinds with formal rules
 - action signatures as first-class checked structure
 - typed chain connectivity
-- the distinction between visible and belief-bearing declarations
+- the distinction between visible and belief-bearing knowledge objects
 - the boundary between surface syntax and checked core IR
 
 ### V1 core categories
@@ -234,7 +234,7 @@ The current categories are the right starting point:
 | `Action` | Procedural (InferAction, ToolCallAction) | No | Via application (factor node) |
 | `Expr` | Compositional (ChainExpr) | No | Via steps |
 | `Ref` | Reference to external knowledge | No | Via resolved target |
-| `Module` | Organizational | No | Via exported declarations |
+| `Module` | Organizational | No | Via exported knowledge objects |
 
 V1 should strengthen the internal representation of these types — stop treating parameter types and return types as bare strings, use explicit type expressions and signatures.
 
@@ -305,13 +305,13 @@ instance : TruthApt Setting
 -- Question has no TruthApt instance → cannot have belief
 ```
 
-Type classes replace the current ad-hoc conventions (scattered if-else checks for "is this type truth-apt?") with explicit, checkable declarations. The `belief_bearing` judgment from V1 becomes derived from type class instances rather than hardcoded rules. Note that `exportable` remains a module-level judgment — it depends on the module's export list, not on type class membership.
+Type classes replace the current ad-hoc conventions (scattered if-else checks for "is this type truth-apt?") with explicit, checkable judgments. The `belief_bearing` judgment from V1 becomes derived from type class instances rather than hardcoded rules. Note that `exportable` remains a module-level judgment — it depends on the module's export list, not on type class membership.
 
 ### Phase 4: User-extensible knowledge types
 
 Move type definitions from the Python implementation layer into the language itself, with a clear distinction between closed and open layers.
 
-**Root types are closed.** The base knowledge categories (Claim, Question, Setting, Action, Expr, Ref, Module) define the grammar of the language. They determine what kernel judgments apply, how declarations participate in BP, and what structural rules hold. These are fixed by the language definition, just as Lean's core type formers (inductive, structure, class) are fixed.
+**Root types are closed.** The base knowledge categories (Claim, Question, Setting, Action, Expr, Ref, Module) define the grammar of the language. They determine what kernel judgments apply, how knowledge objects participate in BP, and what structural rules hold. These are fixed by the language definition, just as Lean's core type formers (inductive, structure, class) are fixed.
 
 **Subtypes are open.** Users can extend any root type with domain-specific subtypes without modifying the root definition:
 

--- a/docs/foundations/product-scope.md
+++ b/docs/foundations/product-scope.md
@@ -104,7 +104,7 @@ What is currently shipped on `main`:
 - GraphStore ABC with Neo4j and Kuzu implementations
 - type-aware belief propagation (contradiction, retraction edges)
 - **CLI with 8 commands** (`init`, `build`, `review`, `infer`, `publish`, `show`, `search`, `clean`) — shipped in PR #63
-- **Gaia Language** — per-module YAML with declarations, chains, and strong/weak references
+- **Gaia Language** — per-module YAML with knowledge objects, chains, and strong/weak references
 - **Inference engine moved to `libs/inference/`** — local belief propagation decoupled from server
 - **Build output** — per-module Markdown for LLM review
 
@@ -191,11 +191,11 @@ The CLI is shipped on `main` with 8 commands:
 | `gaia review` | LLM review of chains → YAML sidecar reports |
 | `gaia infer` | Compile factor graph + run local belief propagation |
 | `gaia publish` | Publish to git or local databases (LanceDB + Kuzu) |
-| `gaia show` | Display declaration details + connected chains |
+| `gaia show` | Display knowledge object details + connected chains |
 | `gaia search` | Search published nodes in local LanceDB |
 | `gaia clean` | Remove build artifacts (`.gaia/` directory) |
 
-Note: the original RFC included `gaia claim` — this was replaced by declarative YAML authoring (per-module YAML files with declarations and chains). `gaia.lock` and cross-package dependency resolution remain deferred.
+Note: the original RFC included `gaia claim` — this was replaced by declarative YAML authoring (per-module YAML files with knowledge objects and chains). `gaia.lock` and cross-package dependency resolution remain deferred.
 
 Still not shipped:
 

--- a/docs/foundations/system-overview.md
+++ b/docs/foundations/system-overview.md
@@ -115,7 +115,7 @@ Each package is a git repo with this structure:
 galileo_tied_balls/              # = 1 git repo = 1 knowledge package
 ├── package.yaml                 # manifest (name, version, modules list)
 ├── gaia.lock                    # (deferred) cross-package dependency lock
-├── aristotle_physics.yaml       # per-module YAML — declarations + chains
+├── aristotle_physics.yaml       # per-module YAML — knowledge objects + chains
 ├── thought_experiment.yaml
 ├── ...
 └── .gaia/                       # build artifacts (git-ignored)
@@ -124,13 +124,13 @@ galileo_tied_balls/              # = 1 git repo = 1 knowledge package
     └── ...
 ```
 
-Module YAML with declarations, including `chain_expr` reasoning:
+Module YAML with knowledge objects, including `chain_expr` reasoning:
 
 ```yaml
 type: reasoning_module
 name: reasoning
 
-declarations:
+knowledge:
   - type: ref
     name: heavier_falls_fast
     target: aristotle.heavier_falls_faster

--- a/libs/lang/compiler.py
+++ b/libs/lang/compiler.py
@@ -76,7 +76,7 @@ def compile_factor_graph(pkg: Package) -> CompiledFactorGraph:
                 continue
             _compile_chain(decl, all_decls, fg)
 
-    # Add constraint factors from Relation declarations.
+    # Add constraint factors from Relation knowledge objects.
     # Iterate all_decls (not module.knowledge) so that Ref aliases are handled:
     # a Relation re-exported via Ref appears under the alias name in all_decls.
     for name, decl in all_decls.items():
@@ -94,7 +94,7 @@ def _compile_chain(
     """Compile a ChainExpr into factor nodes connecting variable nodes."""
     if chain.edge_type is not None:
         warnings.warn(
-            f"ChainExpr.edge_type is deprecated. Use Relation declarations instead. "
+            f"ChainExpr.edge_type is deprecated. Use Relation knowledge objects instead. "
             f"Chain '{chain.name}' uses edge_type='{chain.edge_type}'.",
             DeprecationWarning,
             stacklevel=2,

--- a/libs/lang/loader.py
+++ b/libs/lang/loader.py
@@ -47,7 +47,7 @@ def load_package(path: Path) -> Package:
 
 def _parse_module(data: dict) -> Module:
     """Parse a module YAML dict into a Module with typed knowledge items."""
-    knowledge = [_parse_knowledge(d) for d in data.get("declarations", [])]
+    knowledge = [_parse_knowledge(d) for d in data.get("knowledge", [])]
     return Module(
         type=data["type"],
         name=data["name"],

--- a/libs/lang/models.py
+++ b/libs/lang/models.py
@@ -155,10 +155,8 @@ KNOWLEDGE_TYPE_MAP: dict[str, type[Knowledge]] = {
 class Module(BaseModel):
     type: str  # reasoning_module, setting_module, etc.
     name: str
-    knowledge: list[Knowledge] = Field(default_factory=list, alias="declarations")
+    knowledge: list[Knowledge] = Field(default_factory=list)
     export: list[str] = Field(default_factory=list)
-
-    model_config = {"populate_by_name": True}
 
 
 # ── Package ───────────────────────────────────────────────

--- a/libs/lang/resolver.py
+++ b/libs/lang/resolver.py
@@ -1,4 +1,4 @@
-"""Resolve Ref declarations to their target knowledge objects."""
+"""Resolve Ref knowledge objects to their target knowledge objects."""
 
 from __future__ import annotations
 
@@ -10,12 +10,12 @@ class ResolveError(Exception):
 
 
 def resolve_refs(pkg: Package) -> Package:
-    """Resolve all Ref declarations in the package.
+    """Resolve all Ref knowledge objects in the package.
 
     Builds a knowledge index (module.name -> Knowledge),
     then links each Ref._resolved to its target Knowledge object.
     """
-    # Build index: "module_name.decl_name" -> Knowledge
+    # Build index: "module_name.knowledge_name" -> Knowledge
     index: dict[str, Knowledge] = {}
     for module in pkg.loaded_modules:
         for decl in module.knowledge:

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -32,7 +32,7 @@ def test_init_creates_motivation_module(tmp_path, monkeypatch):
     data = yaml.safe_load(mod_file.read_text())
     assert data["type"] == "motivation_module"
     assert data["name"] == "motivation"
-    assert len(data["declarations"]) >= 1
+    assert len(data["knowledge"]) >= 1
 
 
 def test_init_refuses_existing_directory(tmp_path, monkeypatch):

--- a/tests/fixtures/gaia_language_packages/galileo_falling_bodies/aristotle.yaml
+++ b/tests/fixtures/gaia_language_packages/galileo_falling_bodies/aristotle.yaml
@@ -3,7 +3,7 @@
 type: reasoning_module
 name: aristotle
 
-declarations:
+knowledge:
   - type: claim
     name: heavier_falls_faster
     content: >

--- a/tests/fixtures/gaia_language_packages/galileo_falling_bodies/follow_up.yaml
+++ b/tests/fixtures/gaia_language_packages/galileo_falling_bodies/follow_up.yaml
@@ -3,7 +3,7 @@
 type: follow_up_module
 name: follow_up
 
-declarations:
+knowledge:
   - type: ref
     name: vacuum_prediction
     target: reasoning.vacuum_prediction

--- a/tests/fixtures/gaia_language_packages/galileo_falling_bodies/motivation.yaml
+++ b/tests/fixtures/gaia_language_packages/galileo_falling_bodies/motivation.yaml
@@ -3,7 +3,7 @@
 type: motivation_module
 name: motivation
 
-declarations:
+knowledge:
   - type: question
     name: main_question
     content: >

--- a/tests/fixtures/gaia_language_packages/galileo_falling_bodies/reasoning.yaml
+++ b/tests/fixtures/gaia_language_packages/galileo_falling_bodies/reasoning.yaml
@@ -8,7 +8,7 @@
 type: reasoning_module
 name: reasoning
 
-declarations:
+knowledge:
   # === 引用外部知识 ===
   - type: ref
     name: heavier_falls_faster

--- a/tests/fixtures/gaia_language_packages/galileo_falling_bodies/setting.yaml
+++ b/tests/fixtures/gaia_language_packages/galileo_falling_bodies/setting.yaml
@@ -3,7 +3,7 @@
 type: setting_module
 name: setting
 
-declarations:
+knowledge:
   - type: setting
     name: thought_experiment_env
     content: >

--- a/tests/libs/lang/test_compiler.py
+++ b/tests/libs/lang/test_compiler.py
@@ -171,7 +171,7 @@ def test_compile_single_chain_inline():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, chain],
+        knowledge=[claim_a, claim_b, chain],
         export=["a", "b"],
     )
     pkg = Package(name="inline_test", modules=["m"])
@@ -209,7 +209,7 @@ def test_edge_type_passed_to_factor():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, chain],
+        knowledge=[claim_a, claim_b, chain],
         export=["a", "b"],
     )
     pkg = Package(name="test_edge_type", modules=["m"])
@@ -235,7 +235,7 @@ def test_edge_type_defaults_to_deduction():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, chain],
+        knowledge=[claim_a, claim_b, chain],
         export=["a", "b"],
     )
     pkg = Package(name="test_default_edge", modules=["m"])
@@ -253,7 +253,7 @@ def test_non_exported_claim_excluded():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[exported_claim, private_claim],
+        knowledge=[exported_claim, private_claim],
         export=["public"],  # only 'public' is exported
     )
     pkg = Package(name="export_test", modules=["m"])

--- a/tests/libs/lang/test_executor.py
+++ b/tests/libs/lang/test_executor.py
@@ -133,7 +133,7 @@ async def test_execute_missing_action_skips():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_in, claim_out, chain],
+        knowledge=[claim_in, claim_out, chain],
         export=[],
     )
     pkg = Package(name="test_missing_action", modules=["m"])
@@ -163,7 +163,7 @@ async def test_execute_preserves_nonempty_target():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_in, claim_out, chain],
+        knowledge=[claim_in, claim_out, chain],
         export=[],
     )
     pkg = Package(name="test_preserve", modules=["m"])
@@ -200,7 +200,7 @@ async def test_execute_dispatches_toolcall_to_execute_tool():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[tool_action, claim_in, claim_out, chain],
+        knowledge=[tool_action, claim_in, claim_out, chain],
         export=["ball", "measurement"],
     )
     pkg = Package(name="test_tool", modules=["m"])
@@ -243,7 +243,7 @@ async def test_execute_toolcall_uses_action_name_when_tool_is_none():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[tool_action, claim_in, claim_out, chain],
+        knowledge=[tool_action, claim_in, claim_out, chain],
         export=["material", "density_result"],
     )
     pkg = Package(name="test_tool_fallback", modules=["m"])
@@ -288,7 +288,7 @@ async def test_execute_topo_sorts_chains():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, claim_c, chain_2, chain_1],
+        knowledge=[claim_a, claim_b, claim_c, chain_2, chain_1],
         export=["a", "b", "c"],
     )
     pkg = Package(name="test_topo", modules=["m"])
@@ -325,7 +325,7 @@ async def test_infer_action_still_uses_execute_infer():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[infer_action, claim_in, claim_out, chain],
+        knowledge=[infer_action, claim_in, claim_out, chain],
         export=["premise", "conclusion"],
     )
     pkg = Package(name="test_infer_regression", modules=["m"])

--- a/tests/libs/lang/test_loader.py
+++ b/tests/libs/lang/test_loader.py
@@ -1,7 +1,7 @@
 # tests/libs/lang/test_loader.py
 from pathlib import Path
 
-from libs.lang.loader import load_package
+from libs.lang.loader import _parse_module, load_package
 from libs.lang.models import (
     Claim,
     InferAction,
@@ -38,7 +38,7 @@ def test_module_types():
     assert type_map["follow_up"] == "follow_up_module"
 
 
-def test_declarations_parsed():
+def test_knowledge_parsed():
     pkg = load_package(FIXTURE_DIR)
     reasoning = next(m for m in pkg.loaded_modules if m.name == "reasoning")
     counts: dict[str, int] = {}
@@ -161,7 +161,7 @@ def test_unknown_step_format_raises(tmp_path):
     mod_yaml.write_text(
         "type: reasoning_module\n"
         "name: m\n"
-        "declarations:\n"
+        "knowledge:\n"
         "  - type: chain_expr\n"
         "    name: bad_chain\n"
         "    steps:\n"
@@ -175,7 +175,7 @@ def test_unknown_step_format_raises(tmp_path):
 
 
 def test_unknown_type_falls_back_to_knowledge(tmp_path):
-    """A declaration with an unrecognized type falls back to base Knowledge."""
+    """A knowledge object with an unrecognized type falls back to base Knowledge."""
     pkg_yaml = tmp_path / "package.yaml"
     pkg_yaml.write_text("name: test_pkg\nmodules:\n  - m\n")
 
@@ -183,7 +183,7 @@ def test_unknown_type_falls_back_to_knowledge(tmp_path):
     mod_yaml.write_text(
         "type: reasoning_module\n"
         "name: m\n"
-        "declarations:\n"
+        "knowledge:\n"
         "  - type: custom_type\n"
         "    name: my_custom\n"
         "export: []\n"
@@ -205,7 +205,7 @@ def test_load_minimal_package(tmp_path):
     pkg_yaml.write_text("name: minimal\nmodules:\n  - m\n")
 
     mod_yaml = tmp_path / "m.yaml"
-    mod_yaml.write_text("type: reasoning_module\nname: m\ndeclarations: []\nexport: []\n")
+    mod_yaml.write_text("type: reasoning_module\nname: m\nknowledge: []\nexport: []\n")
 
     pkg = load_package(tmp_path)
     assert pkg.name == "minimal"
@@ -213,6 +213,22 @@ def test_load_minimal_package(tmp_path):
     assert pkg.loaded_modules[0].name == "m"
     assert pkg.loaded_modules[0].knowledge == []
     assert pkg.loaded_modules[0].export == []
+
+
+def test_parse_module_round_trips_model_dump_surface():
+    module = _parse_module(
+        {
+            "type": "reasoning_module",
+            "name": "m",
+            "knowledge": [{"type": "claim", "name": "x", "content": "hello"}],
+            "export": ["x"],
+        }
+    )
+
+    parsed = _parse_module(module.model_dump())
+
+    assert len(parsed.knowledge) == 1
+    assert parsed.knowledge[0].name == "x"
 
 
 def test_load_package_with_dependencies(tmp_path):

--- a/tests/libs/lang/test_models.py
+++ b/tests/libs/lang/test_models.py
@@ -1,3 +1,4 @@
+from libs.lang.loader import _parse_module
 from libs.lang.models import (
     Claim,
     Question,  # noqa: F401 — import-smoke-test
@@ -69,11 +70,11 @@ def test_ref_declaration():
     assert r.target == "other_module.premise"
 
 
-def test_module_with_declarations():
+def test_module_with_knowledge():
     m = Module(
         type="reasoning_module",
         name="reasoning",
-        declarations=[
+        knowledge=[
             Claim(name="c1", content="test"),
         ],
         export=["c1"],
@@ -83,6 +84,20 @@ def test_module_with_declarations():
     assert len(m.knowledge) == 1
     assert m.knowledge[0].name == "c1"
     assert m.export == ["c1"]
+
+
+def test_module_dump_round_trips_through_loader_surface():
+    m = Module(
+        type="reasoning_module",
+        name="reasoning",
+        knowledge=[Claim(name="c1", content="test")],
+        export=["c1"],
+    )
+
+    parsed = _parse_module(m.model_dump())
+
+    assert len(parsed.knowledge) == 1
+    assert parsed.knowledge[0].name == "c1"
 
 
 def test_package():

--- a/tests/libs/lang/test_relation_compiler.py
+++ b/tests/libs/lang/test_relation_compiler.py
@@ -25,7 +25,7 @@ def test_contradiction_compiles_to_variable_node():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, contra],
+        knowledge=[claim_a, claim_b, contra],
         export=["a", "b", "a_contradicts_b"],
     )
     pkg = Package(name="test", modules=["m"])
@@ -50,7 +50,7 @@ def test_equivalence_compiles_to_variable_node():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_x, claim_y, equiv],
+        knowledge=[claim_x, claim_y, equiv],
         export=["x", "y", "x_equiv_y"],
     )
     pkg = Package(name="test", modules=["m"])
@@ -73,7 +73,7 @@ def test_contradiction_generates_constraint_factor():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, contra],
+        knowledge=[claim_a, claim_b, contra],
         export=["a", "b", "a_contradicts_b"],
     )
     pkg = Package(name="test", modules=["m"])
@@ -102,7 +102,7 @@ def test_equivalence_generates_constraint_factor():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_x, claim_y, equiv],
+        knowledge=[claim_x, claim_y, equiv],
         export=["x", "y", "x_equiv_y"],
     )
     pkg = Package(name="test", modules=["m"])
@@ -138,7 +138,7 @@ def test_relation_with_chain_produces_both_factors():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, contra, chain],
+        knowledge=[claim_a, claim_b, contra, chain],
         export=["a", "b", "contra"],
     )
     pkg = Package(name="test", modules=["m"])
@@ -168,7 +168,7 @@ def test_non_exported_relation_excluded():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, contra],
+        knowledge=[claim_a, claim_b, contra],
         export=["a", "b"],  # contra NOT exported
     )
     pkg = Package(name="test", modules=["m"])
@@ -197,7 +197,7 @@ def test_edge_type_emits_deprecation_warning():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, chain],
+        knowledge=[claim_a, claim_b, chain],
         export=["a", "b"],
     )
     pkg = Package(name="test_deprecated", modules=["m"])
@@ -227,7 +227,7 @@ def test_ref_alias_relation_gets_constraint():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, contra, ref_alias],
+        knowledge=[claim_a, claim_b, contra, ref_alias],
         export=["a", "b", "c"],  # Only alias exported, not c0
     )
     pkg = Package(name="test", modules=["m"])
@@ -260,7 +260,7 @@ def test_equivalence_nary_decomposes_to_pairwise():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, claim_c, equiv],
+        knowledge=[claim_a, claim_b, claim_c, equiv],
         export=["a", "b", "c", "abc_equiv"],
     )
     pkg = Package(name="test", modules=["m"])
@@ -294,7 +294,7 @@ def test_equivalence_binary_no_decomposition():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_x, claim_y, equiv],
+        knowledge=[claim_x, claim_y, equiv],
         export=["x", "y", "xy_equiv"],
     )
     pkg = Package(name="test", modules=["m"])

--- a/tests/libs/lang/test_relation_runtime.py
+++ b/tests/libs/lang/test_relation_runtime.py
@@ -27,17 +27,17 @@ def _build_equivalence_package(
         for name, prior in zip(member_names, priors, strict=True)
     ]
     relation = None
-    declarations = list(claims)
+    knowledge = list(claims)
     export = list(member_names)
     if include_equivalence:
         relation = Equivalence(name=relation_name, between=list(member_names), prior=0.85)
-        declarations.append(relation)
+        knowledge.append(relation)
         export.append(relation_name)
 
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=declarations,
+        knowledge=knowledge,
         export=export,
     )
     pkg = Package(name=f"{relation_name}_pkg", modules=["m"])
@@ -69,7 +69,7 @@ def _build_shared_premise_package(
         ],
     )
 
-    declarations = [premise, claim_a, claim_b, chain_a, chain_b]
+    knowledge = [premise, claim_a, claim_b, chain_a, chain_b]
     export = ["premise", "a", "b"]
     contra = None
     if include_contradiction:
@@ -78,13 +78,13 @@ def _build_shared_premise_package(
             between=["a", "b"],
             prior=0.95,
         )
-        declarations.append(contra)
+        knowledge.append(contra)
         export.append("a_vs_b")
 
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=declarations,
+        knowledge=knowledge,
         export=export,
     )
     pkg = Package(name="test_integration", modules=["m"])
@@ -101,9 +101,9 @@ def _build_relation_gate_package(include_support_chain: bool) -> tuple[Package, 
         prior=0.1,
     )
 
-    declarations = [claim_a, claim_b, contra]
+    knowledge = [claim_a, claim_b, contra]
     if include_support_chain:
-        declarations.append(
+        knowledge.append(
             ChainExpr(
                 name="establish_contradiction",
                 steps=[
@@ -125,7 +125,7 @@ def _build_relation_gate_package(include_support_chain: bool) -> tuple[Package, 
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=declarations,
+        knowledge=knowledge,
         export=["a", "b", "a_vs_b"],
     )
     pkg = Package(name="relation_gate_pkg", modules=["m"])
@@ -134,7 +134,7 @@ def _build_relation_gate_package(include_support_chain: bool) -> tuple[Package, 
 
 
 async def test_contradiction_gets_belief_after_inference():
-    """Relation declarations should have .belief set after BP."""
+    """Relation knowledge objects should have .belief set after BP."""
     claim_a = Claim(name="a", content="A", prior=0.8)
     claim_b = Claim(name="b", content="B", prior=0.7)
     contra = Contradiction(
@@ -145,7 +145,7 @@ async def test_contradiction_gets_belief_after_inference():
     mod = Module(
         type="reasoning_module",
         name="m",
-        declarations=[claim_a, claim_b, contra],
+        knowledge=[claim_a, claim_b, contra],
         export=["a", "b", "a_contradicts_b"],
     )
     pkg = Package(name="test_relation_bp", modules=["m"])

--- a/tests/libs/lang/test_resolver.py
+++ b/tests/libs/lang/test_resolver.py
@@ -55,8 +55,8 @@ def test_resolve_undefined_ref_raises():
         resolve_refs(pkg)
 
 
-def test_build_declaration_index():
-    """All declarations should be findable by module.name path."""
+def test_build_knowledge_index():
+    """All knowledge objects should be findable by module.name path."""
     pkg = load_package(FIXTURE_DIR)
     resolved = resolve_refs(pkg)
     # Check that we can look up any exported declaration
@@ -91,13 +91,13 @@ def test_resolve_ref_to_ref_raises():
     mod_a = Module(
         type="reasoning_module",
         name="a",
-        declarations=[Ref(name="x", target="b.y")],
+        knowledge=[Ref(name="x", target="b.y")],
         export=["x"],
     )
     mod_b = Module(
         type="reasoning_module",
         name="b",
-        declarations=[Ref(name="y", target="a.x")],
+        knowledge=[Ref(name="y", target="a.x")],
         export=["y"],
     )
     pkg = Package(name="circular_refs", modules=["a", "b"])


### PR DESCRIPTION
## Summary
- make `knowledge` the canonical module key across the loader, scaffolding, fixtures, and model serialization
- update affected tests with round-trip coverage so `Module.model_dump()` stays aligned with the loader surface
- sync language docs to describe `knowledge` rather than the old `declarations` wire format

## Verification
- `git diff --check`
- manual round-trip check: `Module.model_dump()` -> `_parse_module()` preserves knowledge entries
- manual fixture load check: `load_package(tests/fixtures/gaia_language_packages/galileo_falling_bodies)` loads 5 modules / 36 knowledge objects
- manual CLI check: `gaia init` now writes `knowledge:` in `motivation.yaml`

## Notes
- `pytest` segfaults in this execution environment (`returncode=-11`), so I used direct Python checks for the behavior touched here.