### PR TITLE
fix: enable clean Typst renderer for v4, remove v3 dead code in CLI

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -20,12 +20,6 @@ app = typer.Typer(
 )
 
 
-def _uses_v4_dsl(graph_data: dict) -> bool:
-    if graph_data.get("dsl_version") == "v4":
-        return True
-    return any("premises" in factor for factor in graph_data.get("factors", []))
-
-
 @app.command()
 def build(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
@@ -70,30 +64,21 @@ def _build_typst(pkg_path: Path, format: str, proof_state: bool = False) -> None
     json_path = build_dir / "graph_data.json"
     json_path.write_text(json_mod.dumps(result.graph_data, ensure_ascii=False, indent=2))
 
-    # Save markdown for both v3 and v4 packages.
     if format in ("md", "all"):
-        if _uses_v4_dsl(result.graph_data):
-            from libs.pipeline import render_markdown_from_graph_data
+        from libs.pipeline import render_markdown_from_graph_data
 
-            md = render_markdown_from_graph_data(result.graph_data)
-        else:
-            from libs.lang.typst_renderer import render_typst_to_markdown
-
-            md = render_typst_to_markdown(pkg_path)
+        md = render_markdown_from_graph_data(result.graph_data)
         md_path = build_dir / "package.md"
         md_path.write_text(md)
         typer.echo(f"Markdown: {md_path}")
 
     if format in ("typst", "all"):
-        if _uses_v4_dsl(result.graph_data):
-            typer.echo("Typst clean render is not supported for v4 packages yet; skipping.")
-        else:
-            from libs.lang.typst_clean_renderer import render_typst_to_clean_typst
+        from libs.lang.typst_clean_renderer import render_typst_to_clean_typst
 
-            typ = render_typst_to_clean_typst(pkg_path)
-            typ_path = build_dir / "package.typ"
-            typ_path.write_text(typ)
-            typer.echo(f"Typst: {typ_path}")
+        typ = render_typst_to_clean_typst(pkg_path)
+        typ_path = build_dir / "package.typ"
+        typ_path.write_text(typ)
+        typer.echo(f"Typst: {typ_path}")
 
     if format in ("json", "all"):
         json_out = build_dir / "graph.json"

--- a/libs/lang/typst_clean_renderer.py
+++ b/libs/lang/typst_clean_renderer.py
@@ -21,6 +21,7 @@ _TYPE_LABELS = {
     "setting": "设定",
     "observation": "观察",
     "question": "问题",
+    "action": "操作",
     "contradiction": "矛盾",
     "equivalence": "等价",
 }
@@ -191,8 +192,14 @@ def render_typst_to_clean_typst(pkg_path: Path, output: Path | None = None) -> s
     modules = graph.get("modules", [])
     module_titles = graph.get("module_titles", {})
 
+    # v4 packages have no module field on nodes and modules=[]
+    if not modules:
+        modules = [""]
+
     nodes_by_module: dict[str, list[dict]] = {}
     for node in graph["nodes"]:
+        if node.get("external"):
+            continue
         mod = node.get("module", "")
         nodes_by_module.setdefault(mod, []).append(node)
 
@@ -204,13 +211,14 @@ def render_typst_to_clean_typst(pkg_path: Path, output: Path | None = None) -> s
             chains_by_module.setdefault(mod_name, []).append(chain_name)
 
     for mod_name in modules:
-        lines.append("")
-        title = module_titles.get(mod_name)
-        label = _label(mod_name)
-        if title:
-            lines.append(f"== {title} {label}")
-        else:
-            lines.append(f"== {mod_name.replace('_', ' ')} {label}")
+        if mod_name:
+            lines.append("")
+            title = module_titles.get(mod_name)
+            label = _label(mod_name)
+            if title:
+                lines.append(f"== {title} {label}")
+            else:
+                lines.append(f"== {mod_name.replace('_', ' ')} {label}")
 
         # ── Independent knowledge ──
         mod_nodes = nodes_by_module.get(mod_name, [])
@@ -305,6 +313,32 @@ def render_typst_to_clean_typst(pkg_path: Path, output: Path | None = None) -> s
                     seen_premises.update(premise)
                     seen_context.update(context)
                     chain_step_conclusions.add(conclusion)
+
+    # ── Constraints (contradictions, equivalences) ──
+    constraints = graph.get("constraints", [])
+    if constraints:
+        lines.append("")
+        lines.append("== 约束关系")
+        for constraint in constraints:
+            cname = constraint["name"]
+            ctype = _type_label(constraint.get("type", ""))
+            between = constraint.get("between", [])
+            node = node_map.get(cname)
+            content = _clean_text(node["content"]) if node else ""
+            lines.append(f"- *{ctype}*：{_join_refs(between)} {_label(cname)}")
+            if content:
+                lines.append(f"  {content}")
+
+    # ── External references ──
+    ext_nodes = [n for n in graph["nodes"] if n.get("external")]
+    if ext_nodes:
+        lines.append("")
+        lines.append("== 外部引用")
+        for node in ext_nodes:
+            pkg = node.get("ext_package", "")
+            ver = node.get("ext_version", "")
+            content = _clean_text(node.get("content", ""))
+            lines.append(f"- {content}（{pkg}@{ver}） {_label(node['name'])}")
 
     result = "\n".join(lines)
 

--- a/scripts/pipeline/build_graph_ir.py
+++ b/scripts/pipeline/build_graph_ir.py
@@ -8,7 +8,7 @@ Reads typst.toml + *.typ files, generates:
   graph_ir/local_parameterization.json
 
 Usage:
-    python scripts/pipeline/build_graph_ir.py tests/fixtures/gaia_language_packages/galileo_falling_bodies_v3
+    python scripts/pipeline/build_graph_ir.py tests/fixtures/gaia_language_packages/galileo_falling_bodies_v4
     python scripts/pipeline/build_graph_ir.py tests/fixtures/gaia_language_packages/*
 """
 

--- a/tests/libs/lang/test_typst_clean_renderer.py
+++ b/tests/libs/lang/test_typst_clean_renderer.py
@@ -1,0 +1,107 @@
+"""Tests for typst_clean_renderer with v4 packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from libs.lang.typst_clean_renderer import render_typst_to_clean_typst
+
+FIXTURES = Path(__file__).parents[2] / "fixtures" / "gaia_language_packages"
+GALILEO_V4 = FIXTURES / "galileo_falling_bodies_v4"
+NEWTON_V4 = FIXTURES / "newton_principia_v4"
+EINSTEIN_V4 = FIXTURES / "einstein_gravity_v4"
+
+
+@pytest.fixture(scope="module")
+def galileo_typst():
+    return render_typst_to_clean_typst(GALILEO_V4)
+
+
+@pytest.fixture(scope="module")
+def newton_typst():
+    return render_typst_to_clean_typst(NEWTON_V4)
+
+
+@pytest.fixture(scope="module")
+def einstein_typst():
+    return render_typst_to_clean_typst(EINSTEIN_V4)
+
+
+class TestGalileoCleanTypst:
+    """Galileo v4: settings, claims with premises, contradiction constraint."""
+
+    def test_has_package_header(self, galileo_typst):
+        assert galileo_typst.startswith("= galileo falling bodies")
+
+    def test_has_version_and_authors(self, galileo_typst):
+        assert "Version: 4.0.0" in galileo_typst
+
+    def test_settings_rendered(self, galileo_typst):
+        assert "设定" in galileo_typst
+        assert "<setting.thought-experiment-env>" in galileo_typst
+
+    def test_claims_with_premises_rendered(self, galileo_typst):
+        # vacuum_prediction has multiple premises
+        assert "<galileo.vacuum-prediction>" in galileo_typst
+        assert "@galileo.tied-balls-contradiction" in galileo_typst
+
+    def test_question_rendered(self, galileo_typst):
+        assert "问题" in galileo_typst
+        assert "<motivation.main-question>" in galileo_typst
+
+    def test_constraint_section(self, galileo_typst):
+        assert "约束关系" in galileo_typst
+        assert "矛盾" in galileo_typst
+        assert "@galileo.composite-is-slower" in galileo_typst
+        assert "@galileo.composite-is-faster" in galileo_typst
+
+    def test_single_premise_uses_inline_format(self, galileo_typst):
+        # heavier_falls_faster has a single premise → "基于 @ref，得出："
+        assert "基于 @aristotle.everyday-observation，得出" in galileo_typst
+
+    def test_multi_premise_uses_list_format(self, galileo_typst):
+        # composite_is_slower has multiple premises → "基于以下前提："
+        assert "基于以下前提" in galileo_typst
+
+    def test_no_external_section(self, galileo_typst):
+        # Galileo has no external refs
+        assert "外部引用" not in galileo_typst
+
+
+class TestNewtonCleanTypst:
+    """Newton v4: has external reference to galileo."""
+
+    def test_has_package_header(self, newton_typst):
+        assert newton_typst.startswith("= newton principia")
+
+    def test_external_reference_section(self, newton_typst):
+        assert "外部引用" in newton_typst
+        assert "galileo_falling_bodies@4.0.0" in newton_typst
+
+    def test_external_ref_has_label(self, newton_typst):
+        assert "<vacuum-prediction>" in newton_typst
+
+    def test_claims_reference_external(self, newton_typst):
+        # Newton's derivation references galileo's vacuum_prediction
+        assert "@vacuum-prediction" in newton_typst
+
+
+class TestEinsteinCleanTypst:
+    """Einstein v4: has contradiction and equivalence constraints."""
+
+    def test_has_package_header(self, einstein_typst):
+        assert einstein_typst.startswith("= einstein gravity")
+
+    def test_constraint_section(self, einstein_typst):
+        assert "约束关系" in einstein_typst
+
+    def test_settings_rendered(self, einstein_typst):
+        assert "设定" in einstein_typst
+
+    def test_output_to_file(self, tmp_path):
+        output = tmp_path / "test.typ"
+        result = render_typst_to_clean_typst(EINSTEIN_V4, output=output)
+        assert output.exists()
+        assert output.read_text() == result


### PR DESCRIPTION
## Summary

Fixes the two issues found during PR #184 self-review:

- **Medium**: `typst_clean_renderer.py` existed but was marked unsupported for v4 and had no tests
  - Fixed: handle v4 data (empty `modules` list, no `chain`/`step` fields), add constraint and external ref sections, add `action` to type labels
  - Added 17 tests covering all 3 v4 packages (Galileo, Newton, Einstein)
  - Removed the "not supported for v4" skip in CLI — `gaia build --format typst` now works

- **Low**: `build_graph_ir.py` docstring referenced deleted `galileo_falling_bodies_v3`
  - Fixed: changed to `galileo_falling_bodies_v4`

- **Bonus**: `cli/main.py` still had `_uses_v4_dsl()` and v3 fallback branches (dead code after PR #184)
  - Removed the helper and all v3 branches — CLI now always uses v4 paths

## Test plan

- [x] `pytest` — 702 tests pass
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] Clean renderer output manually verified for all 3 packages
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)