### PR TITLE
docs: redesign server architecture & storage schema for Graph IR v2.0

### DIFF
--- a/docs/foundations/server/architecture.md
+++ b/docs/foundations/server/architecture.md
@@ -2,29 +2,30 @@
 
 | 文档属性 | 值 |
 |---------|---|
-| 版本 | 1.1 |
-| 日期 | 2026-03-10 |
-| 状态 | **Draft — 目标架构设计，非当前实现描述** |
-| 关联文档 | [../product-scope.md](../product-scope.md), [../domain-model.md](../domain-model.md), [../system-overview.md](../system-overview.md) |
+| 版本 | 2.0 |
+| 日期 | 2026-03-13 |
+| 状态 | **Draft — 目标架构设计** |
+| Supersedes | architecture.md v1.1 (2026-03-10) |
+| 关联文档 | [../graph-ir.md](../graph-ir.md), [../bp-on-graph-ir.md](../bp-on-graph-ir.md), [storage-schema.md](storage-schema.md), [../review/publish-pipeline.md](../review/publish-pipeline.md), [../system-overview.md](../system-overview.md) |
 
-> **注意：** 本文档定义的是 server 端的**目标架构**，用于指导后续重构。当前 `main` 上的 server 仍然使用 `/commits/*`、`/jobs/*` 等旧 API，基于 Node/HyperEdge 模型。本文档中的 API 路由（`/packages`、`/bp/*` 等）和数据模型（closure/chain/module/package）是重构后的目标状态。
+> **变更摘要 (v1.1 → v2.0)：** Graph IR 引入后，因子图不再是临时运行时构造物——raw graph 和 local canonical graph 是 package 提交时的 first-class artifact。Server 需要验证、审计、合并这些结构化图。本次修订重新设计了 Storage Layer（新增 FactorNode、CanonicalBinding、GlobalInferenceState）、IngestionService 流程（新增 raw graph 验证 + canonicalization 审计 + global matching）、BPService（从持久化 Graph IR 加载而非动态编译）。
 
 ---
 
 ## 1. Server 定位
 
-Gaia 是 CLI-first, Server-enhanced。Server 是一个可选的 **registry 和计算后端**，类似 Julia General Registry / crates.io。
+Gaia 是 CLI-first, Server-enhanced。Server 是一个可选的 **registry 和计算后端**。
 
 Server 提供四个增强服务：
 
 | 服务 | 说明 |
 |------|------|
-| Knowledge integration | 把 packages 合并到全局 LKM |
+| Knowledge integration | 把 packages 合并到全局知识图（Global Canonical Graph） |
 | Global search | 跨 package 的 vector + BM25 + topology 搜索 |
-| Package preparation and review | 执行 compile、package environment construction、alignment、review |
-| Large-scale BP | 全局图上的信念传播 |
+| Package verification and review | 验证 raw graph、审计 canonicalization、执行 peer review、global matching |
+| Large-scale BP | 在 Global Canonical Graph + GlobalInferenceState 上运行信念传播 |
 
-Server **不修改 package**——它是 package 的只读消费者。
+Server **不修改 package source**——它是 package 的只读消费者。但 server 拥有 global identity assignment（CanonicalBinding）和 GlobalInferenceState，这些是 registry-side 数据。
 
 ---
 
@@ -41,7 +42,7 @@ Server **不修改 package**——它是 package 的只读消费者。
 │  └──────┬───────┘  └────────┬─────────┘              │
 │         └────────┬──────────┘                        │
 │                  ▼                                    │
-│         PackageRequest (统一表示)                      │
+│         PackageSubmission (统一表示)                   │
 └──────────────────┬──────────────────────────────────┘
                    │
 ┌──────────────────▼──────────────────────────────────┐
@@ -50,24 +51,21 @@ Server **不修改 package**——它是 package 的只读消费者。
 │  ┌─────────────────────────────────────────────┐     │
 │  │ IngestionService                             │     │
 │  │                                              │     │
-│  │ submit(pkg) → validate → compile             │     │
-│  │             → context → align                │     │
-│  │             → review → integrate             │     │
+│  │ submit(pkg) → verify_raw_graph               │     │
+│  │             → audit_canonicalization          │     │
+│  │             → peer_review                    │     │
+│  │             → global_match                   │     │
+│  │             → integrate                      │     │
 │  │                                              │     │
-│  │ 拥有 package 生命周期状态机                    │     │
-│  │ 内部组合 Validator + Compiler +              │     │
-│  │ ContextBuilder + Aligner +                   │     │
-│  │ ReviewEngine + Integrator                    │     │
 │  └─────────────────────────────────────────────┘     │
 │                                                      │
 │  ┌──────────────┐  ┌──────────────┐                  │
 │  │ BPService     │  │ QueryService │                  │
 │  │               │  │              │                  │
 │  │ run_global()  │  │ search()     │                  │
-│  │ run_subgraph()│  │ read_node()  │                  │
-│  │               │  │ read_edge()  │                  │
-│  └──────────────┘  │ subgraph()   │                  │
-│                     └──────────────┘                  │
+│  │ run_subgraph()│  │ read()       │                  │
+│  │               │  │ subgraph()   │                  │
+│  └──────────────┘  └──────────────┘                  │
 └──────────────────┬──────────────────────────────────┘
                    │
 ┌──────────────────▼──────────────────────────────────┐
@@ -76,13 +74,14 @@ Server **不修改 package**——它是 package 的只读消费者。
 │  ┌──────────────────────────────────────────┐        │
 │  │ StorageManager                            │        │
 │  │                                           │        │
-│  │ 统一读写接口，封装三个后端的协调           │        │
+│  │ 统一读写接口，封装后端协调                 │        │
 │  └──────────────────────────────────────────┘        │
 │       │            │            │                     │
 │  ┌────▼───┐  ┌─────▼────┐  ┌───▼────────┐           │
-│  │ Neo4j   │  │ LanceDB   │  │ VectorStore│           │
-│  │ (graph) │  │ (content) │  │ (embed)    │           │
-│  └────────┘  └──────────┘  └────────────┘           │
+│  │ Graph   │  │ Content   │  │ VectorStore│           │
+│  │ (Kuzu/  │  │ (LanceDB) │  │ (LanceDB)  │           │
+│  │  Neo4j) │  └──────────┘  └────────────┘           │
+│  └────────┘                                          │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -90,181 +89,439 @@ Server **不修改 package**——它是 package 的只读消费者。
 
 ---
 
-## 3. Storage Layer
+## 3. 与 Graph IR 的关系
 
-### 3.1 设计原则
+Graph IR 引入了四个根本性变化，是本次架构修订的驱动力。
 
-StorageManager 是所有存储操作的**唯一门面**。Domain services 不直接接触 Neo4j / LanceDB / VectorStore。
+### 3.1 因子图从临时变为持久
 
-### 3.2 数据归属
+v1.1 说："因子图不持久存储，每次 BP 运行时从 Knowledge + Chain + ProbabilityRecord 动态构建。"
 
-每个后端是特定数据的 source of truth，不是彼此的副本：
+Graph IR 之后，**raw graph 和 local canonical graph 是 package 的 first-class 提交 artifact**。Server 需要：
 
-| 后端 | Source of truth for | 提供的查询能力 |
-|------|-------------------|---------------|
-| **Neo4j** | 图拓扑（节点间的超边关系、tail/head 连接） | 邻居遍历、子图提取、边类型过滤 |
-| **LanceDB** | 节点/边的内容与元数据（content, prior, keywords, reasoning...） | BM25 全文搜索、元数据过滤、按 ID 读取 |
-| **VectorStore** | Embedding 向量 | top-k 相似度搜索 |
+- 存储这些 artifact
+- 验证 raw graph（re-compile + diff）
+- 审计 local canonicalization
+- 从 local canonical graph 生成 global canonical graph
 
-### 3.3 StorageManager 接口
+### 3.2 三层知识身份
 
