### PR TITLE
fix(lang): preserve Typst relation and renderer semantics

### DIFF
--- a/libs/lang/proof_state.py
+++ b/libs/lang/proof_state.py
@@ -8,7 +8,7 @@ without proofs), and which are open questions.
 
 from __future__ import annotations
 
-RELATION_TYPES = {"contradiction", "equivalence"}
+RELATION_TYPES = {"contradiction", "equivalence", "corroboration"}
 
 
 def analyze_proof_state(graph: dict) -> dict:

--- a/libs/lang/typst_clean_renderer.py
+++ b/libs/lang/typst_clean_renderer.py
@@ -19,8 +19,10 @@ from .typst_loader import load_typst_package
 _TYPE_LABELS = {
     "claim": "主张",
     "setting": "设定",
+    "observation": "观察",
     "question": "问题",
     "contradiction": "矛盾",
+    "corroboration": "印证",
     "equivalence": "等价",
 }
 
@@ -164,9 +166,12 @@ def render_typst_to_clean_typst(pkg_path: Path, output: Path | None = None) -> s
     # ── Pre-compute ──
     node_map = {n["name"]: n for n in graph["nodes"]}
 
-    chain_nodes = set()
-    for factor in graph.get("factors", []):
-        chain_nodes.add(factor.get("conclusion", ""))
+    factor_by_conclusion = {
+        factor["conclusion"]: factor
+        for factor in graph.get("factors", [])
+        if factor.get("conclusion")
+    }
+    proved_nodes = set(factor_by_conclusion)
 
     chains: dict[str, list[dict]] = {}
     for factor in graph.get("factors", []):
@@ -210,7 +215,7 @@ def render_typst_to_clean_typst(pkg_path: Path, output: Path | None = None) -> s
 
         # ── Independent knowledge ──
         mod_nodes = nodes_by_module.get(mod_name, [])
-        independent = [n for n in mod_nodes if n["name"] not in chain_nodes]
+        independent = [n for n in mod_nodes if n["name"] not in proved_nodes]
 
         groups: list[list[dict]] = []
         for node in independent:
@@ -227,6 +232,22 @@ def render_typst_to_clean_typst(pkg_path: Path, output: Path | None = None) -> s
                 tl = _type_label(node["type"])
                 content = _clean_text(node["content"])
                 lines.append(f"- {content}（{tl}） {_label(node['name'])}")
+
+        # ── v3 single-claim proofs (no chain field) ──
+        for node in mod_nodes:
+            factor = factor_by_conclusion.get(node["name"])
+            if factor is None or factor.get("chain"):
+                continue
+
+            lines.append("")
+            lines.append(f"=== {node['name'].replace('_', ' ')} {_label(node['name'])}")
+            _render_single_step(
+                lines,
+                factor,
+                _clean_text(node["content"]),
+                _type_label(node["type"]),
+                node["name"],
+            )
 
         # ── Chains ──
         for chain_name in chains_by_module.get(mod_name, []):

--- a/libs/lang/typst_loader.py
+++ b/libs/lang/typst_loader.py
@@ -8,6 +8,15 @@ from pathlib import Path
 import typst
 
 
+def _flatten_fraction_part(node: dict | str | list | None) -> str:
+    flat = _flatten_content(node).strip()
+    if not flat:
+        return ""
+    if any(ch.isspace() for ch in flat):
+        return f"({flat})"
+    return flat
+
+
 def _flatten_content(node: dict | str | list) -> str:
     """Recursively flatten a Typst content tree to plain text."""
     if isinstance(node, str):
@@ -18,6 +27,8 @@ def _flatten_content(node: dict | str | list) -> str:
         func = node.get("func", "")
         if func == "text":
             return node.get("text", "")
+        if func == "symbol":
+            return node.get("text", "")
         if func == "space":
             return " "
         if func == "parbreak":
@@ -26,15 +37,35 @@ def _flatten_content(node: dict | str | list) -> str:
             return "\n"
         if func == "smartquote":
             return '"'
+        if func == "primes":
+            return "'" * node.get("count", 0)
         if func == "ref":
             target = node.get("target", "")
             # Strip angle brackets: "<foo-bar>" → "foo-bar", then restore underscores
             return target.strip("<>").replace("-", "_")
