### PR TITLE
feat: add Newton and Einstein example packages for cross-package alignment testing

### DIFF
--- a/tests/fixtures/gaia_language_packages/einstein_gravity/equivalence_principle.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/equivalence_principle.yaml
@@ -1,0 +1,120 @@
+# 等价原理模块 — 爱因斯坦 1907 电梯思想实验
+
+type: reasoning_module
+name: equivalence_principle
+
+knowledge:
+  # === 引用 ===
+  - type: ref
+    name: eotvos_experiment
+    target: prior_knowledge.eotvos_experiment
+
+  - type: ref
+    name: newton_mass_equivalence
+    target: prior_knowledge.newton_mass_equivalence
+
+  - type: ref
+    name: maxwell_electromagnetism
+    target: prior_knowledge.maxwell_electromagnetism
+
+  # === 思想实验设定 ===
+
+  - type: setting
+    name: elevator_env
+    content: >
+      想象一个密闭电梯，其中的观察者无法看到外界。
+      如果电梯静止在引力场中（如地表），
+      观察者感受到的"重力"与电梯在无引力的太空中以 g 加速上升时
+      观察者感受到的"惯性力"完全不可区分。
+    prior: 1.0
+
+  # === 推理方法 ===
+
+  - type: infer_action
+    name: generalize_mass_equivalence
+    params:
+      - name: empirical_fact
+        type: claim
+      - name: env
+        type: setting
+    return_type: claim
+    content: >
+      {empirical_fact} 表明惯性质量与引力质量高精度相等。
+      在 {env} 的思想实验中，这意味着引力效应和加速度效应
+      在局域范围内完全等价——不只是数值巧合，
+      而是反映了更深层的物理等价性。
+    prior: 0.92
+
+  - type: infer_action
+    name: deduce_light_bending
+    params:
+      - name: principle
+        type: claim
+      - name: light_theory
+        type: claim
+    return_type: claim
+    content: >
+      由 {principle}：在加速电梯中，水平射入的光束因电梯上升
+      而呈现向下弯曲的路径。
+      如果引力与加速度等价，那么在引力场中光也必须弯曲。
+      结合 {light_theory}，光作为电磁波也不能免于引力的影响。
+    prior: 0.88
+
+  # === 结论 ===
+
+  - type: claim
+    name: equivalence_principle
+    content: >
+      爱因斯坦等价原理：在足够小的时空区域内，
+      引力效应与相应的加速参考系效应不可区分。
+      这不只是 m_i = m_g 的重复陈述，
+      而是将其提升为一条基本物理原理。
+    prior: 0.5
+    metadata:
+      source: "爱因斯坦, Jahrbuch der Radioaktivität und Elektronik, 1907"
+
+  - type: claim
+    name: light_must_bend_in_gravity
+    content: >
+      等价原理的直接推论：光线在引力场中必须弯曲。
+      这对牛顿力学和麦克斯韦电磁理论的结合提出了挑战，
+      因为牛顿力学中引力只作用于有质量的物体。
+    prior: 0.5
+
+  # === 推理链 ===
+
+  - type: chain_expr
+    name: ep_derivation_chain
+    steps:
+      - step: 1
+        ref: eotvos_experiment
+      - step: 2
+        apply: generalize_mass_equivalence
+        args:
+          - ref: eotvos_experiment
+            dependency: direct
+          - ref: elevator_env
+            dependency: indirect
+        prior: 0.92
+      - step: 3
+        ref: equivalence_principle
+
+  - type: chain_expr
+    name: light_bending_chain
+    steps:
+      - step: 1
+        ref: equivalence_principle
+      - step: 2
+        apply: deduce_light_bending
+        args:
+          - ref: equivalence_principle
+            dependency: direct
+          - ref: maxwell_electromagnetism
+            dependency: direct
+        prior: 0.88
+      - step: 3
+        ref: light_must_bend_in_gravity
+
+export:
+  - equivalence_principle
+  - light_must_bend_in_gravity

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/general_relativity.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/general_relativity.yaml
@@ -1,0 +1,149 @@
+# 广义相对论模块 — 1915 场方程、光线偏折预测、与牛顿的关系
+
+type: reasoning_module
+name: general_relativity
+
+knowledge:
+  # === 引用 ===
+  - type: ref
+    name: equivalence_principle
+    target: equivalence_principle.equivalence_principle
+
+  - type: ref
+    name: light_must_bend_in_gravity
+    target: equivalence_principle.light_must_bend_in_gravity
+
+  - type: ref
+    name: soldner_deflection
+    target: prior_knowledge.soldner_deflection
+
+  - type: ref
+    name: newton_gravity
+    target: prior_knowledge.newton_gravity
+
+  - type: ref
+    name: newton_a_equals_g
+    target: prior_knowledge.newton_a_equals_g
+
+  # === 广义相对论核心内容 ===
+
+  - type: claim
+    name: einstein_field_equations
+    content: >
+      爱因斯坦场方程 (1915)：G_μν + Λg_μν = (8πG/c⁴)T_μν。
+      引力不是力，而是时空弯曲的几何效应。
+      物质告诉时空如何弯曲，时空告诉物质如何运动。
+    prior: 0.9
+    metadata:
+      source: "爱因斯坦, Sitzungsberichte der Preussischen Akademie, 1915"
+
+  - type: claim
+    name: gr_light_deflection
+    content: >
+      广义相对论预测：光线掠过太阳表面时偏折 1.75 角秒。
+      这是 Soldner/牛顿预测 (0.87 角秒) 的恰好两倍，
+      因为 GR 同时包含时间弯曲和空间弯曲的贡献，
+      而牛顿框架只捕获了时间弯曲部分。
+    prior: 0.85
+    metadata:
+      source: "爱因斯坦, Annalen der Physik, 1916"
+
+  - type: claim
+    name: mercury_perihelion
+    content: >
+      广义相对论精确预测了水星近日点每世纪 43 角秒的异常进动，
+      这是牛顿引力无法解释的天文观测。
+    prior: 0.92
+    metadata:
+      source: "爱因斯坦, Sitzungsberichte, 1915; Le Verrier 1859 观测"
+
+  - type: claim
+    name: gr_subsumes_newton_weak_field
+    content: >
+      在弱引力场和低速条件下，广义相对论退化为牛顿引力。
+      牛顿的 F=GMm/r² 和 a=g 都是 GR 的弱场近似。
+      GR 不否定牛顿，而是将其包含为特殊情况。
+    prior: 0.5
+
+  # === 定量矛盾：1.75 vs 0.87 角秒 ===
+
+  - type: contradiction
+    name: deflection_contradiction
+    between:
+      - gr_light_deflection
+      - soldner_deflection
+    content: >
+      GR 预测光线偏折 1.75 角秒，牛顿微粒说预测 0.87 角秒。
+      两个预测不能同时正确——它们之间恰好差两倍，
+      差异来源是 GR 的空间弯曲贡献。
+      这是一个可以通过观测判决的定量矛盾。
+
+  # === 推理方法 ===
+
+  - type: infer_action
+    name: derive_subsumption
+    params:
+      - name: general_theory
+        type: claim
+      - name: special_case
+        type: claim
+    return_type: claim
+    content: >
+      {general_theory} 在弱场低速极限下的数学形式
+      精确还原为 {special_case}。
+      这意味着后者不是被"推翻"，而是被包含为前者的近似。
+      旧理论在其有效范围内仍然正确，但不再是最基本的描述。
+    prior: 0.93
+
+  # === 推理链 ===
+
+  - type: chain_expr
+    name: light_deflection_chain
+    steps:
+      - step: 1
+        ref: einstein_field_equations
+      - step: 2
+        lambda: >
+          在 Schwarzschild 度规下求解光的零测地线方程，
+          可以严格计算出光线掠过太阳时的偏折角。
+          GR 的计算同时包含时间分量 (g_00) 和空间分量 (g_rr) 的贡献，
+          给出 1.75 角秒，恰好是只考虑时间分量 (牛顿近似) 的两倍。
+        prior: 0.92
+      - step: 3
+        ref: gr_light_deflection
+
+  - type: chain_expr
+    name: subsumption_chain
+    steps:
+      - step: 1
+        ref: einstein_field_equations
+      - step: 2
+        apply: derive_subsumption
+        args:
+          - ref: einstein_field_equations
+            dependency: direct
+          - ref: newton_gravity
+            dependency: direct
+        prior: 0.93
+      - step: 3
+        ref: gr_subsumes_newton_weak_field
+
+  # === Newton subsumed by GR ===
+
+  - type: equivalence
+    name: newton_subsumed_by_gr
+    between:
+      - newton_gravity
+      - gr_subsumes_newton_weak_field
+    content: >
+      牛顿引力定律 F=GMm/r² 在弱场近似下与 GR 等价。
+      GR 是更一般的理论，牛顿是其弱场极限。
+      这是理论继承而非理论否定。
+
+export:
+  - einstein_field_equations
+  - gr_light_deflection
+  - mercury_perihelion
+  - gr_subsumes_newton_weak_field
+  - deflection_contradiction
+  - newton_subsumed_by_gr

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/observation.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/observation.yaml
@@ -1,0 +1,193 @@
+# 观测验证模块 — Eddington 1919 日食 + Apollo 15 月面实验
+# 演示三条独立路径的汇聚
+
+type: reasoning_module
+name: observation
+
+knowledge:
+  # === 引用 ===
+  - type: ref
+    name: gr_light_deflection
+    target: general_relativity.gr_light_deflection
+
+  - type: ref
+    name: soldner_deflection
+    target: prior_knowledge.soldner_deflection
+
+  - type: ref
+    name: galileo_vacuum_prediction
+    target: prior_knowledge.galileo_vacuum_prediction
+
+  - type: ref
+    name: newton_a_equals_g
+    target: prior_knowledge.newton_a_equals_g
+
+  # === Eddington 1919 日食观测 ===
+
+  - type: claim
+    name: eddington_sobral
+    content: >
+      1919 年 5 月 29 日日全食，Sobral (巴西) 观测站测得
+      恒星光线偏折 1.98 ± 0.16 角秒。
+      与 GR 预测 (1.75) 一致，与牛顿预测 (0.87) 偏离 7σ。
+    prior: 0.92
+    metadata:
+      source: "Dyson, Eddington & Davidson, Phil. Trans. Roy. Soc., 1920"
+
+  - type: claim
+    name: eddington_principe
+    content: >
+      同一日食，Príncipe (西非) 观测站测得偏折 1.61 ± 0.30 角秒。
+      与 GR 预测一致，与牛顿预测偏离约 2.5σ。
+    prior: 0.85
+    metadata:
+      source: "Dyson, Eddington & Davidson, Phil. Trans. Roy. Soc., 1920"
+
+  - type: claim
+    name: eddington_confirms_gr
+    content: >
+      爱丁顿日食观测支持广义相对论的 1.75 角秒预测，
+      排除了牛顿框架的 0.87 角秒预测。
+      GR 被确认为比牛顿引力更准确的理论。
+    prior: 0.5
+
+  # === Apollo 15 月面实验 ===
+
+  - type: claim
+    name: apollo15_feather_drop
+    content: >
+      1971 年 Apollo 15 宇航员 David Scott 在月球表面
+      同时释放一把锤子 (1.32 kg) 和一根羽毛 (0.03 g)，
+      质量比 44:1。两者在月球真空中同时落地。
+    prior: 0.99
+    metadata:
+      source: "NASA Apollo 15 mission, 1971-08-02; 现场视频记录"
+
+  - type: claim
+    name: apollo15_confirms_equal_fall
+    content: >
+      Apollo 15 月面实验在真正的真空环境中直接验证了
+      "不同质量物体自由落体速度相同"这一预测。
+      这是人类首次在自然真空中进行该实验。
+    prior: 0.5
+
+  # === 三条独立路径的汇聚 ===
+
+  - type: claim
+    name: three_path_convergence
+    content: >
+      "所有物体在引力场中等速下落"这一结论
+      被三条完全独立的认识路径所支持：
+      （1）逻辑路径：伽利略 1638 绑球归谬法
+      （2）理论路径：牛顿 1687 F=ma+F=mg 推导
+      （3）观测路径：Apollo 15 月面直接实验
+      三条路径从不同方向到达同一结论，大幅提升可信度。
+    prior: 0.5
+
+  # === 推理方法 ===
+
+  - type: infer_action
+    name: evaluate_observations
+    params:
+      - name: obs_a
+        type: claim
+      - name: obs_b
+        type: claim
+      - name: prediction
+        type: claim
+    return_type: claim
+    content: >
+      {obs_a} 和 {obs_b} 是两个独立观测站的测量结果，
+      两者都与 {prediction} 一致。独立观测的一致性
+      大幅降低了系统误差的可能性，增强了结论的可信度。
+    prior: 0.93
+
+  - type: infer_action
+    name: synthesize_convergence
+    params:
+      - name: logical_path
+        type: claim
+      - name: theoretical_path
+        type: claim
+      - name: observational_path
+        type: claim
+    return_type: claim
+    content: >
+      {logical_path}、{theoretical_path} 和 {observational_path}
+      是三条完全独立的认识路径。
+      逻辑路径不依赖于任何力学定律（纯归谬法），
+      理论路径不依赖于任何具体实验（纯演绎），
+      观测路径不依赖于任何理论假设（直接测量）。
+      三者独立汇聚到同一结论，构成最强形式的认识论支持。
+    prior: 0.96
+
+  # === 推理链 ===
+
+  - type: chain_expr
+    name: eddington_chain
+    steps:
+      - step: 1
+        ref: eddington_sobral
+      - step: 2
+        apply: evaluate_observations
+        args:
+          - ref: eddington_sobral
+            dependency: direct
+          - ref: eddington_principe
+            dependency: direct
+          - ref: gr_light_deflection
+            dependency: indirect
+        prior: 0.93
+      - step: 3
+        ref: eddington_confirms_gr
+
+  - type: chain_expr
+    name: apollo_chain
+    steps:
+      - step: 1
+        ref: apollo15_feather_drop
+      - step: 2
+        lambda: >
+          月球表面没有大气，提供了真正的真空条件。
+          在 44:1 的极端质量比下，两个物体仍然同时落地，
+          直接验证了"自由落体加速度与质量无关"的预测。
+          这回答了伽利略 package 中提出的 follow_up_question。
+        prior: 0.97
+      - step: 3
+        ref: apollo15_confirms_equal_fall
+
+  - type: chain_expr
+    name: convergence_chain
+    steps:
+      - step: 1
+        ref: galileo_vacuum_prediction
+      - step: 2
+        apply: synthesize_convergence
+        args:
+          - ref: galileo_vacuum_prediction
+            dependency: direct
+          - ref: newton_a_equals_g
+            dependency: direct
+          - ref: apollo15_confirms_equal_fall
+            dependency: direct
+        prior: 0.96
+      - step: 3
+        ref: three_path_convergence
+
+  # === Retraction：Soldner/牛顿的 0.87 预测被排除 ===
+
+  - type: retract_action
+    name: retract_soldner
+    target: soldner_deflection
+    reason: deflection_contradiction
+    content: >
+      爱丁顿日食观测（1.98 和 1.61 角秒）与 GR 预测（1.75）一致，
+      与 Soldner/牛顿预测（0.87）偏离显著。
+      0.87 角秒的预测应当被大幅削弱。
+    prior: 0.93
+
+export:
+  - eddington_confirms_gr
+  - apollo15_feather_drop
+  - apollo15_confirms_equal_fall
+  - three_path_convergence

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/package.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/package.yaml
@@ -1,0 +1,34 @@
+# 爱因斯坦引力理论 — 从等价原理到广义相对论
+# 覆盖: 多层跨 package 依赖, 理论继承(subsumption), 定量矛盾, 观测验证
+
+name: einstein_gravity
+version: 1.0.0
+
+manifest:
+  description: >
+    建模爱因斯坦如何从电梯思想实验出发提出等价原理，
+    进而发展广义相对论，预测光线偏折 1.75 角秒
+    （与牛顿理论的 0.87 角秒形成定量矛盾），
+    最终由爱丁顿 1919 日食观测和阿波罗 15 号月面实验验证。
+    同时展示理论继承关系：GR subsumes 牛顿引力为弱场近似，
+    三个 package (Galileo → Newton → Einstein) 构成完整的落体理论演进。
+  authors:
+    - 阿尔伯特·爱因斯坦
+  license: CC-BY-4.0
+
+dependencies:
+  - package: newton_principia
+    version: ">=1.0.0"
+  - package: galileo_falling_bodies
+    version: ">=1.0.0"
+
+modules:
+  - prior_knowledge
+  - equivalence_principle
+  - general_relativity
+  - observation
+
+export:
+  - gr_light_deflection
+  - newton_subsumed_by_gr
+  - three_path_convergence

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/prior_knowledge.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/prior_knowledge.yaml
@@ -1,0 +1,63 @@
+# 先验知识模块 — 从其他 package 和历史背景引入的前提
+
+type: reasoning_module
+name: prior_knowledge
+
+knowledge:
+  # === 引用 Newton package ===
+  - type: ref
+    name: newton_second_law
+    target: newton_principia.laws.second_law
+
+  - type: ref
+    name: newton_gravity
+    target: newton_principia.laws.law_of_gravity
+
+  - type: ref
+    name: newton_mass_equivalence
+    target: newton_principia.laws.mass_equivalence
+
+  - type: ref
+    name: newton_a_equals_g
+    target: newton_principia.derivation.acceleration_independent_of_mass
+
+  # === 引用 Galileo package ===
+  - type: ref
+    name: galileo_vacuum_prediction
+    target: galileo_falling_bodies.reasoning.vacuum_prediction
+
+  # === 本 package 的先验知识 ===
+
+  - type: claim
+    name: eotvos_experiment
+    content: >
+      Eötvös 1889 年的扭摆实验以 10^-9 的精度验证了
+      惯性质量与引力质量的等价性。
+      这是迄今为止对 m_i = m_g 最精确的实验检验。
+    prior: 0.97
+    metadata:
+      source: "Eötvös, Mathematische und Naturwissenschaftliche Berichte aus Ungarn, 1890"
+
+  - type: claim
+    name: maxwell_electromagnetism
+    content: >
+      麦克斯韦电磁理论：光是电磁波，在真空中以恒定速度 c 传播。
+      光不是粒子（至少在经典电磁理论框架下）。
+    prior: 0.94
+    metadata:
+      source: "麦克斯韦《电磁理论》, 1865"
+
+  - type: claim
+    name: soldner_deflection
+    content: >
+      Soldner 1801 年基于牛顿力学的微粒说计算：
+      光线掠过太阳表面时偏折角度为 0.87 角秒。
+      这是纯牛顿框架下的预测。
+    prior: 0.6
+    metadata:
+      source: "Soldner, Berliner Astronomisches Jahrbuch, 1804"
+
+export:
+  - eotvos_experiment
+  - maxwell_electromagnetism
+  - soldner_deflection

