### PR TITLE
feat: add Subsumption relation type and Param type validation

### DIFF
--- a/libs/lang/compiler.py
+++ b/libs/lang/compiler.py
@@ -19,7 +19,8 @@ from .models import (
 )
 
 
-# Types that participate in BP as variable nodes
+# Types that participate in BP as variable nodes.
+# Note: "subsumption" is intentionally excluded — it is annotative metadata only.
 BP_VARIABLE_TYPES = {"claim", "setting", "contradiction", "equivalence"}
 
 

--- a/libs/lang/models.py
+++ b/libs/lang/models.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr, field_validator
 
 
 # ── Terminals ──────────────────────────────────────────────
 
 
+# Knowledge types that can appear as InferAction parameter types.
+PARAM_TYPES = {"claim", "setting", "question", "contradiction", "equivalence", "subsumption"}
+
+
 class Param(BaseModel):
     name: str
     type: str
+
+    @field_validator("type")
+    @classmethod
+    def _validate_type(cls, v: str) -> str:
+        if v not in PARAM_TYPES:
+            raise ValueError(f"Invalid param type '{v}', must be one of {sorted(PARAM_TYPES)}")
+        return v
 
 
 class Arg(BaseModel):
@@ -95,6 +106,15 @@ class Equivalence(Relation):
     type: str = "equivalence"
 
 
+class Subsumption(Relation):
+    """A subsumes B: A is the more general theory, B is a special case.
+
+    Annotative metadata only — does not participate in BP.
+    """
+
+    type: str = "subsumption"
+
+
 class Action(Knowledge):
     """Base for executable actions (InferAction, ToolCallAction)."""
 
@@ -144,6 +164,7 @@ KNOWLEDGE_TYPE_MAP: dict[str, type[Knowledge]] = {
     "setting": Setting,
     "contradiction": Contradiction,
     "equivalence": Equivalence,
+    "subsumption": Subsumption,
     "infer_action": InferAction,
     "toolcall_action": ToolCallAction,
     "retract_action": RetractAction,

--- a/tests/libs/lang/test_models.py
+++ b/tests/libs/lang/test_models.py
@@ -40,6 +40,17 @@ def test_infer_action_with_params():
     assert "{hyp}" in a.content
 
 
+def test_param_type_validation():
+    """Param.type must be a known knowledge type."""
+    import pytest
+
+    Param(name="x", type="claim")  # OK
+    Param(name="x", type="contradiction")  # OK
+    Param(name="x", type="subsumption")  # OK
+    with pytest.raises(Exception, match="Invalid param type"):
+        Param(name="x", type="invalid_type")
+
+
 def test_chain_expr_steps():
     chain = ChainExpr(
         name="my_chain",

--- a/tests/libs/lang/test_relation_models.py
+++ b/tests/libs/lang/test_relation_models.py
@@ -1,5 +1,5 @@
 from libs.lang.loader import _parse_knowledge
-from libs.lang.models import Contradiction, Equivalence, RetractAction
+from libs.lang.models import Contradiction, Equivalence, RetractAction, Subsumption
 
 
 def test_retract_action_model():
@@ -45,6 +45,25 @@ def test_parse_equivalence_from_yaml_dict():
     decl = _parse_knowledge(data)
     assert isinstance(decl, Equivalence)
     assert decl.between == ["claim_x", "claim_y"]
+
+
+def test_parse_subsumption_from_yaml_dict():
+    data = {
+        "type": "subsumption",
+        "name": "gr_subsumes_newton",
+        "between": ["einstein_field_equations", "newton_gravity"],
+        "content": "GR subsumes Newton in the weak-field limit.",
+    }
+    decl = _parse_knowledge(data)
+    assert isinstance(decl, Subsumption)
+    assert decl.between == ["einstein_field_equations", "newton_gravity"]
+    assert decl.type == "subsumption"
+
+
+def test_subsumption_not_in_bp_variable_types():
+    from libs.lang.compiler import BP_VARIABLE_TYPES
+
+    assert "subsumption" not in BP_VARIABLE_TYPES
 
 
 def test_parse_retract_action_from_yaml_dict():


### PR DESCRIPTION
## Summary

- Add `Subsumption(Relation)` as a first-class DSL type for expressing asymmetric theory inheritance (e.g., GR subsumes Newton)
- Annotative metadata only — intentionally excluded from BP variable types
- Define `PARAM_TYPES` vocabulary and add `field_validator` on `Param.type` to catch typos at parse time
- 3 new tests: subsumption parsing, BP exclusion, param validation

Closes #101

## Context

Surfaced during review of PR #99 (example package semantic polish):
1. The Einstein package needed to express "GR subsumes Newton in weak-field limit" — neither `equivalence` (symmetric) nor `contradiction` (opposing) fits
2. `disfavor_conflicting_prediction` in PR #99 introduced `type: contradiction` as a param type — first usage beyond `{claim, setting}`, highlighting the need for validation

## Test plan

- [x] 104 lang tests pass (101 existing + 3 new)
- [x] `ruff check .` and `ruff format --check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)