### PR TITLE
docs: review architecture v2 — separated policies, package environment, BP out of review

### DIFF
--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -73,7 +73,7 @@ Those files do not all exist yet. This directory is the place where they should 
 - `theory/`: Theoretical foundations (Jaynes, BP algorithm) — shared mathematical basis
 - `language/`: Gaia formal language spec, design, and design rationale
 - `cli/`: Gaia CLI runtime boundaries and future CLI-specific docs
-- `review/`: Shared review architecture and review/environment semantics
+- `review/`: Shared review architecture, review policies, and package environment semantics
 - `server/`: Server architecture, storage schema, API contracts
 
 ## Historical docs

--- a/docs/foundations/cli/command-lifecycle.md
+++ b/docs/foundations/cli/command-lifecycle.md
@@ -96,7 +96,7 @@ This is the first stage where Gaia CLI should treat the package as structurally 
 
 `gaia review` performs model-based critique of the built package.
 
-By default this means **package review**. A future scoped form of the command should also support **integration review** against a materialized integration environment. See [../review/architecture.md](../review/architecture.md).
+By default this runs both **package review** and **integration review** (`--scope all`). Package review is a closed-world audit of reasoning quality. Integration review is an open-world check against the package environment. See [../review/architecture.md](../review/architecture.md).
 
 This stage adds assessment artifacts rather than redefining the package's normative content.
 
@@ -195,7 +195,7 @@ Architecturally, `gaia review` should become a scoped command:
 - `gaia review --scope integration` for open-world integration review
 - `gaia review --scope all` for the ordered combination of both
 
-The default local meaning remains package review.
+The default scope is `all` — run both package review and integration review in order.
 
 ### Responsibilities
 

--- a/docs/foundations/review/architecture.md
+++ b/docs/foundations/review/architecture.md
@@ -2,7 +2,7 @@
 
 | 文档属性 | 值 |
 |---------|---|
-| 版本 | 1.0 |
+| 版本 | 2.0 |
 | 日期 | 2026-03-10 |
 | 状态 | **Draft — foundation design** |
 | 关联文档 | [../README.md](../README.md), [../cli/command-lifecycle.md](../cli/command-lifecycle.md), [../server/architecture.md](../server/architecture.md), [../language/gaia-language-spec.md](../language/gaia-language-spec.md) |
@@ -60,22 +60,28 @@ It answers:
 - does this package duplicate existing knowledge?
 - should new declarations be merged, canonicalized, or linked?
 - what cross-package contradiction or equivalence candidates appear?
-- what local BP effects are likely if this package is integrated?
+- what subsumption relationships exist between new and existing declarations?
 
-### 2.4 Local review is preview, server review is authoritative
+### 2.4 Review and inference are separate phases
 
-Local integration review is a preview run against a materialized integration environment.
+Review discovers relations and audits reasoning quality. It does **not** compute beliefs.
+
+Belief propagation belongs to the **inference** phase (`gaia infer` locally, `BPService` on server), which runs after review. This separation is already reflected in the CLI lifecycle: `build → review → infer → publish`.
+
+### 2.5 Local review is preview, server review is authoritative
+
+Local integration review is a preview run against a materialized package environment.
 
 Server review is authoritative because it can use:
 
 - the current shared registry state
 - stronger retrieval and search context
 - managed model policy
-- final integration and large-scale BP
+- final integration path
 
 The two sides must still share the same core contracts and semantics.
 
-### 2.5 Review never rewrites package source
+### 2.6 Review never rewrites package source
 
 Review produces reports, scores, and suggestions.
 
@@ -90,7 +96,7 @@ Package source remains the canonical artifact. Review output remains sidecar/run
 | Scope | Inputs | Context model | Main output | Typical caller |
 |------|--------|---------------|-------------|----------------|
 | `package` | built package | closed-world | `PackageReviewReport` | CLI, server |
-| `integration` | built package + integration environment | open-world | `IntegrationReviewReport` | CLI preview, server |
+| `integration` | built package + package environment | open-world | `IntegrationReviewReport` | CLI preview, server |
 | `all` | same as above | package first, then integration | combined report | CLI, server |
 
 ### 3.1 CLI surface