--- a/tests/fixtures/gaia_language_packages/newton_principia/derivation.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/derivation.yaml
@@ -1,0 +1,108 @@
+# 推导模块 — 从牛顿定律推导出 a = g
+# 核心链：F=ma + F=mg → ma=mg → a=g（与质量无关）
+
+type: reasoning_module
+name: derivation
+
+knowledge:
+  # === 引用本 package 的定律 ===
+  - type: ref
+    name: second_law
+    target: laws.second_law
+
+  - type: ref
+    name: law_of_gravity
+    target: laws.law_of_gravity
+
+  - type: ref
+    name: mass_equivalence
+    target: laws.mass_equivalence
+
+  - type: ref
+    name: near_earth_surface
+    target: laws.near_earth_surface
+
+  # === 推理方法 ===
+
+  - type: infer_action
+    name: equate_forces
+    params:
+      - name: dynamic_law
+        type: claim
+      - name: gravity_law
+        type: claim
+      - name: equivalence
+        type: claim
+    return_type: claim
+    content: >
+      由 {dynamic_law} 得 F = m_i × a；由 {gravity_law} 得 F = m_g × g。
+      因为作用在同一物体上的合力相等，所以 m_i × a = m_g × g。
+      又由 {equivalence} 知 m_i = m_g，两边约去质量，得 a = g。
+      加速度只取决于引力场强度 g，与物体质量完全无关。
+    prior: 0.97
+
+  - type: infer_action
+    name: interpret_mass_independence
+    params:
+      - name: derivation_result
+        type: claim
+    return_type: claim
+    content: >
+      {derivation_result} 意味着在同一引力场中，无论物体质量多大，
+      其自由落体加速度都相同。这不是经验归纳，而是从基本定律出发的
+      纯理论推导。
+    prior: 0.95
+
+  # === 中间结论和最终结论 ===
+
+  - type: claim
+    name: force_equation_result
+    content: >
+      对地表附近的自由落体：m × a = m × g，约去质量得 a = g。
+      自由落体加速度等于引力场强度，与物体的质量无关。
+    prior: 0.5
+
+  - type: claim
+    name: acceleration_independent_of_mass
+    content: >
+      在同一引力场中，所有物体的自由落体加速度相同，与质量无关。
+      这是牛顿力学的理论推论，不依赖于任何具体实验。
+    prior: 0.5
+
+  # === 推理链 ===
+
+  - type: chain_expr
+    name: force_equating_chain
+    steps:
+      - step: 1
+        ref: second_law
+      - step: 2
+        apply: equate_forces
+        args:
+          - ref: second_law
+            dependency: direct
+          - ref: law_of_gravity
+            dependency: direct
+          - ref: mass_equivalence
+            dependency: direct
+        prior: 0.97
+      - step: 3
+        ref: force_equation_result
+
+  - type: chain_expr
+    name: mass_independence_chain
+    steps:
+      - step: 1
+        ref: force_equation_result
+      - step: 2
+        apply: interpret_mass_independence
+        args:
+          - ref: force_equation_result
+            dependency: direct
+        prior: 0.95
+      - step: 3
+        ref: acceleration_independent_of_mass
+
+export:
+  - force_equation_result
+  - acceleration_independent_of_mass

