### PR TITLE
fix: tighten cross-package resolution to package exports

### DIFF
--- a/libs/lang/resolver.py
+++ b/libs/lang/resolver.py
@@ -12,59 +12,113 @@ class ResolveError(Exception):
 def resolve_refs(pkg: Package, deps: dict[str, Package] | None = None) -> Package:
     """Resolve all Ref knowledge objects in the package.
 
-    Builds a knowledge index (module.name -> Knowledge),
-    then links each Ref._resolved to its target Knowledge object.
-
-    Args:
-        pkg: The package whose Refs should be resolved.
-        deps: Optional mapping of dependency package names to their resolved
-            Package objects. Cross-package refs use 3-part paths
-            (``pkg_name.module_name.decl_name``) and are resolved against the
-            module-level exports of these dependency packages.
+    Intra-package refs use ``module.name`` and can point to any declaration in the
+    same package. Cross-package refs are resolved against dependency package exports,
+    exposed under the stable ``pkg.export_name`` surface. For compatibility, exported
+    names are also indexed under ``pkg.module.export_name``.
     """
-    # Build intra-package index: "module_name.decl_name" -> Knowledge
-    index: dict[str, Knowledge] = {}
+    local_decls: dict[str, Knowledge] = {}
     for module in pkg.loaded_modules:
         for decl in module.knowledge:
-            if decl.type != "ref":
-                key = f"{module.name}.{decl.name}"
-                index[key] = decl
+            local_decls[f"{module.name}.{decl.name}"] = decl
 
-    # Add cross-package index: "pkg_name.module_name.decl_name" -> Knowledge
-    # Only module-exported declarations are visible to dependents.
-    if deps:
-        for dep_name, dep_pkg in deps.items():
-            for module in dep_pkg.loaded_modules:
-                exported = set(module.export)
-                for decl in module.knowledge:
-                    if decl.type != "ref" and decl.name in exported:
-                        key = f"{dep_name}.{module.name}.{decl.name}"
-                        index[key] = decl
+    dep_index = _build_dependency_index(deps or {})
+    resolved_index: dict[str, Knowledge] = dict(dep_index)
+    resolving: set[str] = set()
 
-    # Resolve Refs in two passes.
-    # Pass 1: resolve refs whose targets are already in the index (non-ref
-    # declarations and cross-package entries).  After resolving, add the ref's
-    # own "module.name" key to the index so that other refs within the same
-    # package can chain through it in pass 2.
-    unresolved: list[tuple[str, Ref]] = []
-    for module in pkg.loaded_modules:
-        for decl in module.knowledge:
-            if isinstance(decl, Ref):
-                target = index.get(decl.target)
-                if target is not None:
-                    decl._resolved = target
-                    index[f"{module.name}.{decl.name}"] = target
-                else:
-                    unresolved.append((module.name, decl))
+    def resolve_target(target: str) -> Knowledge | None:
+        if target in resolved_index:
+            return resolved_index[target]
+        if target in local_decls:
+            return resolve_local(target)
+        return dep_index.get(target)
 
-    # Pass 2: resolve remaining refs (they may depend on refs resolved in pass 1).
-    for mod_name, decl in unresolved:
-        target = index.get(decl.target)
-        if target is None:
-            raise ResolveError(
-                f"Cannot resolve ref '{mod_name}.{decl.name}' -> '{decl.target}': target not found"
-            )
-        decl._resolved = target
+    def resolve_local(path: str) -> Knowledge:
+        if path in resolved_index:
+            return resolved_index[path]
 
