### PR TITLE
refine example package semantics

### DIFF
--- a/tests/fixtures/gaia_language_packages/einstein_gravity/equivalence_principle.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/equivalence_principle.yaml
@@ -10,10 +10,6 @@ knowledge:
     target: prior_knowledge.eotvos_experiment
 
   - type: ref
-    name: newton_mass_equivalence
-    target: prior_knowledge.newton_mass_equivalence
-
-  - type: ref
     name: maxwell_electromagnetism
     target: prior_knowledge.maxwell_electromagnetism
 
@@ -94,7 +90,7 @@ knowledge:
           - ref: eotvos_experiment
             dependency: direct
           - ref: elevator_env
-            dependency: indirect
+            dependency: direct
         prior: 0.92
       - step: 3
         ref: equivalence_principle

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/general_relativity.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/general_relativity.yaml
@@ -6,10 +6,6 @@ name: general_relativity
 knowledge:
   # === 引用 ===
   - type: ref
-    name: equivalence_principle
-    target: equivalence_principle.equivalence_principle
-
-  - type: ref
     name: light_must_bend_in_gravity
     target: equivalence_principle.light_must_bend_in_gravity
 
@@ -65,6 +61,14 @@ knowledge:
       GR 不否定牛顿，而是将其包含为特殊情况。
     prior: 0.5
 
+  - type: claim
+    name: newton_subsumed_by_gr
+    content: >
+      牛顿引力并不是被广义相对论简单否定，
+      而是在弱场、低速、低曲率条件下被重新解释为其有效近似。
+      旧理论在适用范围内仍然成立，但不再是最基本的描述。
+    prior: 0.5
+
   # === 定量矛盾：1.75 vs 0.87 角秒 ===
 
   - type: contradiction
@@ -87,13 +91,31 @@ knowledge:
         type: claim
       - name: special_case
         type: claim
+      - name: weak_field_result
+        type: claim
     return_type: claim
     content: >
       {general_theory} 在弱场低速极限下的数学形式
-      精确还原为 {special_case}。
+      精确还原为 {special_case}，并继续给出 {weak_field_result}
+      这类熟悉的牛顿式结果。
       这意味着后者不是被"推翻"，而是被包含为前者的近似。
       旧理论在其有效范围内仍然正确，但不再是最基本的描述。
     prior: 0.93
+
+  - type: infer_action
+    name: quantify_light_bending
+    params:
+      - name: qualitative_prediction
+        type: claim
+      - name: field_equations
+        type: claim
+    return_type: claim
+    content: >
+      {qualitative_prediction} 只告诉我们光必须弯曲；
+      {field_equations} 则给出如何从时空几何定量计算这种弯曲。
+      在 Schwarzschild 度规下求解光的零测地线，
+      可得太阳边缘处的偏折角约为 1.75 角秒。
+    prior: 0.92
 
   # === 推理链 ===
 
@@ -101,13 +123,14 @@ knowledge:
     name: light_deflection_chain
     steps:
       - step: 1
-        ref: einstein_field_equations
+        ref: light_must_bend_in_gravity
       - step: 2
-        lambda: >
-          在 Schwarzschild 度规下求解光的零测地线方程，
-          可以严格计算出光线掠过太阳时的偏折角。
-          GR 的计算同时包含时间分量 (g_00) 和空间分量 (g_rr) 的贡献，
-          给出 1.75 角秒，恰好是只考虑时间分量 (牛顿近似) 的两倍。
+        apply: quantify_light_bending
+        args:
+          - ref: light_must_bend_in_gravity
+            dependency: direct
+          - ref: einstein_field_equations
+            dependency: direct
         prior: 0.92
       - step: 3
         ref: gr_light_deflection
@@ -124,21 +147,25 @@ knowledge:
             dependency: direct
           - ref: newton_gravity
             dependency: direct
+          - ref: newton_a_equals_g
+            dependency: direct
         prior: 0.93
       - step: 3
         ref: gr_subsumes_newton_weak_field
 
-  # === Newton subsumed by GR ===
-
-  - type: equivalence
-    name: newton_subsumed_by_gr
-    between:
-      - newton_gravity
-      - gr_subsumes_newton_weak_field
-    content: >
-      牛顿引力定律 F=GMm/r² 在弱场近似下与 GR 等价。
-      GR 是更一般的理论，牛顿是其弱场极限。
-      这是理论继承而非理论否定。
+  - type: chain_expr
+    name: weak_field_summary_chain
+    steps:
+      - step: 1
+        ref: gr_subsumes_newton_weak_field
+      - step: 2
+        lambda: >
+          因而更准确的结论不是“GR 推翻了牛顿”，
+          而是：牛顿引力被纳入一个更一般的几何理论之中，
+          在弱场范围内继续作为有效描述保留下来。
+        prior: 0.92
+      - step: 3
+        ref: newton_subsumed_by_gr
 
 export:
   - einstein_field_equations

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/observation.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/observation.yaml
@@ -1,5 +1,5 @@
 # 观测验证模块 — Eddington 1919 日食 + Apollo 15 月面实验
