### PR TITLE
feat: Typst → Graph IR compiler (Phase 1)

### DIFF
--- a/future/lang/plausible_core.py
+++ b/future/lang/plausible_core.py
@@ -1,0 +1,674 @@
+"""Minimal plausible-reasoning kernel prototype.
+
+This module is intentionally standalone. It does not integrate with the
+existing YAML or Typst pipelines yet; the goal is to make the proposed core
+design executable and inspectable in tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+DeclarationKind = Literal["observation", "setting", "claim", "relation", "question"]
+StructuralStatus = Literal["closed", "has_holes"]
+OriginKind = Literal["global", "local", "assumption"]
+
+
+class KernelError(ValueError):
+    """Raised when a proof is structurally invalid."""
+
+
+@dataclass(frozen=True)
+class Proof:
+    steps: list["Step"]
+
+
+@dataclass(frozen=True)
+class Observation:
+    name: str
+    text: str
+    kind: DeclarationKind = "observation"
+    proof: Proof | None = None
+
+
+@dataclass(frozen=True)
+class Setting:
+    name: str
+    text: str
+    kind: DeclarationKind = "setting"
+    proof: Proof | None = None
+
+
+@dataclass(frozen=True)
+class Claim:
+    name: str
+    text: str
+    proof: Proof | None = None
+    kind: DeclarationKind = "claim"
+
+
+@dataclass(frozen=True)
+class Relation:
+    name: str
+    relation_kind: Literal["contradiction", "equivalence"]
+    text: str
+    proof: Proof | None = None
+    kind: DeclarationKind = "relation"
+
+
+@dataclass(frozen=True)
+class Question:
+    name: str
+    text: str
+    kind: DeclarationKind = "question"
+    proof: Proof | None = None
+
+
+Declaration = Observation | Setting | Claim | Relation | Question
+
+
+@dataclass(frozen=True)
+class Use:
+    name: str
+
+
+@dataclass(frozen=True)
+class Have:
+    name: str
+    statement: str
+    proof: Proof
+
+
+@dataclass(frozen=True)
+class Assume:
+    name: str
+    statement: str
+    proof: Proof
+
+
+@dataclass(frozen=True)
+class DeductionMode:
+    supports: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AbductionMode:
+    observations: tuple[str, ...]
+    alternatives: tuple[str, ...]
+    warrant: str
+    comparison: str
+
+
+@dataclass(frozen=True)
+class SynthesisMode:
+    supports: tuple[str, ...]
+    convergence: str
+
+
+@dataclass(frozen=True)
+class ContradictionMode:
+    between: tuple[str, str]
+
+
+CloseMode = DeductionMode | AbductionMode | SynthesisMode | ContradictionMode
+
+
+@dataclass(frozen=True)
+class Close:
+    mode: CloseMode
+
+
+@dataclass(frozen=True)
+class Hole:
+    reason: str
+
+
+Step = Use | Have | Assume | Close | Hole
+
+
+@dataclass(frozen=True)
+class Program:
+    declarations: list[Declaration]
+
+    def index(self) -> dict[str, Declaration]:
+        seen: dict[str, Declaration] = {}
+        for declaration in self.declarations:
+            if declaration.name in seen:
+                raise KernelError(f"duplicate declaration '{declaration.name}'")
+            seen[declaration.name] = declaration
+        return seen
+
+
+@dataclass(frozen=True)
+class VisibleFact:
+    name: str
+    kind: str
+    text: str
+    origin: OriginKind
+
+
+@dataclass(frozen=True)
+class CheckedFinalStep:
+    strategy: str
+    premise_refs: list[VisibleFact] = field(default_factory=list)
+    alternatives: list[str] = field(default_factory=list)
+    warrant: str | None = None
+    comparison: str | None = None
+    convergence: str | None = None
+    between: list[str] = field(default_factory=list)
+    review_questions: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CheckedDerivedFact:
+    name: str
+    statement: str
+    proof: "CheckedProof"
+
+
+@dataclass(frozen=True)
+class CheckedAssumption:
+    name: str
+    statement: str
+    proof: "CheckedProof"
+
+
+@dataclass(frozen=True)
+class CheckedProof:
+    goal_name: str
+    goal_kind: str
+    goal_text: str
+    structural_status: StructuralStatus
+    trace_lines: list[str]
+    derived_facts: list[CheckedDerivedFact]
+    assumptions: list[CheckedAssumption]
+    final_step: CheckedFinalStep | None
+    holes: list[str]
+
+
+@dataclass(frozen=True)
+class CheckedDeclaration:
+    name: str
+    kind: str
+    text: str
+    relation_kind: str | None
+    proof: CheckedProof | None
+
+
+@dataclass(frozen=True)
+class CheckedProgram:
+    declarations: dict[str, CheckedDeclaration]
+
+
+@dataclass(frozen=True)
+class PacketPremise:
+    name: str
+    kind: str
+    text: str
+    origin: str
+
+
+@dataclass(frozen=True)
+class PacketFinalStep:
+    strategy: str
+    supports: list[str] = field(default_factory=list)
+    alternatives: list[str] = field(default_factory=list)
+    warrant: str | None = None
+    comparison: str | None = None
+    convergence: str | None = None
+    between: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ReviewPacketTarget:
+    name: str
+    kind: str
+    text: str
+
+
+@dataclass(frozen=True)
+class DerivedFactPacket:
+    name: str
+    text: str
+    structural_status: StructuralStatus
+    proof_trace: list[str]
+    final_step: PacketFinalStep | None
+    holes: list[str]
+
+
+@dataclass(frozen=True)
+class ReviewPacket:
+    target: ReviewPacketTarget
+    structural_status: StructuralStatus
+    direct_premises: list[PacketPremise]
+    proof_trace: list[str]
+    derived_facts: list[DerivedFactPacket]
+    final_step: PacketFinalStep | None
+    review_questions: list[str]
+    holes: list[str]
+
+
+def check_program(program: Program) -> CheckedProgram:
+    """Check every declaration proof in the program."""
+    declarations = program.index()
+    checked: dict[str, CheckedDeclaration] = {}
+
+    for declaration in program.declarations:
+        proof = None
+        if declaration.proof is not None:
+            proof = _check_proof(
+                declarations=declarations,
+                proof=declaration.proof,
+                goal_name=declaration.name,
+                goal_kind=declaration.kind,
+                goal_text=declaration.text,
+                relation_kind=getattr(declaration, "relation_kind", None),
+                scope={},
+            )
+
+        checked[declaration.name] = CheckedDeclaration(
+            name=declaration.name,
+            kind=declaration.kind,
+            text=declaration.text,
+            relation_kind=getattr(declaration, "relation_kind", None),
+            proof=proof,
+        )
+
+    return CheckedProgram(declarations=checked)
+
+
+def build_review_packet(checked: CheckedProgram, target_name: str) -> ReviewPacket:
+    """Create a deterministic review packet from a checked declaration."""
+    declaration = checked.declarations.get(target_name)
+    if declaration is None:
+        raise KernelError(f"unknown declaration '{target_name}'")
+    if declaration.proof is None:
+        raise KernelError(f"declaration '{target_name}' has no proof")
+
+    proof = declaration.proof
+    final_step = _packet_final_step(proof.final_step)
+    direct_premises = []
+    if proof.final_step is not None:
+        direct_premises = [
+            PacketPremise(
+                name=premise.name,
+                kind=premise.kind,
+                text=premise.text,
+                origin=premise.origin,
+            )
+            for premise in proof.final_step.premise_refs
+        ]
+
+    derived_facts = [
+        DerivedFactPacket(
+            name=derived.name,
+            text=derived.statement,
+            structural_status=derived.proof.structural_status,
+            proof_trace=derived.proof.trace_lines,
+            final_step=_packet_final_step(derived.proof.final_step),
+            holes=derived.proof.holes,
+        )
+        for derived in proof.derived_facts
+    ]
+
+    return ReviewPacket(
+        target=ReviewPacketTarget(
+            name=declaration.name,
+            kind=declaration.kind,
+            text=declaration.text,
+        ),
+        structural_status=proof.structural_status,
+        direct_premises=direct_premises,
+        proof_trace=proof.trace_lines,
+        derived_facts=derived_facts,
+        final_step=final_step,
+        review_questions=proof.final_step.review_questions if proof.final_step is not None else [],
+        holes=proof.holes,
+    )
+
+
+def render_review_packet_markdown(packet: ReviewPacket) -> str:
+    """Render a review packet as human-readable Markdown."""
+    lines = [
+        "# Review Target",
+        "",
+        f"- Name: {packet.target.name}",
+        f"- Kind: {packet.target.kind}",
+        f"- Structural status: {packet.structural_status}",
+        "",
+        "## Conclusion",
+        "",
+        packet.target.text,
+        "",
+    ]
+
+    if packet.direct_premises:
+        lines.extend(["## Direct Premises", ""])
+        for premise in packet.direct_premises:
+            lines.append(f"- {premise.name} [{premise.kind}, {premise.origin}]")
+            lines.append(f"  {premise.text}")
+        lines.append("")
+
+    if packet.derived_facts:
+        lines.extend(["## Derived Facts", ""])
+        for derived in packet.derived_facts:
+            lines.append(f"- {derived.name} [{derived.structural_status}]")
+            lines.append(f"  {derived.text}")
+            if derived.final_step is not None:
+                lines.append(f"  final step: {derived.final_step.strategy}")
+            if derived.holes:
+                lines.append(f"  holes: {', '.join(derived.holes)}")
+        lines.append("")
+
+    if packet.proof_trace:
+        lines.extend(["## Proof Trace", ""])
+        for line in packet.proof_trace:
+            lines.append(f"- {line}")
+        lines.append("")
+
+    if packet.final_step is not None:
+        lines.extend(["## Final Step", "", f"- Strategy: {packet.final_step.strategy}"])
+        if packet.final_step.supports:
+            lines.append(f"- Supports: {', '.join(packet.final_step.supports)}")
+        if packet.final_step.alternatives:
+            lines.append(f"- Alternatives: {', '.join(packet.final_step.alternatives)}")
+        if packet.final_step.warrant:
+            lines.append(f"- Warrant: {packet.final_step.warrant}")
+        if packet.final_step.comparison:
+            lines.append(f"- Comparison: {packet.final_step.comparison}")
+        if packet.final_step.convergence:
+            lines.append(f"- Convergence: {packet.final_step.convergence}")
+        if packet.final_step.between:
+            lines.append(f"- Between: {', '.join(packet.final_step.between)}")
+        lines.append("")
+
+    if packet.review_questions:
+        lines.extend(["## Review Questions", ""])
+        for question in packet.review_questions:
+            lines.append(f"- {question}")
+        lines.append("")
+
+    if packet.holes:
+        lines.extend(["## Holes", ""])
+        for hole in packet.holes:
+            lines.append(f"- {hole}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def _packet_final_step(final_step: CheckedFinalStep | None) -> PacketFinalStep | None:
+    if final_step is None:
+        return None
+
+    return PacketFinalStep(
+        strategy=final_step.strategy,
+        supports=[premise.name for premise in final_step.premise_refs],
+        alternatives=final_step.alternatives,
+        warrant=final_step.warrant,
+        comparison=final_step.comparison,
+        convergence=final_step.convergence,
+        between=final_step.between,
+    )
+
+
+def _check_proof(
+    declarations: dict[str, Declaration],
+    proof: Proof,
+    goal_name: str,
+    goal_kind: str,
+    goal_text: str,
+    relation_kind: str | None,
+    scope: dict[str, VisibleFact],
+) -> CheckedProof:
+    trace_lines: list[str] = []
+    derived_facts: list[CheckedDerivedFact] = []
+    assumptions: list[CheckedAssumption] = []
+    local_scope = dict(scope)
+    holes: list[str] = []
+    final_step: CheckedFinalStep | None = None
+
+    for index, step in enumerate(proof.steps):
+        is_last = index == len(proof.steps) - 1
+
+        if isinstance(step, Use):
+            if not is_last and final_step is not None:
+                raise KernelError(f"proof for '{goal_name}' continues after close")
+            visible = _lookup_global(declarations, step.name)
+            local_scope[step.name] = visible
+            trace_lines.append(f"use {step.name}")
+            continue
+
+        if isinstance(step, Have):
+            _ensure_new_local_name(step.name, local_scope, declarations)
+            trace_lines.append(f"have {step.name}")
+            checked_nested = _check_proof(
+                declarations=declarations,
+                proof=step.proof,
+                goal_name=step.name,
+                goal_kind="claim",
+                goal_text=step.statement,
+                relation_kind=None,
+                scope=dict(local_scope),
+            )
+            derived_facts.append(
+                CheckedDerivedFact(
+                    name=step.name,
+                    statement=step.statement,
+                    proof=checked_nested,
+                )
+            )
+            if checked_nested.structural_status == "closed":
+                local_scope[step.name] = VisibleFact(
+                    name=step.name,
+                    kind="local_claim",
+                    text=step.statement,
+                    origin="local",
+                )
+            else:
+                holes.append(f"derived fact '{step.name}' is incomplete")
+            continue
+
+        if isinstance(step, Assume):
+            _ensure_new_local_name(step.name, local_scope, declarations)
+            trace_lines.append(f"assume {step.name}")
+            branch_scope = dict(local_scope)
+            branch_scope[step.name] = VisibleFact(
+                name=step.name,
+                kind="assumption",
+                text=step.statement,
+                origin="assumption",
+            )
+            checked_branch = _check_proof(
+                declarations=declarations,
+                proof=step.proof,
+                goal_name=goal_name,
+                goal_kind=goal_kind,
+                goal_text=goal_text,
+                relation_kind=relation_kind,
+                scope=branch_scope,
+            )
+            assumptions.append(
+                CheckedAssumption(
+                    name=step.name,
+                    statement=step.statement,
+                    proof=checked_branch,
+                )
+            )
+            if checked_branch.structural_status != "closed":
+                holes.append(f"assumption branch '{step.name}' is incomplete")
+            continue
+
+        if isinstance(step, Hole):
+            if not is_last:
+                raise KernelError(f"hole in '{goal_name}' must be the final step")
+            holes.append(step.reason)
+            trace_lines.append(f"hole: {step.reason}")
+            continue
+
+        if isinstance(step, Close):
+            if not is_last:
+                raise KernelError(f"close in '{goal_name}' must be the final step")
+            final_step = _validate_close(
+                declarations=declarations,
+                goal_name=goal_name,
+                goal_kind=goal_kind,
+                relation_kind=relation_kind,
+                scope=local_scope,
+                mode=step.mode,
+            )
+            trace_lines.append(_close_trace(step.mode))
+            continue
+
+        raise KernelError(f"unsupported step in '{goal_name}': {step}")
+
+    if final_step is None and not holes:
+        holes.append("missing close step")
+
+    status: StructuralStatus = "closed" if final_step is not None and not holes else "has_holes"
+    return CheckedProof(
+        goal_name=goal_name,
+        goal_kind=goal_kind,
+        goal_text=goal_text,
+        structural_status=status,
+        trace_lines=trace_lines,
+        derived_facts=derived_facts,
+        assumptions=assumptions,
+        final_step=final_step if not holes else None,
+        holes=holes,
+    )
+
+
+def _lookup_global(declarations: dict[str, Declaration], name: str) -> VisibleFact:
+    declaration = declarations.get(name)
+    if declaration is None:
+        raise KernelError(f"unknown declaration '{name}'")
+    kind = declaration.kind
+    if kind == "relation":
+        kind = getattr(declaration, "relation_kind")
+    return VisibleFact(
+        name=declaration.name,
+        kind=kind,
+        text=declaration.text,
+        origin="global",
+    )
+
+
+def _ensure_new_local_name(
+    name: str,
+    scope: dict[str, VisibleFact],
+    declarations: dict[str, Declaration],
+) -> None:
+    if name in scope or name in declarations:
+        raise KernelError(f"local name '{name}' already exists")
+
+
+def _resolve_visible_names(
+    names: tuple[str, ...],
+    scope: dict[str, VisibleFact],
+    *,
+    step_name: str,
+) -> list[VisibleFact]:
+    resolved: list[VisibleFact] = []
+    for name in names:
+        visible = scope.get(name)
+        if visible is None:
+            raise KernelError(f"{step_name} references '{name}' which is not in scope")
+        resolved.append(visible)
+    return resolved
+
+
+def _validate_close(
+    declarations: dict[str, Declaration],
+    goal_name: str,
+    goal_kind: str,
+    relation_kind: str | None,
+    scope: dict[str, VisibleFact],
+    mode: CloseMode,
+) -> CheckedFinalStep:
+    if isinstance(mode, DeductionMode):
+        supports = _resolve_visible_names(mode.supports, scope, step_name="deduction")
+        _ensure_no_self_support(goal_name, supports)
+        return CheckedFinalStep(
+            strategy="deduction",
+            premise_refs=supports,
+            review_questions=[
+                "Do the cited supports bear directly on the conclusion?",
+                "Are there unstated intermediate steps?",
+                "If the supports hold, should the conclusion hold as well?",
+            ],
+        )
+
+    if isinstance(mode, AbductionMode):
+        observations = _resolve_visible_names(mode.observations, scope, step_name="abduction")
+        _ensure_no_self_support(goal_name, observations)
+        alternatives = []
+        for alternative_name in mode.alternatives:
+            _lookup_global(declarations, alternative_name)
+            if alternative_name == goal_name:
+                raise KernelError(f"self-support detected in '{goal_name}'")
+            alternatives.append(alternative_name)
+        return CheckedFinalStep(
+            strategy="abduction",
+            premise_refs=observations,
+            alternatives=alternatives,
+            warrant=mode.warrant,
+            comparison=mode.comparison,
+            review_questions=[
+                "Do the listed observations really fit the proposed explanation?",
+                "Is the candidate explanation better than the listed alternatives?",
+                "Are important alternatives missing from the comparison set?",
+                "How strong is the support if the observations are accepted?",
+            ],
+        )
+
+    if isinstance(mode, SynthesisMode):
+        supports = _resolve_visible_names(mode.supports, scope, step_name="synthesis")
+        if len(supports) < 2:
+            raise KernelError("synthesis requires at least two supports")
+        _ensure_no_self_support(goal_name, supports)
+        return CheckedFinalStep(
+            strategy="synthesis",
+            premise_refs=supports,
+            convergence=mode.convergence,
+            review_questions=[
+                "Are the support lines genuinely independent?",
+                "Does the synthesis step ignore conflicting evidence?",
+                "Do the lines of support converge strongly enough on the conclusion?",
+            ],
+        )
+
+    if isinstance(mode, ContradictionMode):
+        if goal_kind != "relation" or relation_kind != "contradiction":
+            raise KernelError(f"contradiction close is only valid for contradiction relations, not '{goal_name}'")
+        between = _resolve_visible_names(mode.between, scope, step_name="contradiction")
+        return CheckedFinalStep(
+            strategy="contradiction",
+            premise_refs=between,
+            between=[item.name for item in between],
+            review_questions=[
+                "Are the paired claims genuinely incompatible?",
+                "Does the proof make both sides strong enough before declaring contradiction?",
+            ],
+        )
+
+    raise KernelError(f"unsupported close mode in '{goal_name}'")
+
+
+def _ensure_no_self_support(goal_name: str, supports: list[VisibleFact]) -> None:
+    if any(support.name == goal_name for support in supports):
+        raise KernelError(f"self-support detected in '{goal_name}'")
+
+
+def _close_trace(mode: CloseMode) -> str:
+    if isinstance(mode, DeductionMode):
+        return f"close via deduction({', '.join(mode.supports)})"
+    if isinstance(mode, AbductionMode):
+        return f"close via abduction({', '.join(mode.observations)})"
+    if isinstance(mode, SynthesisMode):
+        return f"close via synthesis({', '.join(mode.supports)})"
+    if isinstance(mode, ContradictionMode):
+        return f"close via contradiction({', '.join(mode.between)})"
+    return "close"

--- a/future/lang/plausible_core.py
+++ b/future/lang/plausible_core.py
@@ -642,7 +642,9 @@ def _validate_close(
 
     if isinstance(mode, ContradictionMode):
         if goal_kind != "relation" or relation_kind != "contradiction":
-            raise KernelError(f"contradiction close is only valid for contradiction relations, not '{goal_name}'")
+            raise KernelError(
+                f"contradiction close is only valid for contradiction relations, not '{goal_name}'"
+            )
         between = _resolve_visible_names(mode.between, scope, step_name="contradiction")
         return CheckedFinalStep(
             strategy="contradiction",

--- a/future/lang/test_plausible_core.py
+++ b/future/lang/test_plausible_core.py
@@ -1,0 +1,246 @@
+from libs.lang.plausible_core import (
+    AbductionMode,
+    Claim,
+    Close,
+    ContradictionMode,
+    Hole,
+    KernelError,
+    Observation,
+    Proof,
+    Program,
+    Relation,
+    SynthesisMode,
+    Use,
+    Have,
+    check_program,
+    build_review_packet,
+    render_review_packet_markdown,
+)
+
+
+def test_abduction_packet_contains_process_fields():
+    program = Program(
+        declarations=[
+            Observation(
+                name="medium_effect",
+                text="In denser media, the speed gap between heavier and lighter bodies grows.",
+            ),
+            Claim(
+                name="weight_causes_speed_gap",
+                text="Weight itself causes the observed speed gap.",
+            ),
+            Claim(
+                name="air_drag_explains_gap",
+                text="Air drag is a better explanation for the observed speed gap.",
+                proof=Proof(
+                    steps=[
+                        Use("medium_effect"),
+                        Close(
+                            AbductionMode(
+                                observations=("medium_effect",),
+                                alternatives=("weight_causes_speed_gap",),
+                                warrant=(
+                                    "If drag causes the gap, denser media should amplify the difference."
+                                ),
+                                comparison=(
+                                    "The weight-only story does not explain why the gap changes with the medium."
+                                ),
+                            )
+                        ),
+                    ]
+                ),
+            ),
+        ]
+    )
+
+    checked = check_program(program)
+    packet = build_review_packet(checked, "air_drag_explains_gap")
+
+    assert packet.target.name == "air_drag_explains_gap"
+    assert packet.structural_status == "closed"
+    assert packet.final_step.strategy == "abduction"
+    assert packet.final_step.warrant == (
+        "If drag causes the gap, denser media should amplify the difference."
+    )
+    assert packet.final_step.comparison == (
+        "The weight-only story does not explain why the gap changes with the medium."
+    )
+    assert packet.direct_premises[0].name == "medium_effect"
+    assert packet.final_step.alternatives == ["weight_causes_speed_gap"]
+    assert any("alternative" in question.lower() for question in packet.review_questions)
+
+
+def test_have_can_feed_a_later_synthesis_step():
+    program = Program(
+        declarations=[
+            Observation(
+                name="medium_effect",
+                text="In denser media, the speed gap between heavier and lighter bodies grows.",
+            ),
+            Claim(
+                name="tied_ball_contradiction",
+                text="The tied-ball thought experiment undermines the heavier-falls-faster law.",
+            ),
+            Claim(
+                name="weight_causes_speed_gap",
+                text="Weight itself causes the observed speed gap.",
+            ),
+            Claim(
+                name="vacuum_prediction",
+                text="In vacuum, bodies of different weights should fall at the same rate.",
+                proof=Proof(
+                    steps=[
+                        Use("tied_ball_contradiction"),
+                        Have(
+                            name="drag_is_confound",
+                            statement="Air drag is the confound in ordinary observations.",
+                            proof=Proof(
+                                steps=[
+                                    Use("medium_effect"),
+                                    Close(
+                                        AbductionMode(
+                                            observations=("medium_effect",),
+                                            alternatives=("weight_causes_speed_gap",),
+                                            warrant=(
+                                                "If drag is the confound, denser media should amplify the gap."
+                                            ),
+                                            comparison=(
+                                                "A weight-only explanation does not predict medium sensitivity."
+                                            ),
+                                        )
+                                    ),
+                                ]
+                            ),
+                        ),
+                        Close(
+                            SynthesisMode(
+                                supports=("tied_ball_contradiction", "drag_is_confound"),
+                                convergence=(
+                                    "The thought experiment removes the old law, and the medium effect explains the leftover gap."
+                                ),
+                            )
+                        ),
+                    ]
+                ),
+            ),
+        ]
+    )
+
+    checked = check_program(program)
+    packet = build_review_packet(checked, "vacuum_prediction")
+
+    assert packet.structural_status == "closed"
+    assert packet.final_step.strategy == "synthesis"
+    assert packet.final_step.supports == ["tied_ball_contradiction", "drag_is_confound"]
+    assert len(packet.derived_facts) == 1
+    derived = packet.derived_facts[0]
+    assert derived.name == "drag_is_confound"
+    assert derived.final_step is not None
+    assert derived.final_step.strategy == "abduction"
+    assert "independent" in " ".join(packet.review_questions).lower()
+
+
+def test_relation_goal_can_close_by_contradiction():
+    program = Program(
+        declarations=[
+            Claim(
+                name="slower_than_h",
+                text="The tied pair is slower than H.",
+            ),
+            Claim(
+                name="faster_than_h",
+                text="The tied pair is faster than H.",
+            ),
+            Relation(
+                name="tied_ball_contradiction",
+                relation_kind="contradiction",
+                text="The two tied-ball conclusions cannot both hold.",
+                proof=Proof(
+                    steps=[
+                        Use("slower_than_h"),
+                        Use("faster_than_h"),
+                        Close(ContradictionMode(between=("slower_than_h", "faster_than_h"))),
+                    ]
+                ),
+            ),
+        ]
+    )
+
+    checked = check_program(program)
+    packet = build_review_packet(checked, "tied_ball_contradiction")
+
+    assert packet.final_step is not None
+    assert packet.final_step.strategy == "contradiction"
+    assert packet.final_step.between == ["slower_than_h", "faster_than_h"]
+
+
+def test_unknown_reference_is_rejected():
+    program = Program(
+        declarations=[
+            Claim(
+                name="broken_claim",
+                text="Broken.",
+                proof=Proof(steps=[Use("missing_fact"), Hole("unfinished")]),
+            )
+        ]
+    )
+
+    try:
+        check_program(program)
+    except KernelError as exc:
+        assert "missing_fact" in str(exc)
+    else:
+        raise AssertionError("expected KernelError")
+
+
+def test_self_support_is_rejected():
+    program = Program(
+        declarations=[
+            Observation(name="medium_effect", text="Observed medium effect."),
+            Claim(
+                name="air_drag_explains_gap",
+                text="Air drag explains the gap.",
+                proof=Proof(
+                    steps=[
+                        Use("medium_effect"),
+                        Use("air_drag_explains_gap"),
+                        Close(
+                            SynthesisMode(
+                                supports=("medium_effect", "air_drag_explains_gap"),
+                                convergence="Bad circular closure.",
+                            )
+                        ),
+                    ]
+                ),
+            ),
+        ]
+    )
+
+    try:
+        check_program(program)
+    except KernelError as exc:
+        assert "self-support" in str(exc)
+    else:
+        raise AssertionError("expected KernelError")
+
+
+def test_hole_marks_packet_incomplete():
+    program = Program(
+        declarations=[
+            Observation(name="medium_effect", text="Observed medium effect."),
+            Claim(
+                name="unfinished_claim",
+                text="An unfinished claim.",
+                proof=Proof(steps=[Use("medium_effect"), Hole("missing close step")]),
+            ),
+        ]
+    )
+
+    checked = check_program(program)
+    packet = build_review_packet(checked, "unfinished_claim")
+    markdown = render_review_packet_markdown(packet)
+
+    assert packet.structural_status == "has_holes"
+    assert packet.final_step is None
+    assert packet.holes == ["missing close step"]
+    assert "missing close step" in markdown

--- a/libs/graph_ir/build_utils.py
+++ b/libs/graph_ir/build_utils.py
@@ -1,0 +1,134 @@
+"""Source-agnostic Graph IR build utilities.
+
+Extracted from build.py. These functions operate on Graph IR models
+and do not depend on any source language (YAML or Typst).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from hashlib import sha256
+
+from .models import (
+    CanonicalizationLogEntry,
+    FactorNode,
+    LocalCanonicalGraph,
+    LocalCanonicalNode,
+    Parameter,
+    RawGraph,
+)
+
+_PLACEHOLDER_RE = re.compile(r"{([A-Za-z_][A-Za-z0-9_]*)}")
+
+
+@dataclass
+class CanonicalizationResult:
+    local_graph: LocalCanonicalGraph
+    log: list[CanonicalizationLogEntry]
+
+
+def raw_node_id(
+    package: str,
+    version: str,
+    module_name: str,
+    knowledge_name: str,
+    knowledge_type: str,
+    kind: str | None,
+    content: str,
+    parameters: list[Parameter],
+) -> str:
+    """Generate a deterministic raw node ID from its identity fields."""
+    payload = {
+        "package": package,
+        "version": version,
+        "module_name": module_name,
+        "knowledge_name": knowledge_name,
+        "knowledge_type": knowledge_type,
+        "kind": kind,
+        "content": content,
+        "parameters": [p.model_dump(mode="json") for p in parameters],
+    }
+    digest = sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return f"raw_{digest[:16]}"
+
+
+def local_canonical_id(raw_id: str) -> str:
+    """Generate a deterministic local canonical ID from a raw node ID."""
+    digest = sha256(raw_id.encode("utf-8")).hexdigest()
+    return f"lcn_{digest[:16]}"
+
+
+def factor_id(kind: str, module_name: str, name: str, suffix: str | None = None) -> str:
+    """Generate a deterministic factor ID."""
+    raw = f"{kind}:{module_name}:{name}"
+    if suffix is not None:
+        raw = f"{raw}:{suffix}"
+    digest = sha256(raw.encode("utf-8")).hexdigest()
+    return f"f_{digest[:16]}"
+
+
+def extract_parameters(content: str) -> list[Parameter]:
+    """Extract {X}-style parameter placeholders from content."""
+    names = sorted({match.group(1) for match in _PLACEHOLDER_RE.finditer(content)})
+    return [Parameter(name=name, constraint="unknown") for name in names]
+
+
+def build_singleton_local_graph(raw_graph: RawGraph) -> CanonicalizationResult:
+    """Build a singleton local canonical graph from the raw graph.
+
+    Each raw node maps to exactly one local canonical node (no merging).
+    """
+    raw_to_local: dict[str, str] = {}
+    local_nodes: list[LocalCanonicalNode] = []
+    log: list[CanonicalizationLogEntry] = []
+
+    for raw_node in raw_graph.knowledge_nodes:
+        local_id = local_canonical_id(raw_node.raw_node_id)
+        raw_to_local[raw_node.raw_node_id] = local_id
+        local_nodes.append(
+            LocalCanonicalNode(
+                local_canonical_id=local_id,
+                package=raw_graph.package,
+                knowledge_type=raw_node.knowledge_type,
+                kind=raw_node.kind,
+                representative_content=raw_node.content,
+                parameters=raw_node.parameters,
+                member_raw_node_ids=[raw_node.raw_node_id],
+                source_refs=raw_node.source_refs,
+                metadata=raw_node.metadata,
+            )
+        )
+        log.append(
+            CanonicalizationLogEntry(
+                local_canonical_id=local_id,
+                members=[raw_node.raw_node_id],
+                reason="singleton: no local semantic merge applied",
+            )
+        )
+
+    local_factors = [
+        FactorNode(
+            factor_id=f.factor_id,
+            type=f.type,
+            premises=[raw_to_local[node_id] for node_id in f.premises],
+            contexts=[raw_to_local[node_id] for node_id in f.contexts],
+            conclusion=raw_to_local[f.conclusion],
+            source_ref=f.source_ref,
+            metadata=f.metadata,
+        )
+        for f in raw_graph.factor_nodes
+    ]
+
+    return CanonicalizationResult(
+        local_graph=LocalCanonicalGraph(
+            package=raw_graph.package,
+            version=raw_graph.version,
+            knowledge_nodes=local_nodes,
+            factor_nodes=local_factors,
+        ),
+        log=log,
+    )