-    pkg._index = index
+        decl = local_decls.get(path)
+        if decl is None:
+            raise ResolveError(f"Cannot resolve '{path}': declaration not found")
+
+        if not isinstance(decl, Ref):
+            resolved_index[path] = decl
+            return decl
+
+        if path in resolving:
+            raise ResolveError(f"Circular ref detected while resolving '{path}'")
+
+        resolving.add(path)
+        try:
+            target = resolve_target(decl.target)
+            if target is None:
+                raise ResolveError(
+                    f"Cannot resolve ref '{path}' -> '{decl.target}': target not found"
+                )
+            decl._resolved = target
+            resolved_index[path] = target
+            return target
+        finally:
+            resolving.remove(path)
+
+    for path in local_decls:
+        resolve_local(path)
+
+    pkg._index = {path: resolved_index[path] for path in local_decls}
     return pkg
+
+
+def _build_dependency_index(deps: dict[str, Package]) -> dict[str, Knowledge]:
+    """Build the cross-package public index from dependency package exports."""
+    dep_index: dict[str, Knowledge] = {}
+
+    for dep_name, dep_pkg in deps.items():
+        exported_names = set(dep_pkg.export)
+        if not exported_names:
+            continue
+
+        export_paths: dict[str, list[str]] = {name: [] for name in exported_names}
+        for module in dep_pkg.loaded_modules:
+            for decl in module.knowledge:
+                if decl.name in exported_names:
+                    export_paths[decl.name].append(f"{module.name}.{decl.name}")
+
+        for export_name, candidates in export_paths.items():
+            if not candidates:
+                continue
+
+            resolved_candidates: list[tuple[str, Knowledge]] = []
+            unique_targets: dict[int, Knowledge] = {}
+            for local_path in candidates:
+                target = dep_pkg._index.get(local_path)
+                if target is None:
+                    module_name, _ = local_path.split(".", 1)
+                    decl = next(
+                        d
+                        for m in dep_pkg.loaded_modules
+                        if m.name == module_name
+                        for d in m.knowledge
+                        if d.name == export_name
+                    )
+                    target = decl._resolved if isinstance(decl, Ref) else decl
+
+                if target is None:
+                    raise ResolveError(
+                        f"Dependency package '{dep_name}' export '{export_name}' is unresolved"
+                    )
+
+                resolved_candidates.append((local_path, target))
+                unique_targets[id(target)] = target
+
+            if len(unique_targets) > 1:
+                raise ResolveError(
+                    f"Dependency package '{dep_name}' exports ambiguous name '{export_name}'"
+                )
+
+            _, public_target = resolved_candidates[0]
+            dep_index[f"{dep_name}.{export_name}"] = public_target
+            for candidate_path, candidate_target in resolved_candidates:
+                if candidate_target is public_target:
+                    dep_index[f"{dep_name}.{candidate_path}"] = public_target
+
+    return dep_index

--- a/tests/fixtures/gaia_language_packages/einstein_gravity/prior_knowledge.yaml
+++ b/tests/fixtures/gaia_language_packages/einstein_gravity/prior_knowledge.yaml
@@ -7,16 +7,16 @@ knowledge:
   # === 引用 Newton package ===
   - type: ref
     name: newton_gravity
-    target: newton_principia.laws.law_of_gravity
+    target: newton_principia.law_of_gravity
 
   - type: ref
     name: newton_a_equals_g
-    target: newton_principia.derivation.acceleration_independent_of_mass
+    target: newton_principia.acceleration_independent_of_mass
 
   # === 引用 Galileo package ===
   - type: ref
     name: galileo_vacuum_prediction
-    target: galileo_falling_bodies.reasoning.vacuum_prediction
+    target: galileo_falling_bodies.vacuum_prediction
 
   # === 本 package 的先验知识 ===
 

--- a/tests/fixtures/gaia_language_packages/galileo_falling_bodies/package.yaml
+++ b/tests/fixtures/gaia_language_packages/galileo_falling_bodies/package.yaml
@@ -23,6 +23,7 @@ modules:
   - follow_up
 
 export:
+  - heavier_falls_faster
   - vacuum_prediction
   - aristotle_contradicted
   - follow_up_question

--- a/tests/fixtures/gaia_language_packages/newton_principia/implications.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/implications.yaml
@@ -13,15 +13,15 @@ knowledge:
   # === 引用 Galileo package 的结论 ===
   - type: ref
     name: galileo_vacuum_prediction