@@ -104,15 +110,9 @@ gaia review [PATH] --scope integration
 gaia review [PATH] --scope all
 ```
 
-Default scope is `package`.
+Default scope is `all`. This runs package review first, then integration review. The user should see the full picture by default.
 
-`all` is ordered and means:
-
-```text
-package review -> integration review
-```
-
-Integration review may be run by itself as an explicit dry-run, but it should not replace package review as the normal gate.
+`--scope package` or `--scope integration` can be used to run a single phase when iterating on a specific concern.
 
 ### 3.2 Server surface
 
@@ -130,40 +130,109 @@ External API design may expose that as one submit endpoint or multiple review en
 
 ---
 
-## 4. Shared Review Contracts
+## 4. Review Policies
 
-CLI and server should call the same review core:
+Package review and integration review are fundamentally different processes. Their policies are separate.
+
+### 4.1 PackageReviewPolicy
+
+Package review is a closed-world LLM audit. It needs one model and package-local thresholds.
 
 ```python
-review(
+@dataclass
+class PackageReviewPolicy:
+    """Closed-world audit — only needs an LLM for chain critique."""
+
+    model: LLMModelConfig           # LLM for chain-level reasoning critique
+    checks: list[str]               # e.g. chain_coherence, prior_reasonableness,
+                                    #      dependency_label_validation
+    thresholds: PackageThresholds   # min_chain_score, min_prior_range
+```
+
+### 4.2 IntegrationReviewPolicy
+
+Integration review is an open-world process. It needs embedding, retrieval, and multiple LLM models for different stages.
+
+```python
+@dataclass
+class IntegrationReviewPolicy:
+    """Open-world integration — needs embedding, retrieval, and LLMs."""
+
+    # ── Embedding ──
+    embedding: EmbeddingConfig      # provider, api_url, access_key, dim
+
+    # ── Retrieval (builds the package environment) ──
+    retrieval: RetrievalConfig      # semantic_top_k, structural_max_hops,
+                                    # max_environment_nodes
+
+    # ── Abstraction discovery (join-cc, join-cp) ──
+    abstraction_model: LLMModelConfig
+
+    # ── Verification (two-pass) ──
+    verify_model: LLMModelConfig
+
+    # ── Checks & thresholds ──
+    checks: list[str]               # e.g. duplicate_detection, contradiction_scan,
+                                    #      subsumption_detection
+    thresholds: IntegrationThresholds  # max_overlap_similarity, ...
+```
+
+### 4.3 Mapping to current pipeline operators
+
+The existing `review_pipeline` operators map to `IntegrationReviewPolicy` fields:
+
+| Policy field | Current operator | Current default |
+|---|---|---|
+| `embedding` | `EmbeddingOperator(DashScopeEmbeddingModel)` | dim=512, max_rps=600 |
+| `retrieval.semantic_top_k` | `NNSearchOperator(k=)` | k=20 |
+| `retrieval.structural_max_hops` | not yet implemented | — |
+| `abstraction_model` | `CCAbstractionOperator` + `CPAbstractionOperator` (shared) | dptech_internal/gpt-5-mini |
+| `verify_model` | `AbstractionTreeVerifyOperator` + `VerifyAgainOperator` (shared) | same as above |
+
+The current `BPOperator` in the pipeline does **not** belong to review. It should be moved to the inference phase (see §8).
+
+### 4.4 Policy differences between local and server
+
+| Dimension | Local (CLI) | Server |
+|---|---|---|
+| Package review model | user-configured, may be lightweight | managed, may be stronger |
+| Integration embedding | same provider | same provider |
+| Integration retrieval | against package environment (snapshot) | against live registry |
+| Integration LLMs | user-configured | managed |
+| Gate authority | advisory only | can reject/block integration |
+
+---
+
+## 5. Shared Review Contracts
+
+CLI and server should call the same review core, but with scope-specific signatures:
+
+```python
+# Package review
+package_review(
     request: ReviewRequest,
-    context: ReviewContext,
-    policy: ReviewPolicy,
-) -> ReviewReport
+    policy: PackageReviewPolicy,
+) -> PackageReviewReport
+
+# Integration review
+integration_review(
+    request: ReviewRequest,
+    environment: PackageEnvironment,
+    policy: IntegrationReviewPolicy,
+) -> IntegrationReviewReport
 ```
 
-Recommended core objects:
-
-```python
-ReviewRequest
-ReviewContext
-ReviewPolicy
-ReviewReport
-PackageReviewReport
-IntegrationReviewReport
-```
-
-### 4.1 Contract invariants
+### 5.1 Contract invariants
 
 These are hard requirements:
 
 - local and server review must use the same request and report schema
-- the same request, context, and policy should produce the same class of result locally and on server
+- the same request, environment, and policy should produce the same class of result locally and on server
 - server may add richer context, stronger models, and stricter policy, but must not invent a different report language
 - `PackageReviewReport` is package-scoped and can be stored as a local sidecar
 - `IntegrationReviewReport` is environment-scoped and must be treated as time/version dependent
 
-### 4.2 Package review report
+### 5.2 Package review report
 
 A package review report is stable with respect to package content and build artifacts.
 
@@ -177,25 +246,25 @@ It may contain:
 
 It should be suitable for local storage under `.gaia/reviews/`.
 
-### 4.3 Integration review report
+### 5.3 Integration review report
 
-An integration review report depends on a concrete integration environment.
+An integration review report depends on a concrete package environment.
 
 It may contain:
 
-- duplicate or canonicalization candidates
-- cross-package contradiction/equivalence candidates
+- duplicate or canonicalization candidates (from join-cc, join-cp)
+- cross-package contradiction/equivalence/subsumption candidates
 - join/merge suggestions
-- environment-scoped BP preview
+- verification results with quality metrics (tightness, substantiveness, union error)
 - integration-specific verdicts
 
 It is not a stable part of the package source. It should be labeled with its environment identity.
 
 ---
 
-## 5. Review Core and Runners
+## 6. Review Core and Runners
 
-### 5.1 Review Core
+### 6.1 Review Core
 
 Gaia should have one shared review module, conceptually:
 
@@ -218,20 +287,21 @@ It does **not** own:
 - HTTP routing
 - job lifecycle
 - package persistence
+- belief propagation (that belongs to inference)
 
-### 5.2 CLI runner
+### 6.2 CLI runner
 
 The CLI runner should:
 
 1. load the local package and build artifacts
 2. create `ReviewRequest`
-3. create package-only or integration-aware `ReviewContext`
+3. create package-only or environment-aware `ReviewContext`
 4. call the shared review core
 5. write sidecar artifacts locally
 
 CLI review remains advisory and preview-oriented.
 
-### 5.3 Server runner
+### 6.3 Server runner
 
 The server runner should:
 
@@ -243,45 +313,64 @@ The server runner should:
 
 The server wrapper may live as a worker/service, but it should not fork review semantics from the CLI.
 
-### 5.4 Legacy server pipeline mapping
+### 6.4 Legacy server pipeline mapping
 
-Existing server-side operators such as NN search, `join-cc`, `join-cp`, abstraction verification, and integration-time BP belong conceptually to **Integration Review**, not to package-internal review.
+The existing `review_pipeline` operators belong to **Integration Review**:
 
-That means the old `review_pipeline` should eventually be reinterpreted as:
+| Current operator | Integration review role |
+|---|---|
+| `EmbeddingOperator` | Generate embeddings for new declarations |
+| `NNSearchOperator` | Retrieve semantic neighbors (build package environment) |
+| `CCAbstractionOperator` (join-cc) | Discover conclusion-conclusion relations |
+| `CPAbstractionOperator` (join-cp) | Discover conclusion-premise relations |
+| `AbstractionTreeVerifyOperator` | First-pass verification of discovered relations |
+| `RefineOperator` | Placeholder (Phase 2) |
+| `VerifyAgainOperator` | Second-pass verification, collect verified relations |
 
-- package review operators
-- integration review operators
-- plus server orchestration around them
+The current `BPOperator` should be removed from the review pipeline and handled by the inference phase.
+
+No existing operator corresponds to **Package Review**. The CLI's current chain-level LLM review (`cli/llm_client.py` → `ReviewClient`) is the closest to package review logic and should be extracted into `review_core`.
 
 ---
 
-## 6. Integration Environment
+## 7. Package Environment
 
-### 6.1 Purpose
+### 7.1 Purpose
 
-Local integration review should not require loading the entire shared knowledge system.
+Integration review needs external context beyond the package itself. That context is the **package environment**.
 
-Instead, Gaia should materialize an **integration environment**:
+A package environment is not limited to integration review — it is the general context a package exists in. It may be used by:
 
-- a package-scoped working set
-- derived from the package plus relevant external context
-- sufficient for integration review and local BP preview
+- `gaia review --scope integration` — open-world relation discovery
+- `gaia infer` — more accurate local BP with external context
+- future operations that need awareness of the shared knowledge system
 
-### 6.2 What it contains
+### 7.2 What it contains
 
-An integration environment should include:
+A package environment should include:
 
 - the candidate package under review
 - a snapshot/revision identifier for the shared registry state
-- retrieved semantic neighbors
-- retrieved structural neighbors
+- retrieved semantic neighbors (via embedding similarity)
+- retrieved structural neighbors (via graph topology)
 - candidate duplicate/canonicalization targets
-- local BP configuration
 - an environment fingerprint
 
 Internally this may be implemented by pulling a related subgraph, but the user-facing concept should be **environment**, not "graph snapshot".
 
-### 6.3 Why environment terminology matters
+### 7.3 Retrieval strategy
+
+Building a package environment requires retrieving relevant external context. The retrieval process is:
+
+1. **Embed** all declarations in the package (claims, conclusions of chains) using the configured embedding model.
+2. **Semantic retrieval**: for each embedding, find the top-k nearest neighbors from the shared registry (default k=20). This surfaces potentially duplicate, equivalent, or related declarations.
+3. **Structural retrieval** (when graph is available): starting from any declarations that reference existing registry nodes, traverse up to N hops (default 2) to pull in structurally connected context.
+4. **Dedup and cap**: merge semantic and structural results, deduplicate by node ID, cap at `max_environment_nodes` (default 200).
+5. **Load content**: fetch full content and metadata for all retrieved nodes from the content store.
+
+The result is a self-contained working set sufficient for integration review without loading the entire registry.
+
+### 7.4 Why environment terminology matters
 
 For local UX, Gaia should feel closer to package managers such as Cargo than to a raw graph tool.
 
@@ -300,31 +389,30 @@ Not:
 
 Those remain implementation details.
 
-### 6.4 Local preview semantics
+### 7.5 Local preview semantics
 
-Local integration review and local BP over the environment are preview-only.
+Local integration review over the package environment is preview-only.
 
-They are useful because they let the author answer:
+It is useful because it lets the author answer:
 
 - what would likely happen if I publish this package now?
 - what existing knowledge will this collide with?
-- what local belief shifts are likely?
+- what relations (equivalence, contradiction, subsumption) are likely?
 
-They are not authoritative global results.
+It is not an authoritative global result.
 
-### 6.5 Authoritative server semantics
+### 7.6 Authoritative server semantics
 
 After publish, the server may run:
 
-- the same integration review model against fresher shared state
-- larger-scope or global BP
+- the same integration review against fresher shared state
 - final merge/canonicalization decisions
 
 Differences between local preview and server outcome are acceptable. They should be explainable through environment identity, policy version, and current shared state.
 
 ---
 
-## 7. Package and Environment Management
+## 8. Package and Environment Management
 
 Gaia should separate three artifact classes:
 
@@ -332,7 +420,7 @@ Gaia should separate three artifact classes:
 2. **Environment lock**
 3. **Runtime artifacts**
 
-### 7.1 Package source
+### 8.1 Package source
 
 Package source is the canonical author-maintained artifact.
 
@@ -343,7 +431,7 @@ Today that is centered on:
 
 A future `Gaia.toml` may replace or wrap parts of that manifest story, but the architectural split remains the same.
 
-### 7.2 Environment lock
+### 8.2 Environment lock
 
 Gaia should have a package-level lockfile, tentatively:
 
@@ -354,7 +442,7 @@ gaia.lock
 It should lock both:
 
 - dependency resolution
-- integration environment identity
+- package environment identity
 
 Illustrative shape:
 
@@ -362,17 +450,16 @@ Illustrative shape:
 dependencies:
   ...
 
-integration_environment:
-  revision: ...
-  retrieval_policy: ...
-  review_policy: ...
-  bp_config: ...
-  environment_fingerprint: ...
+environment:
+  registry_revision: ...
+  retrieval_policy:
+    semantic_top_k: 20
+    structural_max_hops: 2
+    max_environment_nodes: 200
+  fingerprint: ...
 ```
 