-```python
-class StorageManager:
-    # ── 写入（package 入库，三写由此层保证一致性）──
-    async def ingest_package(self, package: PackageData) -> IngestResult
+每个知识命题在三个层次上有身份：
 
-    # ── 单实体读取 ──
-    async def get_node(self, node_id: str) -> Node | None
-    async def get_edge(self, edge_id: str) -> HyperEdge | None
+| 层 | 生成者 | 身份 | 范围 |
+|----|--------|------|------|
+| Raw | `gaia build`（确定性） | `raw_node_id`（content hash） | package-local |
+| Local Canonical | agent canonicalization skill | `local_canonical_id` | package-local |
+| Global Canonical | review engine / registry | `global_canonical_id` | 全局 |
 
-    # ── 图查询（委托 Neo4j）──
-    async def get_neighbors(self, node_id: str, direction: str,
-                            edge_types: list[str] | None,
-                            max_hops: int) -> Subgraph
-    async def get_subgraph(self, node_id: str, max_nodes: int) -> Subgraph
+Raw 和 Local Canonical 是 package 提交的一部分。Global Canonical 是 server/registry 分配的。
 
-    # ── 搜索查询（各后端独立）──
-    async def search_vector(self, embedding: list[float], top_k: int) -> list[ScoredNode]
-    async def search_bm25(self, text: str, top_k: int) -> list[ScoredNode]
-    async def search_topology(self, seed_ids: list[str], hops: int) -> list[ScoredNode]
+### 3.3 FactorNode 替代动态因子
+
+v1.1 中 BP 从 Chain + Knowledge 动态编译因子。Graph IR 之后，**FactorNode 是持久化的一等实体**。有四种类型：
+
+| Factor 类型 | 来源 | 语义 |
+|-------------|------|------|
+| `reasoning` | ChainExpr（一个 chain 对应一个 factor，不是一步一个） | 前提为真 → 结论以 conditional_probability 成立 |
+| `instantiation` | schema→ground 实例化 | 确定性蕴含：schema 为真 → instance 为真 |
+| `mutex_constraint` | Contradiction 声明 | 惩罚所有矛盾声称同时为真 |
+| `equiv_constraint` | Equivalence 声明 | 奖励等价声称一致 |
+
+FactorNode 的关键字段（见 graph-ir.md §4.6）：
+
+- `premises` — 直接依赖的知识节点（创建 BP 边）
+- `contexts` — 间接依赖的知识节点（**不**创建 BP 边，影响折入 conditional_probability）
+- `conclusion` — 单个知识节点。reasoning/instantiation: 正常接收消息；constraint: **只读门控**（BP 读其 belief，不向其发消息）
+
+### 3.4 概率与结构分离
+
+Graph IR 本身**不携带概率**。概率来自外部：
+
+- 本地推理：local parameterization overlay（作者本地，不提交）
+- 全局推理：GlobalInferenceState（registry 管理）
+
+Server 存储需要显式管理 GlobalInferenceState，而不是在 Knowledge/Chain 上内嵌概率。
+
+### 3.5 端到端工作流
+
+从 agent 本地创作到 server 入库的完整数据流：
+
+```
+Agent (local)                              Server
+─────────────                              ──────
+
+gaia build          → raw_graph.json
+agent: self-review  → weak points + priors (不提交)
+agent: graph-construction → local_canonical_graph.json
+                           + canonicalization_log.json
+gaia infer          → local BP preview (不提交)
+
+gaia publish ──────────────────────────────→ 提交四个 artifact:
+                                            1. source YAMLs
+                                            2. raw_graph.json
+                                            3. local_canonical_graph.json
+                                            4. canonicalization_log.json
+                                                │
+                                                ▼
+                                     ┌─ 1. 存储 SubmissionArtifact（不可变快照）
+                                     │
+                                     ├─ 2. GraphVerifier
+                                     │     re-compile source → 独立产 raw graph
+                                     │     diff against 提交的 raw_graph
+                                     │     不匹配 → reject
+                                     │
+                                     ├─ 3. CanonicalizationAuditor
+                                     │     审计每个 LocalCanonicalNode 的分组决策
+                                     │     错误合并 → blocking
+                                     │     遗漏合并 → advisory
+                                     │
+                                     ├─ 4. ReviewEngine (peer review)
+                                     │     独立评估推理质量
+                                     │     不看作者的 self-review 概率
+                                     │     给出 probability judgments
+                                     │     → PeerReviewReport
+                                     │
+                                     ├─ 5. Rebuttal cycle (≤5 rounds)
+                                     │     blocking findings → 返回 agent
+agent: rebuttal ←────────────────────┤     agent 修改或反驳
+gaia publish (with rebuttal) ────────→     re-review
+                                     │     > 5 rounds → 升级人工
+                                     │
+                                     ├─ 6. GlobalMatcher
+                                     │     对每个 LocalCanonicalNode:
+                                     │       embed → 搜索全局图
+                                     │       → match_existing | create_new
+                                     │     → list[CanonicalBinding]
+                                     │
+                                     ├─ 7. Integrator
+                                     │     a. 写 CanonicalBinding
+                                     │     b. 更新/创建 GlobalCanonicalNode
+                                     │     c. FactorNode 写入全局图
+                                     │        (premises/conclusion 重映射为 global_canonical_id)
+                                     │     d. 从 review report 刷新 GlobalInferenceState
+                                     │     e. package 标记 merged
+                                     │
+                                     └─ 8. BPService.schedule_update()
+                                           异步在全局图上跑 BP
+                                           更新 GlobalInferenceState.node_beliefs
+                                           写入 BeliefSnapshot history
 ```
 
-### 3.4 三写一致性与降级模式
+**概率从哪来？** 结构和概率严格分离。Graph IR 只有结构（哪些节点通过哪些 factor 连接），概率来自两个源：
 
-Package 入库是 server 唯一的写入路径。不存在单独写某个后端的场景。
+- 作者本地：local parameterization overlay（preview 用，不提交）
+- 全局：GlobalInferenceState（registry 管理，从 peer review 的 probability judgments 初始化，BP 运行后更新 beliefs）
 
-写入行为取决于后端在 **提交时** 的可用状态：
-
-**后端在提交前已知不可用（降级模式）：**
-
-| 状态 | 行为 |
-|------|------|
-| Neo4j 不可用 | 入库只写 LanceDB + Vector，图查询返回空，拓扑搜索跳过 |
-| VectorStore 不可用 | 入库只写 LanceDB + Neo4j，向量搜索跳过 |
-| LanceDB 不可用 | **系统不可用**（核心 source of truth） |
-
-**后端在写入过程中失败（mid-flight failure → 回滚）：**
-
-```
-ingest_package(pkg):
-    1. LanceDB.write(nodes, edges)     ← 内容先落盘（source of truth）
-    2. Neo4j.write(topology)           ← 图拓扑
-    3. VectorStore.write(embeddings)   ← 向量索引
-
-    Mid-flight 失败策略：
-    - 步骤 2 失败 → 删除步骤 1 写入的记录，返回错误
-    - 步骤 3 失败 → 删除步骤 1、2 写入的记录，返回错误
-```
-
-关键区别：降级模式是**启动时已知**的能力缺失，允许部分写入；mid-flight failure 是**运行时意外**，必须回滚以保证一致性。
+**为什么有两层图拓扑（Chain + Factor）？** Chain 是 authoring-layer 概念（多步叙事），一个 Chain 编译成一个 reasoning FactorNode。保留 Chain 用于 package 结构浏览；Factor 层供 BP 直接消费。
 
 ---
 
-## 4. Domain Services Layer
+## 4. Storage Layer
 
-### 4.1 IngestionService
+### 4.1 设计原则
+
+1. StorageManager 是所有存储操作的**唯一门面**
+2. 存储模型基于三层概念：Gaia Language（authoring）→ Graph IR（structural）→ Global Graph（registry）
+3. 每个后端是特定数据的 source of truth
+4. 概率和结构严格分离：Graph IR 只存结构，概率在 GlobalInferenceState
+5. Package submission artifact（source + raw graph + local canonical graph + canonicalization log）作为不可变快照存储
+
+### 4.2 数据归属
+
+| 后端 | Source of truth for | 提供的查询能力 |
+|------|-------------------|---------------|
+| **ContentStore (LanceDB)** | 全量内容：package source、Graph IR artifact、knowledge 内容、chain、factor、CanonicalBinding、GlobalInferenceState、belief/probability history | BM25 搜索、按 ID 读取、BP 批量加载 |
+| **GraphStore (Kuzu / Neo4j)** | 图拓扑：Knowledge → Factor → Knowledge 的 bipartite 结构，CanonicalBinding 关系 | 邻居遍历、子图提取、topology search |
+| **VectorStore (LanceDB)** | Embedding 向量 | top-k 相似度搜索 |
+
+### 4.3 核心实体变化（相对 v1.1）
+
+#### 不变的实体
+
+Package、Module、Chain、ChainStep、KnowledgeRef、ProbabilityRecord、BeliefSnapshot、Resource、ResourceAttachment — schema 不变，语义不变。Chain 仍是 authoring-layer 概念。
+
+#### 扩展的实体
+
+**Knowledge** — 新增字段以支持 Graph IR knowledge node：
+
+```
+Knowledge:
+    ... (v1.1 所有字段保持不变)
+    kind:            str | None       # question/action 的子类型；equivalence 要求同 root type 同 kind
+    parameters:      list[Parameter]  # 空 = ground node，非空 = schema node（∀量化）
+
+Parameter:
+    name:            str
+    constraint:      str
+```
+
+`type` 从 `claim | question | setting | action` 扩展为 `claim | question | setting | action | contradiction | equivalence`。
+
+`is_schema` property：`len(parameters) > 0`。
+
+#### 新增的实体
+
+**FactorNode** — Graph IR 的持久化因子：
+
+```
+FactorNode:
+    factor_id:       str
+    type:            str              # reasoning | instantiation | mutex_constraint | equiv_constraint
+    premises:        list[str]        # knowledge node IDs（该图层的 ID 空间）
+    contexts:        list[str]        # knowledge node IDs（不创建 BP 边）
+    conclusion:      str              # 单个 knowledge node ID
+    source_ref:      SourceRef | None
+    metadata:        dict | None
+
+SourceRef:
+    package:         str
+    version:         str
+    module:          str
+    knowledge_name:  str
+```
+
+属性：`is_gate_factor`（mutex_constraint 或 equiv_constraint）；`bp_participant_ids`（gate factor 返回 premises only，非 gate 返回 premises + conclusion）。
+
+**CanonicalBinding** — 本地→全局身份映射（review/registry-side 记录）：
+
+```
+CanonicalBinding:
+    package:              str
+    version:              str
+    local_graph_hash:     str
+    local_canonical_id:   str
+    decision:             str         # match_existing | create_new
+    global_canonical_id:  str
+    decided_at:           datetime
+    decided_by:           str
+    reason:               str | None
+```
+
+**GlobalCanonicalNode** — 全局去重身份：
+
+```
+GlobalCanonicalNode:
+    global_canonical_id:  str         # registry-assigned, opaque (如 gcn_<ULID>)
+    knowledge_type:       str
+    kind:                 str | None
+    representative_content: str
+    parameters:           list[Parameter]
+    member_local_nodes:   list[LocalCanonicalRef]
+    provenance:           list[PackageRef]
+    metadata:             dict | None
+```
+
+**GlobalInferenceState** — registry 管理的全局推理参数：
+
+```
+GlobalInferenceState:
+    graph_hash:          str
+    node_priors:         dict[str, float]        # keyed by global_canonical_id
+    factor_parameters:   dict[str, FactorParams] # keyed by factor_id
+    node_beliefs:        dict[str, float]        # keyed by global_canonical_id
+    updated_at:          datetime
+```
+
+**PackageSubmissionArtifact** — 提交快照（不可变）：
+
+```
+PackageSubmissionArtifact:
+    package_name:        str
+    commit_hash:         str
+    source_files:        dict[str, str]  # filename → YAML content
+    raw_graph:           dict             # raw_graph.json 内容
+    local_canonical_graph: dict
+    canonicalization_log: list[dict]
+    submitted_at:        datetime
+```
+
+### 4.4 ContentStore（LanceDB）
+
+| 表 | 存储内容 | 相对 v1.1 |
+|---|---|---|
+| `packages` | Package 全部字段 | 不变 |
+| `modules` | Module 全部字段 | 不变 |
+| `knowledge` | Knowledge 全部字段 + embedding | **+kind, +parameters** |
+| `chains` | Chain（authoring-layer，含 steps） | 不变 |
+| `factors` | FactorNode | **新增** |
+| `canonical_bindings` | CanonicalBinding | **新增** |
+| `global_canonical_nodes` | GlobalCanonicalNode | **新增** |
+| `global_inference_state` | GlobalInferenceState（单行或版本化） | **新增** |
+| `submission_artifacts` | PackageSubmissionArtifact（不可变快照） | **新增** |
+| `probabilities` | ProbabilityRecord | 不变 |
+| `belief_history` | BeliefSnapshot | 不变 |
+| `resources` | Resource 元信息 | 不变 |
+| `resource_attachments` | ResourceAttachment | 不变 |
+
+### 4.5 GraphStore（图拓扑）
+
+v1.1 的图模型用 Chain 作为中间节点连接 Knowledge。Graph IR 之后，**FactorNode 成为新的 BP-facing 拓扑节点**，与 Chain 并存。
+
+```
+节点:
+    (:Knowledge  {knowledge_id, version, type, kind, prior, belief})
+    (:Factor     {factor_id, type, is_gate})              # 新增
+    (:Chain      {chain_id, type})                        # 保持
+    (:GlobalCanonicalNode {global_canonical_id, ...})     # 新增
+
+关系 — Authoring layer（Chain）:
+    (:Knowledge)-[:PREMISE {step_index}]->(:Chain)
+    (:Chain)-[:CONCLUSION {step_index}]->(:Knowledge)
+
+关系 — Graph IR layer（Factor）:
+    (:Knowledge)-[:FACTOR_PREMISE]->(:Factor)             # 直接依赖，创建 BP 边
+    (:Knowledge)-[:FACTOR_CONTEXT]->(:Factor)             # 间接依赖，不创建 BP 边
+    (:Factor)-[:FACTOR_CONCLUSION]->(:Knowledge)          # conclusion
+
+关系 — Global layer:
+    (:Knowledge)-[:CANONICAL_BINDING {decision}]->(:GlobalCanonicalNode)
+
+关系 — 组织结构（保持不变）:
+    (:Knowledge)-[:BELONGS_TO]->(:Module)
+    (:Module)-[:BELONGS_TO]->(:Package)
+    (:Module)-[:IMPORTS {strength}]->(:Knowledge)
+    (:Resource)-[:ATTACHED_TO {role}]->(:Knowledge|:Chain)
+```
+
+**两层图拓扑的设计理由：**
+
+Chain 是 authoring-layer 概念（多步推理，叙事结构）。FactorNode 是 Graph IR 概念（编译后的因子，BP 直接消费）。保留 Chain 层用于 package 结构浏览和搜索。Factor 层用于 BP 和推理审计。两层通过 FactorNode.source_ref 关联——source_ref 指向生成该 factor 的 Chain。
+
+这不是冗余存储——Chain 粒度是按步（step），Factor 粒度是按 ChainExpr（整条 chain 编译为一个 reasoning factor）。一个 Chain 对应一个 reasoning FactorNode，但它们的拓扑结构不同：Chain 有多步 PREMISE/CONCLUSION，Factor 只有 premises→conclusion。
+
+### 4.6 降级模式
+
+| 状态 | 影响 |
+|------|------|
+| GraphStore 不可用 | 图查询返回空，topology search 跳过，入库只写 Content + Vector |
+| VectorStore 不可用 | 向量搜索跳过，入库只写 Content + Graph |
+| ContentStore 不可用 | **系统不可用**（core source of truth） |
+
+---
+
+## 5. Domain Services Layer
+
+### 5.1 IngestionService
 
 管理 package 从提交到入库的完整生命周期。
 
 #### 状态机
 
 ```
-submitted → validating → validated → compiling → compiled
-                ↓
-             invalid
-             (rejected)
+submitted → verifying_raw_graph → raw_verified
+                   ↓
+                 invalid (raw graph mismatch → blocking)
 