-    target: galileo_falling_bodies.reasoning.vacuum_prediction
+    target: galileo_falling_bodies.vacuum_prediction
 
   - type: ref
     name: galileo_aristotle_contradicted
-    target: galileo_falling_bodies.reasoning.aristotle_contradicted
+    target: galileo_falling_bodies.aristotle_contradicted
 
   - type: ref
     name: aristotle_law
-    target: galileo_falling_bodies.aristotle.heavier_falls_faster
+    target: galileo_falling_bodies.heavier_falls_faster
 
   # === 等价关系：牛顿的 a=g 与伽利略的真空预测 ===
 

--- a/tests/fixtures/gaia_language_packages/newton_principia/package.yaml
+++ b/tests/fixtures/gaia_language_packages/newton_principia/package.yaml
@@ -25,6 +25,7 @@ modules:
   - implications
 
 export:
+  - law_of_gravity
   - acceleration_independent_of_mass
   - newton_contradicts_aristotle
   - two_path_rejection_of_aristotle

--- a/tests/libs/lang/test_cross_package_resolver.py
+++ b/tests/libs/lang/test_cross_package_resolver.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from libs.lang.loader import load_package
-from libs.lang.models import Module, Package, Ref
+from libs.lang.models import Claim, Module, Package, Ref
 from libs.lang.resolver import ResolveError, resolve_refs
 
 FIXTURES = Path(__file__).parents[2] / "fixtures" / "gaia_language_packages"
@@ -27,7 +27,7 @@ def test_resolve_intra_package_still_works():
 
 
 def test_cross_package_ref_resolves():
-    """Newton refs to Galileo should resolve when Galileo is provided as dep."""
+    """Newton refs to Galileo package exports should resolve when Galileo is provided as dep."""
     galileo = load_package(GALILEO_DIR)
     galileo = resolve_refs(galileo)
 
@@ -40,6 +40,86 @@ def test_cross_package_ref_resolves():
         for d in implications.knowledge
         if isinstance(d, Ref) and d.name == "galileo_vacuum_prediction"
     )
+    assert ref._resolved is not None
+    assert ref._resolved.name == "vacuum_prediction"
+
+
+def test_cross_package_exported_alias_resolves():
+    """Dependency package exports may be Ref aliases, not only concrete declarations."""
+    dep_module = Module(
+        type="reasoning_module",
+        name="core",
+        knowledge=[
+            Claim(type="claim", name="base", content="base claim"),
+            Ref(name="public_alias", target="core.base"),
+        ],
+        export=["public_alias"],
+    )
+    dep_pkg = Package(
+        name="dep_pkg",
+        modules=["core"],
+        export=["public_alias"],
+        loaded_modules=[dep_module],
+    )
+    dep_pkg = resolve_refs(dep_pkg)
+
+    consumer_module = Module(
+        type="reasoning_module",
+        name="consumer",
+        knowledge=[Ref(name="use_alias", target="dep_pkg.public_alias")],
+        export=[],
+    )
+    consumer_pkg = Package(name="consumer_pkg", modules=["consumer"], loaded_modules=[consumer_module])
+    consumer_pkg = resolve_refs(consumer_pkg, deps={"dep_pkg": dep_pkg})
+
+    ref = next(d for d in consumer_module.knowledge if isinstance(d, Ref) and d.name == "use_alias")
+    assert ref._resolved is not None
+    assert ref._resolved.name == "base"
+
+
+def test_multi_hop_alias_chain_resolves():
+    """Ref chains should resolve transitively, not depend on declaration order."""
+    mod = Module(
+        type="reasoning_module",
+        name="m",
+        knowledge=[
+            Ref(name="a", target="m.b"),
+            Ref(name="b", target="m.c"),
+            Ref(name="c", target="m.base"),
+            Claim(type="claim", name="base", content="base claim"),
+        ],
+        export=["a", "b", "c", "base"],
+    )
+    pkg = Package(name="chain_pkg", modules=["m"], loaded_modules=[mod])
+    resolved = resolve_refs(pkg)
+
+    for name in ["a", "b", "c"]:
+        ref = next(d for d in mod.knowledge if isinstance(d, Ref) and d.name == name)
+        assert ref._resolved is not None
+        assert ref._resolved.name == "base"
+        assert resolved._index[f"m.{name}"].name == "base"
+
+
+def test_cross_package_legacy_module_path_for_export_still_resolves():
+    """Legacy pkg.module.name paths remain valid for package-exported names."""
+    galileo = load_package(GALILEO_DIR)
+    galileo = resolve_refs(galileo)
+
+    mod = Module(
+        type="reasoning_module",
+        name="consumer",
+        knowledge=[
+            Ref(
+                name="legacy_ref",
+                target="galileo_falling_bodies.reasoning.vacuum_prediction",
+            )
+        ],
+        export=[],
+    )
+    pkg = Package(name="consumer_pkg", modules=["consumer"], loaded_modules=[mod])
+    pkg = resolve_refs(pkg, deps={"galileo_falling_bodies": galileo})
+
+    ref = next(d for d in mod.knowledge if isinstance(d, Ref) and d.name == "legacy_ref")
     assert ref._resolved is not None
     assert ref._resolved.name == "vacuum_prediction"
 