-Internal field names may still include graph-specific details such as `graph_revision` or `materialized_nodes`, but the external concept should remain "environment lock".
-
-### 7.3 Runtime artifacts
+### 8.3 Runtime artifacts
 
 Runtime and cache artifacts belong under `.gaia/`.
 
@@ -380,34 +467,34 @@ Examples:
 
 - build outputs
 - review sidecars
-- materialized integration environment contents
+- materialized package environment contents
 - cached inference outputs
 
 These are useful for iteration, but they are not the package's normative source definition.
 
 ---
 
-## 8. Inference Relationship
+## 9. Inference Relationship
 
 Review and inference are related, but they are not the same phase.
 
-### 8.1 Package review and inference
+### 9.1 Package review and inference
 
 Package review may suggest priors, dependency labels, or relation candidates that later affect BP.
 
 But package review itself is still an audit step, not inference execution.
 
-### 8.2 Integration review and local BP
+### 9.2 Integration review and inference
 
-Integration review may include local BP preview over the materialized integration environment.
+Integration review discovers relations (equivalence, contradiction, subsumption) between the package and existing knowledge. It does **not** run BP.
 
-That BP run is:
+The discovered relations become inputs to inference: once integrated, they form new edges in the factor graph that BP uses to compute beliefs.
 
-- subgraph-scoped
-- environment-scoped
-- preview-only
+### 9.3 Local inference (`gaia infer`)
 
