### PR TITLE
docs: add storage identity and versioning consolidation plans

### DIFF
--- a/docs/plans/2026-03-12-storage-v2-package-knowledge-versioning-design.zh-CN.md
+++ b/docs/plans/2026-03-12-storage-v2-package-knowledge-versioning-design.zh-CN.md
@@ -1,0 +1,569 @@
+# Storage v2 中 Package Commit 与 Knowledge 身份设计
+
+## 目标
+
+澄清 storage v2 中 package revision、knowledge identity、chain snapshot 和 visibility 的建模方式。
+
+这份文档用于替代当前实现里几种概念混在一起的状态：
+
+- package 级版本
+- knowledge 实体版本
+- publish 可见性
+- graph / vector 的下游索引
+
+目标模型是：
+
+- package revision 用 `package_name + commit_hash` 标识
+- knowledge 同时有逻辑名和不可变的实体 hash
+- chain 没有独立的实体版本
+- 源码中的引用仍然使用逻辑名
+- 存储层中的引用在某个 package commit 快照内解析为不可变实体 ID
+
+## 当前实现方式
+
+### 当前已有的机制
+
+当前 `storage_v2` 是围绕 `StorageManager` 和一套 publish state machine 实现的：
+
+1. 先把 package 写成 `preparing`
+2. 再写 content
+3. 再写 graph
+4. 再写 vector
+5. 最后把 package 标成 `merged`
+
+最近几次修复已经把 package 行部分改成了 version-aware：
+
+- package 按 `(package_id, version)` 存
+- module 和 chain 带 `package_version`
+- knowledge 额外带 `source_package_version`
+
+### 当前的 identity 模型
+
+当前代码实际上在使用下面这些身份定义：
+
+- package snapshot: `(package_id, version)`
+- module snapshot: `(module_id, package_version)`
+- chain snapshot: `(chain_id, package_version)`
+- knowledge row: `(knowledge_id, version)`，并额外带 `source_package_version`
+
+这意味着：
+
+- package 被当作一个版本化的发布快照
+- chain 被当作 package 作用域下的快照，而不是独立版本化的实体
+- knowledge 同时承担了“独立版本实体”和“package 发布快照成员”两种职责
+
+### 当前实现为什么仍然不完整
+
+问题不只是某几个实现 bug，而是当前模型把两种本应分开的语义塞进了同一条 `knowledge` row：
+
+- 实体身份：这条 knowledge 本身是什么
+- 发布归属：这条 knowledge 当前属于哪个 package revision
+
+这会带来几个典型问题：
+
+- 新 package publish 可能会覆盖旧的 committed knowledge 的可见性元数据
+- package visibility 需要靠过滤 knowledge row 上的字段来推断
+- 同一个逻辑 knowledge 在不同 commit 下没有独立的 binding 层
+- graph / vector store 无法直接根据显式 membership 做 visibility 判断
+
+一句话说：当前 package revision identity 和 knowledge entity identity 还没有被干净地拆开。
+
+## 设计原则
+
+目标设计应遵守以下原则：
+
+1. 人写代码时始终用逻辑名引用，不直接写 hash。
+2. 不可变实体用 hash 或不可变 ID 落库存储。
+3. 每个 package commit 都是一个可重现快照。
+4. 新 commit 永远不能改变旧 committed 快照的语义。
+5. visibility 由 package commit membership 决定，而不是靠修改实体行实现。
+6. graph 和 vector store 是 committed snapshot / immutable entity 的索引，不是 source of truth。
+
+## 最终目标模型
+
+### 1. Package Revision Identity
+
+每一次发布的 package revision 用以下字段唯一标识：
+
+- `package_name`
+- `commit_hash`
+
+如果需要人类友好的展示版本号，还可以额外有：
+
+- `revision_no`
+
+但真正的存储主身份应该是：
+
+- `(package_name, commit_hash)`
+
+这和实际工作流一致：
+
+- package 的状态来自一个具体 Git commit
+- 重新发布就是 ingest 一个新的 commit 快照
+- 旧快照必须持续可读
+
+### 2. Knowledge Identity
+
+Knowledge 同时有两层 identity。
+
+#### 逻辑 identity
+
+给作者和语言层使用：
+
+- `package_name + knowledge_name`
+
+这是源码里真正写出来的引用方式。
+
+#### 实体 identity
+
+给存储层做不可变和去重使用：
+
+- `knowledge_hash`
+
+这个 hash 由规范化后的 knowledge 内容和需要参与 identity 的字段共同计算，例如：
+
+- knowledge type
+- content
+- prior
+- keywords
+- 其他语义相关元数据
+
+因此：
+
+- 如果内容没有变化，继续复用同一个 `knowledge_hash`
+- 如果内容发生变化，就产生一个新的 `knowledge_hash`
+
+### 3. Knowledge 的“版本”
+
+在这个模型下，真正的实体版本其实就是 immutable entity hash。
+
+因此并不一定需要强制保留一个独立的数字 `knowledge_version` 字段作为存储主键，只要：
+
+- 逻辑身份是 `package_name + knowledge_name`
+- 实体身份是 `knowledge_hash`
+
+如果后续 UI 或报告需要展示 “v1 / v2 / v3”，可以把数字版本作为派生字段保留，但不建议把它作为主 identity。
+
+### 4. Chain Identity
+
+Chain 没有独立的实体版本。
+
+Chain 只存在于某个 package commit snapshot 中。
+
+它的 identity 应该是：
+
+- `(package_name, commit_hash, chain_name)`
+
+这意味着：
+
+- chain 的变化通过新的 package commit 表达
+- 不需要额外引入 `chain_version`
+- 每次 package revision 下的 chain snapshot 都可以被完整复现
+
+## 必需的 Binding 层
+
+当前实现中最缺失的一层，是逻辑名和不可变实体之间的显式 binding。
+
+### Knowledge Binding
+
+对每个 package commit，都存一份：
+
+- `package_name`
+- `commit_hash`
+- `knowledge_name`
+- `knowledge_hash`
+
+这层表回答的问题是：
+
+“在 package `P` 的 commit `C` 下，逻辑名 `K` 实际绑定到哪个 immutable knowledge entity？”
+
+有了这层之后：
+
+- 老 commit 可以继续保留旧 binding
+- 新 commit 可以让同一个逻辑名指向新的实体 hash
+- 没变化的 knowledge 自动复用旧 hash
+
+## 最终要支持的表结构
+
+最小可行目标 schema 应该包含如下几张表。
+
+### 1. `package_revisions`
+
+表示一个可发布的 package 快照。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `parent_commit_hash`
+- `revision_no`
+- `status`
+- `submitted_at`
+- `manifest_json`
+
+主键：
+
+- `(package_name, commit_hash)`
+
+状态建议：
+
+- `preparing`
+- `reviewed`
+- `committed`
+- `failed`
+
+### 2. `knowledge_entities`
+
+表示不可变的 knowledge 内容实体。
+
+字段：
+
+- `knowledge_hash`
+- `type`
+- `content`
+- `prior`
+- `keywords_json`
+- `metadata_json`
+- `created_at`
+
+主键：
+
+- `knowledge_hash`
+
+说明：
+
+- 这是 canonical 的 knowledge 实体存储
+- 这张表不承载 package visibility 语义
+
+### 3. `knowledge_bindings`
+
+把某个 package revision 下的逻辑 knowledge 名映射到 immutable knowledge entity。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `knowledge_name`
+- `knowledge_hash`
+- `module_name`
+- `is_exported`
+
+主键：
+
+- `(package_name, commit_hash, knowledge_name)`
+
+建议的辅助索引：
+
+- `(package_name, commit_hash, knowledge_hash)`
+
+### 4. `module_snapshots`
+
+表示某个 package revision 下的 module 元数据。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `module_name`
+- `role`
+- `imports_json`
+- `chain_names_json`
+- `export_names_json`
+
+主键：
+
+- `(package_name, commit_hash, module_name)`
+
+### 5. `chain_snapshots`
+
+表示某个 package revision 下的 chain 状态。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `chain_name`
+- `module_name`
+- `type`
+- `steps_source_json`
+- `steps_resolved_json`
+- `chain_hash`
+
+主键：
+
+- `(package_name, commit_hash, chain_name)`
+
+说明：
+
+- `steps_source_json` 保留逻辑引用，也就是 knowledge name
+- `steps_resolved_json` 存解析后的 `knowledge_hash`
+
+### 6. `probability_records`
+
+存 review pipeline 生成的 step probability。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `chain_name`
+- `step_index`
+- `value`
+- `source`
+- `recorded_at`
+
+主键建议：
+
+- append-only，无需强唯一主键
+
+### 7. `belief_snapshots`
+
+存 inference pipeline 生成的 belief 结果。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `knowledge_name`
+- `knowledge_hash`
+- `belief`
+- `bp_run_id`
+- `computed_at`
+
+主键建议：
+
+- append-only，无需强唯一主键
+
+### 8. `resources`
+
+资源元数据表，可基本保持不变。
+
+主键：
+
+- `resource_id`
+
+### 9. `resource_attachments`
+
+当 attachment 指向 snapshot 对象时，它也应该带 package revision 语义。
+
+字段：
+
+- `resource_id`
+- `package_name`
+- `commit_hash`
+- `target_type`
+- `target_name`
+- `role`
+- `description`
+
+主键建议：
+
+- `(resource_id, package_name, commit_hash, target_type, target_name, role)`
+
+## Graph 和 Vector 的建模方式
+
+### Vector Store
+
+Vector store 应该按 immutable knowledge entity 存，而不是按 package revision 存。
+
+推荐 key：
+
+- `knowledge_hash`
+
+原因：
+
+- embedding 是 knowledge 内容的派生物
+- 同一个 knowledge entity 可能被多个 package revision 复用
+- embedding 应该只算一次、存一份、重复使用
+
+### Graph Store
+
+Graph store 更适合作为 package revision snapshot 图来存。
+
+推荐节点 identity：
+
+- package revision node: `(package_name, commit_hash)`
+- knowledge snapshot node: `(package_name, commit_hash, knowledge_name)`
+- chain snapshot node: `(package_name, commit_hash, chain_name)`
+
+同时 knowledge snapshot node 上再带：
+
+- `knowledge_hash`
+
+这样可以做到：
+
+- 历史 graph 可重现
+- topology query 可以明确地限定在某个 commit snapshot 内
+- 同一个 immutable knowledge entity 可被多个 revision 复用
+
+## 最终要支持的接口
+
+API 层应显式分开三类能力：
+
+- package snapshot 读取
+- knowledge entity 读取
+- logical name resolution
+
+### Package Revision APIs
+
+- `write_package_revision(package_revision)`
+- `commit_package_revision(package_name, commit_hash)`
+- `get_package_revision(package_name, commit_hash)`
+- `get_latest_committed_package_revision(package_name)`
+- `list_package_revisions(package_name)`
+
+### Knowledge Entity APIs
+
+- `write_knowledge_entities(entities)`
+- `get_knowledge_entity(knowledge_hash)`
+- `get_knowledge_entities(knowledge_hashes)`
+
+### Binding APIs
+
+- `write_knowledge_bindings(bindings)`
+- `get_knowledge_binding(package_name, commit_hash, knowledge_name)`
+- `list_knowledge_bindings(package_name, commit_hash)`
+- `resolve_knowledge_name(package_name, commit_hash, knowledge_name)`
+
+### Chain Snapshot APIs
+
+- `write_chain_snapshots(chains)`
+- `get_chain_snapshot(package_name, commit_hash, chain_name)`
+- `list_chain_snapshots(package_name, commit_hash, module_name=None)`
+
+### Review / Inference APIs
+
+- `write_probability_records(records)`
+- `get_probability_history(package_name, commit_hash, chain_name, step_index=None)`
+- `write_belief_snapshots(snapshots)`
+- `get_belief_snapshot(package_name, commit_hash, knowledge_name)`
+
+### Manager-Level Publish APIs
+
+Manager 层的 publish 流程不应再是“更新一个可变 package row”，而应是“创建一个新的 immutable revision snapshot”：
+
+- `ingest_package_revision(package_revision, modules, knowledge_entities, bindings, chains, embeddings)`
+- `retry_package_revision(package_name, commit_hash)`
+- `mark_package_revision_failed(package_name, commit_hash, error)`
+
+## 写入流程
+
+### 推荐的 Commit Ingest Flow
+
+1. 插入 `package_revisions(status='preparing')`
+2. 对该 commit 下所有 knowledge 做 canonicalize
+3. 为每个逻辑 knowledge 计算 `knowledge_hash`
+4. upsert `knowledge_entities`
+5. 写 `knowledge_bindings`
+6. 编译 chain snapshot，并将 `knowledge_name -> knowledge_hash` 解析好
+7. 写 `chain_snapshots`
+8. 写 graph snapshot
+9. 写 vector embeddings，key 用 `knowledge_hash`
+10. 写 probabilities 和 beliefs
+11. 将 package revision 标成 `committed`
+
+如果失败：
+
+- 新 revision 保持 `preparing` 或标成 `failed`
+- 不删除旧的 committed revision
+- 不修改历史 binding
+
+## 读取流程
+
+### 读取最新 Package
+
+1. 先 resolve 最新 committed 的 `(package_name, commit_hash)`
+2. 再读该 revision 的 module snapshots 和 chain snapshots
+3. 通过 `knowledge_bindings` 解析出 knowledge entities
+
+### 读取历史 Package
+
+1. 显式传入 `(package_name, commit_hash)`
+2. 只读这个 revision 对应的 snapshot rows
+
+### 读取 Knowledge 历史
+
+1. 按 `(package_name, knowledge_name)` 查询 `knowledge_bindings`
+2. 把每个 commit 对应的 binding join 到 `knowledge_entities`
+
+这样就能得到一个逻辑 knowledge 在不同 commit 下的完整历史。
+
+## 当前方案与目标方案的对比
+
+### 当前方案
+
+- package version 只被部分建模
+- chain 是 package-scoped
+- knowledge 同时承担实体和 membership 两种角色
+- visibility 通过过滤下游 content row 上的字段推断
+
+### 目标方案
+
+- package commit snapshot 是发布 identity
+- knowledge hash 是 immutable entity identity
+- knowledge name 是逻辑 identity
+- chain 只作为 package commit snapshot 存在
+- visibility 由 committed package revision 和 snapshot membership 决定
+
+## 迁移建议
+
+迁移建议分两阶段。
+
+### Phase 1：先止血
+
+如果短期内还继续沿用当前 schema，至少先做到：
+
+- 所有 snapshot 表都完整 commit-aware
+- 新 publish 不能覆盖旧 committed rows
+- topology visibility 不能依赖 graph stub 自带字段推断
+- knowledge 主表不要继续承担 package membership source of truth 的职责
+
+### Phase 2：迁移到 Binding-Based Design
+
+结构性改造建议：
+
+1. 新增 `package_revisions`
+2. 新增 `knowledge_entities`
+3. 新增 `knowledge_bindings`
+4. 把当前 `knowledge` 表的职责拆成：
+   - entity storage
+   - binding storage
+5. 把 chain 存储改成显式 snapshot 表
+6. 更新 graph/vector ingest 流程，让它们消费解析后的 snapshot 数据
+
+## 已确认的设计决策
+
+### 接受
+
+- package identity 是 `package_name + commit_hash`
+- package 展示版本号可以是派生的 `revision_no`
+- knowledge 的逻辑 identity 是 `package_name + knowledge_name`
+- knowledge 的 immutable identity 是 `knowledge_hash`
+- chain 没有独立的实体版本
+- 源码中的引用保持基于逻辑名
+- 存储中的引用在 package revision 内解析成 immutable entity ID
+
+### 拒绝
+
+- 把 `package_name` 单独当作唯一 identity
+- 把 `knowledge_name` 单独当作存储主键
+- 新 commit 到来时修改旧 committed snapshot 的语义
+- 让 graph/vector row 承担 visibility source of truth
+- 在没有真实需求前强行为 chain 引入独立版本号
+
+## 总结
+
+最终设计应显式区分三件事：
+
+- 不可变 knowledge entity
+- 不可变 package commit snapshot
+- 某个 snapshot 中逻辑名到 immutable entity 的 binding
+
+只有把这三层拆开，才能同时得到：
+
+- 可重现的历史
+- 安全的重新发布
+- 面向作者的逻辑名引用
+- 面向存储层的 hash 去重
+- 不需要独立 chain version 的 chain snapshot 模型
+- 正确的 graph/vector 索引，不发生跨版本污染