--- a/libs/graph_ir/typst_compiler.py
+++ b/libs/graph_ir/typst_compiler.py
@@ -1,0 +1,176 @@
+"""Compile Typst loader output to Graph IR RawGraph.
+
+Takes the dict produced by typst_loader.load_typst_package() and
+produces a RawGraph with deterministic IDs and full source refs.
+"""
+
+from __future__ import annotations
+
+from .build_utils import factor_id, raw_node_id
+from .models import (
+    FactorNode,
+    RawGraph,
+    RawKnowledgeNode,
+    SourceRef,
+)
+
+_CONSTRAINT_TYPE_TO_FACTOR_TYPE = {
+    "contradiction": "mutex_constraint",
+    "equivalence": "equiv_constraint",
+}
+
+
+def compile_typst_to_raw_graph(graph_data: dict) -> RawGraph:
+    """Compile typst_loader output dict to RawGraph.
+
+    Args:
+        graph_data: Dict with keys: package, version, nodes, factors, constraints.
+                    Produced by typst_loader.load_typst_package().
+
+    Returns:
+        A RawGraph with deterministic node/factor IDs and source refs.
+    """
+    package = graph_data.get("package", "unknown")
+    version = graph_data.get("version", "0.0.0")
+
+    # Build constraint lookup for metadata injection
+    constraint_map: dict[str, dict] = {}
+    for constraint in graph_data.get("constraints", []):
+        constraint_map[constraint["name"]] = constraint
+
+    # 1. Compile nodes
+    knowledge_nodes: list[RawKnowledgeNode] = []
+    name_to_raw_id: dict[str, str] = {}
+
+    for node in graph_data.get("nodes", []):
+        name = node["name"]
+        knowledge_type = node["type"]
+        content = node.get("content", "")
+        module = node.get("module", "unknown")
+
+        if name in name_to_raw_id:
+            raise ValueError(
+                f"Duplicate node name '{name}' in package '{package}'. "
+                "Node names must be unique within a package."
+            )
+
+        node_id = raw_node_id(
+            package=package,
+            version=version,
+            module_name=module,
+            knowledge_name=name,
+            knowledge_type=knowledge_type,
+            kind=None,
+            content=content,
+            parameters=[],
+        )
+
+        metadata = None
+        if name in constraint_map:
+            metadata = {"between": list(constraint_map[name]["between"])}
+
+        knowledge_nodes.append(
+            RawKnowledgeNode(
+                raw_node_id=node_id,
+                knowledge_type=knowledge_type,
+                kind=None,
+                content=content,
+                parameters=[],
+                source_refs=[
+                    SourceRef(
+                        package=package,
+                        version=version,
+                        module=module,
+                        knowledge_name=name,
+                    )
+                ],
+                metadata=metadata,
+            )
+        )
+        name_to_raw_id[name] = node_id
+
+    # 2. Compile reasoning factors
+    factor_nodes: list[FactorNode] = []
+
+    for factor in graph_data.get("factors", []):
+        if factor.get("type") != "reasoning":
+            continue
+
+        conclusion_name = factor["conclusion"]
+        premise_names = factor.get("premise", [])
+
+        if conclusion_name not in name_to_raw_id:
+            continue
+        premise_ids = [name_to_raw_id[p] for p in premise_names if p in name_to_raw_id]
+        if not premise_ids:
+            continue
+
+        # Determine module from the conclusion node
+        conclusion_module = _find_node_module(graph_data["nodes"], conclusion_name)
+
+        factor_nodes.append(
+            FactorNode(
+                factor_id=factor_id("reasoning", conclusion_module, conclusion_name),
+                type="reasoning",
+                premises=premise_ids,
+                contexts=[],
+                conclusion=name_to_raw_id[conclusion_name],
+                source_ref=SourceRef(
+                    package=package,
+                    version=version,
+                    module=conclusion_module,
+                    knowledge_name=conclusion_name,
+                ),
+                metadata={"edge_type": "deduction"},
+            )
+        )
+
+    # 3. Compile constraint factors
+    for constraint in graph_data.get("constraints", []):
+        constraint_name = constraint["name"]
+        constraint_type = constraint["type"]
+        between = constraint.get("between", [])
+
+        if constraint_name not in name_to_raw_id:
+            continue
+        related_ids = [name_to_raw_id[b] for b in between if b in name_to_raw_id]
+        if len(related_ids) < 2:
+            continue
+
+        ft = _CONSTRAINT_TYPE_TO_FACTOR_TYPE.get(constraint_type)
+        if ft is None:
+            continue
+
+        constraint_module = _find_node_module(graph_data["nodes"], constraint_name)
+
+        factor_nodes.append(
+            FactorNode(
+                factor_id=factor_id(ft, constraint_module, constraint_name),
+                type=ft,
+                premises=related_ids,
+                contexts=[],
+                conclusion=name_to_raw_id[constraint_name],
+                source_ref=SourceRef(
+                    package=package,
+                    version=version,
+                    module=constraint_module,
+                    knowledge_name=constraint_name,
+                ),
+                metadata={"edge_type": f"relation_{constraint_type}"},
+            )
+        )
+
+    return RawGraph(
+        package=package,
+        version=version,
+        knowledge_nodes=knowledge_nodes,
+        factor_nodes=factor_nodes,
+    )
+
+
+def _find_node_module(nodes: list[dict], name: str) -> str:
+    """Find the module of a node by name."""
+    for node in nodes:
+        if node["name"] == name:
+            return node.get("module", "unknown")
+    return "unknown"