-compiled → building_context → context_ready → aligning → aligned → reviewing → reviewed
-                                                                ↓             ↓
-                                                             rejected      rejected
-                                                                               ↓
-                                                                         integrating → merged
+raw_verified → auditing_canonicalization → canonicalization_audited
+                        ↓
+                     needs_revision (bad merge → blocking)
+
+canonicalization_audited → peer_reviewing → reviewed
+                                ↓
+                             needs_revision → (rebuttal cycle, max 5 rounds)
+                                ↓
+                             rejected
+
+reviewed → global_matching → matched → integrating → merged
+                                ↓
+                             conflict (identity collision → blocking)
 ```
 
-> `building_context` materializes the package environment. `aligning` covers open-world relation discovery against the shared registry. `reviewing` is the final package judgment in that aligned context. See [../review/architecture.md](../review/architecture.md).
->
-> This granularity is primarily the internal domain model. External API status surfaces may collapse it into fewer user-facing phases such as `preparing`, `reviewing`, `integrating`, and `merged`.
+外部 API 状态可折叠为：`submitted`、`reviewing`、`integrating`、`merged`、`rejected`。
 
 #### 接口
 
 ```python
 class IngestionService:
-    def __init__(self, validator: Validator,
-                 compiler: Compiler,
-                 context_builder: ContextBuilder,
-                 review_engine: ReviewEngine,
-                 aligner: Aligner,
-                 storage: StorageManager):
+    def __init__(
+        self,
+        compiler: Compiler,
+        graph_verifier: GraphVerifier,
+        canonicalization_auditor: CanonicalizationAuditor,
+        review_engine: ReviewEngine,
+        global_matcher: GlobalMatcher,
+        integrator: Integrator,
+        storage: StorageManager,
+    ):
         ...
 
-    async def submit(self, request: PackageRequest) -> SubmissionResult
+    async def submit(self, submission: PackageSubmission) -> SubmissionResult
     async def get_status(self, submission_id: str) -> SubmissionStatus
 ```
-
-`submit()` 是异步的——立即返回 `submission_id`，客户端通过 `get_status()` 轮询进度。这适配 webhook 场景（GitHub 期望快速响应），direct publish 也用同样模式保持一致。
 
 #### 内部组件
 
 | 组件 | 职责 | 输入 → 输出 |
 |------|------|------------|
-| **Validator** | schema 校验、引用完整性、prior 范围检查、边类型约束 | PackageData → ValidationResult |
-| **Compiler** | 执行 deterministic compile/elaboration，产出显式 package 结构 | PackageData → CompiledPackage |
-| **ContextBuilder** | 基于 compiled package 构建 package environment | CompiledPackage + ContextPolicy + EnvironmentLock? → PackageEnvironment |
-| **Aligner** | 在 package environment 上执行 open-world alignment（AlignmentPolicy） | CompiledPackage + PackageEnvironment + AlignmentPolicy → AlignmentResult |
-| **ReviewEngine** | 在 aligned context 中执行 final package review（ReviewPolicy） | CompiledPackage + PackageEnvironment + AlignmentResult + ReviewPolicy → PackageReviewReport |
-| **Integrator** | 把 package 映射到全局图结构，调用 StorageManager 写入 | PackageData → IngestResult |
+| **Compiler** | re-compile package source（不信任客户端编译） | PackageSource → RawGraph |
+| **GraphVerifier** | diff 提交的 raw_graph 与 re-compile 结果 | SubmittedRawGraph + RecompiledRawGraph → VerifyResult |
+| **CanonicalizationAuditor** | 审计 local canonical graph 的分组决策 | LocalCanonicalGraph + CanonLog → AuditResult |
+| **ReviewEngine** | peer review：推理质量、dependency 标注、probability judgments | Package + LocalCanonicalGraph → PeerReviewReport |
+| **GlobalMatcher** | 搜索全局图，为每个 LocalCanonicalNode 决定 match_existing 或 create_new | LocalCanonicalGraph + GlobalGraph → list[CanonicalBinding] |
+| **Integrator** | 写入 binding + 更新 GlobalCanonicalNode + 写 factors 到全局图 + 刷新 GlobalInferenceState | MatchResult + ReviewReport → IntegrateResult |
 
-#### Validator 职责
+#### 从 v1.1 的变化
 
-1. Schema 合法性（package.yaml + module YAML 结构）
-2. 引用完整性（chain 中的 premise 引用都指向存在的 declaration）
-3. Prior ∈ (0, 1)（Cromwell 规则，setting type 允许 1.0）
-4. 边类型约束（induction 的 probability 必须 < 1.0）
-5. Export 的 closure_id 存在于某个 module 中
+| v1.1 组件 | v2.0 | 说明 |
+|-----------|------|------|
+| Validator | → Compiler + GraphVerifier | 校验拆分为 re-compile + graph diff |
+| Compiler | 保持 | 仍然做 deterministic lowering |
+| ContextBuilder | 移除 | 外部 context 搜索是 peer review / global matching 的内部步骤 |
+| Aligner | → GlobalMatcher | 从 "开放世界关系发现" 演化为 "全局身份分配" |
+| ReviewEngine | 保持（消费方式变化） | 现在消费 Graph IR artifact，不再直接消费 source |
+| Integrator | 扩展 | 新增 CanonicalBinding 写入、GlobalInferenceState 刷新 |
 
-#### Compiler 职责
+#### Integration 数据流
 
-`Compiler` 负责 deterministic package lowering：
+Package 提交四个 artifact（graph-ir.md §8.1）：
 
-1. parse 后的 package 结构检查
-2. elaboration
-3. local ref resolution
-4. 生成供 context/alignment/review/integration 共用的 compiled package
+1. Gaia Lang source
+2. Raw Graph IR (raw_graph.json)
+3. Local Canonical Graph (local_canonical_graph.json)
+4. Canonicalization log
 
-#### ContextBuilder 职责
+Server-side 完整流程：
 
-`ContextBuilder` 负责 **Package Environment**：
+```
+1. 存储 PackageSubmissionArtifact（不可变快照）
 
-1. 对 compiled package 里的候选 declaration 生成 embedding
-2. 从 local / remote / both source 检索语义邻居
-3. 从显式外部引用和语义命中继续扩展结构邻居
-4. materialize package environment 和 environment identity
+2. GraphVerifier:
+   - re-compile package source → 独立产出 raw graph
+   - diff against 提交的 raw_graph.json
+   - 任何不匹配 → blocking finding, reject
 
-#### Aligner 职责
+3. CanonicalizationAuditor:
+   - 审计每个 LocalCanonicalNode 及其 log entry
+   - 错误合并 → blocking
+   - 遗漏合并 → advisory
 
-`Aligner` 负责 **Package Alignment**（`AlignmentPolicy`）：
+4. ReviewEngine:
+   - 独立评估推理质量（不信任作者的 self-review 概率或 local parameterization）
+   - 可给出 node_prior_judgments 和 factor_probability_judgments
+   → PeerReviewReport
 
-1. 在 package environment 上发现 duplicate / canonicalization 候选
-2. 发现 conclusion-conclusion 关系（join-cc）
-3. 发现 conclusion-premise 关系（join-cp）
-4. 两轮 verification（验证发现关系的质量）
-5. 输出 relation 候选（equivalence, contradiction, subsumption）+ alignment verdict
+5. Rebuttal cycle (max 5 rounds, per publish-pipeline.md §5.3)
 
-#### ReviewEngine 职责
+6. GlobalMatcher:
+   - 对每个 LocalCanonicalNode: embed + 搜索全局图
+   - 决定 match_existing(global_canonical_id) | create_new
+   - question/action 还要求 root type 和 kind 匹配
+   → list[CanonicalBinding]
 
-`ReviewEngine` 只负责 **Package Review**（`ReviewPolicy`）：
+7. Integrator:
+   a. 写入 CanonicalBinding 记录
+   b. 更新/创建 GlobalCanonicalNode（membership + provenance）
+   c. 将 FactorNode 写入全局图（premises/conclusion 重映射为 global_canonical_id）
+   d. 从 PeerReviewReport 的 probability judgments 刷新 GlobalInferenceState
+   e. 标记 package 为 merged
 
-1. 推理步骤是否逻辑连贯
-2. 结论是否被前提支持
-3. 推理类型是否正确标注（deduction vs induction vs abstraction）
-4. prior、dependency label 与 alignment 发现是否一致
-5. 输出 per-chain 评分 + 总体 accept/reject 建议
+8. BPService.schedule_update()
+   → 异步在 Global Canonical Graph + GlobalInferenceState 上运行 BP
+```
 
-Compile、context、alignment、review 都不包含 BP。BP 属于 inference 阶段，由 `BPService` 在 integration 之后执行。
+### 5.2 BPService
 
-详细边界见 [../review/architecture.md](../review/architecture.md).
-
-### 4.2 BPService
+Graph IR 之后，BP 不再从 Knowledge + Chain 动态编译因子。它从持久化的 FactorNode + GlobalInferenceState 加载。
 
 ```python
 class BPService:
@@ -276,227 +533,290 @@ class BPService:
     async def schedule_update(self) -> None
 ```
 
-- 复用 `libs/inference/` 的 CPU 实现（FactorGraph + BeliefPropagation）
-- `run_global()` 从 storage 加载全局图，运行 BP，把更新后的 beliefs 写回 storage
-- `schedule_update()` 由 IngestionService 在入库完成后异步调用，支持 debounce（多个 package 短时间内入库只跑一次 BP）
+BP 执行流程：
 
-### 4.3 QueryService
+```
+1. 加载 GlobalInferenceState（node_priors + factor_parameters）
+2. 加载全局图的 FactorNode 集合
+3. 对每个 FactorNode:
+   - premises → BP 边（knowledge→factor 和 factor→knowledge 消息）
+   - contexts → 不创建 BP 边
+   - conclusion:
+     - reasoning/instantiation → 正常 BP 参与者
+     - mutex_constraint/equiv_constraint → 只读门控
+4. 运行 sum-product message passing（复用 libs/inference/bp.py）
+5. 更新 GlobalInferenceState.node_beliefs
+6. 写入 BeliefSnapshot history
+```
+
+与 v1.1 的关键变化：
+
+| 维度 | v1.1 | v2.0 |
+|------|------|------|
+| Variable ID | `int` | `global_canonical_id: str`（内部映射到 int） |
+| Factor 来源 | 从 Chain + Knowledge 动态编译 | 从持久化 FactorNode 加载 |
+| Factor 类型 | deduction, induction, retraction, contradiction | reasoning, instantiation, mutex_constraint, equiv_constraint |
+| Factor 粒度 | 一步一个 factor | 一个 ChainExpr 一个 factor |
+| 新 factor | — | instantiation（确定性蕴含） |
+| 概率来源 | Knowledge.prior + ProbabilityRecord | GlobalInferenceState.node_priors + factor_parameters |
+| Gate 机制 | bp.py 的 `gate_var` | FactorNode.is_gate_factor + conclusion 字段 |
+
+### 5.3 QueryService
 
 ```python
 class QueryService:
     def __init__(self, storage: StorageManager):
         ...
 