+        if func == "equation":
+            return _flatten_content(node.get("body")).strip()
+        if func == "frac":
+            num = _flatten_fraction_part(node.get("num"))
+            denom = _flatten_fraction_part(node.get("denom"))
+            if num and denom:
+                return f"{num}/{denom}"
+            return num or denom
+        if func == "attach":
+            parts = [_flatten_content(node.get("base"))]
+            for key, prefix in (("b", "_"), ("t", "^"), ("tr", "")):
+                value = node.get(key)
+                if value is None:
+                    continue
+                flat = _flatten_content(value).strip()
+                if flat:
+                    parts.append(f"{prefix}{flat}")
+            return "".join(parts)
         children = node.get("children", [])
         if children:
             return "".join(_flatten_content(c) for c in children)
         body = node.get("body")
-        if body:
+        if body is not None:
             return _flatten_content(body)
     return ""
 
@@ -70,7 +101,9 @@ def load_typst_package(pkg_path: Path) -> dict:
 
     # Flatten content in nodes
     for node in data.get("nodes", []):
-        if isinstance(node.get("content"), (dict, list)):
+        if node.get("content") is None:
+            node["content"] = ""
+        elif isinstance(node.get("content"), (dict, list)):
             node["content"] = _flatten_content(node["content"]).strip()
         # Normalize ctx -> context key for downstream consumers (v1 compat)
         if "ctx" in node:

--- a/libs/lang/typst_renderer.py
+++ b/libs/lang/typst_renderer.py
@@ -19,6 +19,7 @@ _TYPE_LABELS = {
     "observation": "observation",
     "question": "question",
     "contradiction": "contradiction",
+    "corroboration": "corroboration",
     "equivalence": "equivalence",
 }
 
@@ -29,7 +30,7 @@ _KNOWLEDGE_TYPES = {"setting", "observation"}
 _QUESTION_TYPES = {"question"}
 
 # Relation types that belong in the Constraints section
-_RELATION_TYPES = {"contradiction", "equivalence"}
+_RELATION_TYPES = {"contradiction", "equivalence", "corroboration"}
 
 
 def _clean_text(text: str) -> str:

--- a/tests/libs/lang/test_proof_state.py
+++ b/tests/libs/lang/test_proof_state.py
@@ -149,6 +149,17 @@ def test_newton_v3_derivation_chain():
     assert "apollo_galileo_convergence" in constraint_names
 
 
+def test_newton_v3_corroborations_are_established():
+    graph = load_typst_package(NEWTON_V3)
+    state = analyze_proof_state(graph)
+    established = {d["name"] for d in state["established"]}
+    standalone = {d["name"] for d in state["standalone"]}
+    assert "galileo_newton_convergence" in established
+    assert "apollo_galileo_convergence" in established
+    assert "galileo_newton_convergence" not in standalone
+    assert "apollo_galileo_convergence" not in standalone
+
+
 def test_newton_v3_only_axioms_are_holes():
     """Only the two axioms (second/third law) should be holes."""
     graph = load_typst_package(NEWTON_V3)
@@ -206,6 +217,15 @@ def test_einstein_v3_constraints():
     assert set(constraint_map["gr_dual_confirmation"]["between"]) == {
         "eddington_confirms_gr", "gr_mercury_precession"
     }
+
+
+def test_einstein_v3_corroboration_is_established():
+    graph = load_typst_package(EINSTEIN_V3)
+    state = analyze_proof_state(graph)
+    established = {d["name"] for d in state["established"]}
+    standalone = {d["name"] for d in state["standalone"]}
+    assert "gr_dual_confirmation" in established
+    assert "gr_dual_confirmation" not in standalone
 
 
 def test_einstein_v3_holes():