--- a/libs/lang/typst_loader.py
+++ b/libs/lang/typst_loader.py
@@ -116,5 +116,7 @@ def load_typst_package(pkg_path: Path) -> dict:
 
     # Ensure keys exist (default to empty for v1 packages)
     data.setdefault("constraints", [])
+    data.setdefault("package", None)
+    data.setdefault("version", None)
 
     return data

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -60,6 +60,15 @@ class PublishResult:
     stats: dict
 
 
+@dataclass
+class TypstBuildResult:
+    graph_data: dict
+    raw_graph: RawGraph
+    local_graph: LocalCanonicalGraph
+    canonicalization_log: list
+    source_files: dict[str, str] = field(default_factory=dict)
+
+
 # ── Pipeline Functions ───────────────────────────────────
 
 
@@ -109,6 +118,30 @@ async def pipeline_build(
         package=pkg,
         elaborated=elaborated,
         markdown=markdown,
+        raw_graph=raw_graph,
+        local_graph=canonicalization.local_graph,
+        canonicalization_log=canonicalization.log,
+        source_files=source_files,
+    )
+
+
+async def pipeline_build_typst(pkg_path: Path) -> TypstBuildResult:
+    """Load, compile, and canonicalize a Typst package — all in memory.
+
+    Args:
+        pkg_path: Path to the Typst package directory (contains typst.toml + lib.typ).
+    """
+    from libs.graph_ir.build_utils import build_singleton_local_graph
+    from libs.graph_ir.typst_compiler import compile_typst_to_raw_graph
+    from libs.lang.typst_loader import load_typst_package
+
+    graph_data = load_typst_package(pkg_path)
+    raw_graph = compile_typst_to_raw_graph(graph_data)
+    canonicalization = build_singleton_local_graph(raw_graph)
+    source_files = {p.name: p.read_text() for p in pkg_path.glob("*.typ") if p.is_file()}
+
+    return TypstBuildResult(
+        graph_data=graph_data,
         raw_graph=raw_graph,
         local_graph=canonicalization.local_graph,
         canonicalization_log=canonicalization.log,

--- a/libs/typst/gaia-lang/module.typ
+++ b/libs/typst/gaia-lang/module.typ
@@ -6,6 +6,8 @@
 #let _gaia_module_titles = state("gaia-module-titles", (:))
 #let _gaia_refs = state("gaia-refs", ())
 #let _gaia_exports = state("gaia-exports", ())
+#let _gaia_package_name = state("gaia-package-name", none)
+#let _gaia_package_version = state("gaia-package-version", none)
 
 // v2+ accumulators — premise tactic pushes entries, export-graph reads final()
 #let _gaia_proof_premises = state("gaia-proof-premises", ())  // (conclusion, name) pairs
@@ -52,6 +54,10 @@
   modules: (),
   export: (),
 ) = {
+  _gaia_package_name.update(_ => name)
+  if version != none {
+    _gaia_package_version.update(_ => str(version))
+  }
   _gaia_exports.update(_ => export)
 
   // Render title block
@@ -102,6 +108,9 @@
   // but those edges belong to the constraint factor, not a reasoning factor.
   let constraint_names = raw_constraints.map(c => c.name)
 
+  let pkg_name = _gaia_package_name.final()
+  let pkg_version = _gaia_package_version.final()
+
   let conclusions = raw_premises.map(p => p.at(0)).dedup()
   let proof_factors = conclusions.map(c => {
     let premises = raw_premises.filter(p => p.at(0) == c).map(p => p.at(1))
@@ -109,6 +118,8 @@
   }).filter(f => f.premise.len() > 0 and f.conclusion not in constraint_names)
 
   [#metadata((
+    package: pkg_name,
+    version: pkg_version,
     nodes: _gaia_nodes.final(),
     factors: _gaia_factors.final() + proof_factors,
     refs: _gaia_refs.final(),

--- a/tests/libs/graph_ir/test_build_utils.py
+++ b/tests/libs/graph_ir/test_build_utils.py
@@ -1,0 +1,124 @@
+"""Tests for Graph IR build utilities."""
+
+from libs.graph_ir.build_utils import (
+    CanonicalizationResult,
+    build_singleton_local_graph,
+    extract_parameters,
+    factor_id,
+    local_canonical_id,
+    raw_node_id,
+)
+from libs.graph_ir.models import (
+    FactorNode,
+    RawGraph,
+    RawKnowledgeNode,
+    SourceRef,
+)
+
+
+def test_raw_node_id_is_deterministic():
+    id1 = raw_node_id(
+        package="pkg",
+        version="1.0.0",
+        module_name="mod",
+        knowledge_name="claim_a",
+        knowledge_type="claim",
+        kind=None,
+        content="hello",
+        parameters=[],
+    )
+    id2 = raw_node_id(
+        package="pkg",
+        version="1.0.0",
+        module_name="mod",
+        knowledge_name="claim_a",
+        knowledge_type="claim",
+        kind=None,
+        content="hello",
+        parameters=[],
+    )
+    assert id1 == id2
+    assert id1.startswith("raw_")
+    assert len(id1) == 4 + 16  # "raw_" + 16 hex chars
+
+
+def test_raw_node_id_differs_on_content():
+    id1 = raw_node_id("p", "1", "m", "k", "claim", None, "aaa", [])
+    id2 = raw_node_id("p", "1", "m", "k", "claim", None, "bbb", [])
+    assert id1 != id2
+
+
+def test_local_canonical_id_is_deterministic():
+    lcn1 = local_canonical_id("raw_abc123")
+    lcn2 = local_canonical_id("raw_abc123")
+    assert lcn1 == lcn2
+    assert lcn1.startswith("lcn_")
+
+
+def test_factor_id_is_deterministic():
+    fid1 = factor_id("reasoning", "mod", "chain_a")
+    fid2 = factor_id("reasoning", "mod", "chain_a")
+    assert fid1 == fid2
+    assert fid1.startswith("f_")
+
+
+def test_factor_id_with_suffix():
+    fid1 = factor_id("equiv", "mod", "name", suffix="1")
+    fid2 = factor_id("equiv", "mod", "name", suffix="2")
+    assert fid1 != fid2
+
+
+def test_extract_parameters_empty():
+    assert extract_parameters("no placeholders here") == []
+
+
+def test_extract_parameters_finds_placeholders():
+    params = extract_parameters("For all {X}, if {Y} then {X}")
+    names = [p.name for p in params]
+    assert names == ["X", "Y"]  # sorted, deduplicated
+
+
+def test_build_singleton_local_graph():
+    raw = RawGraph(
+        package="test_pkg",
+        version="1.0.0",
+        knowledge_nodes=[
+            RawKnowledgeNode(
+                raw_node_id="raw_a",
+                knowledge_type="claim",
+                content="A is true",
+                source_refs=[
+                    SourceRef(package="test_pkg", version="1.0.0", module="m", knowledge_name="a")
+                ],
+            ),
+            RawKnowledgeNode(
+                raw_node_id="raw_b",
+                knowledge_type="observation",
+                content="B observed",
+                source_refs=[
+                    SourceRef(package="test_pkg", version="1.0.0", module="m", knowledge_name="b")
+                ],
+            ),
+        ],
+        factor_nodes=[
+            FactorNode(
+                factor_id="f_test",
+                type="reasoning",
+                premises=["raw_b"],
+                conclusion="raw_a",
+                source_ref=SourceRef(
+                    package="test_pkg", version="1.0.0", module="m", knowledge_name="chain_a"
+                ),
+            ),
+        ],
+    )
+    result = build_singleton_local_graph(raw)
+    assert isinstance(result, CanonicalizationResult)
+    assert len(result.local_graph.knowledge_nodes) == 2
+    assert len(result.local_graph.factor_nodes) == 1
+    assert result.local_graph.package == "test_pkg"
+
+    # Factor premises/conclusion should be remapped to local IDs
+    factor = result.local_graph.factor_nodes[0]
+    assert factor.conclusion.startswith("lcn_")
+    assert all(p.startswith("lcn_") for p in factor.premises)

--- a/tests/libs/graph_ir/test_typst_compiler.py
+++ b/tests/libs/graph_ir/test_typst_compiler.py
@@ -1,9 +1,13 @@
 """Tests for Typst -> RawGraph compiler."""
 
+from pathlib import Path
+
 import pytest
 
+from libs.graph_ir.build_utils import build_singleton_local_graph
 from libs.graph_ir.models import RawGraph
 from libs.graph_ir.typst_compiler import compile_typst_to_raw_graph
+from libs.lang.typst_loader import load_typst_package
 
 
 def _make_graph_data(
@@ -199,3 +203,56 @@ def test_duplicate_node_name_raises():
     )
     with pytest.raises(ValueError, match="Duplicate node name"):
         compile_typst_to_raw_graph(data)
+
+
+# -- Integration tests (Typst fixture → RawGraph) --
+
+GALILEO_V3 = (
+    Path(__file__).parent.parent.parent
+    / "fixtures"
+    / "gaia_language_packages"
+    / "galileo_falling_bodies_v3"
+)
+
+
+def test_galileo_v3_full_compile():
+    """End-to-end: load Typst fixture -> compile -> verify RawGraph structure."""
+    graph_data = load_typst_package(GALILEO_V3)
+    raw = compile_typst_to_raw_graph(graph_data)
+
+    assert raw.package == "galileo_falling_bodies"
+    assert raw.version == "3.0.0"
+
+    # Should have nodes for observations, settings, claims, and constraints
+    types = {n.knowledge_type for n in raw.knowledge_nodes}
+    assert "observation" in types
+    assert "claim" in types
+
+    # Should have reasoning factors
+    reasoning = [f for f in raw.factor_nodes if f.type == "reasoning"]
+    assert len(reasoning) >= 3  # vacuum_prediction, composite_is_slower, etc.
+
+    # Should have constraint factor for tied_balls_contradiction
+    constraints = [f for f in raw.factor_nodes if f.type == "mutex_constraint"]
+    assert len(constraints) >= 1
+
+    # All factor premises/conclusions should reference valid node IDs
+    node_ids = {n.raw_node_id for n in raw.knowledge_nodes}
+    for factor in raw.factor_nodes:
+        assert factor.conclusion in node_ids, f"conclusion {factor.conclusion} not in nodes"
+        for p in factor.premises:
+            assert p in node_ids, f"premise {p} not in nodes"
+
+
+def test_galileo_v3_through_canonicalization():
+    """End-to-end: Typst -> RawGraph -> LocalCanonicalGraph."""
+    graph_data = load_typst_package(GALILEO_V3)
+    raw = compile_typst_to_raw_graph(graph_data)
+    result = build_singleton_local_graph(raw)
+
+    assert len(result.local_graph.knowledge_nodes) == len(raw.knowledge_nodes)
+    assert len(result.local_graph.factor_nodes) == len(raw.factor_nodes)
+
+    # All local IDs should start with "lcn_"
+    for node in result.local_graph.knowledge_nodes:
+        assert node.local_canonical_id.startswith("lcn_")

--- a/tests/libs/graph_ir/test_typst_compiler.py
+++ b/tests/libs/graph_ir/test_typst_compiler.py
@@ -1,0 +1,201 @@
+"""Tests for Typst -> RawGraph compiler."""
+
+import pytest
+
+from libs.graph_ir.models import RawGraph
+from libs.graph_ir.typst_compiler import compile_typst_to_raw_graph
+
+
+def _make_graph_data(
+    nodes=None,
+    factors=None,
+    constraints=None,
+    package="test_pkg",
+    version="1.0.0",
+):
+    """Build a minimal graph_data dict for testing."""
+    return {
+        "package": package,
+        "version": version,
+        "nodes": nodes or [],
+        "factors": factors or [],
+        "constraints": constraints or [],
+    }
+
+
+# -- Node compilation --
+
+
+def test_empty_graph():
+    data = _make_graph_data()
+    raw = compile_typst_to_raw_graph(data)
+    assert isinstance(raw, RawGraph)
+    assert raw.package == "test_pkg"
+    assert raw.version == "1.0.0"
+    assert raw.knowledge_nodes == []
+    assert raw.factor_nodes == []
+
+
+def test_single_observation_node():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "obs_a", "type": "observation", "content": "A observed", "module": "mod1"},
+        ]
+    )
+    raw = compile_typst_to_raw_graph(data)
+    assert len(raw.knowledge_nodes) == 1
+    node = raw.knowledge_nodes[0]
+    assert node.raw_node_id.startswith("raw_")
+    assert node.knowledge_type == "observation"
+    assert node.content == "A observed"
+    assert node.kind is None
+    assert node.parameters == []
+    assert len(node.source_refs) == 1
+    sr = node.source_refs[0]
+    assert sr.package == "test_pkg"
+    assert sr.version == "1.0.0"
+    assert sr.module == "mod1"
+    assert sr.knowledge_name == "obs_a"
+
+
+def test_claim_node():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "claim_x", "type": "claim", "content": "X is true", "module": "mod1"},
+        ]
+    )
+    raw = compile_typst_to_raw_graph(data)
+    node = raw.knowledge_nodes[0]
+    assert node.knowledge_type == "claim"
+
+
+def test_constraint_node_has_between_metadata():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "a", "type": "claim", "content": "A", "module": "m"},
+            {"name": "b", "type": "claim", "content": "B", "module": "m"},
+            {"name": "c_rel", "type": "contradiction", "content": "C", "module": "m"},
+        ],
+        constraints=[
+            {"name": "c_rel", "type": "contradiction", "between": ["a", "b"]},
+        ],
+    )
+    raw = compile_typst_to_raw_graph(data)
+    rel_node = [n for n in raw.knowledge_nodes if n.knowledge_type == "contradiction"][0]
+    assert rel_node.metadata == {"between": ["a", "b"]}
+
+
+def test_node_ids_are_deterministic():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "obs_a", "type": "observation", "content": "A", "module": "m"},
+        ]
+    )
+    raw1 = compile_typst_to_raw_graph(data)
+    raw2 = compile_typst_to_raw_graph(data)
+    assert raw1.knowledge_nodes[0].raw_node_id == raw2.knowledge_nodes[0].raw_node_id
+
+
+# -- Factor compilation --
+
+
+def test_reasoning_factor():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "obs_a", "type": "observation", "content": "A", "module": "m"},
+            {"name": "claim_b", "type": "claim", "content": "B", "module": "m"},
+        ],
+        factors=[
+            {"type": "reasoning", "premise": ["obs_a"], "conclusion": "claim_b"},
+        ],
+    )
+    raw = compile_typst_to_raw_graph(data)
+    assert len(raw.factor_nodes) == 1
+    factor = raw.factor_nodes[0]
+    assert factor.type == "reasoning"
+    assert factor.factor_id.startswith("f_")
+    assert factor.contexts == []
+    assert factor.metadata == {"edge_type": "deduction"}
+
+    # premises and conclusion should be raw_node_ids, not names
+    node_ids = {n.raw_node_id for n in raw.knowledge_nodes}
+    assert factor.conclusion in node_ids
+    assert all(p in node_ids for p in factor.premises)
+
+    # source_ref should point to conclusion
+    assert factor.source_ref is not None
+    assert factor.source_ref.knowledge_name == "claim_b"
+
+
+def test_reasoning_factor_multiple_premises():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "a", "type": "observation", "content": "A", "module": "m"},
+            {"name": "b", "type": "observation", "content": "B", "module": "m"},
+            {"name": "c", "type": "claim", "content": "C", "module": "m"},
+        ],
+        factors=[
+            {"type": "reasoning", "premise": ["a", "b"], "conclusion": "c"},
+        ],
+    )
+    raw = compile_typst_to_raw_graph(data)
+    factor = raw.factor_nodes[0]
+    assert len(factor.premises) == 2
+
+
+# -- Constraint compilation --
+
+
+def test_contradiction_constraint():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "a", "type": "claim", "content": "A", "module": "m"},
+            {"name": "b", "type": "claim", "content": "B", "module": "m"},
+            {"name": "c", "type": "contradiction", "content": "C", "module": "m"},
+        ],
+        constraints=[
+            {"name": "c", "type": "contradiction", "between": ["a", "b"]},
+        ],
+    )
+    raw = compile_typst_to_raw_graph(data)
+    constraint_factors = [f for f in raw.factor_nodes if f.type == "mutex_constraint"]
+    assert len(constraint_factors) == 1
+    cf = constraint_factors[0]
+    assert len(cf.premises) == 2
+    assert cf.metadata == {"edge_type": "relation_contradiction"}
+
+    # conclusion should be the constraint node's ID
+    node_map = {n.knowledge_type: n.raw_node_id for n in raw.knowledge_nodes}
+    assert cf.conclusion == node_map["contradiction"]
+
+
+def test_equivalence_constraint():
+    data = _make_graph_data(
+        nodes=[
+            {"name": "a", "type": "claim", "content": "A", "module": "m"},
+            {"name": "b", "type": "claim", "content": "B", "module": "m"},
+            {"name": "eq", "type": "equivalence", "content": "E", "module": "m"},
+        ],
+        constraints=[
+            {"name": "eq", "type": "equivalence", "between": ["a", "b"]},
+        ],
+    )
+    raw = compile_typst_to_raw_graph(data)
+    equiv_factors = [f for f in raw.factor_nodes if f.type == "equiv_constraint"]
+    assert len(equiv_factors) == 1
+    assert equiv_factors[0].metadata == {"edge_type": "relation_equivalence"}
+
+
+# -- Duplicate detection --
+
+
+def test_duplicate_node_name_raises():
+    """Duplicate node names within a package should raise ValueError."""
+    data = _make_graph_data(
+        nodes=[
+            {"name": "obs", "type": "observation", "content": "Same", "module": "mod_a"},
+            {"name": "obs", "type": "observation", "content": "Same", "module": "mod_b"},
+        ]
+    )
+    with pytest.raises(ValueError, match="Duplicate node name"):
+        compile_typst_to_raw_graph(data)