-    async def get_node(self, node_id: str) -> Node | None
-    async def get_edge(self, edge_id: str) -> HyperEdge | None
-    async def get_subgraph(self, node_id: str, direction: str,
+    async def get_knowledge(self, knowledge_id: str, version: int | None = None) -> Knowledge | None
+    async def get_factor(self, factor_id: str) -> FactorNode | None
+    async def get_global_node(self, global_id: str) -> GlobalCanonicalNode | None
+    async def get_subgraph(self, knowledge_id: str, direction: str,
                            max_nodes: int) -> Subgraph
-    async def search(self, text: str, top_k: int) -> list[ScoredNode]
+    async def search(self, text: str, top_k: int) -> list[ScoredKnowledge]
 ```
 
-`search()` 内部执行三路并行召回 + 归一化 + 加权融合 + 去重 + top-k 过滤。
-
-搜索的具体策略（权重、召回路径）在后续设计中细化，当前优先级较低。
+`search()` 内部执行三路并行召回（vector + BM25 + topology）+ 归一化 + 加权融合。搜索策略后续细化。
 
 ---
 
-## 5. Transport Layer
+## 6. Transport Layer
 
-### 5.1 统一请求表示
-
-两条路径（HTTP direct / GitHub webhook）最终都构造同一个 `PackageRequest`：
+### 6.1 统一请求表示
 
 ```python
 @dataclass
-class PackageRequest:
+class PackageSubmission:
     source: Literal["webhook", "direct"]
-    package_files: dict[str, str]   # filename → YAML content
-    metadata: RequestMetadata
+    source_files: dict[str, str]        # filename → YAML content
+    raw_graph: dict                      # raw_graph.json content
+    local_canonical_graph: dict          # local_canonical_graph.json content
+    canonicalization_log: list[dict]      # canonicalization_log.json content
+    metadata: SubmissionMetadata
 
 @dataclass
-class RequestMetadata:
+class SubmissionMetadata:
     submitter: str
     submitted_at: datetime
-    # webhook 专有
     repo_url: str | None = None
     pr_number: int | None = None
     commit_sha: str | None = None
 ```
 
-### 5.2 HTTP Routes
+相比 v1.1 的 `PackageRequest`（只有 `package_files`），现在携带四个 artifact。
+
+### 6.2 HTTP Routes
 
 ```
-POST   /packages              # direct publish
-GET    /packages/{id}/status   # 查询提交状态
+# Package submission
+POST   /packages                    # direct publish（提交四个 artifact）
+GET    /packages/{id}/status        # 查询提交状态
 
-GET    /nodes/{id}
-GET    /edges/{id}
-GET    /nodes/{id}/subgraph
+# Entity reads — authoring layer
+GET    /knowledge/{id}
+GET    /knowledge/{id}/versions
+GET    /chains/{module_id}
 
+# Entity reads — Graph IR layer
+GET    /factors/{id}                # 新增
+GET    /factors?package={id}        # 新增
+
+# Entity reads — Global layer
+GET    /global-nodes/{id}           # 新增
+GET    /bindings?package={name}&version={ver}  # 新增
+
+# Graph
+GET    /knowledge/{id}/subgraph
+
+# Search
 POST   /search
 
-POST   /bp/run                 # 手动触发全局 BP
+# BP
+POST   /bp/run
 GET    /bp/status
+
+# Webhook
+POST   /webhooks/github
 ```
 
-路由实现只做 transport 转换，不含业务逻辑：
+### 6.3 Webhook Handler
+
+与 v1.1 相同模式。webhook 触发后构造 `PackageSubmission`（包含从 PR 获取的四个 artifact），调用 `IngestionService.submit()`。
+
+### 6.4 Application Bootstrap
 
 ```python
-@router.post("/packages")
-async def submit_package(files: UploadFiles, deps: Deps):
-    request = PackageRequest(
-        source="direct",
-        package_files=parse_uploads(files),
-        metadata=RequestMetadata(submitter=current_user(), ...)
-    )
-    result = await deps.ingestion.submit(request)
-    return result
-```
-
-### 5.3 Webhook Handler
-
-```python
-@router.post("/webhooks/github")
-async def github_webhook(request: Request, deps: Deps):
-    event = verify_and_parse(request)  # 验证 webhook secret
-
-    if event.action not in ("opened", "synchronize"):
-        return {"status": "ignored"}
-
-    package_files = await fetch_package_from_pr(event)
-
-    request = PackageRequest(
-        source="webhook",
-        package_files=package_files,
-        metadata=RequestMetadata(
-            submitter=event.sender,
-            repo_url=event.repo_url,
-            pr_number=event.pr_number,
-            commit_sha=event.head_sha,
-        )
-    )
-
-    submission = await deps.ingestion.submit(request)
-
-    # 立即回复 GitHub 一个 pending comment
-    await post_pending_comment(event, submission.id)
-```
-
-`submit()` 立即返回 `submission_id`（非阻塞）。Review 完成后通过回调投递结果：
-
-```python
-# IngestionService 内部，review 完成时的回调
-async def _on_review_complete(self, submission_id: str, result: ReviewResult):
-    ...
-    await self._result_adapter.deliver(submission_id, result)
-```
-
-```python
-# ResultAdapter 根据来源投递结果
-class ResultAdapter:
-    async def deliver(self, submission_id: str, result: SubmissionResult):
-        request = self._get_request(submission_id)
-        if request.source == "webhook":
-            await self.github.post_pr_comment(
-                repo=request.metadata.repo_url,
-                pr=request.metadata.pr_number,
-                body=format_review_comment(result),
-            )
-        # direct publish: 客户端通过 GET /packages/{id}/status 轮询
-```
-
-### 5.4 结果投递流程
-
-| 路径 | 提交响应 | 结果投递 |
-|------|---------|---------|
-| Direct (HTTP) | 立即返回 `submission_id` | 客户端轮询 `GET /packages/{id}/status` |
-| Webhook | 立即回复 GitHub 200 + pending comment | Review 完成后回调写 PR comment |
-
-### 5.5 Application Bootstrap
-
-系统组装从 gateway 中剥离，独立为 bootstrap 模块：
-
-```python
-# server/bootstrap.py
 def create_dependencies() -> Dependencies:
-    # Storage
-    neo4j = Neo4jClient(settings.neo4j_url)
-    lance = LanceDB(settings.lancedb_path)
-    vector = VectorStore(settings.vector_config)
-    storage = StorageManager(neo4j, lance, vector)
+    storage = StorageManager(config)
+    await storage.initialize()
 
-    # Domain Services
-    validator = Validator()
     compiler = Compiler()
-    context_builder = ContextBuilder(
-        embedding=create_embedding_client(),
+    graph_verifier = GraphVerifier(compiler)
+    canonicalization_auditor = CanonicalizationAuditor(
+        llm_client=create_llm_client()
     )
     review_engine = ReviewEngine(llm_client=create_llm_client())
-    aligner = Aligner(
-        llm_client=create_llm_client(),
+    global_matcher = GlobalMatcher(
+        storage=storage,
+        embedding_client=create_embedding_client(),
     )
+    integrator = Integrator(storage=storage)
+
     ingestion = IngestionService(
-        validator,
-        compiler,
-        context_builder,
-        review_engine,
-        aligner,
-        storage,
+        compiler, graph_verifier, canonicalization_auditor,
+        review_engine, global_matcher, integrator, storage,
     )
     bp = BPService(storage)
     query = QueryService(storage)
 
     return Dependencies(ingestion, bp, query)
-
-# server/app.py
-def create_app() -> FastAPI:
-    app = FastAPI()
-    deps = create_dependencies()
-    app.include_router(package_routes(deps))
-    app.include_router(query_routes(deps))
-    app.include_router(webhook_routes(deps))
-    return app
 ```
 
 ---
 
-## 6. 模块优先级
+## 7. StorageManager 接口
 
-| 模块 | 优先级 | 说明 |
-|------|--------|------|
-| Storage Layer | 高 | 一切的基础 |
-| IngestionService (Validator + Compiler + ContextBuilder + Aligner + ReviewEngine + Integrator) | 高 | 核心写入路径 |
-| QueryService (读取 + 搜索) | 中 | 搜索策略后续细化 |
-| BPService | 中 | 先复用 libs/inference/ CPU 实现 |
-| Transport Layer | 高 | HTTP routes + webhook handler |
+```python
+class StorageManager:
+    """所有存储操作的唯一门面"""
+
+    # ── Package Ingestion（三写 + Graph IR artifact）──
+    async def ingest_package(
+        self,
+        package: Package,
+        modules: list[Module],
+        knowledge_items: list[Knowledge],
+        chains: list[Chain],
+        factors: list[FactorNode],
+        submission_artifact: PackageSubmissionArtifact,
+        embeddings: list[KnowledgeEmbedding] | None = None,
+    ) -> None
+
+    # ── Canonical Binding（integration 阶段）──
+    async def write_canonical_bindings(self, bindings: list[CanonicalBinding]) -> None
+    async def get_bindings_for_package(self, package: str, version: str) -> list[CanonicalBinding]
+
+    # ── Global Canonical Node ──
+    async def upsert_global_node(self, node: GlobalCanonicalNode) -> None
+    async def get_global_node(self, global_id: str) -> GlobalCanonicalNode | None
+
+    # ── Global Inference State ──
+    async def get_inference_state(self) -> GlobalInferenceState | None
+    async def update_inference_state(self, state: GlobalInferenceState) -> None
+
+    # ── Knowledge ──
+    async def get_knowledge(self, knowledge_id: str, version: int | None = None) -> Knowledge | None
+    async def get_knowledge_versions(self, knowledge_id: str) -> list[Knowledge]
+
+    # ── Factor (Graph IR) ──
+    async def list_factors(self) -> list[FactorNode]
+    async def get_factors_by_package(self, package_id: str) -> list[FactorNode]
+
+    # ── Package / Module / Chain ──
+    async def get_package(self, package_id: str) -> Package | None
+    async def get_module(self, module_id: str) -> Module | None
+    async def get_chains_by_module(self, module_id: str) -> list[Chain]
+
+    # ── Submission Artifact（不可变快照）──
+    async def get_submission_artifact(
+        self, package: str, commit_hash: str
+    ) -> PackageSubmissionArtifact | None
+
+    # ── Probability / Belief ──
+    async def add_probabilities(self, records: list[ProbabilityRecord]) -> None
+    async def write_beliefs(self, snapshots: list[BeliefSnapshot]) -> None
+    async def get_belief_history(self, knowledge_id: str) -> list[BeliefSnapshot]
+
+    # ── 图查询（委托 GraphStore）──
+    async def get_neighbors(self, knowledge_id: str, direction: str,
+                            max_hops: int) -> Subgraph
+    async def get_subgraph(self, knowledge_id: str, max_knowledge: int) -> Subgraph
+
+    # ── 搜索 ──
+    async def search_vector(self, embedding: list[float], top_k: int) -> list[ScoredKnowledge]
+    async def search_bm25(self, text: str, top_k: int) -> list[ScoredKnowledge]
+    async def search_topology(self, seed_ids: list[str], hops: int) -> list[ScoredKnowledge]
+
+    # ── BP 用 ──
+    async def load_global_factor_graph(self) -> tuple[list[FactorNode], GlobalInferenceState]
+```
+
+与 v1.1 的关键差异：
+
+- `ingest_package` 增加 `factors` 和 `submission_artifact` 参数
+- 新增 CanonicalBinding、GlobalCanonicalNode、GlobalInferenceState 读写
+- 新增 `list_factors()` 和 `get_factors_by_package()`
+- `load_all_knowledge() + load_all_chains()` 被 `load_global_factor_graph()` 替代
 
 ---
 
-## 7. 设计决策记录
+## 8. 三写一致性
+
+Package 入库写入顺序：
+
+```
+ingest_package(pkg, factors, artifact, ...):
+    1. ContentStore.write(artifact, package, modules, knowledge, chains, factors)
+       ← source of truth 先落盘，status = 'preparing'
+    2. GraphStore.write(knowledge nodes + chain topology + factor topology)
+       ← 图拓扑
+    3. VectorStore.write(embeddings)
+       ← 向量索引
+    4. ContentStore.commit_package(package_id, version)
+       ← 翻转为 'merged'，数据变为可见
+
+    失败策略：
+    - 步骤 2/3 失败 → 数据留在 'preparing' 状态（不可见），安全重试
+    - 显式清理需要 delete_package()
+```
+
+Integration 阶段的额外写入（在 ingest 完成之后）：
+
+```
+integrate(bindings, global_nodes, inference_state):
+    1. ContentStore.write_canonical_bindings(bindings)
+    2. ContentStore.upsert_global_nodes(global_nodes)
+    3. GraphStore.write_global_topology(bindings, factor_remapping)
+    4. ContentStore.update_inference_state(inference_state)
+```
+
+---
+
+## 9. 设计决策记录
 
 | 决策 | 选择 | 理由 |
 |------|------|------|
-| 架构风格 | 分层服务 | 契合 registry 本质，规模适当，不需要 event bus 或微服务复杂性 |
-| 存储选型 | Neo4j + LanceDB + VectorStore（不变） | 现有选型满足需求 |
-| 三写一致性 | LanceDB 优先写入，失败回滚 | LanceDB 是 source of truth |
-| submit 模式 | 异步（返回 id + 轮询） | 适配 webhook 快速响应需求 |
-| webhook + direct 统一 | 共享 PackageRequest + IngestionService | 底层完全一致，只有 transport 差异 |
-| BP | 复用 libs/inference/ CPU 实现 | 现阶段够用，GPU 加速后续再做 |
-| 搜索 | 后续细化 | 架构预留三路召回接口，策略优先级低 |
-| 系统组装 | 独立 bootstrap 模块 | 解决 deps.py 做太多事的问题 |
+| Chain 与 FactorNode 共存 | 保留 Chain + 新增 FactorNode | Chain 用于结构浏览和叙事，FactorNode 用于 BP 和推理审计。粒度不同（step vs chain-level） |
+| Graph IR artifact 存为不可变快照 | PackageSubmissionArtifact | 支持 re-verify、审计追溯、重现。对应 git commit 的不可变性 |
+| CanonicalBinding 是 server-side 记录 | 不属于 package 提交物 | 只有 review/registry 有权分配全局身份 |
+| GlobalInferenceState 独立于 Graph IR | 单独的 runtime state | 概率与结构严格分离。Graph IR 是审计 artifact，InferenceState 是运行时参数 |
+| GraphStore 有两层拓扑 | Chain PREMISE/CONCLUSION + Factor FACTOR_PREMISE/CONCLUSION/CONTEXT | 向后兼容 authoring-layer 查询；Factor 层供 BP 使用 |
+| ContextBuilder 移除 | 搜索是 review/matching 的内部步骤 | 对齐 publish-pipeline.md：`gaia build context` 已被移除 |
+| Aligner → GlobalMatcher | 从"关系发现"变为"身份分配" | Graph IR 的 canonicalization 分三层；server 只做第三层 |
+| 动态因子编译废弃 | `load_global_factor_graph()` 替代 `load_all_knowledge() + load_all_chains()` | BP 从持久化 FactorNode 加载 |
 
 ---
 
-## 8. 与 Foundation Reset Plan 的关系
+## 10. 与其他文档的关系
 
-本文档是目标架构设计，为 foundation-reset-plan 中以下阶段提供方向：
+| 文档 | 关系 |
+|------|------|
+| [graph-ir.md](../graph-ir.md) | 定义 Graph IR 结构。本文档定义 server 如何存储和处理这些结构 |
+| [bp-on-graph-ir.md](../bp-on-graph-ir.md) | 定义 BP 语义。本文档的 BPService 实现这些语义 |
+| [storage-schema.md](storage-schema.md) | 需要同步更新。本文档 §4 supersedes 部分内容 |
+| [publish-pipeline.md](../review/publish-pipeline.md) | 定义 publish cycle。本文档的 IngestionService 实现该 cycle |
+| [domain-model.md](../domain-model.md) | closure kind 扩展为包含 contradiction / equivalence |
 
-- Phase 4 (storage-schema): §3 给出了存储层职责和接口的目标设计，详细 schema 见 `server/storage-schema.md`
-- Phase 5 (module-boundaries): §2-5 给出了模块划分和依赖方向的目标设计
-- Phase 6 (api-contract): §5.2 给出了目标 API 路由（非当前 API 描述）
+---
 
-以下仍需独立完成：
+## 11. 未覆盖的内容
 
-- Phase 3 (graph-spec): 图的形式化定义（节点/超边字段、遍历语义）
-- 搜索策略详细设计
-- GPU BP 架构设计
+以下需要后续独立设计：
+
+1. **storage-schema.md 同步更新** — 将 §4 的实体变化反映到详细 LanceDB 表定义和 Kuzu 建表语句
+2. **GlobalMatcher 算法** — embedding 搜索策略、match_existing vs create_new 的判定阈值
+3. **CanonicalizationAuditor 策略** — 如何评估 local canonicalization 质量
+4. **GraphVerifier 的 build 版本兼容** — 不同 `gaia build` 版本的 raw graph schema 差异处理
+5. **GlobalInferenceState 刷新策略** — 如何从 review report 的 probability judgments 生成/更新全局参数
+6. **GPU BP 架构** — large-scale BP 的分布式执行
+7. **搜索策略详细设计** — 三路召回的权重和策略

--- a/docs/foundations/server/storage-schema.md
+++ b/docs/foundations/server/storage-schema.md
@@ -2,21 +2,26 @@
 
 | 文档属性 | 值 |
 |---------|---|
-| 版本 | 1.1 |
-| 日期 | 2026-03-10 |
-| 状态 | Draft — §3.2 Neo4j 图拓扑部分为 provisional，依赖 Phase 3 graph-spec.md 确认 |
-| 关联文档 | [architecture.md](architecture.md) — Server 整体架构, [../domain-model.md](../domain-model.md) — 领域模型, [../theory/inference-theory.md](../theory/inference-theory.md) — BP 理论 |
+| 版本 | 2.0 |
+| 日期 | 2026-03-13 |
+| 状态 | Draft |
+| Supersedes | storage-schema.md v1.1 (2026-03-10) |
+| 关联文档 | [architecture.md](architecture.md) — Server 整体架构 v2.0, [../graph-ir.md](../graph-ir.md) — Graph IR 规范, [../bp-on-graph-ir.md](../bp-on-graph-ir.md) — BP on Graph IR, [../review/publish-pipeline.md](../review/publish-pipeline.md) — Publish Pipeline |
+
+> **变更摘要 (v1.1 → v2.0)：** Graph IR 使因子图成为持久化的 first-class artifact。本次修订新增 5 个实体（FactorNode、CanonicalBinding、GlobalCanonicalNode、GlobalInferenceState、PackageSubmissionArtifact），扩展 Knowledge（+kind, +parameters, +contradiction/equivalence），重写图拓扑设计（新增 Factor 层），更新所有后端分工和查询模式。
 
 ---
 
 ## 1. 设计原则
 
-- 存储模型直接基于 **Gaia Language** 概念（knowledge、chain、module、package），不引入中间的 Node/HyperEdge 抽象层
+- 存储模型基于三层概念：**Gaia Language**（authoring）→ **Graph IR**（structural）→ **Global Graph**（registry）
 - **StorageManager 是唯一门面**——domain services 不直接接触具体后端
 - 每个后端是特定数据的 **source of truth**，不是彼此的副本
-- BP 的因子图从 knowledge + chain 动态构建，不持久存储
+- **FactorNode 持久存储**——raw graph 和 local canonical graph 是 package 提交的 first-class artifact，不再动态构建
+- **概率与结构分离**——Graph IR 只存结构，概率在 GlobalInferenceState（registry 管理）
 - Knowledge 有显式版本号，同 id 同 version 只存一份
 - Belief 和 probability 保留完整演化历史
+- Package submission artifact（source + raw graph + local canonical graph + canonicalization log）作为不可变快照存储
 - 多模态资源文件存 TOS（对象存储），数据库只存元信息和路径
 
 ---
@@ -68,26 +73,36 @@ ImportRef:
 Knowledge:
     knowledge_id:  str           # 全局唯一
     version:       int           # 显式版本号，同 id 同 version 只存一份
-    type:          str           # claim | question | setting | action
+    type:          str           # claim | question | setting | action | contradiction | equivalence
+    kind:          str | None    # root-type-specific kind label（question/action 的子类型）
     content:       str
+    parameters:    list[Parameter]  # 空 = ground node，非空 = schema node（∀量化）
     prior:         float         # ∈ (0, 1)，setting 允许 1.0
     keywords:      list[str]
     source_package_id: str       # 创建此版本的 package
     source_module_id:  str
     created_at:    datetime
     embedding:     list[float] | None
+
+Parameter:
+    name:          str           # 占位符名称，如 "A", "X"
+    constraint:    str           # 约束描述
 ```
 
-**版本规则：**
-- `(knowledge_id, version)` 唯一。入库时如果已存在则跳过
-- 新版本由新 package 提交时创建，旧版本不可变
-- Belief 不在 Knowledge 表中——独立存储在 BeliefHistory 中
+**相对 v1.1 的变化：**
 
-**未来扩展：** Knowledge 之间的 bundle 和聚类通过新建边关系实现，不修改 knowledge 本身。
+| 变化 | 说明 |
+|------|------|
+| `type` 扩展 | 新增 `contradiction`, `equivalence`（Relation 作为 knowledge root type） |
+| `kind` 新增 | question/action 的子类型；equivalence 要求同 root type 同 kind |
+| `parameters` 新增 | 空 = ground node，非空 = schema node。支持 ∀ 量化 |
+| `is_schema` 派生属性 | `len(parameters) > 0` |
+
+**版本规则：** 同 v1.1——`(knowledge_id, version)` 唯一，新版本由新 package 提交时创建，旧版本不可变。
 
 ### 2.4 Chain
 
-Module 内的推理链，连接 knowledge 之间的推理关系。
+Module 内的推理链，连接 knowledge 之间的推理关系。**Authoring-layer 概念**，用于 package 结构浏览和叙事。
 
 ```
 Chain:
@@ -98,226 +113,461 @@ Chain:
     steps:         list[ChainStep]
 
 ChainStep:
-    step_index:    int           # 步骤序号（从 0 开始），作为步骤的稳定标识
-    premises:      list[KnowledgeRef]  # 引用的 knowledge（含版本）
-    reasoning:     str           # inference 文本（局部，不导出）
-    conclusion:    KnowledgeRef  # 结论 knowledge（含版本）
+    step_index:    int           # 步骤序号（从 0 开始）
+    premises:      list[KnowledgeRef]
+    reasoning:     str           # inference 文本
+    conclusion:    KnowledgeRef
 
 KnowledgeRef:
     knowledge_id:  str
-    version:       int           # 锁定引用的 knowledge 版本
+    version:       int
 ```
 
-### 2.5 ProbabilityRecord
+**与 FactorNode 的关系：** 一个 Chain 编译成一个 reasoning FactorNode（不是一步一个）。Chain 保留多步叙事结构，供浏览使用；Factor 供 BP 消费。两者通过 `FactorNode.source_ref` 关联。
 
-推理步骤的可靠性，按 `(chain_id, step_index)` 粒度存储，支持多来源动态调整。
+### 2.5 FactorNode
+
+**Graph IR 的持久化因子**（v2.0 新增）。因子定义知识节点间的约束关系，不携带 belief。
+
+```
+FactorNode:
+    factor_id:       str
+    type:            str              # reasoning | instantiation | mutex_constraint | equiv_constraint
+    premises:        list[str]        # knowledge node IDs（该图层的 ID 空间）
+    contexts:        list[str]        # knowledge node IDs（不创建 BP 边）
+    conclusion:      str              # 单个 knowledge node ID
+    source_ref:      SourceRef | None
+    metadata:        dict | None
+
+SourceRef:
+    package:         str
+    version:         str
+    module:          str
+    knowledge_name:  str
+```
+
+**四种 factor 类型：**
+
+| Factor 类型 | 生成来源 | premises | contexts | conclusion | 语义 |
+|-------------|---------|----------|----------|------------|------|
+| `reasoning` | ChainExpr | direct-dep knowledge | indirect-dep knowledge | 推理结论 | 前提真 → 结论以 conditional_probability 成立 |
+| `instantiation` | schema→ground 实例化 | `[schema node]` | `[]` | instance node | 确定性蕴含 |
+| `mutex_constraint` | Contradiction 声明 | 矛盾 claim nodes | `[]` | Contradiction node（只读门控） | 惩罚矛盾声称同时为真 |
+| `equiv_constraint` | Equivalence 声明 | 等价 claim nodes | `[]` | Equivalence node（只读门控） | 奖励等价声称一致 |
+
+**字段语义：**
+- `premises` — 直接依赖，创建 BP 边
+- `contexts` — 间接依赖，**不**创建 BP 边，影响折入 conditional_probability
+- `conclusion` — reasoning/instantiation：正常接收 BP 消息；constraint：**只读门控**（BP 读其 belief，不向其发消息）
+
+**派生属性：**
+- `is_gate_factor` = type ∈ {mutex_constraint, equiv_constraint}
+- `bp_participant_ids` = gate factor 返回 premises only，非 gate 返回 premises + [conclusion]
+
+### 2.6 CanonicalBinding
+
+**本地→全局身份映射**（v2.0 新增）。Server/registry-side 记录，不属于 package 提交物。
+
+```
+CanonicalBinding:
+    package:              str
+    version:              str
+    local_graph_hash:     str
+    local_canonical_id:   str
+    decision:             str         # match_existing | create_new
+    global_canonical_id:  str
+    decided_at:           datetime
+    decided_by:           str
+    reason:               str | None
+```
+
+**约束：**
+- `(package, version, local_graph_hash, local_canonical_id)` 唯一
+- 一个 binding 指向恰好一个 `global_canonical_id`
+- 多个 package 的 local node 可绑定到同一 global node
+- question/action 的 binding 要求 root type + kind 同时匹配
+
+### 2.7 GlobalCanonicalNode
+
+**全局去重身份**（v2.0 新增）。Registry 分配的全局知识标识。
+
+```
+GlobalCanonicalNode:
+    global_canonical_id:  str         # registry-assigned, opaque (如 gcn_<ULID>)
+    knowledge_type:       str
+    kind:                 str | None
+    representative_content: str
+    parameters:           list[Parameter]
+    member_local_nodes:   list[LocalCanonicalRef]
+    provenance:           list[PackageRef]
+    metadata:             dict | None
+
+LocalCanonicalRef:
+    package:             str
+    version:             str
+    local_canonical_id:  str
+
+PackageRef:
+    package:             str
+    version:             str
+```
+
+### 2.8 GlobalInferenceState
+
+**Registry 管理的全局推理状态**（v2.0 新增）。概率与结构严格分离——Graph IR 只存结构，此实体存运行时参数。
+
+```
+GlobalInferenceState:
+    graph_hash:          str
+    node_priors:         dict[str, float]        # keyed by global_canonical_id
+    factor_parameters:   dict[str, FactorParams] # keyed by factor_id
+    node_beliefs:        dict[str, float]        # keyed by global_canonical_id
+    updated_at:          datetime
+
+FactorParams:
+    conditional_probability: float
+```
+
+`GlobalInferenceState` 不是 package artifact。由 registry 从 peer review report 的 probability judgments 初始化，BP 运行后更新 `node_beliefs`。
+
+### 2.9 PackageSubmissionArtifact
+
+**提交快照**（v2.0 新增）。不可变，支持 re-verify 和审计追溯。
+
+```
+PackageSubmissionArtifact:
+    package_name:        str
+    commit_hash:         str
+    source_files:        dict[str, str]  # filename → YAML content
+    raw_graph:           dict             # raw_graph.json 内容
+    local_canonical_graph: dict
+    canonicalization_log: list[dict]
+    submitted_at:        datetime
+```
+
+### 2.10 ProbabilityRecord
+
+推理步骤的可靠性，按 `(chain_id, step_index)` 粒度存储。
+
+> **注意：** 这是 authoring-layer 的概率记录（对应 Chain 步骤）。全局 BP 使用 GlobalInferenceState 中的 factor_parameters，不直接使用 ProbabilityRecord。ProbabilityRecord 的主要用途是记录 review 过程中按步骤的 probability 评估历史。
 
 ```
 ProbabilityRecord:
     chain_id:      str
-    step_index:    int           # 对应 ChainStep.step_index
-    value:         float         # ∈ (0, 1]，induction 必须 < 1.0
+    step_index:    int
+    value:         float         # ∈ (0, 1]
     source:        str           # author | llm_review | lean_verify | code_verify
-    source_detail: str | None    # model name, verifier version 等
+    source_detail: str | None
     recorded_at:   datetime
 ```
 
-**步骤粒度：** Gaia Language 的 chain_expr 是多步推理，每步有独立的 probability。Review sidecar 也按步调整 `suggested_prior`。因此 probability 绑定到 `(chain_id, step_index)` 而非整个 chain。Chain 的整体可靠性可由各步概率推导（如连乘）。
+### 2.11 BeliefSnapshot
 
-**多来源策略：** 同一个 step 可有多条 ProbabilityRecord。BP 使用当前生效值，默认取最新一条。未来可支持多来源加权。
-
-**可能的 source 来源：**
-- `author` — package 作者在 YAML 中设定
-- `llm_review` — LLM review engine 评估后调整
-- `lean_verify` — Lean 4 形式化验证结果
-- `code_verify` — 代码执行验证结果
-
-### 2.6 BeliefSnapshot
-
-BP 计算结果的历史记录，追踪每个 knowledge 的信念演化。
+BP 计算结果的历史记录。
 
 ```
 BeliefSnapshot:
-    knowledge_id:  str
-    version:       int
+    knowledge_id:  str           # global_canonical_id
     belief:        float         # ∈ [0, 1]
-    bp_run_id:     str           # 哪次 BP 计算的
+    bp_run_id:     str
     computed_at:   datetime
 ```
 
-每次 BP 运行产生一批 BeliefSnapshot。可追踪任意 knowledge 的信念演化：
+**相对 v1.1 的变化：** `knowledge_id` 现在是 `global_canonical_id`（而非 package-local knowledge_id + version）。BP 在 Global Canonical Graph 上运行。
 
-```
-knowledge "Heavy objects fall faster" (prior=0.3):
-  BP run #1 (2 packages):  belief=0.28
-  BP run #2 (5 packages):  belief=0.12  ← 新矛盾证据入库
-  BP run #3 (8 packages):  belief=0.05  ← 更多反驳
-```
+### 2.12 Resource
 
-### 2.7 Resource
-
-附加资源的元信息。实际文件存 TOS，数据库只存元信息和 TOS 路径。
+附加资源的元信息。同 v1.1，不变。
 
 ```
 Resource:
-    resource_id:       str           # 全局唯一
+    resource_id:       str
     type:              str           # image | code | notebook | dataset | checkpoint | tool_output | other
-    format:            str           # png, py, ipynb, parquet, safetensors, json...
+    format:            str
     title:             str | None
     description:       str | None
     storage_backend:   str           # tos
-    storage_path:      str           # TOS bucket + key
+    storage_path:      str
     size_bytes:        int | None
     checksum:          str | None    # sha256
-    metadata:          dict          # 自由 key-value，按 type 不同存不同元信息
+    metadata:          dict
     created_at:        datetime
     source_package_id: str
 ```
 
-`metadata` 按 type 约定不同字段：
+### 2.13 ResourceAttachment
 
-| type | metadata 示例 |
-|------|-------------|
-| image | `{"width": 800, "height": 600, "caption": "Figure 3"}` |
-| code | `{"language": "python", "entrypoint": "main.py"}` |
-| notebook | `{"kernel": "python3", "cell_count": 42}` |
-| dataset | `{"rows": 10000, "columns": ["x", "y"], "format": "parquet"}` |
-| checkpoint | `{"framework": "pytorch", "model_name": "gpt-neo", "epoch": 5}` |
-| tool_output | `{"tool": "lean4", "exit_code": 0, "verified": true}` |
-
-### 2.8 ResourceAttachment
-
-Resource 和 knowledge/chain/module/package 的多对多关联。
+Resource 和实体的多对多关联。同 v1.1，不变。
 
 ```
 ResourceAttachment:
     resource_id:   str
     target_type:   str           # knowledge | chain | chain_step | module | package
-    target_id:     str           # 对应实体的 id（chain_step 使用 "chain_id:step_index" 复合键）
+    target_id:     str
     role:          str           # evidence | visualization | implementation | reproduction | supplement
-    description:   str | None    # 这个资源在此处的作用说明
+    description:   str | None
 ```
-
-一个 resource 可关联多个实体。例如一张实验图同时支撑两个 claim。
-
-**chain_step 寻址：** `ChainStep` 通过 `step_index` 获得稳定标识。当 `target_type = "chain_step"` 时，`target_id` 使用 `"chain_id:step_index"` 复合键（如 `"mod1.chain1:2"`）。
-
-### 2.9 FactorGraph（BP 运行时，不持久存储）
-
-```
-Variable:   (knowledge_id, version) → prior, current_belief
-Factor:     (chain_id, step_index) → type, current_probability, premise_ids, conclusion_id
-```
-
-每次 BP 运行时从 Knowledge + Chain + ProbabilityRecord 动态构建。每个 ChainStep 对应一个 Factor。
 
 ---
 
 ## 3. 各后端存储分工
 
-### 3.1 LanceDB — 全量信息，支持搜索和浏览
+### 3.1 LanceDB — 全量内容，source of truth
 
-LanceDB 是核心 source of truth。
+LanceDB 是核心 source of truth，存储所有实体的完整内容。
 
-| 表 | 存储内容 | 主要查询 |
-|---|---|---|
-| `packages` | Package 全部字段 | 按 name/status 查询 |
-| `modules` | Module 全部字段（含 imports） | 按 package_id 查询 |
-| `knowledge` | Knowledge 全部字段 + embedding | BM25 搜索、向量搜索、按 (id, version) 精确查 |
-| `chains` | Chain 全部字段（含 steps） | 按 module_id/package_id 查询 |
-| `probabilities` | ProbabilityRecord | 按 (chain_id, step_index) 查询历史 |
-| `belief_history` | BeliefSnapshot | 按 knowledge_id 查询演化 |
-| `resources` | Resource 元信息 | 按 type/package_id 查询 |
-| `resource_attachments` | ResourceAttachment | 按 target_type + target_id 查询 |
+| 表 | 存储内容 | 主要查询 | 相对 v1.1 |
+|---|---|---|---|
+| `packages` | Package 全部字段 | 按 name/status 查询 | 不变 |
+| `modules` | Module 全部字段（含 imports） | 按 package_id 查询 | 不变 |
+| `knowledge` | Knowledge 全部字段 + embedding | BM25 搜索、向量搜索、按 (id, version) 精确查 | **+kind, +parameters** |
+| `chains` | Chain 全部字段（含 steps） | 按 module_id/package_id 查询 | 不变 |
+| `factors` | FactorNode 全部字段 | 按 package 查、按 type 查、BP 批量加载 | **新增** |
+| `canonical_bindings` | CanonicalBinding | 按 (package, version) 查、按 global_canonical_id 反查 | **新增** |
+| `global_canonical_nodes` | GlobalCanonicalNode | 按 global_canonical_id 精确查、BM25 搜索 representative_content | **新增** |
+| `global_inference_state` | GlobalInferenceState（单行或版本化） | 加载当前状态 | **新增** |
+| `submission_artifacts` | PackageSubmissionArtifact（不可变快照） | 按 (package_name, commit_hash) 查 | **新增** |
+| `probabilities` | ProbabilityRecord | 按 (chain_id, step_index) 查询历史 | 不变 |
+| `belief_history` | BeliefSnapshot | 按 knowledge_id (global_canonical_id) 查询演化 | **key 变为 global_canonical_id** |
+| `resources` | Resource 元信息 | 按 type/package_id 查询 | 不变 |
+| `resource_attachments` | ResourceAttachment | 按 target_type + target_id 查询 | 不变 |
 
-### 3.2 Neo4j — 图拓扑，支持遍历和 BP 构建
+**Knowledge 表 PyArrow schema 变化：**
 
-> **Provisional:** 本节定义的图模型（节点类型、关系类型、属性）依赖 Phase 3 `graph-spec.md` 最终确认。在 graph-spec 完成前，此处的设计可能调整。
+```
+v1.1 columns:
+    knowledge_id, version, type, content, prior, keywords,
+    source_package_id, source_module_id, created_at, embedding
+
+v2.0 新增 columns:
+    kind:        pa.utf8()        # nullable
+    parameters:  pa.utf8()        # JSON-serialized list[Parameter]
+```
+
+**新增 factors 表 PyArrow schema：**
+
+```
+factors:
+    factor_id:    pa.utf8()
+    type:         pa.utf8()       # reasoning | instantiation | mutex_constraint | equiv_constraint
+    premises:     pa.utf8()       # JSON-serialized list[str]
+    contexts:     pa.utf8()       # JSON-serialized list[str]
+    conclusion:   pa.utf8()       # single knowledge node ID
+    source_ref:   pa.utf8()       # JSON-serialized SourceRef | null
+    metadata:     pa.utf8()       # JSON-serialized dict | null
+    package_id:   pa.utf8()       # 冗余，方便按 package 查询
+```
+
+### 3.2 GraphStore — 图拓扑，两层并存
+
+GraphStore 存储两层图拓扑：Authoring layer（Chain）和 Graph IR layer（Factor）。
 
 ```
 节点:
-    (:Knowledge  {knowledge_id, version, type, prior, belief})
-    (:Chain    {chain_id, type, probability})
+    (:Knowledge  {knowledge_id, version, type, kind})
+    (:Factor     {factor_id, type, is_gate})              # v2.0 新增
+    (:Chain      {chain_id, type})                        # 保持
+    (:GlobalCanonicalNode {global_canonical_id,           # v2.0 新增
+                           knowledge_type, kind,
+                           representative_content})
     (:Module   {module_id, name, role})
     (:Package  {package_id, name, version})
     (:Resource {resource_id, type, format})
 
-关系:
-    # 推理拓扑（BP 核心）
+关系 — Authoring layer（Chain，保持不变）:
     (:Knowledge)-[:PREMISE {step_index}]->(:Chain)
     (:Chain)-[:CONCLUSION {step_index}]->(:Knowledge)
 
-    # 组织结构
+关系 — Graph IR layer（Factor，v2.0 新增）:
+    (:Knowledge)-[:FACTOR_PREMISE]->(:Factor)             # 直接依赖，创建 BP 边
+    (:Knowledge)-[:FACTOR_CONTEXT]->(:Factor)             # 间接依赖，不创建 BP 边
+    (:Factor)-[:FACTOR_CONCLUSION]->(:Knowledge)          # conclusion
+
+关系 — Global layer（v2.0 新增）:
+    (:Knowledge)-[:CANONICAL_BINDING {decision, package, version}]->(:GlobalCanonicalNode)
+
+关系 — 组织结构（保持不变）:
     (:Knowledge)-[:BELONGS_TO]->(:Module)
     (:Chain)-[:BELONGS_TO]->(:Module)
     (:Module)-[:BELONGS_TO]->(:Package)
-
-    # 跨 module 依赖
     (:Module)-[:IMPORTS {strength}]->(:Knowledge)
-
-    # 资源关联
-    (:Resource)-[:ATTACHED_TO {role}]->(:Knowledge)
-    (:Resource)-[:ATTACHED_TO {role}]->(:Chain)
+    (:Resource)-[:ATTACHED_TO {role}]->(:Knowledge|:Chain)
 ```
 
-Belief 和 probability 的最新值冗余存在 Neo4j 节点属性上，方便遍历时直接读取。由 StorageManager 在 BP 完成或 probability 更新时同步。
+**两层拓扑的设计理由：**
+
+Chain 是 authoring-layer 概念（多步推理叙事），Factor 是 Graph IR 概念（编译后因子，BP 直接消费）。粒度不同：Chain 按步有多个 PREMISE/CONCLUSION 关系，Factor 是整条 chain 编译为一个 reasoning factor，只有 premises→conclusion。通过 `FactorNode.source_ref` 关联。
+
+**v1.1 中 belief/probability 冗余在 Neo4j 节点属性上，v2.0 不再如此**——概率存在 GlobalInferenceState，图拓扑只存结构。
 
 ### 3.3 VectorStore — 向量搜索
 
 | 存储 | 内容 |
 |---|---|
 | knowledge 向量 | `(knowledge_id, version, embedding)` |
+| global_canonical_node 向量 | `(global_canonical_id, embedding)` — GlobalMatcher 用 |
 
-查询：`search(embedding, top_k) → list[(knowledge_id, version, score)]`
+查询：`search(embedding, top_k) → list[(id, score)]`
+
+**ByteHouse embedding search：** 可作为 VectorStore 的替代后端，延后设计。当前 VectorStore 接口不变，后续可替换实现。
 
 ### 3.4 TOS — 对象存储
 
-存储实际的多模态文件（图片、代码、notebook、数据集、checkpoint 等）。
-
-数据库中 Resource.storage_path 指向 TOS 路径。
+存储实际的多模态文件。同 v1.1，数据库中 `Resource.storage_path` 指向 TOS 路径。
 
 ### 3.5 降级模式
 
 | 状态 | 影响 |
 |------|------|
-| Neo4j 不可用 | 图查询返回空，拓扑搜索跳过，入库只写 LanceDB + Vector |
-| VectorStore 不可用 | 向量搜索跳过，入库只写 LanceDB + Neo4j |
+| GraphStore 不可用 | 图查询返回空，topology search 跳过，入库只写 Content + Vector |
+| VectorStore 不可用 | 向量搜索跳过，入库只写 Content + Graph |
 | TOS 不可用 | 资源文件无法上传/下载，元信息仍可查询 |
-| LanceDB 不可用 | **系统不可用**（核心 source of truth） |
+| ContentStore (LanceDB) 不可用 | **系统不可用**（core source of truth） |
 
 ---
 
-## 4. StorageManager 接口
+## 4. 查询模式
+
+不同使用场景需要查询不同后端。
+
+### 4.1 Package 结构浏览
+
+用户查看某个 package 的结构和推理链。
+
+```
+查询路径: ContentStore (LanceDB)
+
+get_package(package_id) → Package
+get_module(module_id) → Module (含 imports, chain_ids)
+get_chains_by_module(module_id) → list[Chain] (含 steps)
+get_knowledge(knowledge_id, version) → Knowledge
+```
+
+Chain 的多步叙事在此场景中保留完整的 step 结构，供用户阅读。
+
+### 4.2 知识搜索
+
+跨 package 搜索知识。三路并行召回 + 归一化 + 加权融合。
+
+```
+vector 搜索: VectorStore.search(embedding, top_k)
+BM25 搜索:   ContentStore.search_bm25(text, top_k)
+topology:    GraphStore.search_topology(seed_ids, hops)
+
+→ 归一化 + 加权(vector=0.5, bm25=0.3, topology=0.2) + top-k
+```
+
+搜索对象：Knowledge（最终可能扩展到 GlobalCanonicalNode）。
+
+### 4.3 子图探索
+
+从某个 knowledge 出发探索相关图结构。
+
+```
+查询路径: GraphStore
+
+get_subgraph(knowledge_id, max_nodes) → Subgraph
+    → 返回相关 Knowledge + Chain + Factor 节点及关系
+
+get_neighbors(knowledge_id, direction, max_hops) → Subgraph
+    → 可指定 Authoring layer (Chain) 或 Graph IR layer (Factor) 遍历
+```
+
+### 4.4 BP 执行
+
+在 Global Canonical Graph 上运行信念传播。
+
+```
+查询路径: ContentStore (批量加载)
+
+load_global_factor_graph() → (list[FactorNode], GlobalInferenceState)
+    → FactorNode 的 premises/conclusion 使用 global_canonical_id
+    → GlobalInferenceState 提供 node_priors + factor_parameters
+    → BP 运行后更新 node_beliefs + 写入 BeliefSnapshot
+```
+
+### 4.5 Global Matching
+
+Integration 阶段为 LocalCanonicalNode 分配全局身份。
+
+```
+查询路径: VectorStore + ContentStore
+
+1. embed(LocalCanonicalNode.representative_content)
+2. VectorStore.search(embedding, top_k) → 候选 GlobalCanonicalNode
+3. ContentStore.get_global_node(global_id) → 详细信息
+4. 判定 match_existing | create_new
+5. ContentStore.write_canonical_bindings(bindings)
+6. GraphStore.write_global_topology(bindings, factor_remapping)
+```
+
+### 4.6 审计追溯
+
+回溯某个 package 的提交和验证历史。
+
+```
+查询路径: ContentStore
+
+get_submission_artifact(package, commit_hash) → PackageSubmissionArtifact
+    → 包含 source YAMLs, raw_graph, local_canonical_graph, canonicalization_log
+    → 不可变快照，支持 re-verify
+get_bindings_for_package(package, version) → list[CanonicalBinding]
+```
+
+---
+
+## 5. StorageManager 接口
 
 ```python
 class StorageManager:
     """所有存储操作的唯一门面"""
 
-    # ── Package 入库（三写原子性）──
-    async def ingest_package(self, package: PackageData) -> IngestResult
+    # ── Package Ingestion（三写 + Graph IR artifact）──
+    async def ingest_package(
+        self,
+        package: Package,
+        modules: list[Module],
+        knowledge_items: list[Knowledge],
+        chains: list[Chain],
+        factors: list[FactorNode],
+        submission_artifact: PackageSubmissionArtifact,
+        embeddings: list[KnowledgeEmbedding] | None = None,
+    ) -> None
+
+    # ── Canonical Binding（integration 阶段）──
+    async def write_canonical_bindings(self, bindings: list[CanonicalBinding]) -> None
+    async def get_bindings_for_package(self, package: str, version: str) -> list[CanonicalBinding]
+
+    # ── Global Canonical Node ──
+    async def upsert_global_node(self, node: GlobalCanonicalNode) -> None
+    async def get_global_node(self, global_id: str) -> GlobalCanonicalNode | None
+
+    # ── Global Inference State ──
+    async def get_inference_state(self) -> GlobalInferenceState | None
+    async def update_inference_state(self, state: GlobalInferenceState) -> None
 
     # ── Knowledge ──
     async def get_knowledge(self, knowledge_id: str, version: int | None = None) -> Knowledge | None
-    async def get_knowledge_list(self, knowledge_ids: list[str]) -> list[Knowledge]
     async def get_knowledge_versions(self, knowledge_id: str) -> list[Knowledge]
 
-    # ── Package / Module ──
+    # ── Factor (Graph IR) ──
+    async def list_factors(self) -> list[FactorNode]
+    async def get_factors_by_package(self, package_id: str) -> list[FactorNode]
+
+    # ── Package / Module / Chain ──
     async def get_package(self, package_id: str) -> Package | None
     async def get_module(self, module_id: str) -> Module | None
     async def get_chains_by_module(self, module_id: str) -> list[Chain]
 
-    # ── Probability（按步粒度，动态多来源）──
-    async def add_probability(self, record: ProbabilityRecord) -> None
-    async def get_probability(self, chain_id: str, step_index: int) -> float
-    async def get_probability_history(self, chain_id: str,
-                                      step_index: int | None = None) -> list[ProbabilityRecord]
+    # ── Submission Artifact（不可变快照）──
+    async def get_submission_artifact(
+        self, package: str, commit_hash: str
+    ) -> PackageSubmissionArtifact | None
 
-    # ── Belief（BP 结果，按版本化 knowledge）──
-    async def write_beliefs(self, bp_run_id: str,
-                            beliefs: dict[tuple[str, int], float]) -> None  # key=(knowledge_id, version)
-    async def get_current_belief(self, knowledge_id: str, version: int | None = None) -> float | None
-    async def get_belief_history(self, knowledge_id: str,
-                                 version: int | None = None) -> list[BeliefSnapshot]
+    # ── Probability / Belief ──
+    async def add_probabilities(self, records: list[ProbabilityRecord]) -> None
+    async def write_beliefs(self, snapshots: list[BeliefSnapshot]) -> None
+    async def get_belief_history(self, knowledge_id: str) -> list[BeliefSnapshot]
 
     # ── Resource ──
     async def write_resources(self, resources: list[Resource],
@@ -325,9 +575,8 @@ class StorageManager:
     async def get_resource(self, resource_id: str) -> Resource | None
     async def get_resources_for(self, target_type: str, target_id: str) -> list[Resource]
 
-    # ── 图查询（委托 Neo4j）──
+    # ── 图查询（委托 GraphStore）──
     async def get_neighbors(self, knowledge_id: str, direction: str,
-                            chain_types: list[str] | None,
                             max_hops: int) -> Subgraph
     async def get_subgraph(self, knowledge_id: str, max_knowledge: int) -> Subgraph
 
@@ -337,20 +586,29 @@ class StorageManager:
     async def search_topology(self, seed_ids: list[str], hops: int) -> list[ScoredKnowledge]
 
     # ── BP 用 ──
-    async def load_all_knowledge(self) -> list[Knowledge]
-    async def load_all_chains(self) -> list[Chain]
-    async def load_all_probabilities(self) -> dict[tuple[str, int], float]  # key=(chain_id, step_index)
+    async def load_global_factor_graph(self) -> tuple[list[FactorNode], GlobalInferenceState]
 ```
+
+**与 v1.1 的关键差异：**
+
+| 变化 | 说明 |
+|------|------|
+| `ingest_package` 增加参数 | 新增 `factors` 和 `submission_artifact` |
+| 新增 CanonicalBinding 读写 | `write_canonical_bindings`, `get_bindings_for_package` |
+| 新增 GlobalCanonicalNode 读写 | `upsert_global_node`, `get_global_node` |
+| 新增 GlobalInferenceState | `get_inference_state`, `update_inference_state` |
+| 新增 Factor 查询 | `list_factors`, `get_factors_by_package` |
+| BP 加载方式 | `load_all_knowledge() + load_all_chains()` → `load_global_factor_graph()` |
 
 ---
 
-## 5. 各后端 ABC
+## 6. 各后端 ABC
 
 ```python
 class ContentStore(ABC):
     """LanceDB — 全量内容与元数据"""
 
-    # 写入
+    # 写入 — Authoring layer
     async def write_package(self, package: PackageData) -> None
     async def write_knowledge(self, knowledge_list: list[Knowledge]) -> None
     async def write_chains(self, chains: list[Chain]) -> None
@@ -359,7 +617,16 @@ class ContentStore(ABC):
     async def write_resources(self, resources: list[Resource],
                               attachments: list[ResourceAttachment]) -> None
 
-    # 读取
+    # 写入 — Graph IR layer (v2.0 新增)
+    async def write_factors(self, factors: list[FactorNode]) -> None
+    async def write_submission_artifact(self, artifact: PackageSubmissionArtifact) -> None
+
+    # 写入 — Global layer (v2.0 新增)
+    async def write_canonical_bindings(self, bindings: list[CanonicalBinding]) -> None
+    async def upsert_global_nodes(self, nodes: list[GlobalCanonicalNode]) -> None
+    async def update_inference_state(self, state: GlobalInferenceState) -> None
+
+    # 读取 — Authoring layer
     async def get_knowledge(self, knowledge_id: str, version: int | None) -> Knowledge | None
     async def get_knowledge_versions(self, knowledge_id: str) -> list[Knowledge]
     async def get_package(self, package_id: str) -> Package | None
@@ -370,6 +637,16 @@ class ContentStore(ABC):
     async def get_belief_history(self, knowledge_id: str) -> list[BeliefSnapshot]
     async def get_resources_for(self, target_type: str, target_id: str) -> list[Resource]
 
+    # 读取 — Graph IR layer (v2.0 新增)
+    async def list_factors(self) -> list[FactorNode]
+    async def get_factors_by_package(self, package_id: str) -> list[FactorNode]
+    async def get_submission_artifact(self, package: str, commit_hash: str) -> PackageSubmissionArtifact | None
+
+    # 读取 — Global layer (v2.0 新增)
+    async def get_canonical_bindings(self, package: str, version: str) -> list[CanonicalBinding]
+    async def get_global_node(self, global_id: str) -> GlobalCanonicalNode | None
+    async def get_inference_state(self) -> GlobalInferenceState | None
+
     # 搜索
     async def search_bm25(self, text: str, top_k: int) -> list[ScoredKnowledge]
 
@@ -379,13 +656,18 @@ class ContentStore(ABC):
 
 
 class GraphStore(ABC):
-    """Neo4j — 图拓扑"""
+    """图拓扑 — 两层结构"""
 
-    # 写入
+    # 写入 — Authoring layer（保持不变）
     async def write_topology(self, knowledge_list: list[Knowledge], chains: list[Chain]) -> None
     async def write_resource_links(self, attachments: list[ResourceAttachment]) -> None
-    async def update_beliefs(self, beliefs: dict[str, float]) -> None
-    async def update_probability(self, chain_id: str, step_index: int, value: float) -> None
+
+    # 写入 — Graph IR layer (v2.0 新增)
+    async def write_factor_topology(self, factors: list[FactorNode]) -> None
+
+    # 写入 — Global layer (v2.0 新增)
+    async def write_global_topology(self, bindings: list[CanonicalBinding],
+                                     global_nodes: list[GlobalCanonicalNode]) -> None
 
     # 查询
     async def get_neighbors(self, knowledge_id: str, direction: str,
@@ -401,42 +683,81 @@ class VectorStore(ABC):
     async def search(self, embedding: list[float], top_k: int) -> list[ScoredKnowledge]
 ```
 
+**与 v1.1 的 GraphStore 差异：**
+- 移除 `update_beliefs` 和 `update_probability`（概率不再冗余在图节点上）
+- 新增 `write_factor_topology`（Factor 层拓扑写入）
+- 新增 `write_global_topology`（GlobalCanonicalNode + CANONICAL_BINDING 关系写入）
+
 ---
 
-## 6. 三写一致性
+## 7. 写入一致性
 
-Package 入库是 server 唯一的写入路径：
+### 7.1 Package Ingestion（三写）
 
 ```
-ingest_package(pkg):
-    1. LanceDB.write(knowledge, chains, modules, package, resources)  ← source of truth 先落盘
-    2. Neo4j.write(topology + resource links)                        ← 图拓扑
-    3. VectorStore.write(embeddings)                                  ← 向量索引
+ingest_package(pkg, factors, artifact, ...):
+    1. ContentStore.write(artifact, package, modules, knowledge, chains, factors)
+       ← source of truth 先落盘，status = 'preparing'
+    2. GraphStore.write(knowledge nodes + chain topology + factor topology)
+       ← 两层图拓扑
+    3. VectorStore.write(embeddings)
+       ← 向量索引
+    4. ContentStore.commit_package(package_id, version)
+       ← 翻转为 'merged'，数据变为可见
 
     失败策略：
-    - 步骤 2 失败 → 删除步骤 1 写入的记录
-    - 步骤 3 失败 → 删除步骤 1、2 写入的记录
-    - LanceDB 优先：它是 source of truth，最先写入
+    - 步骤 2/3 失败 → 数据留在 'preparing' 状态（不可见），安全重试
+    - 显式清理需要 delete_package()
 ```
 
-其他写入路径（非 package 入库）：
-- `add_probability()` → 写 LanceDB（按 chain_id + step_index）+ 同步 Neo4j 属性
-- `write_beliefs()` → 写 LanceDB belief_history（按 knowledge_id + version）+ 同步 Neo4j 属性
+### 7.2 Integration（在 ingestion 之后）
+
+```
+integrate(bindings, global_nodes, inference_state):
+    1. ContentStore.write_canonical_bindings(bindings)
+    2. ContentStore.upsert_global_nodes(global_nodes)
+    3. GraphStore.write_global_topology(bindings, global_nodes)
+       ← CANONICAL_BINDING 关系 + GlobalCanonicalNode 节点
+    4. ContentStore.update_inference_state(inference_state)
+```
+
+### 7.3 BP 结果写入
+
+```
+write_bp_results(beliefs, bp_run_id):
+    1. ContentStore.update_inference_state(updated_state)
+       ← 更新 node_beliefs
+    2. ContentStore.write_belief_snapshots(snapshots)
+       ← 历史记录
+```
 
 ---
 
-## 7. 设计决策记录
+## 8. 设计决策记录
 
 | 决策 | 选择 | 理由 |
 |------|------|------|
-| 数据模型基础 | Gaia Language 概念（knowledge/chain/module/package） | 直接对齐领域模型，不引入中间抽象 |
-| Knowledge 版本 | 显式版本号，`(knowledge_id, version)` 唯一 | 支持 track 用户多次提交修订 |
-| 版本化引用 | ChainStep 通过 KnowledgeRef 锁定 `(knowledge_id, version)` | 避免多版本歧义，chain 始终引用确定的 knowledge 版本 |
-| Probability 粒度 | 按 `(chain_id, step_index)` 而非整个 chain | 对齐 Gaia Language 多步推理和 review sidecar 按步调整 |
-| ChainStep 标识 | `step_index` 作为稳定标识，复合键 `chain_id:step_index` | 支持 ResourceAttachment 和 ProbabilityRecord 的步骤级引用 |
-| Belief | 保留完整演化历史 | 可追踪命题可信度随时间变化 |
-| 因子图 | 不持久存储，每次 BP 运行时构建 | 因子图是派生数据，不是 source of truth |
-| 多模态资源 | Resource + ResourceAttachment + TOS | 灵活关联，文件存 TOS |
-| Neo4j 超边建模 | Chain 作为中间节点（provisional，依赖 graph-spec） | 保留"多前提联合支持结论"的超边语义 |
-| Neo4j belief/probability | 冗余存储最新值在节点属性 | 方便遍历时直接读取 |
-| 术语 | premises/conclusions（不用 head/tail） | 对齐 Gaia Language 领域词汇 |
+| 数据模型基础 | 三层：Gaia Language → Graph IR → Global Graph | 对齐 Graph IR 架构，每层有明确职责 |
+| 因子图 | **持久存储** FactorNode | Graph IR 使 factor 成为 first-class artifact，不再是派生数据 |
+| Chain 与 FactorNode 共存 | 两层图拓扑 | Chain 用于叙事浏览（按步），Factor 用于 BP（按 ChainExpr），粒度不同 |
+| 概率存储 | 从 Knowledge/Chain 属性分离到 GlobalInferenceState | 概率与结构严格分离，对齐 Graph IR 设计 |
+| GraphStore 不存概率 | 移除 belief/probability 节点属性 | 概率集中在 GlobalInferenceState，避免多处同步 |
+| Knowledge 版本 | 保持 `(knowledge_id, version)` 唯一 | v1.1 设计合理，无需改变 |
+| Knowledge 扩展 | +kind, +parameters, +contradiction/equivalence | 对齐 Graph IR 的 knowledge node 定义 |
+| CanonicalBinding 位置 | Server/registry-side 记录，不属于 package 提交 | 全局身份分配是 registry 职责 |
+| GlobalInferenceState | 独立实体，不嵌入 Graph IR | 概率是运行时参数，不是审计 artifact |
+| 提交快照 | PackageSubmissionArtifact 不可变 | 支持 re-verify、审计追溯、重现 |
+| BeliefSnapshot key | 从 (knowledge_id, version) 改为 global_canonical_id | BP 在 Global Canonical Graph 上运行 |
+| VectorStore 后端 | 当前 LanceDB，ByteHouse 延后 | 接口不变，后续可替换实现 |
+| 术语 | premises/conclusions/contexts | 对齐 Graph IR 和 BP on Graph IR 文档 |
+
+---
+
+## 9. 与其他文档的关系
+
+| 文档 | 关系 |
+|------|------|
+| [architecture.md](architecture.md) v2.0 | 本文档 §2-3 展开 architecture.md §4 的实体和后端设计 |
+| [../graph-ir.md](../graph-ir.md) | 定义 Graph IR 结构。本文档定义 server 如何存储这些结构 |
+| [../bp-on-graph-ir.md](../bp-on-graph-ir.md) | 定义 BP 语义。影响 FactorNode 字段设计和 GlobalInferenceState 结构 |
+| [../review/publish-pipeline.md](../review/publish-pipeline.md) | 定义 publish cycle。影响 PackageSubmissionArtifact 和 CanonicalBinding 的写入时机 |


### PR DESCRIPTION
## Summary

- **architecture.md v1.1 → v2.0**: Rewrites server architecture to align with Graph IR. Factor graphs become persistent first-class artifacts. New IngestionService pipeline (verify → audit → review → match → integrate). BPService loads from persisted FactorNodes + GlobalInferenceState instead of dynamic compilation. New entities: FactorNode, CanonicalBinding, GlobalCanonicalNode, GlobalInferenceState, PackageSubmissionArtifact.
- **storage-schema.md v1.1 → v2.0**: Expands LanceDB from 8 to 13 tables. Two-layer graph topology (Chain authoring + Factor BP-facing). Knowledge gains +kind, +parameters, +contradiction/equivalence. Probability/structure separation. New §4 documenting query patterns for 6 use cases (browsing, search, subgraph, BP, global matching, audit).

## Context

Follows Graph IR spec (#125) which introduced persistent factor graphs, three-layer canonicalization (Raw → Local Canonical → Global Canonical), and probability/structure separation. These design docs define how the server stores, verifies, and processes Graph IR artifacts.

## Test plan

- [ ] Review architecture.md v2.0 for consistency with graph-ir.md and bp-on-graph-ir.md
- [ ] Review storage-schema.md v2.0 entity definitions match architecture.md §4
- [ ] Verify query patterns in §4 cover all domain service use cases
- [ ] Confirm backward-compatible entities (Package, Module, Chain, Resource) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)