### PR TITLE
fix: align publish artifacts with v4 storage semantics

### DIFF
--- a/libs/graph_ir/storage_converter.py
+++ b/libs/graph_ir/storage_converter.py
@@ -100,6 +100,15 @@ def _make_knowledge_id(package: str, knowledge_name: str) -> str:
     return f"{package}/{knowledge_name}"
 
 
+def _make_chain_id(package_id: str, factor) -> str:
+    """Build a published chain ID from author-facing provenance when available."""
+    if factor.source_ref:
+        return (
+            f"{package_id}.{factor.source_ref.module}.{factor.source_ref.knowledge_name}"
+        )
+    return f"{package_id}.{factor.factor_id}"
+
+
 def convert_graph_ir_to_storage(
     lcg: LocalCanonicalGraph,
     params: LocalParameterization,
@@ -121,17 +130,13 @@ def convert_graph_ir_to_storage(
     package_id = lcg.package
     package_version = lcg.version
 
-    # -- Discover modules from source_refs --
-    module_names: dict[str, set[str]] = {}  # module_name -> set of knowledge_ids
-    for node in lcg.knowledge_nodes:
-        for ref in node.source_refs:
-            if ref.module not in module_names:
-                module_names[ref.module] = set()
-
     # -- Build knowledge items --
+    module_names: dict[str, set[str]] = {}  # module_name -> set of knowledge_ids
     knowledge_items: list[storage.Knowledge] = []
     # Map from lcn_id to knowledge_id for factor rewiring (includes external nodes)
     lcn_to_kid: dict[str, str] = {}
+    # Map from local, materialized lcn_id to knowledge_id for publishable artifacts
+    materialized_lcn_to_kid: dict[str, str] = {}
 
     for node in lcg.knowledge_nodes:
         # Use first source_ref's knowledge_name for the id, fallback to lcn_id
@@ -172,6 +177,7 @@ def convert_graph_ir_to_storage(
         module_names[module_name].add(knowledge_id)
 
         module_id = f"{package_id}.{module_name}"
+        materialized_lcn_to_kid[node.local_canonical_id] = knowledge_id
 
         knowledge_items.append(
             storage.Knowledge(
@@ -260,7 +266,7 @@ def convert_graph_ir_to_storage(
         # Determine module from source_ref
         mod_name = f.source_ref.module if f.source_ref else "unknown"
         module_id = f"{package_id}.{mod_name}"
-        chain_id = f"{package_id}.{mod_name}.{f.factor_id}"
+        chain_id = _make_chain_id(package_id, f)
 
         chains.append(
             storage.Chain(
@@ -293,7 +299,7 @@ def convert_graph_ir_to_storage(
     belief_snapshots: list[storage.BeliefSnapshot] = []
     if beliefs:
         for lcn_id, belief_value in beliefs.items():
-            kid = lcn_to_kid.get(lcn_id)
+            kid = materialized_lcn_to_kid.get(lcn_id)
             if kid is not None:
                 belief_snapshots.append(
                     storage.BeliefSnapshot(

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -225,45 +225,35 @@ async def pipeline_publish(
         embed_dim: Embedding dimension for stub embeddings.
     """
     from libs.embedding import StubEmbeddingModel
+    from libs.graph_ir.storage_converter import convert_graph_ir_to_storage
     from libs.storage.config import StorageConfig
     from libs.storage.manager import StorageManager
     from libs.storage.models import KnowledgeEmbedding
 
-    from libs.graph_ir.storage_converter import convert_graph_ir_to_storage
-
     package_name = build.local_graph.package
     local_graph = build.local_graph
 
-    # 1. Convert label-based beliefs to lcn_id-based
-    label_to_lcn = {v: k for k, v in infer.adapted_graph.local_id_to_label.items()}
-    lcn_beliefs = {
-        label_to_lcn[label]: belief
-        for label, belief in infer.beliefs.items()
-        if label in label_to_lcn
-    }
+    # 1. Convert LocalCanonicalGraph → storage models via unified converter.
+    # Local BP beliefs remain author-local preview artifacts and are not published.
+    data = convert_graph_ir_to_storage(local_graph, infer.local_parameterization)
 
-    # 2. Convert LocalCanonicalGraph → storage models via unified converter
-    data = convert_graph_ir_to_storage(
-        local_graph, infer.local_parameterization, lcn_beliefs, infer.bp_run_id
-    )
-
-    # 3. Patch package fields for CLI publish context
+    # 2. Patch package fields for CLI publish context
     data.package.submitter = "cli"
     data.package.status = "merged"
     desc = build.graph_data.get("module_titles", {}).get("lib")
     if desc:
         data.package.description = desc
 
-    # 4. Build ProbabilityRecords from review factor_params
+    # 3. Build ProbabilityRecords from review factor_params
     probabilities = _build_probability_records(local_graph, review, package_name)
 
-    # 5. Build submission artifact (in-memory, no git)
+    # 4. Build submission artifact (in-memory, no git)
     submission_artifact = _build_submission_artifact_in_memory(
         build=build,
         package_name=package_name,
     )
 
-    # 6. Generate embeddings
+    # 5. Generate embeddings
     embed_model = StubEmbeddingModel(dim=embed_dim)
     texts = [k.content for k in data.knowledge_items]
     vectors = await embed_model.embed(texts) if texts else []
@@ -276,7 +266,7 @@ async def pipeline_publish(
         for k, vec in zip(data.knowledge_items, vectors)
     ]
 
-    # 7. Resolve StorageManager — external (batch/server) or self-managed (CLI)
+    # 6. Resolve StorageManager — external (batch/server) or self-managed (CLI)
     _owns_mgr = storage_manager is None
     if _owns_mgr:
         if storage_config is None:
@@ -293,7 +283,7 @@ async def pipeline_publish(
         mgr = storage_manager
 
     try:
-        # 8. Ingest
+        # 7. Ingest
         await mgr.ingest_package(
             package=data.package,
             modules=data.modules,
@@ -304,11 +294,9 @@ async def pipeline_publish(
             embeddings=embeddings,
         )
 
-        # 9. Write supplementary data
+        # 8. Write supplementary data
         if probabilities:
             await mgr.add_probabilities(probabilities)
-        if data.belief_snapshots:
-            await mgr.write_beliefs(data.belief_snapshots)
     finally:
         if _owns_mgr:
             await mgr.close()
@@ -318,7 +306,7 @@ async def pipeline_publish(
         "chains": len(data.chains),
         "factors": len(data.factors),
         "probabilities": len(probabilities),
-        "belief_snapshots": len(data.belief_snapshots),
+        "belief_snapshots": 0,
     }
 
     return PublishResult(
@@ -435,12 +423,12 @@ def _build_probability_records(
     package_name: str,
 ) -> list[storage_models.ProbabilityRecord]:
     """Build ProbabilityRecords from review factor_params."""
+    from libs.graph_ir.storage_converter import _make_chain_id
+
     now = datetime.now(timezone.utc)
     factor_to_chain: dict[str, str] = {}
     for factor in local_graph.factor_nodes:
-        if factor.source_ref:
-            sr = factor.source_ref
-            factor_to_chain[factor.factor_id] = f"{package_name}.{sr.module}.{sr.knowledge_name}"
+        factor_to_chain[factor.factor_id] = _make_chain_id(package_name, factor)
 
     probabilities: list[storage_models.ProbabilityRecord] = []
     for factor_id, params in review.factor_params.items():

--- a/tests/test_pipeline_converter.py
+++ b/tests/test_pipeline_converter.py
@@ -104,10 +104,14 @@ async def test_probability_records_from_pipeline():
 
     build = await pipeline_build(GALILEO_V3)
     review = await pipeline_review(build, mock=True)
+    infer_result = await pipeline_infer(build, review)
+    data = convert_graph_ir_to_storage(build.local_graph, infer_result.local_parameterization)
     probs = _build_probability_records(build.local_graph, review, build.local_graph.package)
     assert len(probs) > 0
+    chain_ids = {chain.chain_id for chain in data.chains}
     for p in probs:
         assert 0 < p.value <= 1.0
+        assert p.chain_id in chain_ids
 
 
 # ── 2. render_markdown_from_graph_data tests ──
@@ -179,6 +183,8 @@ async def test_converter_v4_external_refs_are_not_materialized_locally():
             for p in step.premises:
                 all_premises.add(p.knowledge_id)
     assert "galileo_falling_bodies/vacuum_prediction" in all_premises
+    assert {m.name for m in data.modules} == {"default"}
+    assert {snap.knowledge_id for snap in data.belief_snapshots} <= knowledge_ids
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline_publish.py
+++ b/tests/test_pipeline_publish.py
@@ -33,12 +33,62 @@ async def test_pipeline_publish_has_chains(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_publish_has_belief_snapshots(tmp_path):
+async def test_pipeline_publish_does_not_persist_local_belief_previews(tmp_path):
     build = await pipeline_build(GALILEO_V3)
     review = await pipeline_review(build, mock=True)
     infer = await pipeline_infer(build, review)
-    result = await pipeline_publish(build, review, infer, db_path=str(tmp_path / "db"))
-    assert result.stats["belief_snapshots"] > 0
+    db_path = str(tmp_path / "db")
+    result = await pipeline_publish(build, review, infer, db_path=db_path)
+    assert result.stats["belief_snapshots"] == 0
+
+    from libs.storage.config import StorageConfig
+    from libs.storage.manager import StorageManager
+
+    config = StorageConfig(lancedb_path=db_path, graph_backend="kuzu", kuzu_path=f"{db_path}/kuzu")
+    mgr = StorageManager(config)
+    await mgr.initialize()
+    try:
+        history = await mgr.get_belief_history("galileo_falling_bodies/composite_is_slower")
+        assert history == []
+    finally:
+        await mgr.close()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_publish_probability_records_match_chain_ids(tmp_path):
+    build = await pipeline_build(GALILEO_V3)
+    review = await pipeline_review(build, mock=True)
+    infer = await pipeline_infer(build, review)
+    db_path = str(tmp_path / "db")
+    result = await pipeline_publish(build, review, infer, db_path=db_path)
+    assert result.stats["probabilities"] > 0
+
+    from libs.storage.config import StorageConfig
+    from libs.storage.manager import StorageManager
+
+    config = StorageConfig(lancedb_path=db_path, graph_backend="kuzu", kuzu_path=f"{db_path}/kuzu")
+    mgr = StorageManager(config)
+    await mgr.initialize()
+    try:
+        chains, _ = await mgr.list_chains_paged(page=1, page_size=100)
+        chain_ids = {chain.chain_id for chain in chains}
+        assert "galileo_falling_bodies.galileo.composite_is_slower" in chain_ids
+
+        probabilities = await mgr.get_probability_history(
+            "galileo_falling_bodies.galileo.composite_is_slower"
+        )
+        assert probabilities
+        assert all(p.chain_id in chain_ids for p in probabilities)
+
+        import lancedb
+
+        db = lancedb.connect(db_path)
+        raw_probs = db.open_table("probabilities").search().limit(1000).to_list()
+        assert raw_probs
+        for row in raw_probs:
+            assert row["chain_id"] in chain_ids
+    finally:
+        await mgr.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- unify published chain IDs so `Chain` and `ProbabilityRecord` use the same identifier
- stop publishing local BP belief previews during `gaia publish`
- derive package-owned modules from materialized local knowledge only, so external refs do not leak into `external` modules or publish-time belief rows
- add regression tests for chain/probability joins, publish-time belief absence, and v4 external-ref behavior

## Validation
- `python -c "import sys, types, pytest; sys.modules['readline']=types.ModuleType('readline'); args=['tests/test_pipeline_converter.py','tests/test_pipeline_publish.py','-q']; code=pytest.main(args); print('exit', code); sys.exit(code)"`
- `python -c "import sys, types, pytest; sys.modules['readline']=types.ModuleType('readline'); args=['tests/integration/test_v4_pipeline.py','-q']; code=pytest.main(args); print('exit', code); sys.exit(code)"`

## Context
This PR is intended as a follow-up on top of #182.