### PR TITLE
fix: align observation proof-state semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ Every node is classified after compilation:
 |----------|---------|
 | **established** | Has proof (conclusion of a reasoning factor or relation) |
 | **assumption** | Setting — contextual choice, no proof needed, but challengeable |
-| **hole** | Used as premise but has no proof in this package |
+| **hole** | Used as premise but has no proof in this package, including observations without experimental justification |
 | **imported** | External reference (from another package via `gaia-deps.yml`) |
 | **question** | Open inquiry |
 | **standalone** | Declared but unreferenced and unproven |
+
+Gaia does not currently expose an `axiom` proof-state bucket or API key. If future inference or explanation tooling needs multiple alternative starting-point sets, those will be modeled as explicit `assumption basis` / proof-view metadata layered on top of the same graph, not as a node-level type.
 
 ## Architecture
 

--- a/docs/foundations/language/gaia-language-design.md
+++ b/docs/foundations/language/gaia-language-design.md
@@ -39,6 +39,12 @@ There is no `corroboration` relation type. Independent evidence for the same cla
 | Claim or Action with `from:` | Variable node + reasoning factor connecting premises to conclusion |
 | Relation | Constraint (not a factor; enforces structural rules on the graph) |
 
+### Assumptions and Observations
+
+- `#setting` occupies the current proof-state `assumption` role: accepted locally without proof, but still challengeable by other packages.
+- `#claim(kind: "observation")` remains a claim. If it is used as a premise without a local proof or imported justification, it is a `hole`, not an assumption.
+- Gaia intentionally does not expose a node-level `axiom` category. If future inference or explanation tooling needs multiple alternative starting-point sets, those should be represented as explicit `assumption basis` / proof-view selections on top of the same graph.
+
 ## Declaration Syntax
 
 ### Setting and Question (no premises, no proof)

--- a/docs/foundations/language/gaia-language-spec.md
+++ b/docs/foundations/language/gaia-language-spec.md
@@ -419,6 +419,7 @@ Key design decisions:
 
 - **Observations are not special-cased.** A `claim(kind: "observation")` follows the same rules as any claim: if it has `from:` it can be established; if it is used as a premise without proof, it is a hole. The `kind` field records the *evidence type* but does not exempt the node from needing proof.
 - **Settings are assumptions, not axioms.** A setting can always be challenged by a `relation(type: "contradiction")` in another package. The label "assumption" reflects this: accepted without proof here, but not immune to revision.
+- **Axiom systems are future proof views, not node properties.** Gaia does not expose `axiom` as a declaration type or proof-state bucket. If the system later needs alternative starting-point sets for explanation trees, loop cuts, or inference views, those should be represented as explicit `assumption basis` metadata layered on top of the graph.
 - **Holes are actionable.** Each hole represents a concrete next step — provide a proof, import from another package, or demote to standalone if the premise link was accidental.
 
 Run `gaia build --proof-state` to generate the proof state report for a package.

--- a/docs/foundations/server/storage-schema.md
+++ b/docs/foundations/server/storage-schema.md
@@ -76,7 +76,7 @@ Knowledge:
     knowledge_id:  str           # 全局唯一
     version:       int           # 显式版本号，同 id 同 version 只存一份
     type:          str           # claim | question | setting | action | contradiction | equivalence
-    kind:          str | None    # root-type-specific kind label（question/action 的子类型）
+    kind:          str | None    # root-type-specific kind label（如 claim: observation, action: python）
     content:       str
     parameters:    list[Parameter]  # 空 = ground node，非空 = schema node（∀量化）
     prior:         float         # reviewed prior attached to this authored knowledge unit；历史/审计参考，不是 active global BP prior
@@ -96,7 +96,7 @@ Parameter:
 | 变化 | 说明 |
 |------|------|
 | `type` 扩展 | 新增 `contradiction`, `equivalence`（Relation 作为 knowledge root type） |
-| `kind` 新增 | question/action 的子类型；equivalence 要求同 root type 同 kind |
+| `kind` 新增 | root-type-specific subtype（如 `claim(kind="observation")`, `action(kind="python")`）；equivalence 要求同 root type 同 kind |
 | `parameters` 新增 | 空 = ground node，非空 = schema node。支持 ∀ 量化 |
 | `is_schema` 派生属性 | `len(parameters) > 0` |
 | `prior` 语义更新 | 保留为 package review 产出的 reviewed prior；全局 BP 使用 `GlobalInferenceState.node_priors` |