--- a/docs/plans/2026-03-12-version-management-storage-identity-consolidated-plan.zh-CN.md
+++ b/docs/plans/2026-03-12-version-management-storage-identity-consolidated-plan.zh-CN.md
@@ -1,0 +1,626 @@
+# Package Version Management 与 Storage Identity 整合方案
+
+## 目的
+
+这份文档用于和 PR 117 的 owner 对齐两个已经分别成形、但尚未完全统一的设计方向：
+
+1. PR 117 的 package version management 设计
+2. storage v2 的 package commit / knowledge identity / chain snapshot 设计
+
+目标不是直接给出实现细节，而是先明确：
+
+- 哪些部分已经一致
+- 哪些部分存在根本冲突
+- 最终应该采用什么统一模型
+- 这个统一模型对应的表结构与接口边界是什么
+
+## 背景
+
+### PR 117 已明确的方向
+
+PR 117 的版本管理文档已经明确了以下原则：
+
+1. package 版本采用 semver，由系统根据 diff 自动推导
+2. knowledge 没有独立数字版本，使用 content hash 表示变化
+3. dependencies 精确 pin，不使用 range
+4. major 版本允许新旧版本共存
+
+这套设计解决的是：
+
+- 用户如何发布
+- package 对外如何表达版本
+- 下游依赖如何锁定
+- review / BP 如何根据版本级别路由
+
+### storage v2 这边已经明确的方向
+
+storage v2 这边已经澄清了几个核心点：
+
+1. 逻辑引用不应直接写 hash，而应继续使用逻辑名
+2. knowledge 的不可变实体身份应与 package publish 身份分离
+3. chain 不需要独立实体版本，但必须存在于某个 package snapshot 中
+4. visibility 不应靠修改 knowledge row 本身来实现，而应通过 package snapshot membership 实现
+
+这套设计解决的是：
+
+- 数据库内部应该如何组织 identity
+- graph/vector 应该依附哪个层级
+- 历史快照如何保持可重现
+
+## 当前分歧的本质
+
+当前并不是“一个方案对、一个方案错”，而是两个方案分别站在不同层次上定义版本：
+
+- PR 117 主要定义的是对外的 package version 语义
+- storage v2 主要定义的是内部存储和快照 identity 语义
+
+真正需要统一的是：
+
+**系统内部到底以 semver 为主 identity，还是以 commit hash 为主 identity。**
+
+这决定了后面所有表结构和读取接口的形态。
+
+## 已经可以直接整合的部分
+
+以下内容可以视为已经达成一致，不需要再争论：
+
+### 1. Knowledge 没有独立数字版本
+
+这一点 PR 117 和 storage 设计是一致的。
+
+正确表达应为：
+
+- knowledge 的逻辑 identity 是 `package_name + knowledge_name`
+- knowledge 的实体变化通过 `knowledge_hash` 表示
+- 不再引入独立的 `knowledge_version` 计数器作为主 identity
+
+### 2. Chain 没有独立实体版本
+
+这一点也已经一致：
+
+- chain 的变化通过 package revision 表达
+- chain 不需要自己的 version counter
+- chain 只在某个 package snapshot 中有意义
+
+### 3. Dependencies 必须精确 pin
+
+这和 snapshot 可重现性完全一致。
+
+无论最终内部主 identity 选 semver 还是 commit hash，都应保持：
+
+- 依赖必须能唯一解析到一个不可变 package snapshot
+
+### 4. 历史版本必须可共存、可查询
+
+无论是 PR 117 的 major coexistence，还是 storage 设计中的 immutable snapshot，最终都要求：
+
+- 旧版本不能被新版本覆盖
+- 历史版本必须能重放和查询
+
+## 需要统一的关键设计决策
+
+## 1. Package 的主 identity 到底是什么
+
+这是最核心的问题。
+
+目前存在两种候选方案：
+
+### 方案 A：以 semver 为主 identity
+
+即：
+
+- package 唯一身份 = `package_name + semver`
+
+优点：
+
+- 对用户最直观
+- lock file 直接保存 semver 即可
+- 文档和 CLI 语义简单
+
+缺点：
+
+- 不容易表达“同一个 semver 对应哪个具体源码状态”
+- 不利于和 Git / review pipeline / reproducibility 做强绑定
+- 并发 publish、重试 publish、未发布 commit 都会比较难建模
+
+### 方案 B：以 commit hash 为内部主 identity，semver 为外部发布标签
+
+即：
+
+- 内部唯一身份 = `package_name + commit_hash`
+- 对外版本标签 = `semver`
+- 系统保证每个 committed semver 唯一映射一个 commit hash
+
+优点：
+
+- 和 Git、review pipeline、build artifact、snapshot 重放天然一致
+- 失败重试、并发提交、临时 preparing 状态都更容易建模
+- 内部 identity 不会和用户展示版本纠缠
+
+缺点：
+
+- 文档层和实现层需要明确区分 “外部版本” 与 “内部主键”
+- lock file 需要回答是存 semver 还是 commit hash，或者两者都存
+
+### 建议
+
+建议采用方案 B：
+
+- **内部存储主 identity 使用 `(package_name, commit_hash)`**
+- **外部发布语义继续使用 `package_name @ semver`**
+
+也就是说：
+
+- semver 是 publish label
+- commit hash 是 immutable snapshot identity
+
+两者的关系应定义为：
+
+- 每个 committed `package_name @ semver` 唯一映射到一个 `commit_hash`
+- 一个 `commit_hash` 在 committed 状态下最多对应一个 semver
+
+## 2. Knowledge 的 identity 应如何表达
+
+建议统一成三层：
+
+### 逻辑 identity
+
+- `package_name + knowledge_name`
+
+用于作者写 DSL、module export、chain step 引用。
+
+### 实体 identity
+
+- `knowledge_hash`
+
+用于去重、不可变实体存储、embedding 复用。
+
+### 发布绑定
+
+在某个 package snapshot 中，逻辑 knowledge 名实际绑定到哪个实体 hash，需要一层显式 binding：
+
+- `(package_name, commit_hash, knowledge_name) -> knowledge_hash`
+
+这是最终必须补上的结构。
+
+## 3. Chain 的 identity 应如何表达
+
+chain 只有发布版本，没有实体版本。
+
+因此 chain 的 identity 应该是：
+
+- `(package_name, commit_hash, chain_name)`
+
+它是一个 snapshot object，不是一个独立演化的 immutable entity。
+
+## 统一后的最终模型
+
+## 1. Package 层
+
+### 内部 identity
+
+- `package_name`
+- `commit_hash`
+
+### 对外 version label
+
+- `semver`
+
+### 关系
+
+- `(package_name, semver) <-> (package_name, commit_hash)` 一对一映射，仅对 committed revision 成立
+
+## 2. Knowledge 层
+
+### 逻辑 identity
+
+- `package_name + knowledge_name`
+
+### 实体 identity
+
+- `knowledge_hash`
+
+### 绑定关系
+
+- `(package_name, commit_hash, knowledge_name) -> knowledge_hash`
+
+## 3. Chain 层
+
+### 逻辑 identity
+
+- `package_name + chain_name`
+
+### snapshot identity
+
+- `(package_name, commit_hash, chain_name)`
+
+## 最终建议的表结构
+
+下面是整合后的推荐最小 schema。
+
+## 1. `package_revisions`
+
+表示 package 的内部不可变 revision。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `semver`
+- `parent_commit_hash`
+- `status`
+- `submitted_at`
+- `manifest_json`
+
+主键：
+
+- `(package_name, commit_hash)`
+
+唯一约束：
+
+- `(package_name, semver)` 在 `committed` 状态下唯一
+
+状态建议：
+
+- `preparing`
+- `reviewed`
+- `committed`
+- `failed`
+- `archived`
+
+说明：
+
+- `archived` 可选，仅用于 active graph / archive 分层
+- 不建议用它表达“逻辑上被推翻”，那仍然应由 BP 处理
+
+## 2. `knowledge_entities`
+
+表示不可变 knowledge 实体。
+
+字段：
+
+- `knowledge_hash`
+- `type`
+- `content`
+- `prior`
+- `keywords_json`
+- `metadata_json`
+- `created_at`
+
+主键：
+
+- `knowledge_hash`
+
+说明：
+
+- 只表达实体内容
+- 不表达 package 可见性
+
+## 3. `knowledge_bindings`
+
+表示 package revision 中逻辑 knowledge 名到实体 hash 的绑定。
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `knowledge_name`
+- `knowledge_hash`
+- `module_name`
+- `is_exported`
+
+主键：
+
+- `(package_name, commit_hash, knowledge_name)`
+
+辅助索引：
+
+- `(package_name, commit_hash, knowledge_hash)`
+
+## 4. `module_snapshots`
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `module_name`
+- `role`
+- `imports_json`
+- `chain_names_json`
+- `export_names_json`
+
+主键：
+
+- `(package_name, commit_hash, module_name)`
+
+## 5. `chain_snapshots`
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `chain_name`
+- `module_name`
+- `type`
+- `steps_source_json`
+- `steps_resolved_json`
+- `chain_hash`
+
+主键：
+
+- `(package_name, commit_hash, chain_name)`
+
+说明：
+
+- `steps_source_json` 保存逻辑引用
+- `steps_resolved_json` 保存解析后的 `knowledge_hash`
+
+## 6. `probability_records`
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `chain_name`
+- `step_index`
+- `value`
+- `source`
+- `recorded_at`
+
+说明：
+
+- append-only
+
+## 7. `belief_snapshots`
+
+字段：
+
+- `package_name`
+- `commit_hash`
+- `knowledge_name`
+- `knowledge_hash`
+- `belief`
+- `bp_run_id`
+- `computed_at`
+
+说明：
+
+- append-only
+
+## 8. `resources`
+
+字段：
+
+- `resource_id`
+- `type`
+- `format`
+- `storage_backend`
+- `storage_path`
+- `metadata_json`
+
+主键：
+
+- `resource_id`
+
+## 9. `resource_attachments`
+
+字段：
+
+- `resource_id`
+- `package_name`
+- `commit_hash`
+- `target_type`
+- `target_name`
+- `role`
+- `description`
+
+主键建议：
+
+- `(resource_id, package_name, commit_hash, target_type, target_name, role)`
+
+## Graph / Vector 的整合方案
+
+## Vector Store
+
+Vector store 应按 immutable entity 存。
+
+推荐 key：
+
+- `knowledge_hash`
+
+理由：
+
+- embedding 是 knowledge 内容的派生物
+- 相同内容不应重复计算、重复存储
+- package commit 只决定“是否可见”，不决定 embedding identity
+
+## Graph Store
+
+Graph store 更适合作为 package revision snapshot 图。
+
+推荐节点 identity：
+
+- package revision node: `(package_name, commit_hash)`
+- knowledge snapshot node: `(package_name, commit_hash, knowledge_name)`
+- chain snapshot node: `(package_name, commit_hash, chain_name)`
+
+同时 knowledge snapshot node 上携带：
+
+- `knowledge_hash`
+
+这样做可以同时满足：
+
+- snapshot 可重现
+- graph 可按 commit 查询
+- 相同 knowledge entity 可被多个 snapshot 复用
+
+## 最终接口建议
+
+## Package Revision APIs
+
+- `write_package_revision(package_revision)`
+- `commit_package_revision(package_name, commit_hash, semver)`
+- `get_package_revision(package_name, commit_hash)`
+- `get_package_revision_by_semver(package_name, semver)`
+- `get_latest_committed_package_revision(package_name)`
+- `list_package_revisions(package_name)`
+
+## Knowledge Entity APIs
+
+- `write_knowledge_entities(entities)`
+- `get_knowledge_entity(knowledge_hash)`
+- `get_knowledge_entities(knowledge_hashes)`
+
+## Knowledge Binding APIs
+
+- `write_knowledge_bindings(bindings)`
+- `resolve_knowledge_name(package_name, commit_hash, knowledge_name)`
+- `list_knowledge_bindings(package_name, commit_hash)`
+- `list_knowledge_history(package_name, knowledge_name)`
+
+## Chain Snapshot APIs
+
+- `write_chain_snapshots(chains)`
+- `get_chain_snapshot(package_name, commit_hash, chain_name)`
+- `list_chain_snapshots(package_name, commit_hash, module_name=None)`
+
+## Review / Inference APIs
+
+- `write_probability_records(records)`
+- `get_probability_history(package_name, commit_hash, chain_name, step_index=None)`
+- `write_belief_snapshots(snapshots)`
+- `get_belief_snapshot(package_name, commit_hash, knowledge_name)`
+
+## Publish / Build APIs
+
+- `ingest_package_revision(package_revision, modules, knowledge_entities, bindings, chains, embeddings)`
+- `compute_manifest_hashes(package_dir)`
+- `derive_semver_bump(previous_revision, current_manifest)`
+- `bind_semver_to_commit(package_name, semver, commit_hash)`
+
+## 统一后的工作流
+
+### Build
+
+1. 读取源码中的逻辑 knowledge / chain / module
+2. 计算每个 knowledge 的 canonical hash
+3. 输出 manifest：`knowledge_name -> knowledge_hash`
+4. 与上一个 committed revision 比较，推导 semver bump
+
+### Publish
+
+1. 创建 `package_revisions(status='preparing')`
+2. upsert `knowledge_entities`
+3. 写入 `knowledge_bindings`
+4. 写入 `module_snapshots`
+5. 写入 `chain_snapshots`
+6. 写 graph snapshot
+7. 写 vector embeddings
+8. 写 review / inference 结果
+9. 绑定 semver 与 commit hash
+10. 标记 package revision 为 `committed`
+
+### Dependency Resolution
+
+建议采用双层模型：
+
+- 用户/lockfile 层保存 `package_name @ semver`
+- build/runtime 内部解析到具体 `commit_hash`
+
+也就是说：
+
+- 外部 pin semver
+- 内部 resolve commit hash
+
+这样兼顾：
+
+- 人类可读性
+- 内部不可变 identity
+- 重放与审计能力
+
+## 还需要继续讨论的未定义项
+
+以下问题在 PR 117 中仍未完全定义，需要在讨论中确认：
+
+### 1. `semver` 与 `commit_hash` 的一一映射规则
+
+必须明确：
+
+- committed 后是否保证 `(package_name, semver)` 唯一映射到一个 `commit_hash`
+- 同一个 commit 是否允许重新绑定不同 semver
+
+建议答案：
+
+- committed 状态下必须一对一
+
+### 2. `knowledge_hash` 的计算域
+
+需要明确哪些字段参与 hash：
+
+- `type`
+- `content`
+- `prior`
+- `keywords`
+- 其他 metadata
+
+如果这点不定义清楚：
+
+- patch / minor / major 分类会不稳定
+- 去重也会不稳定
+
+### 3. Patch 的判定标准
+
+PR 117 目前把 “prior adjustment” 放进 patch，但如果 prior 参与 knowledge_hash，则 manifest diff 也会变化。
+
+需要明确：
+
+- knowledge_hash 是“全文语义实体 hash”
+- 还是“内容 hash”
+- patch/minor/major 是根据另一个 change classifier 判断
+
+建议：
+
+- `knowledge_hash` 负责实体不可变性
+- semver classifier 负责变更等级判定
+- 两者不要强行耦合
+
+### 4. Major coexistence 的 graph 连接语义
+
+PR 117 说 major old/new exports 会自动建立 factor，但还没定义：
+
+- 旧 export 与新 export 如何配对
+- rename 时怎样识别同一逻辑对象
+- 一个 package 多 export 时如何批量生成连接
+
+这需要后续单独设计。
+
+## 推荐的统一结论
+
+建议和 PR 117 owner 讨论后，把统一方案定为：
+
+1. **对外版本语义保留 PR 117 的 semver 体系**
+2. **内部主 identity 采用 `package_name + commit_hash`**
+3. **knowledge 不使用独立数字版本，只使用 `knowledge_hash`**
+4. **chain 没有独立实体版本，只存在于 package revision snapshot 中**
+5. **必须引入 `knowledge_bindings` 层，不能继续让 knowledge row 同时承担 entity 和 membership**
+6. **lockfile 对用户暴露 semver，但系统内部必须能解析到 commit hash**
+
+## 为什么这份整合方案更稳
+
+这样统一之后：
+
+- PR 117 想保留的 semver / publish / dependency 语义都还在
+- storage 侧需要的 immutable snapshot / binding / reproducibility 也能成立
+- graph/vector 的可见性不再依赖脆弱的字段过滤
+- 历史 package revision 不会被新 publish 污染
+- 同一个 knowledge 内容可以天然复用 embedding 和实体存储
+
+## 最后一句话
+
+推荐把整个系统拆成三层去理解：
+
+- **对外发布层：** `package_name @ semver`
+- **内部快照层：** `package_name + commit_hash`
+- **实体内容层：** `knowledge_hash`
+
+这三层一旦明确，后面的表结构、接口和 publish pipeline 就都能落稳。


### PR DESCRIPTION
## Summary

<!-- What changed and why? Keep it concise. -->

## Changes

-

## Test plan

- [ ] `pytest tests` passes locally
- [ ] `ruff check . && ruff format --check .` passes
- [ ] Manually tested the affected functionality

## Checklist

- [ ] Branch is rebased on latest `main`
- [ ] No `.env`, secrets, or large binary files included
- [ ] PR is focused on a single feature/fix (split if >3 days of work)