--- a/tests/fixtures/gaia_language_packages/newton_principia/implications.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/implications.yaml
@@ -1,0 +1,111 @@
+# 含义模块 — 牛顿推导与伽利略和亚里士多德的关系
+# 演示跨 package 引用和 relation 类型
+
+type: reasoning_module
+name: implications
+
+knowledge:
+  # === 引用本 package 的结论 ===
+  - type: ref
+    name: acceleration_independent_of_mass
+    target: derivation.acceleration_independent_of_mass
+
+  # === 引用 Galileo package 的结论 ===
+  - type: ref
+    name: galileo_vacuum_prediction
+    target: galileo_falling_bodies.reasoning.vacuum_prediction
+
+  - type: ref
+    name: galileo_aristotle_contradicted
+    target: galileo_falling_bodies.reasoning.aristotle_contradicted
+
+  - type: ref
+    name: aristotle_law
+    target: galileo_falling_bodies.aristotle.heavier_falls_faster
+
+  - type: ref
+    name: inclined_plane_supports
+    target: galileo_falling_bodies.reasoning.inclined_plane_supports_equal_fall
+
+  # === 等价关系：牛顿的 a=g 与伽利略的真空预测 ===
+
+  - type: equivalence
+    name: galileo_equivalence
+    between:
+      - acceleration_independent_of_mass
+      - galileo_vacuum_prediction
+    content: >
+      牛顿从 F=ma 和 F=mg 推导出的"a=g 与质量无关"
+      与伽利略从思想实验和经验分析预测的"真空中不同重量物体等速下落"
+      在物理含义上等价。
+      区别在于：伽利略是经验论证（归谬法 + 介质分析 + 斜面实验），
+      牛顿是理论推导（从基本定律出发的演绎）。
+
+  # === 牛顿独立反驳亚里士多德 ===
+
+  - type: claim
+    name: newton_contradicts_aristotle
+    content: >
+      牛顿的 a=g 推导从理论上排除了"下落速度与重量成正比"的可能：
+      如果加速度不依赖质量，那么亚里士多德的 v∝W 就不是自然界的规律。
+      这与伽利略的归谬法反驳独立，提供了第二条反驳路径。
+    prior: 0.5
+
+  - type: contradiction
+    name: newton_vs_aristotle
+    between:
+      - acceleration_independent_of_mass
+      - aristotle_law
+    content: >
+      牛顿的 a=g（加速度与质量无关）直接矛盾于
+      亚里士多德的 v∝W（下落速度与重量成正比）。
+      前者是理论推导，后者是未经控制的经验归纳。
+
+  # === 推理链 ===
+
+  - type: infer_action
+    name: derive_theoretical_contradiction
+    params:
+      - name: newton_result
+        type: claim
+      - name: aristotle_claim
+        type: claim
+    return_type: claim
+    content: >
+      {newton_result} 断言加速度与质量无关；{aristotle_claim} 断言速度与重量成正比。
+      在自由落体条件下（无介质阻力），这两个命题不能同时为真。
+      牛顿的推导基于更基本的力学定律，亚里士多德的归纳缺乏对混淆变量的控制，
+      因此应当接受前者、拒绝后者。
+    prior: 0.95
+
+  - type: chain_expr
+    name: theoretical_contradiction_chain
+    steps:
+      - step: 1
+        ref: acceleration_independent_of_mass
+      - step: 2
+        apply: derive_theoretical_contradiction
+        args:
+          - ref: acceleration_independent_of_mass
+            dependency: direct
+          - ref: aristotle_law
+            dependency: direct
+        prior: 0.95
+      - step: 3
+        ref: newton_contradicts_aristotle
+
+  - type: retract_action
+    name: retract_aristotle_theoretically
+    target: aristotle_law
+    reason: newton_vs_aristotle
+    content: >
+      牛顿的理论推导提供了第二条独立的反驳路径：
+      伽利略通过归谬法暴露了亚里士多德定律的内在矛盾，
+      牛顿则从更基本的力学定律直接推导出与之矛盾的结论。
+      两条独立路径汇聚，进一步降低亚里士多德定律的可信度。
+    prior: 0.95
+
+export:
+  - galileo_equivalence
+  - newton_contradicts_aristotle
+  - newton_vs_aristotle