-### 8.3 Server BP
+`gaia infer` compiles the factor graph from build/review outputs and runs local belief propagation. If a package environment is available, it may include environment context for more accurate local BP.
+
+### 9.4 Server inference (`BPService`)
 
 The server remains responsible for authoritative larger-scope computation after review and integration.
 
@@ -419,24 +506,23 @@ This may include:
 
 ---
 
-## 9. Lifecycle
+## 10. Lifecycle
 
-### 9.1 Local authoring loop
+### 10.1 Local authoring loop
 
 The target local loop is:
 
 ```text
 workspace
 -> gaia build
--> gaia review --scope package
--> gaia review --scope integration
--> local infer / inspect
+-> gaia review                  (default: --scope all)
+-> gaia infer
 -> edit package
 -> repeat
 -> gaia publish
 ```
 
-### 9.2 Server publish loop
+### 10.2 Server publish loop
 
 The target server loop is:
 
@@ -454,25 +540,23 @@ The server may expose that as one asynchronous job or several endpoints, but tho
 
 ---
 
-## 10. Non-Goals
+## 11. Non-Goals
 
 This document does not yet define:
 
 - the final YAML/JSON schema for review reports
-- the final retrieval policy for building integration environments
 - the final server API route layout
 - the final local command set for environment management
 - whether package review and integration review should use one combined file or multiple sidecar files
 
 Those are follow-up design tasks.
 
