### PR TITLE
fix: unblock gpt-5 review and v2 publish pipeline

### DIFF
--- a/cli/lang_to_v2.py
+++ b/cli/lang_to_v2.py
@@ -59,9 +59,10 @@ def convert_to_v2(
 
     # 1. Package -> v2.Package
     v2_package = _convert_package(pkg, now)
+    module_decl_index = _build_module_decl_index(pkg)
 
     # 2. Build a unified knowledge index resolving Refs
-    #    Maps (module_name, decl_name) -> (resolved Knowledge, owning module name)
+    #    Maps decl name -> resolved Knowledge.
     decls_by_name: dict[str, tuple[Knowledge, str]] = {}
     for mod in pkg.loaded_modules:
         for decl in mod.knowledge:
@@ -83,9 +84,16 @@ def convert_to_v2(
             actual = _resolve(decl)
             if not _is_closure_type(actual):
                 continue
-            # Check if the actual declaration belongs to this package
-            if not _belongs_to_package(actual, decl, pkg):
+
+            origin_package, origin_module = _resolve_decl_origin(
+                decl=decl,
+                module_name=mod.name,
+                pkg=pkg,
+                module_decl_index=module_decl_index,
+            )
+            if origin_package != pkg.name:
                 continue
+
             closure_id = f"{pkg.name}/{actual.name}"
             if closure_id in seen_closure_ids:
                 continue
@@ -95,7 +103,7 @@ def convert_to_v2(
                 actual=actual,
                 closure_id=closure_id,
                 package_id=pkg.name,
-                module_id=f"{pkg.name}.{mod.name}",
+                module_id=f"{pkg.name}.{origin_module}",
                 now=now,
             )
             v2_closures.append(closure)
@@ -103,6 +111,7 @@ def convert_to_v2(
     # 5. ChainExpr -> v2.Chain[] + collect chain_ids per module
     v2_chains: list[v2.Chain] = []
     module_chain_ids: dict[str, list[str]] = {mod.name: [] for mod in pkg.loaded_modules}
+    review_step_index: dict[str, tuple[str, int]] = {}
 
     for mod in pkg.loaded_modules:
         for decl in mod.knowledge:
@@ -113,6 +122,8 @@ def convert_to_v2(
                     package_name=pkg.name,
                     decls_by_name=decls_by_name,
                     pkg=pkg,
+                    module_decl_index=module_decl_index,
+                    review_step_index=review_step_index,
                 )
                 if chain is not None:
                     v2_chains.append(chain)
@@ -128,6 +139,7 @@ def convert_to_v2(
                     package_name=pkg.name,
                     decls_by_name=decls_by_name,
                     pkg=pkg,
+                    module_decl_index=module_decl_index,
                 )
                 if chain is not None:
                     v2_chains.append(chain)
@@ -147,7 +159,7 @@ def convert_to_v2(
             ]
 
     # 7. Review -> ProbabilityRecord[]
-    v2_probabilities = _convert_review(review, pkg.name, now)
+    v2_probabilities = _convert_review(review, review_step_index, now)
 
     # 8. Beliefs -> BeliefSnapshot[]
     v2_snapshots = _convert_beliefs(beliefs, pkg.name, bp_run_id, seen_closure_ids, now)
@@ -174,27 +186,49 @@ def _resolve(decl: Knowledge) -> Knowledge:
 
 def _is_closure_type(k: Knowledge) -> bool:
     """Return True if the knowledge object should become a v2.Closure."""
-    return isinstance(k, (Claim, Setting, Question, Contradiction))
+    return isinstance(k, (Claim, Setting, Question, Contradiction, Equivalence, Subsumption))
 
 
-def _belongs_to_package(actual: Knowledge, decl: Knowledge, pkg: Package) -> bool:
-    """Check if a knowledge object belongs to this package (not imported).
+def _build_module_decl_index(pkg: Package) -> dict[str, dict[str, Knowledge]]:
+    """Index declarations by module and local name for ref provenance tracing."""
+    return {
+        mod.name: {decl.name: decl for decl in mod.knowledge}
+        for mod in pkg.loaded_modules
+    }
 
-    For a Ref, we check whether its target path starts with an external package.
-    If the Ref's target contains a dot and the prefix before the dot is not a
-    module name in this package, it's cross-package.
-    """
+
+def _resolve_decl_origin(
+    decl: Knowledge,
+    module_name: str,
+    pkg: Package,
+    module_decl_index: dict[str, dict[str, Knowledge]],
+    seen: set[tuple[str, str]] | None = None,
+) -> tuple[str, str]:
+    """Resolve the owning package/module for a declaration or ref alias."""
     if not isinstance(decl, Ref):
-        return True  # Non-ref declarations always belong to current package
+        return pkg.name, module_name
+
+    if seen is None:
+        seen = set()
 
     target = decl.target
-    if "." in target:
-        prefix = target.split(".")[0]
-        module_names = {m.name for m in pkg.loaded_modules}
-        if prefix not in module_names:
-            # Target is in a different package
-            return False
-    return True
+    if "." not in target:
+        return pkg.name, module_name
+
+    prefix, local_name = target.split(".", 1)
+    if prefix not in module_decl_index:
+        return prefix, module_name
+
+    marker = (prefix, local_name)
+    if marker in seen:
+        return pkg.name, prefix
+
+    target_decl = module_decl_index[prefix].get(local_name)
+    if target_decl is None:
+        return pkg.name, prefix
+
+    seen.add(marker)
+    return _resolve_decl_origin(target_decl, prefix, pkg, module_decl_index, seen)
 
 
 def _convert_package(pkg: Package, now: datetime) -> v2.Package:
@@ -239,7 +273,7 @@ def _closure_type(k: Knowledge) -> str:
         return "setting"
     if isinstance(k, Question):
         return "question"
-    if isinstance(k, Contradiction):
+    if isinstance(k, (Contradiction, Equivalence, Subsumption)):
         return "claim"  # contradictions stored as claims
     return "claim"
 
@@ -274,8 +308,10 @@ def _convert_closure(
 
 def _make_closure_ref(
     name: str,
+    module_name: str,
     decls_by_name: dict[str, tuple[Knowledge, str]],
     pkg: Package,
+    module_decl_index: dict[str, dict[str, Knowledge]],
 ) -> v2.ClosureRef | None:
     """Create a ClosureRef for a declaration name, resolving the package-qualified ID."""
     entry = decls_by_name.get(name)
@@ -284,22 +320,17 @@ def _make_closure_ref(
     actual, _mod_name = entry
     actual = _resolve(actual) if isinstance(actual, Ref) else actual
 
-    # Determine which package the actual declaration belongs to
-    # Check if the name was a Ref to an external package
-    closure_id = f"{pkg.name}/{actual.name}"
-
-    # Check all modules for this name to see if it's a cross-package ref
-    for mod in pkg.loaded_modules:
-        for decl in mod.knowledge:
-            if decl.name == name and isinstance(decl, Ref):
-                target = decl.target
-                if "." in target:
-                    prefix = target.split(".")[0]
-                    module_names = {m.name for m in pkg.loaded_modules}
-                    if prefix not in module_names:
-                        # Cross-package: use the external package name
-                        closure_id = f"{prefix}/{actual.name}"
-                        break
+    decl = module_decl_index.get(module_name, {}).get(name)
+    if decl is None:
+        closure_id = f"{pkg.name}/{actual.name}"
+    else:
+        origin_package, _origin_module = _resolve_decl_origin(
+            decl=decl,
+            module_name=module_name,
+            pkg=pkg,
+            module_decl_index=module_decl_index,
+        )
+        closure_id = f"{origin_package}/{actual.name}"
 
     return v2.ClosureRef(closure_id=closure_id, version=1)
 
@@ -310,6 +341,8 @@ def _convert_chain_expr(
     package_name: str,
     decls_by_name: dict[str, tuple[Knowledge, str]],
     pkg: Package,
+    module_decl_index: dict[str, dict[str, Knowledge]],
+    review_step_index: dict[str, tuple[str, int]],
 ) -> v2.Chain | None:
     """Convert a ChainExpr to a v2.Chain with ChainStep entries."""
     chain_id = f"{package_name}.{module_name}.{chain.name}"
@@ -337,7 +370,13 @@ def _convert_chain_expr(
             # Premises from args
             premises: list[v2.ClosureRef] = []
             for arg in step.args:
-                cref = _make_closure_ref(arg.ref, decls_by_name, pkg)
+                cref = _make_closure_ref(
+                    arg.ref,
+                    module_name=module_name,
+                    decls_by_name=decls_by_name,
+                    pkg=pkg,
+                    module_decl_index=module_decl_index,
+                )
                 if cref is not None:
                     premises.append(cref)
 
@@ -359,7 +398,13 @@ def _convert_chain_expr(
             if conclusion_name is None:
                 continue
 
-            conclusion_ref = _make_closure_ref(conclusion_name, decls_by_name, pkg)
+            conclusion_ref = _make_closure_ref(
+                conclusion_name,
+                module_name=module_name,
+                decls_by_name=decls_by_name,
+                pkg=pkg,
+                module_decl_index=module_decl_index,
+            )
             if conclusion_ref is None:
                 continue
 
@@ -371,6 +416,7 @@ def _convert_chain_expr(
                     conclusion=conclusion_ref,
                 )
             )
+            review_step_index[f"{chain.name}.{step.step}"] = (chain_id, step_index)
             step_index += 1
 
         elif isinstance(step, StepLambda):
@@ -380,7 +426,13 @@ def _convert_chain_expr(
             if i > 0:
                 prev_step = chain.steps[i - 1]
                 if isinstance(prev_step, StepRef):
-                    cref = _make_closure_ref(prev_step.ref, decls_by_name, pkg)
+                    cref = _make_closure_ref(
+                        prev_step.ref,
+                        module_name=module_name,
+                        decls_by_name=decls_by_name,
+                        pkg=pkg,
+                        module_decl_index=module_decl_index,
+                    )
                     if cref is not None:
                         premises.append(cref)
 
@@ -396,7 +448,13 @@ def _convert_chain_expr(
             if conclusion_name is None:
                 continue
 
-            conclusion_ref = _make_closure_ref(conclusion_name, decls_by_name, pkg)
+            conclusion_ref = _make_closure_ref(
+                conclusion_name,
+                module_name=module_name,
+                decls_by_name=decls_by_name,
+                pkg=pkg,
+                module_decl_index=module_decl_index,
+            )
             if conclusion_ref is None:
                 continue
 
@@ -408,6 +466,7 @@ def _convert_chain_expr(
                     conclusion=conclusion_ref,
                 )
             )
+            review_step_index[f"{chain.name}.{step.step}"] = (chain_id, step_index)
             step_index += 1
 
     if not v2_steps:
@@ -428,6 +487,7 @@ def _convert_relation_to_chain(
     package_name: str,
     decls_by_name: dict[str, tuple[Knowledge, str]],
     pkg: Package,
+    module_decl_index: dict[str, dict[str, Knowledge]],
 ) -> v2.Chain | None:
     """Convert a Relation (e.g. Contradiction) to a single-step v2.Chain."""
     chain_id = f"{package_name}.{module_name}.{rel.name}"
@@ -442,7 +502,13 @@ def _convert_relation_to_chain(
     # Members become premises
     premises: list[v2.ClosureRef] = []
     for member_name in rel.between:
-        cref = _make_closure_ref(member_name, decls_by_name, pkg)
+        cref = _make_closure_ref(
+            member_name,
+            module_name=module_name,
+            decls_by_name=decls_by_name,
+            pkg=pkg,
+            module_decl_index=module_decl_index,
+        )
         if cref is not None:
             premises.append(cref)
 
@@ -473,7 +539,7 @@ def _convert_relation_to_chain(
 
 def _convert_review(
     review: dict,
-    package_name: str,
+    review_step_index: dict[str, tuple[str, int]],
     now: datetime,
 ) -> list[v2.ProbabilityRecord]:
     """Convert review dict to ProbabilityRecord entries."""
@@ -481,17 +547,18 @@ def _convert_review(
     chains_data = review.get("chains", [])
 
     for chain_entry in chains_data:
-        chain_name = chain_entry.get("name", "")
+        chain_name = chain_entry.get("chain") or chain_entry.get("name") or ""
         steps = chain_entry.get("steps", [])
         for step_data in steps:
-            step_id = step_data.get("step_id", "")
-            # Step ID format: "chain_name.N" -> extract N
-            step_index = 0
-            if "." in step_id:
-                try:
-                    step_index = int(step_id.rsplit(".", 1)[1])
-                except (ValueError, IndexError):
-                    pass
+            raw_step_id = step_data.get("step") or step_data.get("step_id") or ""
+            step_id = str(raw_step_id)
+            if "." not in step_id and chain_name:
+                step_id = f"{chain_name}.{step_id}"
+
+            step_ref = review_step_index.get(step_id)
+            if step_ref is None:
+                continue
+            chain_id, step_index = step_ref
 
             value = step_data.get("conditional_prior") or step_data.get("suggested_prior")
             if value is None:
@@ -503,10 +570,11 @@ def _convert_review(
 
             records.append(
                 v2.ProbabilityRecord(
-                    chain_id=chain_name,
+                    chain_id=chain_id,
                     step_index=step_index,
                     value=value,
                     source="llm_review",
+                    source_detail=step_data.get("explanation") or None,
                     recorded_at=now,
                 )
             )

--- a/cli/llm_client.py
+++ b/cli/llm_client.py
@@ -9,7 +9,10 @@ from pathlib import Path
 class ReviewClient:
     """LLM-based package reviewer using litellm."""
 
-    def __init__(self, model: str = "claude-sonnet-4-20250514"):
+    _CODE_FENCE_RE = re.compile(r"```(?:yaml|yml)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+    _STEP_ID_RE = re.compile(r"^[\w.-]+\.\d+$")
+
+    def __init__(self, model: str = "gpt-5-mini"):
         self._model = model
         self._system_prompt = self._load_system_prompt()
 
@@ -49,13 +52,129 @@ class ReviewClient:
         """Parse LLM YAML response."""
         import yaml
 
+        text = response.strip()
+        fenced = self._CODE_FENCE_RE.search(text)
+        if fenced:
+            text = fenced.group(1).strip()
+
         try:
-            parsed = yaml.safe_load(response)
-            if isinstance(parsed, dict) and "chains" in parsed:
-                return parsed
+            parsed = yaml.safe_load(text)
+            normalized = self._normalize_review_payload(parsed)
+            if normalized is not None:
+                return normalized
         except Exception:
             pass
         return {"summary": "Parse error — falling back to defaults.", "chains": []}
+
+    def _normalize_review_payload(self, parsed: object) -> dict | None:
+        """Normalize several YAML shapes into the sidecar schema used by the CLI."""
+        if not isinstance(parsed, dict):
+            return None
+
+        if "chains" in parsed:
+            return {
+                "summary": parsed.get("summary", "") or "",
+                "chains": self._normalize_chain_entries(parsed.get("chains", [])),
+            }
+
+        flat_chains = self._normalize_flat_step_map(parsed)
+        if flat_chains:
+            summary = parsed.get("summary", "")
+            return {"summary": summary if isinstance(summary, str) else "", "chains": flat_chains}
+
+        return None
+
+    def _normalize_chain_entries(self, chains: object) -> list[dict]:
+        """Normalize mixed chain entry formats into {chain, steps} objects."""
+        if isinstance(chains, dict):
+            chain_items = list(chains.values())
+        elif isinstance(chains, list):
+            chain_items = chains
+        else:
+            return []
+
+        normalized: list[dict] = []
+        for chain_entry in chain_items:
+            if not isinstance(chain_entry, dict):
+                continue
+
+            chain_name = chain_entry.get("chain") or chain_entry.get("name")
+            if not isinstance(chain_name, str) or not chain_name:
+                continue
+
+            steps = self._normalize_step_entries(chain_entry.get("steps", []))
+            if not steps:
+                continue
+
+            normalized.append({"chain": chain_name, "steps": steps})
+
+        return normalized
+
+    def _normalize_step_entries(self, steps: object) -> list[dict]:
+        """Normalize step payloads, preserving the fields consumed downstream."""
+        if isinstance(steps, dict):
+            step_items = list(steps.values())
+        elif isinstance(steps, list):
+            step_items = steps
+        else:
+            return []
+
+        normalized: list[dict] = []
+        for step_entry in step_items:
+            if not isinstance(step_entry, dict):
+                continue
+
+            step_id = step_entry.get("step") or step_entry.get("step_id")
+            if not isinstance(step_id, str) or not step_id:
+                continue
+
+            step: dict[str, object] = {
+                "step": step_id,
+                "weak_points": step_entry.get("weak_points", []) or [],
+                "explanation": step_entry.get("explanation", "") or "",
+            }
+
+            conditional_prior = step_entry.get("conditional_prior")
+            if conditional_prior is None:
+                conditional_prior = step_entry.get("suggested_prior")
+            if conditional_prior is not None:
+                step["conditional_prior"] = conditional_prior
+
+            normalized.append(step)
+
+        return normalized
+
+    def _normalize_flat_step_map(self, parsed: dict) -> list[dict]:
+        """Handle flat YAML like `chain_name.2: {conditional_prior: ...}`."""
+        grouped: dict[str, list[dict]] = {}
+        for key, value in parsed.items():
+            if key == "summary" or not isinstance(key, str) or not isinstance(value, dict):
+                continue
+            if not self._STEP_ID_RE.match(key):
+                continue
+
+            chain_name = key.rsplit(".", 1)[0]
+            step = {
+                "step": key,
+                "weak_points": value.get("weak_points", []) or [],
+                "explanation": value.get("explanation", "") or "",
+            }
+            conditional_prior = value.get("conditional_prior")
+            if conditional_prior is None:
+                conditional_prior = value.get("suggested_prior")
+            if conditional_prior is not None:
+                step["conditional_prior"] = conditional_prior
+            grouped.setdefault(chain_name, []).append(step)
+
+        normalized = []
+        for chain_name, steps in grouped.items():
+            steps.sort(
+                key=lambda step: int(str(step["step"]).rsplit(".", 1)[1])
+                if "." in str(step["step"])
+                else 0
+            )
+            normalized.append({"chain": chain_name, "steps": steps})
+        return normalized
 
     # Backward compat
     def review_chain(self, chain_data: dict) -> dict:

--- a/cli/main.py
+++ b/cli/main.py
@@ -65,7 +65,7 @@ def build(
 def review(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
     mock: bool = typer.Option(False, "--mock", help="Use mock reviewer (no LLM calls)"),
-    model: str = typer.Option("claude-sonnet-4-20250514", "--model", help="LLM model for review"),
+    model: str = typer.Option("gpt-5-mini", "--model", help="LLM model for review"),
 ) -> None:
     """LLM reviews chains -> sidecar report (.gaia/reviews/)."""
     from datetime import datetime, timezone
@@ -362,6 +362,9 @@ async def _publish_local(pkg_path: Path, db_path: str) -> None:
 
     # 7. Write to Kuzu
     await graph.write_topology(data.closures, data.chains)
+    if data.probabilities:
+        for record in data.probabilities:
+            await graph.update_probability(record.chain_id, record.step_index, record.value)
     if data.belief_snapshots:
         await graph.update_beliefs(data.belief_snapshots)
 

--- a/cli/prompts/review_system.md
+++ b/cli/prompts/review_system.md
@@ -34,3 +34,17 @@ reliability of reasoning chains in a knowledge package.
 
 Reply with ONLY a YAML document (no markdown fences, no extra text).
 Use step IDs exactly as they appear in the document (e.g., `synthesis_chain.2`).
+Use this exact schema:
+
+summary: Short overall assessment of the package.
+chains:
+  - chain: synthesis_chain
+    steps:
+      - step: synthesis_chain.2
+        weak_points:
+          - proposition: A complete standalone proposition.
+            classification: direct
+        conditional_prior: 0.85
+        explanation: Short explanation for the score.
+
+Do NOT use a flat top-level mapping keyed by step IDs.

--- a/libs/storage_v2/kuzu_graph_store.py
+++ b/libs/storage_v2/kuzu_graph_store.py
@@ -106,22 +106,23 @@ class KuzuGraphStore(GraphStore):
 
     def _delete_package_sync(self, package_id: str) -> None:
         c = self._conn
-        prefix = f"{package_id}."
+        chain_prefix = f"{package_id}."
+        closure_prefix = f"{package_id}/"
         # Delete chains (chain_id starts with "package_id.")
         c.execute(
             "MATCH (ch:Chain) WHERE starts_with(ch.chain_id, $prefix) DETACH DELETE ch",
-            {"prefix": prefix},
+            {"prefix": chain_prefix},
         )
-        # Delete closures (closure_vid starts with "package_id." since
-        # closure_vid = closure_id@version and closure_id starts with package_id.)
+        # Delete closures (closure_vid starts with "package_id/" since
+        # closure_vid = closure_id@version and closure_id is slash-qualified.)
         c.execute(
             "MATCH (cl:Closure) WHERE starts_with(cl.closure_vid, $prefix) DETACH DELETE cl",
-            {"prefix": prefix},
+            {"prefix": closure_prefix},
         )
         # Delete resources (resource_id starts with "package_id.")
         c.execute(
             "MATCH (r:Resource) WHERE starts_with(r.resource_id, $prefix) DETACH DELETE r",
-            {"prefix": prefix},
+            {"prefix": chain_prefix},
         )
 
     # ── Write ──

--- a/libs/storage_v2/lance_content_store.py
+++ b/libs/storage_v2/lance_content_store.py
@@ -390,10 +390,10 @@ class LanceContentStore(ContentStore):
         except Exception:
             pass
 
-        # Belief history: closure_id starts with "package_id."
+        # Belief history: closure_id starts with "package_id/"
         try:
             tbl = self._db.open_table("belief_history")
-            tbl.delete(f"closure_id LIKE '{escaped}.%'")
+            tbl.delete(f"closure_id LIKE '{escaped}/%'")
         except Exception:
             pass
 

--- a/tests/cli/test_lang_to_v2.py
+++ b/tests/cli/test_lang_to_v2.py
@@ -77,3 +77,75 @@ def test_beliefs_become_snapshots():
     snapshots_by_name = {s.closure_id.split("/")[1]: s for s in data.belief_snapshots}
     assert snapshots_by_name["vacuum_prediction"].belief == 0.82
     assert snapshots_by_name["heavier_falls_faster"].belief == 0.35
+
+
+def test_review_probabilities_use_full_chain_ids():
+    """Review sidecars should map chain names back to full v2 chain IDs."""
+    from cli.lang_to_v2 import convert_to_v2
+
+    pkg = load_package(GALILEO_DIR)
+    pkg = resolve_refs(pkg)
+
+    review = {
+        "chains": [
+            {
+                "chain": "drag_prediction_chain",
+                "steps": [
+                    {
+                        "step": "drag_prediction_chain.2",
+                        "conditional_prior": 0.93,
+                        "explanation": "Looks sound.",
+                    }
+                ],
+            }
+        ]
+    }
+    data = convert_to_v2(pkg=pkg, review=review, beliefs={}, bp_run_id="test")
+
+    assert len(data.probabilities) == 1
+    record = data.probabilities[0]
+    assert record.chain_id == "galileo_falling_bodies.reasoning.drag_prediction_chain"
+    assert record.step_index == 0
+    assert record.value == 0.93
+    assert record.source_detail == "Looks sound."
+
+
+def test_einstein_cross_package_aliases_keep_external_ids():
+    """Nested local refs to dependency exports should not become local closures."""
+    from cli.main import _load_with_deps
+    from cli.lang_to_v2 import convert_to_v2
+
+    pkg = _load_with_deps(EINSTEIN_DIR)
+    data = convert_to_v2(pkg=pkg, review={}, beliefs={}, bp_run_id="test")
+
+    closure_ids = {c.closure_id for c in data.closures}
+    assert "einstein_gravity/law_of_gravity" not in closure_ids
+    assert "einstein_gravity/acceleration_independent_of_mass" not in closure_ids
+    assert "einstein_gravity/vacuum_prediction" not in closure_ids
+
+    chains = {c.chain_id: c for c in data.chains}
+    subsumption = chains["einstein_gravity.general_relativity.subsumption_chain"]
+    assert [prem.closure_id for prem in subsumption.steps[0].premises] == [
+        "einstein_gravity/einstein_field_equations",
+        "newton_principia/law_of_gravity",
+        "newton_principia/acceleration_independent_of_mass",
+    ]
+
+    convergence = chains["einstein_gravity.observation.convergence_chain"]
+    assert [prem.closure_id for prem in convergence.steps[0].premises] == [
+        "galileo_falling_bodies/vacuum_prediction",
+        "newton_principia/acceleration_independent_of_mass",
+        "einstein_gravity/apollo15_confirms_equal_fall",
+    ]
+
+
+def test_einstein_subsumption_export_is_materialized_for_publish():
+    """Exported subsumption declarations should become local closures for storage."""
+    from cli.main import _load_with_deps
+    from cli.lang_to_v2 import convert_to_v2
+
+    pkg = _load_with_deps(EINSTEIN_DIR)
+    data = convert_to_v2(pkg=pkg, review={}, beliefs={}, bp_run_id="test")
+
+    closure_ids = {c.closure_id for c in data.closures}
+    assert "einstein_gravity/newton_subsumed_by_gr" in closure_ids

--- a/tests/cli/test_llm_client.py
+++ b/tests/cli/test_llm_client.py
@@ -120,3 +120,46 @@ async def test_mock_areview_package():
     assert "summary" in result
     assert "chains" in result
     assert len(result["chains"]) == 1
+
+
+def test_review_client_parses_flat_step_map_response():
+    """Real-model flat YAML keyed by step ID should normalize into chain entries."""
+    client = ReviewClient(model="test")
+    raw = """
+summary: Overall package review.
+drag_prediction_chain.2:
+  weak_points:
+    - proposition: The tethered system must fall more slowly.
+      classification: direct
+  conditional_prior: 0.6
+verdict_chain.2:
+  weak_points:
+    - proposition: The contradiction really refutes the doctrine.
+      classification: direct
+  conditional_prior: 0.7
+"""
+    result = client._parse_response(raw)
+    assert result["summary"] == "Overall package review."
+    assert len(result["chains"]) == 2
+    by_name = {chain["chain"]: chain for chain in result["chains"]}
+    assert by_name["drag_prediction_chain"]["steps"][0]["step"] == "drag_prediction_chain.2"
+    assert by_name["drag_prediction_chain"]["steps"][0]["conditional_prior"] == 0.6
+    assert by_name["verdict_chain"]["steps"][0]["step"] == "verdict_chain.2"
+
+
+def test_review_client_parses_fenced_yaml():
+    """Responses wrapped in ```yaml fences should still be parsed."""
+    client = ReviewClient(model="test")
+    raw = """```yaml
+chains:
+  - chain: synthesis_chain
+    steps:
+      - step: synthesis_chain.2
+        conditional_prior: 0.85
+        weak_points: []
+        explanation: ok
+```"""
+    result = client._parse_response(raw)
+    assert len(result["chains"]) == 1
+    assert result["chains"][0]["chain"] == "synthesis_chain"
+    assert result["chains"][0]["steps"][0]["step"] == "synthesis_chain.2"

--- a/tests/cli/test_publish.py
+++ b/tests/cli/test_publish.py
@@ -136,6 +136,36 @@ def test_publish_local_idempotent(tmp_path):
     assert len(ids) == len(set(ids)), f"Duplicate closure IDs after re-publish: {ids}"
 
 
+def test_publish_local_writes_mapped_probabilities_and_syncs_graph(tmp_path):
+    """Published review probabilities should use full chain IDs and reach Kuzu edges."""
+    pkg_dir = _setup_full_pipeline(tmp_path)
+    db_path = str(tmp_path / "testdb")
+    result = runner.invoke(app, ["publish", str(pkg_dir), "--local", "--db-path", db_path])
+    assert result.exit_code == 0, f"publish failed: {result.output}"
+
+    import kuzu
+    import lancedb
+
+    db = lancedb.connect(db_path)
+    prob_rows = db.open_table("probabilities").search().limit(1000).to_list()
+    assert prob_rows, "No probability rows were written"
+    assert all(row["chain_id"] for row in prob_rows)
+    assert any(
+        row["chain_id"] == "galileo_falling_bodies.reasoning.drag_prediction_chain"
+        and row["step_index"] == 0
+        and row["value"] == 0.93
+        for row in prob_rows
+    )
+
+    conn = kuzu.Connection(kuzu.Database(str(Path(db_path) / "kuzu")))
+    query = conn.execute(
+        "MATCH (ch:Chain {chain_id: 'galileo_falling_bodies.reasoning.drag_prediction_chain'})"
+        "-[r:CONCLUSION]->(:Closure) "
+        "WHERE r.step_index = 0 RETURN r.probability"
+    )
+    assert abs(query.get_next()[0] - 0.93) < 1e-9
+
+
 def test_publish_local_errors_without_build(tmp_path):
     """publish --local should error when no manifest.json exists."""
     pkg_dir = tmp_path / "galileo"

--- a/tests/libs/storage_v2/test_graph_store.py
+++ b/tests/libs/storage_v2/test_graph_store.py
@@ -643,6 +643,39 @@ class TestDeletePackage:
         """Deleting a non-existent package should not raise."""
         await graph_store.delete_package("nonexistent_pkg")  # should not raise
 
+    async def test_delete_package_removes_slash_qualified_closure_nodes(self, graph_store):
+        """CLI-published closure IDs use `package/decl`, not `package.module.decl`."""
+        closure = Closure(
+            closure_id="galileo_falling_bodies/vacuum_prediction",
+            version=1,
+            type="claim",
+            content="In a vacuum, bodies fall equally.",
+            prior=0.7,
+            source_package_id="galileo_falling_bodies",
+            source_module_id="galileo_falling_bodies.reasoning",
+            created_at=datetime(2026, 1, 1),
+        )
+        chain = Chain(
+            chain_id="galileo_falling_bodies.reasoning.vacuum_chain",
+            module_id="galileo_falling_bodies.reasoning",
+            package_id="galileo_falling_bodies",
+            type="deduction",
+            steps=[
+                ChainStep(
+                    step_index=0,
+                    premises=[ClosureRef(closure_id=closure.closure_id, version=1)],
+                    reasoning="Reasoning text.",
+                    conclusion=ClosureRef(closure_id=closure.closure_id, version=1),
+                )
+            ],
+        )
+
+        await graph_store.write_topology([closure], [chain])
+        await graph_store.delete_package("galileo_falling_bodies")
+
+        assert _count_nodes(graph_store, "Closure") == 0
+        assert _count_nodes(graph_store, "Chain") == 0
+
 
 # ── close ──
 

--- a/tests/libs/storage_v2/test_lance_content.py
+++ b/tests/libs/storage_v2/test_lance_content.py
@@ -1,6 +1,10 @@
 """Tests for LanceContentStore."""
 
+from datetime import datetime
+
 import pytest
+
+from libs.storage_v2.models import BeliefSnapshot, Closure
 
 
 class TestInitialize:
@@ -240,6 +244,33 @@ class TestDeletePackage:
     async def test_delete_package_is_idempotent(self, content_store):
         """Deleting a non-existent package should not raise."""
         await content_store.delete_package("nonexistent_pkg")  # should not raise
+
+    async def test_delete_package_removes_slash_qualified_belief_history(self, content_store):
+        """Current CLI closures use `package/decl` IDs, which must be deleted too."""
+        closure = Closure(
+            closure_id="galileo_falling_bodies/vacuum_prediction",
+            version=1,
+            type="claim",
+            content="In a vacuum, fall rates are equal.",
+            prior=0.7,
+            source_package_id="galileo_falling_bodies",
+            source_module_id="galileo_falling_bodies.reasoning",
+            created_at=datetime(2026, 1, 1),
+        )
+        belief = BeliefSnapshot(
+            closure_id=closure.closure_id,
+            version=1,
+            belief=0.9,
+            bp_run_id="bp-run",
+            computed_at=datetime(2026, 1, 2),
+        )
+
+        await content_store.write_closures([closure])
+        await content_store.write_belief_snapshots([belief])
+        await content_store.delete_package("galileo_falling_bodies")
+
+        assert await content_store.get_closure(closure.closure_id) is None
+        assert await content_store.get_belief_history(closure.closure_id) == []
 
 
 class TestBM25Search:


### PR DESCRIPTION
## Summary

This is a stacked follow-up PR for #107, targeting `feature/cli-convergence`.

While running the real CLI pipeline against the fixture packages, I found that the main `build -> review -> infer -> publish --local` path still broke in a few places:

- `gaia review --model gpt-5-mini` successfully called the model, but the review sidecar fell back to `chains: []` because the parser only accepted one YAML shape.
- review probabilities were written to LanceDB with empty `chain_id` values because the sidecar schema and the converter disagreed on field names.
- even when probabilities existed in LanceDB, `publish --local` never pushed them into Kuzu, so every `CONCLUSION.probability` stayed at `0.0`.
- slash-qualified closure IDs (`pkg/decl`) were not fully deleted on re-publish, so `belief_history` and Kuzu closure nodes could go stale.
- nested local refs to dependency exports in Einstein were being incorrectly materialized as local closures, which made content-store IDs and graph-store IDs diverge.

This PR fixes those issues and adds regression coverage around them.

## What Changed

### 1. Review client now accepts real `gpt-5-mini` output

Files:
- `cli/llm_client.py`
- `cli/prompts/review_system.md`
- `cli/main.py`
- `tests/cli/test_llm_client.py`

Changes:
- changed the default review model from `claude-sonnet-4-20250514` to `gpt-5-mini`
- taught `ReviewClient` to normalize multiple YAML shapes:
  - the existing `{summary, chains: [...]}` shape
  - flat top-level maps like `chain_name.2: {conditional_prior: ...}`
  - fenced YAML blocks wrapped in ```yaml
- kept the sidecar schema stable after normalization (`summary` + `chains` + `steps`)
- tightened the review system prompt so the model is explicitly asked for the exact sidecar-friendly schema

Why this matters:
- before this patch, real OpenAI review calls succeeded at the API layer but still produced `Reviewed 0 chains ...`
- after this patch, the same command writes a populated review sidecar that downstream stages can consume

### 2. Review probabilities now map to the correct v2 chain IDs and step indexes

Files:
- `cli/lang_to_v2.py`
- `tests/cli/test_lang_to_v2.py`
- `tests/cli/test_publish.py`

Changes:
- added explicit mapping from source review step IDs (`chain_name.N`) to:
  - the full v2 `chain_id` (`package.module.chain`)
  - the internal v2 `step_index` (`0`-based within the stored chain)
- normalized both `step` and `step_id` input forms
- preserved review explanations in `ProbabilityRecord.source_detail`

Why this matters:
- PR 107’s review sidecar uses `chain` / `step`
- the converter was reading `name` / `step_id`
- as a result, probabilities were being stored with empty `chain_id` values and useless step metadata
- after this patch, published probability rows point at the real chain records, and Kuzu can be updated with the same values

### 3. `publish --local` now syncs probabilities into Kuzu

Files:
- `cli/main.py`
- `tests/cli/test_publish.py`

Changes:
- after writing topology, `publish --local` now iterates over the converted probability records and calls `graph.update_probability(...)`

Why this matters:
- previously, LanceDB could contain probability rows while Kuzu still showed every `CONCLUSION.probability = 0.0`
- after this patch, the graph store reflects the reviewed step strengths instead of the placeholder default

### 4. Slash-qualified package cleanup is now actually idempotent

Files:
- `libs/storage_v2/lance_content_store.py`
- `libs/storage_v2/kuzu_graph_store.py`
- `tests/libs/storage_v2/test_lance_content.py`
- `tests/libs/storage_v2/test_graph_store.py`

Changes:
- fixed LanceDB `delete_package()` cleanup for `belief_history` so it deletes `closure_id LIKE 'pkg/%'`
- fixed Kuzu `delete_package()` so closure deletion uses the slash-qualified prefix (`pkg/`) while chain deletion still uses the dotted prefix (`pkg.`)
- added regression tests for slash-qualified closure IDs in both stores

Why this matters:
- PR 107 switched CLI-published closure IDs to `pkg/decl`
- the cleanup logic still assumed older dotted IDs for some tables/nodes
- that meant re-publish could leave stale belief rows and stale closure nodes behind

### 5. Cross-package provenance now stays stable through nested local refs

Files:
- `cli/lang_to_v2.py`
- `tests/cli/test_lang_to_v2.py`

Changes:
- added provenance tracking through module-local declarations so the converter can tell whether a declaration is:
  - genuinely owned by the current package, or
  - just a local alias/ref chain pointing into a dependency package
- fixed closure materialization to skip cross-package aliases even when they are reached through an intermediate local ref
- fixed `ClosureRef` generation so Einstein chains keep references like:
  - `newton_principia/law_of_gravity`
  - `newton_principia/acceleration_independent_of_mass`
  - `galileo_falling_bodies/vacuum_prediction`
  instead of incorrectly rewriting them as `einstein_gravity/...`

Why this matters:
- before this patch, Einstein could publish local-looking closures for dependency-owned declarations, while some chain premises still pointed at the external IDs
- that produced a content/graph mismatch and made the final storage state internally inconsistent

### 6. Exported non-BP relation metadata can now be published coherently

Files:
- `cli/lang_to_v2.py`
- `tests/cli/test_lang_to_v2.py`

Changes:
- extended closure materialization to include package-owned `Equivalence` and `Subsumption` declarations
- this specifically fixes exported metadata declarations such as `einstein_gravity/newton_subsumed_by_gr`

Why this matters:
- this declaration is intentionally excluded from BP, but it is still exported package content
- before this patch, Kuzu could create a stub node for it via chain topology while LanceDB had no corresponding closure row
- after this patch, content-store and graph-store agree on the entity set

## Validation

### Real CLI run with OpenAI model

I ran the real command sequence on `tests/fixtures/gaia_language_packages/galileo_falling_bodies` after sourcing `~/.bash_profile` so `OPENAI_API_KEY` was available:

- `gaia build`
- `gaia review --model gpt-5-mini`
- `gaia infer`
- `gaia publish --local`

Observed result after the fix:
- `gaia review` no longer falls back to `chains: []`
- the generated sidecar contained `10` reviewed chains
- `infer` completed successfully using that real review output
- `publish --local` wrote non-empty probability rows with real `chain_id` values
- the corresponding Kuzu `CONCLUSION.probability` values were updated from `0.0` to the reviewed values

### Full three-package pipeline check

I also re-ran the three fixture packages (`galileo_falling_bodies`, `newton_principia`, `einstein_gravity`) through the full mock pipeline into one shared DB.

Observed final state after the fix:
- `packages = 3`
- `modules = 13`
- `closures = 48`
- `chains = 26`
- `probabilities = 22`
- `belief_history = 41`
- no probability rows with empty `chain_id`
- no incorrectly localized Einstein closures for dependency-owned declarations
- Kuzu and LanceDB closure sets matched exactly (`48` / `48`, no Kuzu-only nodes)
- exported Einstein subsumption metadata now exists as a real content-store closure

### Local verification notes

I also ran:
- `python -m py_compile` on the modified Python/test files
- direct Python assertions covering the new parser normalization, probability mapping, and slash-qualified cleanup behavior

One caveat from this local machine: `python -m pytest ...` segfaulted in the environment (`SIGSEGV`) before producing usable output, so I used direct assertions plus real CLI runs for validation here. The added tests are included in the branch so CI can exercise them normally.
