### PR TITLE
fix: preserve external refs and restore v4 build behavior

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -20,6 +20,12 @@ app = typer.Typer(
 )
 
 
+def _uses_v4_dsl(graph_data: dict) -> bool:
+    if graph_data.get("dsl_version") == "v4":
+        return True
+    return any("premises" in factor for factor in graph_data.get("factors", []))
+
+
 @app.command()
 def build(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
@@ -64,28 +70,33 @@ def _build_typst(pkg_path: Path, format: str, proof_state: bool = False) -> None
     json_path = build_dir / "graph_data.json"
     json_path.write_text(json_mod.dumps(result.graph_data, ensure_ascii=False, indent=2))
 
-    # Save markdown (v3 renderer only — v4 packages skip this)
+    # Save markdown for both v3 and v4 packages.
     if format in ("md", "all"):
-        try:
+        if _uses_v4_dsl(result.graph_data):
+            from libs.pipeline import _render_markdown_from_graph_data
+
+            md = _render_markdown_from_graph_data(result.graph_data)
+            md_path = build_dir / "package.md"
+            md_path.write_text(md)
+            typer.echo(f"Markdown: {md_path}")
+        else:
             from libs.lang.typst_renderer import render_typst_to_markdown
 
             md = render_typst_to_markdown(pkg_path)
             md_path = build_dir / "package.md"
             md_path.write_text(md)
             typer.echo(f"Markdown: {md_path}")
-        except Exception:
-            pass  # v4 packages don't have #export-graph()
 
     if format in ("typst", "all"):
-        try:
+        if _uses_v4_dsl(result.graph_data):
+            typer.echo("Typst clean render is not supported for v4 packages yet; skipping.")
+        else:
             from libs.lang.typst_clean_renderer import render_typst_to_clean_typst
 
             typ = render_typst_to_clean_typst(pkg_path)
             typ_path = build_dir / "package.typ"
             typ_path.write_text(typ)
             typer.echo(f"Typst: {typ_path}")
-        except Exception:
-            pass  # v4 packages don't have #export-graph()
 
     if format in ("json", "all"):
         json_out = build_dir / "graph.json"

--- a/libs/graph_ir/typst_compiler.py
+++ b/libs/graph_ir/typst_compiler.py
@@ -276,7 +276,7 @@ def compile_v4_to_raw_graph(graph_data: dict) -> RawGraph:
                 raw_node_id=node_id,
                 knowledge_type=node.get("type", "claim"),
                 kind=None,
-                content="",
+                content=node.get("content", ""),
                 parameters=[],
                 source_refs=[
                     SourceRef(

--- a/libs/lang/proof_state.py
+++ b/libs/lang/proof_state.py
@@ -36,12 +36,15 @@ def analyze_proof_state(graph: dict) -> dict:
             used_as_premise.add(p)
 
     # Also count constraint `between` members as structurally referenced
+    constraint_names = set()
     for constraint in graph.get("constraints", []):
+        constraint_names.add(constraint.get("name"))
         for member in constraint.get("between", []):
             used_as_premise.add(member)
 
     established: list[dict] = []
     axioms: list[dict] = []
+    imported: list[dict] = []
     holes: list[dict] = []
     questions: list[dict] = []
     standalone: list[dict] = []
@@ -49,12 +52,14 @@ def analyze_proof_state(graph: dict) -> dict:
     for name, node in nodes.items():
         node_type = node.get("type", "")
 
-        if node_type == "question":
+        if node.get("external"):
+            imported.append(node)
+        elif node_type == "question":
             questions.append(node)
         elif node_type in ("setting", "observation"):
             axioms.append(node)
-        elif node_type in RELATION_TYPES:
-            # claim_relation nodes are always established
+        elif node_type in RELATION_TYPES or node_type == "relation" or name in constraint_names:
+            # Relation nodes are structurally established by their constraint declaration.
             established.append(node)
         elif name in proven_names:
             established.append(node)
@@ -63,11 +68,12 @@ def analyze_proof_state(graph: dict) -> dict:
         else:
             standalone.append(node)
 
-    report = _format_report(established, axioms, holes, questions, standalone)
+    report = _format_report(established, axioms, imported, holes, questions, standalone)
 
     return {
         "established": established,
         "axioms": axioms,
+        "imported": imported,
         "holes": holes,
         "questions": questions,
         "standalone": standalone,
@@ -78,6 +84,7 @@ def analyze_proof_state(graph: dict) -> dict:
 def _format_report(
     established: list[dict],
     axioms: list[dict],
+    imported: list[dict],
     holes: list[dict],
     questions: list[dict],
     standalone: list[dict] | None = None,
@@ -94,6 +101,15 @@ def _format_report(
         lines.append("\u25cb axioms (no proof needed):")
         for d in axioms:
             lines.append(f"  {d['name']}  ({d.get('type', '')})")
+
+    if imported:
+        lines.append("")
+        lines.append("imports:")
+        for d in imported:
+            pkg = d.get("ext_package", "")
+            ver = d.get("ext_version", "")
+            suffix = f"  ({pkg}@{ver})" if pkg and ver else ""
+            lines.append(f"  {d['name']}{suffix}")
 
     if holes:
         lines.append("")

--- a/libs/lang/typst_loader.py
+++ b/libs/lang/typst_loader.py
@@ -119,6 +119,7 @@ def load_typst_package(pkg_path: Path) -> dict:
     data.setdefault("constraints", [])
     data.setdefault("package", None)
     data.setdefault("version", None)
+    data.setdefault("dsl_version", "v3")
 
     return data
 
@@ -258,7 +259,7 @@ def load_typst_package_v4(pkg_path: Path) -> dict:
             {
                 "name": label,
                 "type": meta.get("ext-content-type", "claim"),
-                "content": "",
+                "content": meta.get("ext-content", meta.get("ext-node", label)),
                 "kind": None,
                 "external": True,
                 "ext_package": meta.get("ext-package", ""),
@@ -276,4 +277,5 @@ def load_typst_package_v4(pkg_path: Path) -> dict:
         "refs": [],
         "modules": [],
         "module_titles": {},
+        "dsl_version": "v4",
     }

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -334,6 +334,24 @@ _DEFAULT_PRIORS: dict[str, float] = {
 }
 
 
+def _source_ref_knowledge_id(
+    source_ref: storage_models.SourceRef | None,
+    current_package: str,
+) -> str | None:
+    """Build a storage knowledge_id while preserving external provenance."""
+    if source_ref is None or not source_ref.knowledge_name:
+        return None
+    package = source_ref.package or current_package
+    return f"{package}/{source_ref.knowledge_name}"
+
+
+def _is_external_source_ref(
+    source_ref: storage_models.SourceRef | None,
+    current_package: str,
+) -> bool:
+    return bool(source_ref and source_ref.package and source_ref.package != current_package)
+
+
 def _build_node_priors(local_graph: LocalCanonicalGraph) -> dict[str, float]:
     """Build node_priors dict: lcn_id → default prior based on knowledge_type."""
     priors: dict[str, float] = {}
@@ -399,7 +417,12 @@ def _render_markdown_from_graph_data(graph_data: dict) -> str:
     lines.append(f"# Package: {package_name}\n")
 
     for node in graph_data.get("nodes", []):
-        lines.append(f"### {node['name']} [{node.get('type', 'claim')}]")
+        label = node.get("type", "claim")
+        if node.get("external"):
+            ext_pkg = node.get("ext_package", "unknown")
+            ext_ver = node.get("ext_version", "") or "unknown"
+            label = f"{label}, external from {ext_pkg}@{ext_ver}"
+        lines.append(f"### {node['name']} [{label}]")
         lines.append(f"> {node.get('content', '')}\n")
 
     for factor in graph_data.get("factors", []):
@@ -474,7 +497,11 @@ def _convert_local_graph_to_storage(
             )
             continue
         sr = node.source_refs[0]
-        knowledge_id = f"{package_name}/{sr.knowledge_name}"
+        if _is_external_source_ref(sr, package_name):
+            continue
+        knowledge_id = _source_ref_knowledge_id(sr, package_name)
+        if knowledge_id is None:
+            continue
         if knowledge_id in seen_kids:
             continue
         seen_kids.add(knowledge_id)
@@ -508,7 +535,9 @@ def _convert_local_graph_to_storage(
     for node in local_graph.knowledge_nodes:
         if node.source_refs:
             sr = node.source_refs[0]
-            lcn_to_kid[node.local_canonical_id] = f"{package_name}/{sr.knowledge_name}"
+            kid = _source_ref_knowledge_id(sr, package_name)
+            if kid is not None:
+                lcn_to_kid[node.local_canonical_id] = kid
 
     chains: list[storage_models.Chain] = []
     for factor in local_graph.factor_nodes:
@@ -641,7 +670,9 @@ def _convert_local_graph_to_storage(
         if node.source_refs:
             sr = node.source_refs[0]
             label = f"{sr.module}.{sr.knowledge_name}"
-            label_to_kid[label] = f"{package_name}/{sr.knowledge_name}"
+            kid = _source_ref_knowledge_id(sr, package_name)
+            if kid is not None:
+                label_to_kid[label] = kid
 
     belief_snapshots: list[storage_models.BeliefSnapshot] = []
     for label, belief_value in beliefs.items():
@@ -679,7 +710,9 @@ def _map_graph_ir_factors(
     for node in local_graph.knowledge_nodes:
         if node.source_refs:
             sr = node.source_refs[0]
-            lcn_to_kid[node.local_canonical_id] = f"{package_name}/{sr.knowledge_name}"
+            kid = _source_ref_knowledge_id(sr, package_name)
+            if kid is not None:
+                lcn_to_kid[node.local_canonical_id] = kid
 
     factors: list[storage_models.FactorNode] = []
     for f in local_graph.factor_nodes:

--- a/libs/typst/gaia-lang-v4/bibliography.typ
+++ b/libs/typst/gaia-lang-v4/bibliography.typ
@@ -15,6 +15,7 @@
         "ext-version": entry.at("version", default: ""),
         "ext-node": entry.at("node", default: key),
         "ext-content-type": entry.at("type", default: "claim"),
+        "ext-content": entry.at("content", default: key),
       )))
       hide(text(entry.at("content", default: key)))
     }) #label(key)]

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -11,6 +11,7 @@ from cli.main import app
 runner = CliRunner()
 
 TYPST_FIXTURE = "tests/fixtures/gaia_language_packages/galileo_falling_bodies_typst"
+V4_TYPST_FIXTURE = "tests/fixtures/gaia_language_packages/newton_principia_v4"
 
 
 def test_build_invalid_path():
@@ -72,3 +73,21 @@ def test_build_typst_package_all_format(typst_fixture):
     assert (build_dir / "package.md").exists()
     assert (build_dir / "graph.json").exists()
     assert "Build complete." in result.output
+
+
+def test_build_v4_package_default_format_produces_markdown():
+    pkg = Path(V4_TYPST_FIXTURE)
+    gaia_dir = pkg / ".gaia"
+    if gaia_dir.exists():
+        shutil.rmtree(gaia_dir)
+    try:
+        result = runner.invoke(app, ["build", str(pkg)])
+        assert result.exit_code == 0, result.output
+        md_path = pkg / ".gaia" / "build" / "package.md"
+        assert md_path.exists()
+        content = md_path.read_text()
+        assert "external from galileo_falling_bodies@4.0.0" in content
+        assert "Build complete." in result.output
+    finally:
+        if gaia_dir.exists():
+            shutil.rmtree(gaia_dir)

--- a/tests/libs/graph_ir/test_typst_compiler_v4.py
+++ b/tests/libs/graph_ir/test_typst_compiler_v4.py
@@ -78,6 +78,7 @@ def test_external_nodes_prefixed(raw_graph):
     ext = ext_nodes[0]
     assert ext.metadata is not None
     assert ext.metadata.get("ext_package") == "cmb-analysis"
+    assert "CMB" in ext.content
 
 
 def test_deterministic_ids(raw_graph):

--- a/tests/libs/lang/test_proof_state.py
+++ b/tests/libs/lang/test_proof_state.py
@@ -10,6 +10,8 @@ GALILEO_V3 = _FIXTURES / "galileo_falling_bodies_v3"
 NEWTON_V3 = _FIXTURES / "newton_principia_v3"
 EINSTEIN_V3 = _FIXTURES / "einstein_gravity_v3"
 GALILEO_V4 = _FIXTURES / "galileo_falling_bodies_v4"
+NEWTON_V4 = _FIXTURES / "newton_principia_v4"
+DARK_ENERGY_V4 = _FIXTURES / "dark_energy_v4"
 
 
 def test_established_claims():
@@ -286,3 +288,21 @@ def test_v4_questions_detected():
     state = analyze_proof_state(graph)
     question_names = {d["name"] for d in state["questions"]}
     assert "motivation.main_question" in question_names
+
+
+def test_v4_relation_nodes_are_established():
+    graph = load_typst_package_v4(DARK_ENERGY_V4)
+    state = analyze_proof_state(graph)
+    established = {d["name"] for d in state["established"]}
+    standalone = {d["name"] for d in state["standalone"]}
+    assert "vacuum_catastrophe" in established
+    assert "vacuum_catastrophe" not in standalone
+
+
+def test_v4_external_refs_are_imports_not_holes():
+    graph = load_typst_package_v4(NEWTON_V4)
+    state = analyze_proof_state(graph)
+    imports = {d["name"] for d in state["imported"]}
+    holes = {d["name"] for d in state["holes"]}
+    assert "vacuum_prediction" in imports
+    assert "vacuum_prediction" not in holes

--- a/tests/libs/lang/test_typst_loader_v4.py
+++ b/tests/libs/lang/test_typst_loader_v4.py
@@ -73,9 +73,11 @@ def test_v4_loader_external_refs(v4_data):
     assert len(ext_nodes) >= 1
     ext = next(n for n in ext_nodes if n["name"] == "prior_cmb_analysis")
     assert ext["ext_package"] == "cmb-analysis"
+    assert "CMB" in ext["content"]
 
 
 def test_v4_loader_package_metadata(v4_data):
     """Package name and version come from typst.toml."""
     assert v4_data["package"] == "dark_energy"
     assert v4_data["version"] == "1.0.0"
+    assert v4_data["dsl_version"] == "v4"

--- a/tests/test_pipeline_converter.py
+++ b/tests/test_pipeline_converter.py
@@ -15,6 +15,9 @@ from libs.pipeline import (
 GALILEO_V3 = (
     Path(__file__).parent / "fixtures" / "gaia_language_packages" / "galileo_falling_bodies_v3"
 )
+NEWTON_V4 = (
+    Path(__file__).parent / "fixtures" / "gaia_language_packages" / "newton_principia_v4"
+)
 
 
 # ── Shared fixture to avoid rebuilding the pipeline 9 times ──
@@ -136,3 +139,32 @@ def test_render_markdown_skips_non_reasoning_factors():
     }
     md = _render_markdown_from_graph_data(graph_data)
     assert "[proof]" not in md
+
+
+@pytest.mark.asyncio
+async def test_converter_v4_external_refs_are_not_materialized_locally():
+    build = await pipeline_build(NEWTON_V4)
+    review = await pipeline_review(build, mock=True)
+    infer = await pipeline_infer(build, review)
+    data = _convert_local_graph_to_storage(build, review, infer.beliefs, infer.bp_run_id)
+
+    knowledge_ids = {k.knowledge_id for k in data.knowledge_items}
+    assert "newton_principia/vacuum_prediction" not in knowledge_ids
+    assert len(data.knowledge_items) == 15
+
+    premise_sets = {
+        chain.chain_id: {premise.knowledge_id for premise in chain.steps[0].premises}
+        for chain in data.chains
+    }
+    assert (
+        "galileo_falling_bodies/vacuum_prediction"
+        in premise_sets["newton_principia.default.derivation.galileo_newton_convergence"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_render_markdown_includes_external_content():
+    build = await pipeline_build(NEWTON_V4)
+    md = _render_markdown_from_graph_data(build.graph_data)
+    assert "external from galileo_falling_bodies@4.0.0" in md
+    assert "在真空中，不同重量的物体应以相同速率下落。" in md


### PR DESCRIPTION
## Summary

This follow-up PR fixes the main correctness issues found during review of #174.

- preserve `gaia-bibliography` external content and provenance through v4 load/compile/review
- stop materializing external references as local package knowledge during publish
- keep external premises pointing at their original package knowledge IDs
- treat v4 relation nodes as established in proof-state and list external refs as imports
- restore `gaia build` markdown output for v4 packages without swallowing renderer errors
- add regression coverage for v4 external refs, proof-state, converter, and CLI build behavior

## Verification

- targeted non-sandbox pytest run with readline workaround
- `97 passed in 24.62s`

## Notes

- base branch is `feature/typst-dsl-v4` so this can be reviewed as a direct follow-up to #174
- local generated `.gaia/` fixture artifacts were not included in this PR