### PR TITLE
fix: knowledge merge key and topology visibility gate

### DIFF
--- a/libs/storage_v2/lance_content_store.py
+++ b/libs/storage_v2/lance_content_store.py
@@ -476,7 +476,7 @@ class LanceContentStore(ContentStore):
         table = self._db.open_table("knowledge")
         rows = [_knowledge_to_row(k) for k in knowledge_items]
         (
-            table.merge_insert(["knowledge_id", "version"])
+            table.merge_insert(["knowledge_id", "version", "source_package_version"])
             .when_matched_update_all()
             .when_not_matched_insert_all()
             .execute(rows)

--- a/libs/storage_v2/manager.py
+++ b/libs/storage_v2/manager.py
@@ -208,9 +208,15 @@ class StorageManager:
         if self.graph_store is None:
             return []
         results = await self.graph_store.search_topology(seed_ids, hops)
-        committed = await self.content_store.get_committed_packages()
-        committed_pkg_ids = {pkg_id for pkg_id, _ver in committed}
-        return [r for r in results if r.knowledge.source_package_id in committed_pkg_ids]
+        # Hydrate stubs through ContentStore (visibility-gated)
+        filtered: list[ScoredKnowledge] = []
+        for r in results:
+            k = await self.content_store.get_knowledge(
+                r.knowledge.knowledge_id, r.knowledge.version
+            )
+            if k is not None:
+                filtered.append(ScoredKnowledge(knowledge=k, score=r.score))
+        return filtered
 
     # ── Read delegation (VectorStore — degraded-safe) ──
 

--- a/tests/libs/storage_v2/test_three_write.py
+++ b/tests/libs/storage_v2/test_three_write.py
@@ -237,10 +237,23 @@ class TestVersionedRePublish:
                 chains=pkg_chains,
             )
 
-        # v1 must still be visible
+        # v1 must still be visible — package, knowledge, modules, chains
         p = await manager.get_package(pkg_v1.package_id)
-        assert p is not None, "v1 should still be visible after v2 failure"
+        assert p is not None, "v1 package should still be visible after v2 failure"
         assert p.version == pkg_v1.version
+
+        k = await manager.get_knowledge(pkg_knowledge[0].knowledge_id)
+        assert k is not None, "v1 knowledge should still be visible after v2 failure"
+        assert k.source_package_version == pkg_v1.version
+
+        m = await manager.content_store.get_module(pkg_modules[0].module_id)
+        assert m is not None, "v1 module should still be visible after v2 failure"
+        assert m.package_version == pkg_v1.version
+
+        chain_module_id = pkg_chains[0].module_id
+        visible_chains = await manager.content_store.get_chains_by_module(chain_module_id)
+        assert len(visible_chains) > 0, "v1 chains should still be visible after v2 failure"
+        assert all(c.package_version == pkg_v1.version for c in visible_chains)
 
 
 class TestPartialWriteVisibility:


### PR DESCRIPTION
## Summary

Fixes two issues found during PR #111 review:

- **Knowledge merge key missing package version** — `write_knowledge` used `["knowledge_id", "version"]` as merge key, where `version` is the knowledge content version (e.g. `1`). Publishing package v2 with the same knowledge item overwrote v1's `source_package_version`, making v1 invisible if v2 failed. Fixed by adding `source_package_version` to the merge key: `["knowledge_id", "version", "source_package_version"]`.

- **search_topology weaker visibility gate** — flattened `(package_id, version)` pairs to just `package_id`, inconsistent with all other read paths. Now hydrates graph stubs through ContentStore (same pattern as `search_vector`).

- **Strengthened test** — `test_v1_survives_failed_v2_publish` now asserts knowledge, module, and chain visibility after v2 failure, not just package.

## Reproduction

Before this fix:
```
After v1 publish: content='v1 content', source_pkg_ver='1.0.0'
BUG: v1 knowledge is INVISIBLE after v2 failure!
```

After:
```
PASS: v1 knowledge preserved after v2 failure
```

## Test plan

- [x] `pytest tests/libs/storage_v2/test_three_write.py::TestVersionedRePublish` — passes
- [x] Full suite: 853 passed, 15 skipped
- [x] `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)