### PR TITLE
fix: unblock paper and curation e2e pipeline

### DIFF
--- a/scripts/pipeline/paper_to_yaml.py
+++ b/scripts/pipeline/paper_to_yaml.py
@@ -111,7 +111,7 @@ def _extract_inference_unit(text: str) -> str:
 # ── Step Runners ───────────────────────────────────────────────────────
 
 
-PROMPTS_DIR = Path(__file__).parent.parent / "libs" / "prompts"
+PROMPTS_DIR = Path(__file__).resolve().parents[2] / "libs" / "prompts"
 
 
 async def run_step1(client: AsyncOpenAI, paper_md: str, model: str) -> str:

--- a/scripts/pipeline/run_curation_db.py
+++ b/scripts/pipeline/run_curation_db.py
@@ -121,10 +121,9 @@ def parse_args() -> argparse.Namespace:
 
 async def create_storage_manager(args: argparse.Namespace) -> StorageManager:
     """Create and initialize a StorageManager from CLI args."""
-    graph_backend = args.graph_backend if args.graph_backend != "none" else None
     config = StorageConfig(
         lancedb_path=str(args.db_path),
-        graph_backend=graph_backend,
+        graph_backend=args.graph_backend,
     )
     mgr = StorageManager(config)
     await mgr.initialize()


### PR DESCRIPTION
## Summary
- fix `paper_to_yaml` prompt discovery so `paper_to_typst` can run non-`--skip-llm` paper extraction end to end
- fix `run_curation_db` so `--graph-backend none` passes the literal value expected by `StorageConfig`
- keep the change set minimal and limited to the two blocking issues found while running the real pipeline

## Why
This is a small follow-up to #180.

While running a real paper -> global-bp pipeline against local LanceDB with official OpenAI `gpt-5-mini`, two issues blocked execution:
1. `scripts/pipeline/paper_to_yaml.py` resolved prompts relative to `scripts/`, so `paper_to_typst.py` failed before the first LLM step.
2. `scripts/pipeline/run_curation_db.py` converted `--graph-backend none` to `None`, which fails `StorageConfig` validation.

## Validation
- `python -m py_compile scripts/pipeline/paper_to_yaml.py scripts/pipeline/run_curation_db.py`
- real e2e smoke on one paper with official OpenAI `gpt-5-mini` and local LanceDB:
  - `paper_to_typst`
  - `build_graph_ir`
  - `run_local_bp`
  - `canonicalize_global`
  - `persist_to_db --graph-backend none`
  - `run_curation_db --llm-model openai/gpt-5-mini`
  - `run_global_bp_db`