--- a/tests/libs/lang/test_typst_clean_renderer.py
+++ b/tests/libs/lang/test_typst_clean_renderer.py
@@ -1,0 +1,28 @@
+"""Tests for Typst -> clean Typst rendering."""
+
+from pathlib import Path
+
+from libs.lang.typst_clean_renderer import render_typst_to_clean_typst
+
+_FIXTURES = Path(__file__).parent.parent.parent / "fixtures" / "gaia_language_packages"
+GALILEO_V3 = _FIXTURES / "galileo_falling_bodies_v3"
+NEWTON_V3 = _FIXTURES / "newton_principia_v3"
+EINSTEIN_V3 = _FIXTURES / "einstein_gravity_v3"
+
+
+def test_clean_renderer_keeps_galileo_proved_claims():
+    text = render_typst_to_clean_typst(GALILEO_V3)
+    assert "vacuum prediction" in text
+    assert "air resistance is confound" in text
+
+
+def test_clean_renderer_keeps_newton_proved_claims():
+    text = render_typst_to_clean_typst(NEWTON_V3)
+    assert "law of gravity" in text
+    assert "freefall acceleration equals g" in text
+
+
+def test_clean_renderer_keeps_einstein_proved_claims():
+    text = render_typst_to_clean_typst(EINSTEIN_V3)
+    assert "gr light deflection" in text
+    assert "gr mercury precession" in text

--- a/tests/libs/lang/test_typst_loader.py
+++ b/tests/libs/lang/test_typst_loader.py
@@ -11,6 +11,12 @@ GALILEO_V3 = (
     / "gaia_language_packages"
     / "galileo_falling_bodies_v3"
 )
+EINSTEIN_V3 = (
+    Path(__file__).parent.parent.parent
+    / "fixtures"
+    / "gaia_language_packages"
+    / "einstein_gravity_v3"
+)
 
 
 def test_load_typst_package_returns_graph_with_nodes():
@@ -141,3 +147,13 @@ def test_v3_node_has_no_premise_field():
         assert "module" in node
         assert "premise" not in node
         assert "context" not in node
+
+
+def test_v3_math_content_is_preserved():
+    graph = load_typst_package(EINSTEIN_V3)
+    node_map = {node["name"]: node["content"] for node in graph["nodes"]}
+    assert "1.75''" in node_map["gr_light_deflection"]
+    assert "43''" in node_map["mercury_perihelion"]
+    assert "10^" in node_map["eotvos_experiment"]
+    assert "m_i" in node_map["eotvos_experiment"]
+    assert "m_g" in node_map["eotvos_experiment"]

--- a/tests/libs/lang/test_typst_renderer.py
+++ b/tests/libs/lang/test_typst_renderer.py
@@ -11,6 +11,18 @@ GALILEO_V3 = (
     / "gaia_language_packages"
     / "galileo_falling_bodies_v3"
 )
+NEWTON_V3 = (
+    Path(__file__).parent.parent.parent
+    / "fixtures"
+    / "gaia_language_packages"
+    / "newton_principia_v3"
+)
+EINSTEIN_V3 = (
+    Path(__file__).parent.parent.parent
+    / "fixtures"
+    / "gaia_language_packages"
+    / "einstein_gravity_v3"
+)
 
 
 def test_render_produces_nonempty_markdown():
@@ -72,3 +84,12 @@ def test_render_v3_to_file(tmp_path):
     content = out.read_text()
     assert "## Proofs" in content
     assert "## Constraints" in content
+
+
+def test_render_v3_corroboration_constraints_appear():
+    newton_md = render_typst_to_markdown(NEWTON_V3)
+    einstein_md = render_typst_to_markdown(EINSTEIN_V3)
+    assert "galileo_newton_convergence" in newton_md
+    assert "apollo_galileo_convergence" in newton_md
+    assert "gr_dual_confirmation" in einstein_md
+    assert "corroboration" in newton_md.lower()


### PR DESCRIPTION
## Summary

This PR stacks on top of #149 and fixes several downstream Typst semantics regressions introduced during the v3 language work.

- treat `corroboration` as a first-class relation in proof-state and Markdown rendering
- preserve inline math / quantitative content when flattening Typst metadata into graph text
- render v3 proved claims in clean Typst output even when factors have no `chain` field
- add regression coverage for loader, Markdown renderer, clean Typst renderer, and proof-state

## Verification

- exercised the affected Typst packages directly (`galileo_falling_bodies_v3`, `newton_principia_v3`, `einstein_gravity_v3`)
- executed all tests in `tests/libs/lang/test_typst_loader.py`, `tests/libs/lang/test_typst_renderer.py`, `tests/libs/lang/test_typst_clean_renderer.py`, and `tests/libs/lang/test_proof_state.py` via a local harness (55 passing checks)