--- a/tests/libs/lang/test_typst_loader.py
+++ b/tests/libs/lang/test_typst_loader.py
@@ -157,3 +157,10 @@ def test_v3_math_content_is_preserved():
     assert "10^" in node_map["eotvos_experiment"]
     assert "m_i" in node_map["eotvos_experiment"]
     assert "m_g" in node_map["eotvos_experiment"]
+
+
+def test_v3_package_metadata():
+    """v3 export-graph() should include package name and version."""
+    graph = load_typst_package(GALILEO_V3)
+    assert graph["package"] == "galileo_falling_bodies"
+    assert graph["version"] == "3.0.0"

--- a/tests/test_pipeline_typst.py
+++ b/tests/test_pipeline_typst.py
@@ -1,0 +1,47 @@
+"""Tests for Typst pipeline_build_typst()."""
+
+from pathlib import Path
+
+import pytest
+
+from libs.pipeline import TypstBuildResult, pipeline_build_typst
+
+GALILEO_V3 = (
+    Path(__file__).parent / "fixtures" / "gaia_language_packages" / "galileo_falling_bodies_v3"
+)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_build_typst_returns_result():
+    result = await pipeline_build_typst(GALILEO_V3)
+    assert isinstance(result, TypstBuildResult)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_build_typst_has_graph_data():
+    result = await pipeline_build_typst(GALILEO_V3)
+    assert "nodes" in result.graph_data
+    assert "factors" in result.graph_data
+    assert result.graph_data["package"] == "galileo_falling_bodies"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_build_typst_has_raw_graph():
+    result = await pipeline_build_typst(GALILEO_V3)
+    assert result.raw_graph.package == "galileo_falling_bodies"
+    assert len(result.raw_graph.knowledge_nodes) > 0
+    assert len(result.raw_graph.factor_nodes) > 0
+
+
+@pytest.mark.asyncio
+async def test_pipeline_build_typst_has_local_graph():
+    result = await pipeline_build_typst(GALILEO_V3)
+    assert len(result.local_graph.knowledge_nodes) > 0
+    assert result.local_graph.package == "galileo_falling_bodies"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_build_typst_collects_source_files():
+    result = await pipeline_build_typst(GALILEO_V3)
+    assert "lib.typ" in result.source_files
+    assert "galileo.typ" in result.source_files


