### PR TITLE
fix: make init templates buildable

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -176,27 +176,54 @@ def init_cmd(
 ) -> None:
     """Initialize a new Typst knowledge package."""
     pkg_dir = Path(name)
+    pkg_name = pkg_dir.name
     if pkg_dir.exists():
         typer.echo(f"Error: directory '{name}' already exists", err=True)
         raise typer.Exit(1)
 
     pkg_dir.mkdir(parents=True)
 
+    # Vendor the minimal Gaia Typst runtime so the package can build anywhere.
+    runtime_src_dir = Path(__file__).resolve().parents[1] / "libs" / "typst" / "gaia-lang"
+    runtime_dst_dir = pkg_dir / "_gaia"
+    runtime_dst_dir.mkdir()
+    for filename in ("v2.typ", "module.typ", "declarations.typ", "tactics.typ"):
+        src = runtime_src_dir / filename
+        (runtime_dst_dir / filename).write_text(src.read_text())
+
     # typst.toml
     toml_content = f"""[package]
-name = "{name}"
+name = "{pkg_name}"
 version = "1.0.0"
+entrypoint = "lib.typ"
+authors = ["Gaia Project"]
+description = "Starter Gaia knowledge package"
 """
     (pkg_dir / "typst.toml").write_text(toml_content)
 
+    # gaia.typ
+    gaia_content = """#import "_gaia/v2.typ": *
+"""
+    (pkg_dir / "gaia.typ").write_text(gaia_content)
+
     # lib.typ
     lib_content = f"""#import "gaia.typ": *
+#show: gaia-style
 
-// {name} — knowledge package
+// {pkg_name} — knowledge package
 //
 // Modules: motivation
 
-#import "motivation.typ"
+#package("{pkg_name}",
+  title: "{pkg_name.replace('_', ' ')}",
+  version: "1.0.0",
+  modules: ("motivation",),
+  export: ("main_question",),
+)
+
+#include "motivation.typ"
+
+#export-graph()
 """
     (pkg_dir / "lib.typ").write_text(lib_content)
 
@@ -205,13 +232,15 @@ version = "1.0.0"
 
 // motivation module
 
-#let main_question = question("main_question",
-  "What is the main research question?"
-)
+#module("motivation", title: "研究动机")
+
+#question("main_question")[
+  What is the main research question?
+]
 """
     (pkg_dir / "motivation.typ").write_text(motivation_content)
 
-    typer.echo(f"Initialized Typst package '{name}' in ./{name}/")
+    typer.echo(f"Initialized Typst package '{pkg_name}' in {pkg_dir}/")
 
 
 @app.command()

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -42,3 +42,15 @@ def test_init_refuses_existing_directory(tmp_path, monkeypatch):
     (tmp_path / "existing_pkg").mkdir()
     result = runner.invoke(app, ["init", "existing_pkg"])
     assert result.exit_code != 0
+
+
+def test_init_package_builds_from_absolute_path(tmp_path):
+    pkg_dir = tmp_path / "my_package"
+    result = runner.invoke(app, ["init", str(pkg_dir)])
+    assert result.exit_code == 0
+
+    build_result = runner.invoke(app, ["build", str(pkg_dir)])
+    assert build_result.exit_code == 0, build_result.output
+    assert "Build complete." in build_result.output
+    assert (pkg_dir / "gaia.typ").exists()
+    assert (pkg_dir / ".gaia" / "build" / "graph_data.json").exists()


### PR DESCRIPTION
## Summary

- vendor the minimal Gaia Typst runtime into newly initialized packages so they build outside the repo tree
- generate a valid minimal Typst v3 package structure with `#package(...)`, `#module(...)`, and `#export-graph()`
- add a regression test covering `gaia init <absolute-path>` followed by `gaia build`

## Validation

- manual smoke test: `python cli/main.py init /tmp/pr168_init_smoke && python cli/main.py build /tmp/pr168_init_smoke`
- direct test harness run for `tests/cli/test_init.py` cases, including the new buildable-template regression