--- a/libs/graph_ir/build_utils.py
+++ b/libs/graph_ir/build_utils.py
@@ -138,9 +138,9 @@ def build_singleton_local_graph(raw_graph: RawGraph) -> CanonicalizationResult:
 
 def _default_node_prior(knowledge_type: str) -> float:
     """Default prior based on knowledge type."""
-    if knowledge_type in {"contradiction", "equivalence"}:
-        return 0.5
-    return 1.0
+    if knowledge_type == "setting":
+        return 1.0
+    return 0.5
 
 
 def derive_local_parameterization_from_raw(

--- a/libs/graph_ir/storage_converter.py
+++ b/libs/graph_ir/storage_converter.py
@@ -25,6 +25,7 @@ _FACTOR_TYPE_MAP: dict[str, str] = {
 
 _KNOWLEDGE_TYPE_MAP: dict[str, str] = {
     "claim": "claim",
+    "observation": "claim",
     "question": "question",
     "setting": "setting",
     "action": "action",
@@ -71,6 +72,16 @@ def _map_knowledge_type(
     if mapped is not None:
         return mapped
     return "claim"
+
+
+def _map_knowledge_kind(
+    knowledge_type: str,
+    kind: str | None,
+) -> str | None:
+    """Preserve evidence-like subtyping when storage lacks a root observation type."""
+    if knowledge_type == "observation" and kind is None:
+        return "observation"
+    return kind
 
 
 def _map_factor_type(
@@ -157,7 +168,7 @@ def convert_graph_ir_to_storage(
                 knowledge_id=knowledge_id,
                 version=1,
                 type=k_type,
-                kind=node.kind,
+                kind=_map_knowledge_kind(node.knowledge_type, node.kind),
                 content=node.representative_content,
                 parameters=k_params,
                 prior=prior,

--- a/libs/lang/proof_state.py
+++ b/libs/lang/proof_state.py
@@ -119,7 +119,8 @@ def _format_report(
         lines.append("")
         lines.append("? holes:")
         for d in holes:
-            lines.append(f"  {d['name']}  (claim, used as premise, no proof)")
+            node_type = d.get("type", "claim")
+            lines.append(f"  {d['name']}  ({node_type}, used as premise, no proof)")
 
     if questions:
         lines.append("")

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -324,7 +324,7 @@ async def pipeline_publish(
 # Default priors by knowledge_type
 _DEFAULT_PRIORS: dict[str, float] = {
     "setting": 1.0,
-    "observation": 1.0,
+    "observation": 0.5,
     "question": 0.5,
     "action": 0.5,
     "contradiction": 0.5,
@@ -418,6 +418,8 @@ def render_markdown_from_graph_data(graph_data: dict) -> str:
 
     for node in graph_data.get("nodes", []):
         label = node.get("type", "claim")
+        if node.get("kind"):
+            label = f"{label}, kind={node['kind']}"
         if node.get("external"):
             ext_pkg = node.get("ext_package", "unknown")
             ext_ver = node.get("ext_version", "") or "unknown"
@@ -445,7 +447,7 @@ _KNOWLEDGE_TYPE_MAP: dict[str, str] = {
     "question": "question",
     "setting": "setting",
     "action": "action",
-    "observation": "setting",  # observation → setting
+    "observation": "claim",  # preserve evidence semantics via kind="observation"
     "corroboration": "claim",  # corroboration → claim
     "contradiction": "contradiction",
     "equivalence": "equivalence",
@@ -466,6 +468,13 @@ _MODULE_ROLE_MAP: dict[str, str] = {
     "reasoning": "reasoning",
     "follow_up": "follow_up_question",
 }
+
+
+def _storage_kind_for_node(knowledge_type: str, kind: str | None) -> str | None:
+    """Normalize authoring-layer kinds before writing storage Knowledge rows."""
+    if knowledge_type == "observation" and kind is None:
+        return "observation"
+    return kind
 
 
 def _convert_local_graph_to_storage(
@@ -518,7 +527,7 @@ def _convert_local_graph_to_storage(
                 knowledge_id=knowledge_id,
                 version=1,
                 type=k_type,
-                kind=node.kind,
+                kind=_storage_kind_for_node(node.knowledge_type, node.kind),
                 content=node.representative_content.strip(),
                 prior=prior,
                 keywords=[],

--- a/tests/libs/graph_ir/test_build_utils.py
+++ b/tests/libs/graph_ir/test_build_utils.py
@@ -3,6 +3,7 @@
 from libs.graph_ir.build_utils import (
     CanonicalizationResult,
     build_singleton_local_graph,
+    derive_local_parameterization_from_raw,
     extract_parameters,
     factor_id,
     local_canonical_id,
@@ -122,3 +123,63 @@ def test_build_singleton_local_graph():
     factor = result.local_graph.factor_nodes[0]
     assert factor.conclusion.startswith("lcn_")
     assert all(p.startswith("lcn_") for p in factor.premises)
+
+
+def test_derive_local_parameterization_defaults_only_settings_to_one():
+    raw = RawGraph(
+        package="test_pkg",
+        version="1.0.0",
+        knowledge_nodes=[
+            RawKnowledgeNode(
+                raw_node_id="raw_setting",
+                knowledge_type="setting",
+                content="In vacuum conditions.",
+                source_refs=[
+                    SourceRef(
+                        package="test_pkg",
+                        version="1.0.0",
+                        module="m",
+                        knowledge_name="vacuum_env",
+                    )
+                ],
+            ),
+            RawKnowledgeNode(
+                raw_node_id="raw_obs",
+                knowledge_type="observation",
+                content="A detector reading was observed.",
+                source_refs=[
+                    SourceRef(
+                        package="test_pkg",
+                        version="1.0.0",
+                        module="m",
+                        knowledge_name="detector_observation",
+                    )
+                ],
+            ),
+            RawKnowledgeNode(
+                raw_node_id="raw_claim",
+                knowledge_type="claim",
+                content="A hypothesis holds.",
+                source_refs=[
+                    SourceRef(
+                        package="test_pkg",
+                        version="1.0.0",
+                        module="m",
+                        knowledge_name="hypothesis",
+                    )
+                ],
+            ),
+        ],
+        factor_nodes=[],
+    )
+
+    result = build_singleton_local_graph(raw)
+    params = derive_local_parameterization_from_raw(raw, result.local_graph)
+    by_name = {
+        node.source_refs[0].knowledge_name: params.node_priors[node.local_canonical_id]
+        for node in result.local_graph.knowledge_nodes
+    }
+
+    assert by_name["vacuum_env"] == 1.0
+    assert by_name["detector_observation"] == 0.5
+    assert by_name["hypothesis"] == 0.5

--- a/tests/libs/graph_ir/test_storage_converter.py
+++ b/tests/libs/graph_ir/test_storage_converter.py
@@ -161,6 +161,23 @@ class TestKnowledgePriors:
         k = result.knowledge_items[0]
         assert k.prior == 0.5  # default
 
+    def test_observation_maps_to_claim_with_observation_kind(self):
+        obs = _make_node(
+            "lcn_obs",
+            content="The apparatus recorded a signal.",
+            knowledge_type="observation",
+            knowledge_name="signal_observation",
+        )
+        lcg = _make_lcg(nodes=[obs])
+        params = _make_params(node_priors={"lcn_obs": 0.4})
+
+        result = convert_graph_ir_to_storage(lcg, params)
+
+        stored = result.knowledge_items[0]
+        assert stored.type == "claim"
+        assert stored.kind == "observation"
+        assert stored.prior == 0.4
+
 
 class TestFactorTypeMapping:
     """test_factor_type_mapping: reasoning→infer, mutex_constraint→contradiction, etc."""

--- a/tests/libs/lang/test_proof_state.py
+++ b/tests/libs/lang/test_proof_state.py
@@ -65,8 +65,7 @@ def test_observations_are_holes():
     assert "inclined_plane_observation" in hole_names
 
 
-def test_observation_standalone_when_not_referenced():
-    """An observation not used as premise and not proven is standalone."""
+def test_unreferenced_observation_is_standalone():
     graph = load_typst_package(GALILEO_V3)
     state = analyze_proof_state(graph)
     standalone_names = {d["name"] for d in state["standalone"]}
@@ -132,6 +131,13 @@ def test_proof_state_format_string():
     report = state["report"]
     assert "established" in report.lower() or "\u2713" in report
     assert "assumption" in report.lower() or "\u25cb" in report
+    assert "medium_density_observation  (observation, used as premise, no proof)" in report
+
+
+def test_proof_state_does_not_return_axioms_key():
+    graph = load_typst_package(GALILEO_V3)
+    state = analyze_proof_state(graph)
+    assert "axioms" not in state
 
 
 # ── Newton v3 ────────────────────────────────────────────────────────────────
@@ -171,7 +177,7 @@ def test_newton_v3_corroborations_are_established():
     assert "apollo_galileo_convergence" not in standalone
 
 
-def test_newton_v3_observations_are_holes():
+def test_newton_v3_observations_and_unproved_claims_are_holes():
     """Observations used as premises should be holes (need experimental proof)."""
     graph = load_typst_package(NEWTON_V3)
     state = analyze_proof_state(graph)
@@ -179,7 +185,6 @@ def test_newton_v3_observations_are_holes():
     assert "kepler_third_law" in hole_names
     assert "pendulum_experiment" in hole_names
     assert "apollo15_feather_drop" in hole_names
-    # Claims without proof used as premises are also holes
     assert "second_law" in hole_names
     assert "third_law" in hole_names
 
@@ -251,15 +256,13 @@ def test_einstein_v3_holes():
     graph = load_typst_package(EINSTEIN_V3)
     state = analyze_proof_state(graph)
     hole_names = {d["name"] for d in state["holes"]}
-    # Claims without proof
     assert "maxwell_electromagnetism" in hole_names
     assert "soldner_deflection" in hole_names
     assert "einstein_field_equations" in hole_names
-    # Observations without proof (need experimental evidence)
     assert "eotvos_experiment" in hole_names
-    assert "mercury_perihelion" in hole_names
     assert "eddington_sobral" in hole_names
     assert "eddington_principe" in hole_names
+    assert "mercury_perihelion" in hole_names
 
 
 # ── v4 proof state (uses "premises" key) ────────────────────────────────────

--- a/tests/test_pipeline_converter.py
+++ b/tests/test_pipeline_converter.py
@@ -36,10 +36,10 @@ async def converter_data():
 
 async def test_converter_knowledge_type_mapping(converter_data):
     data, _build = converter_data
-    types = {k.type for k in data.knowledge_items}
-    # observation → setting, claim stays claim
-    assert "setting" in types
-    assert "claim" in types
+    by_id = {k.knowledge_id: k for k in data.knowledge_items}
+    assert by_id["galileo_falling_bodies/medium_density_observation"].type == "claim"
+    assert by_id["galileo_falling_bodies/medium_density_observation"].kind == "observation"
+    assert by_id["galileo_falling_bodies/thought_experiment_env"].type == "setting"
 
 
 async def test_converter_knowledge_id_format(converter_data):
@@ -102,12 +102,12 @@ async def test_converter_probability_records(converter_data):
 def test_render_markdown_has_package_header():
     graph_data = {
         "package": "test_pkg",
-        "nodes": [{"name": "n1", "type": "claim", "content": "hello"}],
+        "nodes": [{"name": "n1", "type": "claim", "kind": "observation", "content": "hello"}],
         "factors": [],
     }
     md = render_markdown_from_graph_data(graph_data)
     assert "# Package: test_pkg" in md
-    assert "### n1 [claim]" in md
+    assert "### n1 [claim, kind=observation]" in md
     assert "> hello" in md
 
 
@@ -166,3 +166,12 @@ async def test_render_markdown_includes_external_content():
     md = render_markdown_from_graph_data(build.graph_data)
     assert "external from galileo_falling_bodies@4.0.0" in md
     assert "在真空中，不同重量的物体应以相同速率下落。" in md
+
+
+@pytest.mark.asyncio
+async def test_render_markdown_preserves_v4_observation_kind():
+    build = await pipeline_build(
+        Path(__file__).parent / "fixtures" / "gaia_language_packages" / "dark_energy_v4"
+    )
+    md = render_markdown_from_graph_data(build.graph_data)
+    assert "claim, kind=observation" in md

--- a/tests/test_pipeline_review.py
+++ b/tests/test_pipeline_review.py
@@ -44,9 +44,9 @@ async def test_pipeline_review_default_priors_by_type():
     review = await pipeline_review(build, mock=True)
     for node in build.local_graph.knowledge_nodes:
         prior = review.node_priors[node.local_canonical_id]
-        if node.knowledge_type in ("setting", "observation"):
+        if node.knowledge_type == "setting":
             assert prior == 1.0
-        elif node.knowledge_type in ("claim", "question"):
+        elif node.knowledge_type in ("claim", "observation", "question"):
             assert prior == 0.5
 
 


### PR DESCRIPTION
## Summary
- keep `setting` as the only proof-state assumption class and treat unsupported observations as holes
- remove the `axioms` proof-state API key and document future axiom handling as assumption-basis / proof-view metadata
- align review, publish, and storage semantics so observations are stored as `claim` + `kind="observation"` instead of being rewritten to `setting`
- add regression coverage for proof-state, pipeline conversion/review, and Graph IR storage conversion

## Verification
- `python -m compileall libs tests`
- targeted pytest workaround: `78 passed`
- integration/publish/e2e pytest workaround: `32 passed`