-## 11. Immediate Follow-Ups
+## 12. Immediate Follow-Ups
 
 The next architectural follow-ups should be:
 
-1. define the structured review report schema
-2. extract or define a shared `review_core`
-3. define the integration environment lockfile format
-4. align CLI command semantics with review scopes
+1. define the structured review report schema (unifying CLI and server report formats)
+2. extract or define a shared `review_core` module (from CLI chain review + server pipeline operators)
+3. design the package environment lockfile format (coordinate with Issue #68 package management)
+4. align CLI command semantics with review scopes (`--scope` flag)
 5. align server ingestion architecture with package review plus integration review
-

--- a/docs/foundations/server/architecture.md
+++ b/docs/foundations/server/architecture.md
@@ -198,7 +198,7 @@ class IngestionService:
 | 组件 | 职责 | 输入 → 输出 |
 |------|------|------------|
 | **Validator** | schema 校验、引用完整性、prior 范围检查、边类型约束 | PackageData → ValidationResult |
-| **ReviewEngine** | 执行 package review 与 integration review | PackageData + ReviewContext → ReviewReport |
+| **ReviewEngine** | 执行 package review（PackageReviewPolicy）与 integration review（IntegrationReviewPolicy） | PackageData + PackageEnvironment + Policies → ReviewReport |
 | **Integrator** | 把 package 映射到全局图结构，调用 StorageManager 写入 | PackageData → IngestResult |
 
 #### Validator 职责
@@ -211,19 +211,25 @@ class IngestionService:
 
 #### ReviewEngine 职责
 
-ReviewEngine 分成两个逻辑阶段：
+ReviewEngine 分成两个逻辑阶段，各自有独立的 policy：
 
-1. **Package Review**：对 package 内部 chain、dependency、prior、relation 候选做闭世界审查
-2. **Integration Review**：结合 shared registry context 做重复检测、join/canonicalization 候选、cross-package relation 候选和 integration-time BP preview
+1. **Package Review**（`PackageReviewPolicy`）：闭世界审查，只需要一个 LLM
+   - 推理步骤是否逻辑连贯
+   - 结论是否被前提支持
+   - 推理类型是否正确标注（deduction vs induction vs abstraction）
+   - prior 和 dependency label 是否合理
+   - 输出 per-chain 评分 + 总体 accept/reject 建议
 
-对 package review 而言，典型职责是：
+2. **Integration Review**（`IntegrationReviewPolicy`）：开世界审查，需要 embedding + retrieval + LLM
+   - 生成 embedding，检索语义和结构邻居（构建 package environment）
+   - 发现 conclusion-conclusion 关系（join-cc）
+   - 发现 conclusion-premise 关系（join-cp）
+   - 两轮 verification（验证发现的关系质量）
+   - 输出 relation 候选（equivalence, contradiction, subsumption）+ integration verdict
 
-1. 推理步骤是否逻辑连贯
-2. 结论是否被前提支持
-3. 推理类型是否正确标注（deduction vs induction vs abstraction）
-4. 输出 per-chain 评分 + 总体 accept/reject 建议
+Review 不包含 BP。BP 属于 inference 阶段，由 `BPService` 在 integration 之后执行。
 
-Integration review 的更详细边界见 [../review/architecture.md](../review/architecture.md).
+详细边界见 [../review/architecture.md](../review/architecture.md).
 
 ### 4.2 BPService
 


### PR DESCRIPTION
## Summary

Improvements to the review architecture foundation doc based on design discussion:

- **Separated ReviewPolicy**: Split into `PackageReviewPolicy` (closed-world, single LLM for chain critique) and `IntegrationReviewPolicy` (open-world, needs embedding + retrieval + abstraction LLM + verify LLM)
- **Package environment**: Renamed from "integration environment" — this is a broader concept (the full context a package exists in), usable by review, infer, and future operations
- **BP removed from review**: Belief propagation belongs to inference (`gaia infer` / `BPService`), not review. Review discovers relations; inference computes beliefs.
- **Operator classification**: Mapped all existing pipeline operators (join-cc, join-cp, verify, embedding, NN search) explicitly to integration review
- **Default scope → `all`**: Changed from `package` to `all` so users see the full picture by default
- **Retrieval strategy defined**: Concrete 5-step process for building package environments (embed → semantic retrieval → structural retrieval → dedup/cap → load content)
- **Server architecture aligned**: Updated ReviewEngine section to reflect two-policy design

## Related

- Issue #90
- Base branch: `foundation/review-architecture`

## Test plan

- [ ] Review doc consistency across all four changed files
- [ ] Verify terminology alignment (package environment, not integration environment)
- [ ] Confirm no references to BP in review sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)