--- a/tests/fixtures/gaia_language_packages/newton_principia/laws.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/laws.yaml
@@ -1,0 +1,71 @@
+# 牛顿定律模块 — 力学基本定律
+
+type: reasoning_module
+name: laws
+
+knowledge:
+  # === 牛顿三大运动定律 ===
+
+  - type: claim
+    name: first_law
+    content: >
+      牛顿第一定律（惯性定律）：不受外力作用的物体保持静止或匀速直线运动。
+    prior: 0.95
+    metadata:
+      source: "牛顿《自然哲学的数学原理》第一卷, 1687"
+
+  - type: claim
+    name: second_law
+    content: >
+      牛顿第二定律：物体的加速度与所受合外力成正比、与惯性质量成反比。
+      F = m_i × a，其中 m_i 是惯性质量。
+    prior: 0.95
+    metadata:
+      source: "牛顿《自然哲学的数学原理》第一卷, 1687"
+
+  - type: claim
+    name: third_law
+    content: >
+      牛顿第三定律（作用与反作用定律）：两个物体之间的力总是大小相等、方向相反。
+    prior: 0.95
+    metadata:
+      source: "牛顿《自然哲学的数学原理》第三卷, 1687"
+
+  # === 万有引力定律 ===
+
+  - type: claim
+    name: law_of_gravity
+    content: >
+      万有引力定律：任意两个物体之间存在引力，大小为 F = G × M × m_g / r²，
+      其中 m_g 是引力质量，M 是地球质量，r 是距离，G 是引力常数。
+    prior: 0.93
+    metadata:
+      source: "牛顿《自然哲学的数学原理》第三卷, 1687"
+
+  # === 惯性质量 = 引力质量（经验事实）===
+
+  - type: claim
+    name: mass_equivalence
+    content: >
+      惯性质量与引力质量在实验精度范围内相等：m_i = m_g。
+      这是一个经验事实，牛顿注意到了它但没有给出理论解释。
+    prior: 0.92
+    metadata:
+      source: "牛顿摆实验; 后经 Eötvös 1889 精确验证至 10^-9"
+
+  # === 地表近似 ===
+
+  - type: setting
+    name: near_earth_surface
+    content: >
+      在地球表面附近，距离 r 近似等于地球半径 R，
+      因而引力加速度 g = GM/R² 可视为常数（约 9.8 m/s²）。
+    prior: 1.0
+
+export:
+  - first_law
+  - second_law
+  - third_law
+  - law_of_gravity
+  - mass_equivalence
+  - near_earth_surface