-# 演示三条独立路径的汇聚
+# 演示三条方法不同路径的汇聚
 
 type: reasoning_module
 name: observation
@@ -13,6 +13,10 @@ knowledge:
   - type: ref
     name: soldner_deflection
     target: prior_knowledge.soldner_deflection
+
+  - type: ref
+    name: deflection_contradiction
+    target: general_relativity.deflection_contradiction
 
   - type: ref
     name: galileo_vacuum_prediction
@@ -51,6 +55,14 @@ knowledge:
       GR 被确认为比牛顿引力更准确的理论。
     prior: 0.5
 
+  - type: claim
+    name: soldner_prediction_disfavored
+    content: >
+      在爱丁顿 1919 年观测之后，
+      Soldner/牛顿的 0.87 角秒预测不再是与数据相容的最佳解释，
+      至少在太阳边缘光偏折问题上应被显著削弱。
+    prior: 0.5
+
   # === Apollo 15 月面实验 ===
 
   - type: claim
@@ -71,13 +83,13 @@ knowledge:
       这是人类首次在自然真空中进行该实验。
     prior: 0.5
 
-  # === 三条独立路径的汇聚 ===
+  # === 三条不同路径的汇聚 ===
 
   - type: claim
     name: three_path_convergence
     content: >
       "所有物体在引力场中等速下落"这一结论
-      被三条完全独立的认识路径所支持：
+      被三条方法上彼此不同、相对独立的认识路径所支持：
       （1）逻辑路径：伽利略 1638 绑球归谬法
       （2）理论路径：牛顿 1687 F=ma+F=mg 推导
       （3）观测路径：Apollo 15 月面直接实验
@@ -114,12 +126,26 @@ knowledge:
     return_type: claim
     content: >
       {logical_path}、{theoretical_path} 和 {observational_path}
-      是三条完全独立的认识路径。
+      是三条方法上彼此不同、关键假设上相对独立的认识路径。
       逻辑路径不依赖于任何力学定律（纯归谬法），
       理论路径不依赖于任何具体实验（纯演绎），
-      观测路径不依赖于任何理论假设（直接测量）。
-      三者独立汇聚到同一结论，构成最强形式的认识论支持。
+      观测路径则提供了接近直接测量的经验检验。
+      三者从不同方向汇聚到同一结论，显著提升其可信度。
     prior: 0.96
+
+  - type: infer_action
+    name: disfavor_conflicting_prediction
+    params:
+      - name: supporting_evidence
+        type: claim
+      - name: quantified_conflict
+        type: contradiction
+    return_type: claim
+    content: >
+      {supporting_evidence} 支持了与观测相符的一侧预测，
+      而 {quantified_conflict} 指出另一侧预测与之不能同时成立。
+      因而相冲突的旧预测应当被显著削弱，而不是继续与新证据并列保留。
+    prior: 0.93
 
   # === 推理链 ===
 
@@ -136,7 +162,7 @@ knowledge:
           - ref: eddington_principe
             dependency: direct
           - ref: gr_light_deflection
-            dependency: indirect
+            dependency: direct
         prior: 0.93
       - step: 3
         ref: eddington_confirms_gr
@@ -150,11 +176,27 @@ knowledge:
         lambda: >
           月球表面没有大气，提供了真正的真空条件。
           在 44:1 的极端质量比下，两个物体仍然同时落地，
-          直接验证了"自由落体加速度与质量无关"的预测。
-          这回答了伽利略 package 中提出的 follow_up_question。
+          直接验证了"自由落体加速度与质量无关"的预测，
+          并为“真空中不同重量物体等速下落”提供了近乎理想条件下的经验支持。
         prior: 0.97
       - step: 3
         ref: apollo15_confirms_equal_fall
+
+  - type: chain_expr
+    name: soldner_rejection_chain
+    steps:
+      - step: 1
+        ref: eddington_confirms_gr
+      - step: 2
+        apply: disfavor_conflicting_prediction
+        args:
+          - ref: eddington_confirms_gr
+            dependency: direct
+          - ref: deflection_contradiction
+            dependency: direct
+        prior: 0.93
+      - step: 3
+        ref: soldner_prediction_disfavored
 
   - type: chain_expr
     name: convergence_chain
@@ -188,6 +230,7 @@ knowledge:
 
 export:
   - eddington_confirms_gr
+  - soldner_prediction_disfavored
   - apollo15_feather_drop
   - apollo15_confirms_equal_fall
   - three_path_convergence

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/prior_knowledge.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/prior_knowledge.yaml
@@ -6,16 +6,8 @@ name: prior_knowledge
 knowledge:
   # === 引用 Newton package ===
   - type: ref
-    name: newton_second_law
-    target: newton_principia.laws.second_law
-
-  - type: ref
     name: newton_gravity
     target: newton_principia.laws.law_of_gravity