@@ -73,20 +153,20 @@ def test_transitive_deps_resolve():
     assert ref._resolved.name == "law_of_gravity"
 
 
-def test_dep_non_exported_name_not_resolvable():
-    """A dep module's non-exported declaration should NOT be resolvable."""
+def test_dep_name_not_in_package_export_is_not_resolvable():
+    """Cross-package visibility follows package export, not module export."""
     galileo = load_package(GALILEO_DIR)
     galileo = resolve_refs(galileo)
 
-    # deduce_drag_effect is an infer_action in galileo's reasoning module
-    # but it is NOT in reasoning's export list.
+    # everyday_observation is module-exported in Galileo's aristotle module,
+    # but it is not part of the package's public export surface.
     mod = Module(
         type="reasoning_module",
         name="test_mod",
         knowledge=[
             Ref(
                 name="sneaky_ref",
-                target="galileo_falling_bodies.reasoning.deduce_drag_effect",
+                target="galileo_falling_bodies.everyday_observation",
             )
         ],
         export=[],

--- a/tests/libs/lang/test_resolver.py
+++ b/tests/libs/lang/test_resolver.py
@@ -84,10 +84,7 @@ def test_resolve_empty_package():
 
 
 def test_resolve_ref_to_ref_raises():
-    """A Ref targeting another Ref's path should raise ResolveError.
-
-    Because Refs are skipped during index building, the target won't be found.
-    """
+    """Circular ref chains should raise a clear ResolveError."""
     mod_a = Module(
         type="reasoning_module",
         name="a",
@@ -103,5 +100,5 @@ def test_resolve_ref_to_ref_raises():
     pkg = Package(name="circular_refs", modules=["a", "b"])
     pkg.loaded_modules = [mod_a, mod_b]
 
-    with pytest.raises(ResolveError, match="target not found"):
+    with pytest.raises(ResolveError, match="Circular ref detected"):
         resolve_refs(pkg)


### PR DESCRIPTION
## Summary
- resolve dependency refs against package exports instead of module exports
- support dependency-exported `Ref` aliases and multi-hop intra-package alias chains
- update cross-package fixtures/tests to use package-level public names while keeping legacy `pkg.module.name` compatibility for exported targets

## Testing
- `uv run --with .[dev] pytest tests/libs/lang/test_resolver.py tests/libs/lang/test_cross_package_resolver.py tests/libs/lang/test_build_review_pipeline.py tests/libs/lang/test_integration.py -q`\n- `uv run --with .[dev] pytest tests/libs/lang -q`