### PR TITLE
fix(tests): clear leaked GAIA_LANCEDB_URI between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,23 @@
 """Shared test fixtures."""
 
+import os
+
 import pytest
 
 import lancedb.background_loop as _lance_bg
+
+# Env vars that load_dotenv() may inject from .env and leak across tests.
+# gateway/app.py calls load_dotenv() when create_app() is invoked without deps,
+# which sets GAIA_LANCEDB_URI to s3://... causing later tests to hit remote S3.
+_LEAKED_ENV_VARS = ("GAIA_LANCEDB_URI", "GAIA_NEO4J_URI")
+
+
+@pytest.fixture(autouse=True)
+def _clean_dotenv_leaks():
+    """Remove env vars that load_dotenv() may have injected from .env."""
+    yield
+    for var in _LEAKED_ENV_VARS:
+        os.environ.pop(var, None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Gateway tests calling `create_app()` without deps trigger `load_dotenv()`, which sets `GAIA_LANCEDB_URI=s3://...` from `.env`
- This leaks into subsequent tests, causing `StorageConfig` to connect to remote S3 instead of local `tmp_path`
- Results in "Spill has sent an error" failures on merge-insert operations

## Fix
- Add autouse `_clean_dotenv_leaks` fixture in `tests/conftest.py` that pops `GAIA_LANCEDB_URI` and `GAIA_NEO4J_URI` from `os.environ` after every test

## Test plan
- [x] Full test suite: 714 passed, 0 failed, 63 seconds
- [x] Previously flaky tests now stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)