-
-  - type: ref
-    name: newton_mass_equivalence
-    target: newton_principia.laws.mass_equivalence
 
   - type: ref
     name: newton_a_equals_g

--- a/tests/fixtures/gaia_language_packages/galileo_falling_bodies/package.yaml
+++ b/tests/fixtures/gaia_language_packages/galileo_falling_bodies/package.yaml
@@ -24,4 +24,5 @@ modules:
 
 export:
   - vacuum_prediction
+  - aristotle_contradicted
   - follow_up_question

--- a/tests/fixtures/gaia_language_packages/newton_principia/implications.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/implications.yaml
@@ -23,10 +23,6 @@ knowledge:
     name: aristotle_law
     target: galileo_falling_bodies.aristotle.heavier_falls_faster
 
-  - type: ref
-    name: inclined_plane_supports
-    target: galileo_falling_bodies.reasoning.inclined_plane_supports_equal_fall
-
   # === 等价关系：牛顿的 a=g 与伽利略的真空预测 ===
 
   - type: equivalence
@@ -49,6 +45,15 @@ knowledge:
       牛顿的 a=g 推导从理论上排除了"下落速度与重量成正比"的可能：
       如果加速度不依赖质量，那么亚里士多德的 v∝W 就不是自然界的规律。
       这与伽利略的归谬法反驳独立，提供了第二条反驳路径。
+    prior: 0.5
+
+  - type: claim
+    name: two_path_rejection_of_aristotle
+    content: >
+      亚里士多德落体学说同时遭到两条方法上不同的反驳路径削弱：
+      伽利略通过绑球归谬法暴露其内在矛盾，
+      牛顿则从更基本的力学定律推导出与之不相容的结果。
+      两条路径相互独立地汇聚到同一结论。
     prior: 0.5
 
   - type: contradiction
@@ -78,6 +83,21 @@ knowledge:
       因此应当接受前者、拒绝后者。
     prior: 0.95
 
+  - type: infer_action
+    name: synthesize_independent_refutations
+    params:
+      - name: galileo_result
+        type: claim
+      - name: newton_result
+        type: claim
+    return_type: claim
+    content: >
+      {galileo_result} 来自思想实验中的归谬法，
+      {newton_result} 来自基本力学定律的演绎推导。
+      二者在方法上不同，却都指向同一个判断：
+      亚里士多德的落体规律不能作为普遍定律保留。
+    prior: 0.94
+
   - type: chain_expr
     name: theoretical_contradiction_chain
     steps:
@@ -105,7 +125,24 @@ knowledge:
       两条独立路径汇聚，进一步降低亚里士多德定律的可信度。
     prior: 0.95
 
+  - type: chain_expr
+    name: two_path_rejection_chain
+    steps:
+      - step: 1
+        ref: galileo_aristotle_contradicted
+      - step: 2
+        apply: synthesize_independent_refutations
+        args:
+          - ref: galileo_aristotle_contradicted
+            dependency: direct
+          - ref: newton_contradicts_aristotle
+            dependency: direct
+        prior: 0.94
+      - step: 3
+        ref: two_path_rejection_of_aristotle
+
 export:
   - galileo_equivalence
   - newton_contradicts_aristotle
   - newton_vs_aristotle
+  - two_path_rejection_of_aristotle

--- a/tests/fixtures/gaia_language_packages/newton_principia/package.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/package.yaml
@@ -1,5 +1,5 @@
 # 牛顿力学 — 从运动定律推导出落体加速度与质量无关
-# 覆盖: 跨 package 依赖, ref 到外部 package, equivalence/subsumption 关系
+# 覆盖: 跨 package 依赖, ref 到外部 package, equivalence/contradiction/retraction
 
 name: newton_principia
 version: 1.0.0
@@ -8,7 +8,7 @@ manifest:
   description: >
     建模牛顿如何从三大运动定律和万有引力定律出发，
     通过纯理论推导得出"自由落体加速度与质量无关"(a=g)，
-    从而在理论层面 subsume 了伽利略的经验预测，
+    从而为伽利略的经验预测提供理论根基，
     并独立于伽利略的思想实验反驳了亚里士多德。
   authors:
     - 艾萨克·牛顿
@@ -27,4 +27,5 @@ modules:
 export:
   - acceleration_independent_of_mass
   - newton_contradicts_aristotle
+  - two_path_rejection_of_aristotle
   - galileo_equivalence


### PR DESCRIPTION
## Summary

- tighten the Galileo/Newton/Einstein example packages as semantic fixtures, not just YAML fixtures
- make retraction provenance local and explicit in 
- replace the misleading GR/Newton equivalence with clearer claim-level weak-field inheritance structure
- tighten dependency classification and remove unused cross-package refs
- add a stable exported Galileo conclusion and a Newton two-path convergence conclusion to clarify package surfaces

## Verification

-  for , , and 
- 

## Notes

This PR is stacked on top of #98 and only refines the example packages themselves. It does not change the current cross-package runtime/resolver implementation.