### PR DESCRIPTION
## Summary

- Extract source-agnostic build utilities (`build_utils.py`) from `build.py` — deterministic ID generation, `build_singleton_local_graph()`, `CanonicalizationResult`
- Add package name/version metadata to Typst `export-graph()` output via new state variables in `module.typ`
- Implement `typst_compiler.py` — compiles Typst loader dict to `RawGraph` with deterministic node/factor IDs, `SourceRef` provenance, and constraint handling
- Add `pipeline_build_typst()` to `pipeline.py` — end-to-end Typst build: load → compile → canonicalize
- Move `plausible_core.py` to `future/` (Codex-generated exploration, not needed for v3)

This is **Phase 1** of the Typst → Graph IR compiler spec (`docs/superpowers/specs/2026-03-19-typst-graph-ir-compiler-design.md`). Phase 2 (downstream pipeline rewrite + YAML cleanup) is a follow-up.

## Test plan

- [x] 8 tests for `build_utils.py` (ID determinism, parameter extraction, singleton graph)
- [x] 12 tests for `typst_compiler.py` (10 unit + 2 integration with galileo v3 fixture)
- [x] 5 tests for `pipeline_build_typst()` (result types, graph data, source files)
- [x] 1 new test for `typst_loader.py` (v3 package metadata)
- [x] Full regression suite: 854 tests pass, 0 failures
- [x] Ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)