--- a/tests/fixtures/gaia_language_packages/newton_principia/motivation.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/motivation.yaml
@@ -1,0 +1,15 @@
+# 动机模块 — 为什么需要力学定律
+
+type: motivation_module
+name: motivation
+
+knowledge:
+  - type: question
+    name: main_question
+    content: >
+      能否从更基本的力学原理出发，推导出落体运动的普遍规律？
+      伽利略的思想实验和经验观察已经暗示"真空中等速下落"，
+      但这个预测是否有更深层的理论根基？
+
+export:
+  - main_question

--- a/tests/fixtures/gaia_language_packages/newton_principia/package.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/package.yaml
@@ -1,0 +1,30 @@
+# 牛顿力学 — 从运动定律推导出落体加速度与质量无关
+# 覆盖: 跨 package 依赖, ref 到外部 package, equivalence/subsumption 关系
+
+name: newton_principia
+version: 1.0.0
+
+manifest:
+  description: >
+    建模牛顿如何从三大运动定律和万有引力定律出发，
+    通过纯理论推导得出"自由落体加速度与质量无关"(a=g)，
+    从而在理论层面 subsume 了伽利略的经验预测，
+    并独立于伽利略的思想实验反驳了亚里士多德。
+  authors:
+    - 艾萨克·牛顿
+  license: CC-BY-4.0
+
+dependencies:
+  - package: galileo_falling_bodies
+    version: ">=1.0.0"
+
+modules:
+  - motivation
+  - laws
+  - derivation
+  - implications
+
+export:
+  - acceleration_independent_of_mass
+  - newton_contradicts_aristotle
+  - galileo_equivalence


### PR DESCRIPTION
## Summary

- Add `newton_principia` and `einstein_gravity` YAML language packages alongside existing `galileo_falling_bodies`
- Three packages form a scientific revolution chain (Aristotle → Galileo → Newton → Einstein) with rich cross-package relations
- Designed as test cases for the build→review→infer pipeline (PR #95 architecture)

## Cross-package relation coverage

| Relation | Type | Location |
|---|---|---|
| Newton a=g ↔ Galileo vacuum prediction | equivalence | `newton_principia/implications` |
| Newton a=g vs Aristotle v∝W | contradiction + retraction | `newton_principia/implications` |
| GR 1.75″ vs Soldner 0.87″ | contradiction + retraction | `einstein_gravity/general_relativity` + `observation` |
| GR ⊃ Newton (weak-field limit) | subsumption | `einstein_gravity/general_relativity` |
| Galileo + Newton + Apollo → same conclusion | convergence | `einstein_gravity/observation` |

## Package stats

| Package | Modules | Declarations | Dependencies |
|---|---|---|---|
| `galileo_falling_bodies` (existing) | 5 | 36 | — |
| `newton_principia` (new) | 4 | 28 | `galileo_falling_bodies` |
| `einstein_gravity` (new) | 4 | 48 | `newton_principia`, `galileo_falling_bodies` |

## Verification

All three packages load successfully via `libs.lang.loader.load_package()`.

Closes #97
Ref #90
Ref #95

## Test plan

- [x] All three packages load without errors
- [ ] Existing tests still pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)