### PR TITLE
fix(curation): abstraction creates correct factor type and node kind

### DIFF
--- a/frontend/src/pages/v2/GraphViewer.tsx
+++ b/frontend/src/pages/v2/GraphViewer.tsx
@@ -10,7 +10,7 @@ import { Link } from "react-router-dom";
 
 const TYPE_COLORS: Record<string, string> = {
   claim: "#1677ff",
-  schema: "#9254de",  // abstraction nodes from curation
+  abstraction: "#9254de",  // abstraction nodes from curation
   setting: "#52c41a",
   question: "#fa8c16",
   action: "#722ed1",
@@ -21,7 +21,6 @@ const TYPE_COLORS: Record<string, string> = {
 const FACTOR_COLORS: Record<string, string> = {
   infer: "#595959",
   abstraction: "#595959",
-  instantiation: "#8c8c8c",
   contradiction: "#cf1322",
   equivalence: "#08979c",
 };
@@ -71,22 +70,22 @@ function buildVisGraph(data: UnifiedGraphData) {
       `module: ${n.source_module_id}`,
     ].join("\n");
 
-    // Schema (abstraction) nodes get distinct color and larger size
-    const isSchema = n.kind === "schema";
-    const bgColor = isSchema ? TYPE_COLORS.schema : (TYPE_COLORS[n.type] ?? "#aaa");
+    // Abstraction nodes get distinct color and larger size
+    const isAbstraction = n.kind === "abstraction";
+    const bgColor = isAbstraction ? TYPE_COLORS.abstraction : (TYPE_COLORS[n.type] ?? "#aaa");
 
     nodes.push({
       id: n.knowledge_id,
-      label: isSchema ? `⬡ ${label}` : label,
+      label: isAbstraction ? `⬡ ${label}` : label,
       title: tooltip,
       color: {
         background: bgColor,
-        border: isSchema ? "#531dab" : "#555",
+        border: isAbstraction ? "#531dab" : "#555",
       },
-      font: { color: "#fff", size: isSchema ? 12 : 10 },
+      font: { color: "#fff", size: isAbstraction ? 12 : 10 },
       shape: "box",
-      size: isSchema ? 20 : 14,
-      borderWidth: isSchema ? 2 : 1,
+      size: isAbstraction ? 20 : 14,
+      borderWidth: isAbstraction ? 2 : 1,
     });
   }
 

--- a/libs/curation/abstraction.py
+++ b/libs/curation/abstraction.py
@@ -344,15 +344,15 @@ class AbstractionAgent:
                     member_ids=current_group.member_node_ids,
                     reason=current_group.reason,
                 )
-                # Attach refine history to schema node metadata
+                # Attach refine history to abstracted node metadata
                 if current_group.refine_history:
-                    meta = dict(abs_result.schema_node.metadata or {})
+                    meta = dict(abs_result.abstracted_node.metadata or {})
                     meta["refine_history"] = current_group.refine_history
-                    abs_result.schema_node = abs_result.schema_node.model_copy(
+                    abs_result.abstracted_node = abs_result.abstracted_node.model_copy(
                         update={"metadata": meta}
                     )
-                result.new_nodes.append(abs_result.schema_node)
-                result.new_factors.extend(abs_result.instantiation_factors)
+                result.new_nodes.append(abs_result.abstracted_node)
+                result.new_factors.extend(abs_result.abstraction_factors)
                 result.suggestions.append(
                     CurationSuggestion(
                         operation="create_abstraction",

--- a/libs/curation/cleanup.py
+++ b/libs/curation/cleanup.py
@@ -203,17 +203,17 @@ def _execute_suggestion(
             member_ids=suggestion.target_ids,
             reason=suggestion.reason,
         )
-        # Add schema node and instantiation factors
-        nodes[result.schema_node.global_canonical_id] = result.schema_node
-        factors.extend(result.instantiation_factors)
+        # Add abstracted node and abstraction factors
+        nodes[result.abstracted_node.global_canonical_id] = result.abstracted_node
+        factors.extend(result.abstraction_factors)
 
         return AuditEntry(
             operation="create_abstraction",
             target_ids=list(suggestion.target_ids),
             suggestion_id=suggestion.suggestion_id,
             rollback_data={
-                "schema_node_id": result.schema_node.global_canonical_id,
-                "factor_ids": [f.factor_id for f in result.instantiation_factors],
+                "abstracted_node_id": result.abstracted_node.global_canonical_id,
+                "factor_ids": [f.factor_id for f in result.abstraction_factors],
             },
         )
 

--- a/libs/curation/operations.py
+++ b/libs/curation/operations.py
@@ -122,10 +122,10 @@ def merge_nodes(
 
 @dataclass
 class AbstractionResult:
-    """Result of creating an abstraction (schema node + instantiation factors)."""
+    """Result of creating an abstraction (abstracted node + abstraction factor)."""
 
-    schema_node: GlobalCanonicalNode
-    instantiation_factors: list[FactorNode]
+    abstracted_node: GlobalCanonicalNode
+    abstraction_factors: list[FactorNode]
 
 
 def create_abstraction(
@@ -133,7 +133,10 @@ def create_abstraction(
     member_ids: list[str],
     reason: str = "",
 ) -> AbstractionResult:
-    """Create a schema node and instantiation factors for an abstraction group.
+    """Create an abstracted node and an abstraction factor for an abstraction group.
+
+    The abstraction factor has the member nodes as premises and the abstracted
+    node as conclusion: member_1, member_2, ... → abstraction → abstracted_node.
 
     Args:
         abstraction_content: The common weaker conclusion text.
@@ -141,17 +144,16 @@ def create_abstraction(
         reason: Why this abstraction was created.
 
     Returns:
-        AbstractionResult with the schema node and per-member instantiation factors.
+        AbstractionResult with the abstracted node and abstraction factor.
     """
-    # Deterministic schema node ID
     sorted_members = sorted(member_ids)
     digest = sha256(":".join(sorted_members).encode()).hexdigest()[:16]
-    schema_id = f"gcn_schema_{digest}"
+    abstracted_id = f"gcn_abs_{digest}"
 
-    schema_node = GlobalCanonicalNode(
-        global_canonical_id=schema_id,
+    abstracted_node = GlobalCanonicalNode(
+        global_canonical_id=abstracted_id,
         knowledge_type="claim",
-        kind="schema",
+        kind="abstraction",
         representative_content=abstraction_content,
         metadata={
             "curation_created": True,
@@ -160,22 +162,19 @@ def create_abstraction(
         },
     )
 
-    # One instantiation factor per member: schema → member
-    factors: list[FactorNode] = []
-    for member_id in sorted_members:
-        pair_key = f"{schema_id}:{member_id}:instantiation"
-        f_digest = sha256(pair_key.encode()).hexdigest()[:16]
-        factor = FactorNode(
-            factor_id=f"f_inst_{f_digest}",
-            type="instantiation",
-            premises=[schema_id],
-            conclusion=member_id,
-            package_id="__curation__",
-            metadata={"curation_created": True},
-        )
-        factors.append(factor)
+    # Single abstraction factor: members → abstracted node
+    factor_key = f"{abstracted_id}:abstraction"
+    f_digest = sha256(factor_key.encode()).hexdigest()[:16]
+    factor = FactorNode(
+        factor_id=f"f_abs_{f_digest}",
+        type="abstraction",
+        premises=sorted_members,
+        conclusion=abstracted_id,
+        package_id="__curation__",
+        metadata={"curation_created": True},
+    )
 
-    return AbstractionResult(schema_node=schema_node, instantiation_factors=factors)
+    return AbstractionResult(abstracted_node=abstracted_node, abstraction_factors=[factor])
 
 
 def create_constraint(

--- a/libs/curation/scheduler.py
+++ b/libs/curation/scheduler.py
@@ -109,9 +109,9 @@ async def run_curation(
     logger.info("Loaded %d global nodes and %d factors", len(all_nodes), len(all_factors))
 
     # Step 2: Cluster similar nodes
-    # Exclude schema nodes (already abstractions) from clustering
-    clusterable_nodes = [n for n in all_nodes if n.kind != "schema"]
-    # Exclude pairs already connected by factors (instantiation, reasoning, etc.)
+    # Exclude abstraction nodes (already abstractions) from clustering
+    clusterable_nodes = [n for n in all_nodes if n.kind != "abstraction"]
+    # Exclude pairs already connected by factors (abstraction, reasoning, etc.)
     connected_pairs: set[tuple[str, str]] = set()
     for f in all_factors:
         for p in f.premises:

--- a/libs/graph_ir/adapter.py
+++ b/libs/graph_ir/adapter.py
@@ -58,14 +58,6 @@ def adapt_local_graph_to_factor_graph(
                 probability=params.conditional_probability,
                 edge_type=factor.type,
             )
-        elif factor.type == "instantiation":
-            factor_graph.add_factor(
-                edge_id=factor_index,
-                premises=premise_ids,
-                conclusions=[local_id_to_var_id[factor.conclusion]],
-                probability=1.0,
-                edge_type=factor.type,
-            )
         elif factor.type in ("contradiction", "equivalence"):
             # Relation node is already in premises[0], no conclusion
             factor_graph.add_factor(

--- a/scripts/pipeline/run_curation_db.py
+++ b/scripts/pipeline/run_curation_db.py
@@ -164,15 +164,15 @@ async def main() -> None:
     logger.info("--- Step 1: Clustering ---")
     t0 = time.monotonic()
     embedding_model = DPEmbeddingModel()
-    # Exclude schema nodes and already-connected pairs
-    clusterable_nodes = [n for n in nodes if n.kind != "schema"]
+    # Exclude abstraction nodes and already-connected pairs
+    clusterable_nodes = [n for n in nodes if n.kind != "abstraction"]
     connected_pairs: set[tuple[str, str]] = set()
     for f in factors:
         for p in f.premises:
             if f.conclusion:
                 connected_pairs.add((min(p, f.conclusion), max(p, f.conclusion)))
     logger.info(
-        "Clustering: %d nodes (excluded %d schema), %d connected pairs excluded",
+        "Clustering: %d nodes (excluded %d abstraction), %d connected pairs excluded",
         len(clusterable_nodes),
         len(nodes) - len(clusterable_nodes),
         len(connected_pairs),

--- a/scripts/smoke_curation.py
+++ b/scripts/smoke_curation.py
@@ -97,8 +97,8 @@ async def main() -> None:
     logger.info("--- Step 1: Clustering ---")
     t0 = time.monotonic()
     embedding_model = DPEmbeddingModel()
-    # Exclude schema nodes and already-connected pairs
-    clusterable_nodes = [n for n in nodes if n.kind != "schema"]
+    # Exclude abstraction nodes and already-connected pairs
+    clusterable_nodes = [n for n in nodes if n.kind != "abstraction"]
     connected_pairs: set[tuple[str, str]] = set()
     for f in factors:
         for p in f.premises:

--- a/tests/libs/curation/test_abstraction.py
+++ b/tests/libs/curation/test_abstraction.py
@@ -77,36 +77,32 @@ def test_create_abstraction_deterministic_ids():
 
     sorted_members = sorted(members)
     digest = sha256(":".join(sorted_members).encode()).hexdigest()[:16]
-    expected_id = f"gcn_schema_{digest}"
+    expected_id = f"gcn_abs_{digest}"
 
-    assert result.schema_node.global_canonical_id == expected_id
-    assert result.schema_node.representative_content == "Force law"
-    assert result.schema_node.kind == "schema"
-    assert result.schema_node.metadata["abstraction_source_nodes"] == sorted_members
+    assert result.abstracted_node.global_canonical_id == expected_id
+    assert result.abstracted_node.representative_content == "Force law"
+    assert result.abstracted_node.kind == "abstraction"
+    assert result.abstracted_node.metadata["abstraction_source_nodes"] == sorted_members
 
     # Same inputs in different order produce same ID
     result2 = create_abstraction("Force law", [ID_FMA_1, ID_FMA_2], reason="test")
-    assert result2.schema_node.global_canonical_id == expected_id
+    assert result2.abstracted_node.global_canonical_id == expected_id
 
 
 def test_create_abstraction_factor_structure():
-    """Each member gets an instantiation factor with correct premises/conclusion."""
+    """Abstraction factor has members as premises and abstracted node as conclusion."""
     members = [ID_FMA_1, ID_HEAT]
     result = create_abstraction("Common energy", members, reason="test")
 
-    schema_id = result.schema_node.global_canonical_id
-    assert len(result.instantiation_factors) == 2
+    abstracted_id = result.abstracted_node.global_canonical_id
+    assert len(result.abstraction_factors) == 1
 
-    for factor in result.instantiation_factors:
-        assert factor.type == "instantiation"
-        assert factor.premises == [schema_id]
-        assert factor.conclusion in sorted(members)
-        assert factor.package_id == "__curation__"
-        assert factor.metadata["curation_created"] is True
-
-    # Verify each member has exactly one factor
-    conclusions = {f.conclusion for f in result.instantiation_factors}
-    assert conclusions == set(members)
+    factor = result.abstraction_factors[0]
+    assert factor.type == "abstraction"
+    assert factor.premises == sorted(members)
+    assert factor.conclusion == abstracted_id
+    assert factor.package_id == "__curation__"
+    assert factor.metadata["curation_created"] is True
 
 
 # ── AbstractionAgent._abstract_cluster tests ──
@@ -410,8 +406,8 @@ async def test_run_end_to_end(mock_acompletion, physics_node_map):
     result = await agent.run([cluster], physics_node_map)
 
     assert len(result.new_nodes) == 1
-    assert result.new_nodes[0].kind == "schema"
-    assert len(result.new_factors) == 2  # one per member
+    assert result.new_nodes[0].kind == "abstraction"
+    assert len(result.new_factors) == 1  # single abstraction factor
     assert len(result.suggestions) == 1
     assert result.suggestions[0].operation == "create_abstraction"
 

--- a/tests/libs/curation/test_coverage_pr161.py
+++ b/tests/libs/curation/test_coverage_pr161.py
@@ -183,10 +183,11 @@ class TestCleanupCreateAbstraction:
         result = await execute_cleanup(plan, nodes, factors, audit_log)
         assert len(result.executed) == 1
         assert result.executed[0].operation == "create_abstraction"
-        # Schema node should be added to nodes
+        # Abstracted node should be added to nodes
         assert len(nodes) > 3
-        # Instantiation factors should be created
-        assert len(factors) >= 2
+        # Abstraction factor should be created
+        assert len(factors) == 1
+        assert factors[0].type == "abstraction"
 
     async def test_create_abstraction_too_few_targets(self):
         """create_abstraction with <2 targets → skipped."""
@@ -540,8 +541,8 @@ class TestSchedulerPaths:
         mgr.upsert_global_nodes.assert_called_once()
         mgr.write_factors.assert_called_once()
 
-    async def test_scheduler_schema_nodes_excluded_from_clustering(self):
-        """Schema nodes should be excluded from clustering."""
+    async def test_scheduler_abstraction_nodes_excluded_from_clustering(self):
+        """Abstraction nodes should be excluded from clustering."""
         from libs.curation.scheduler import run_curation
 
         nodes = [
@@ -551,10 +552,10 @@ class TestSchedulerPaths:
                 representative_content="Normal claim",
             ),
             GlobalCanonicalNode(
-                global_canonical_id="gcn_schema",
+                global_canonical_id="gcn_abstraction",
                 knowledge_type="claim",
-                kind="schema",
-                representative_content="Normal claim",  # same content but schema
+                kind="abstraction",
+                representative_content="Normal claim",  # same content but abstraction
             ),
         ]
         mgr = AsyncMock()


### PR DESCRIPTION
## Summary

Fixes #198.

- **Factor type**: changed from `instantiation` (schema→member) to `abstraction` (members→abstracted_node), matching the correct reasoning direction where original claims are premises and the abstracted claim is the conclusion
- **Node kind**: changed from `kind="schema"` to `kind="abstraction"`, distinguishing curation-derived abstractions from future universally-quantified schema templates
- **Adapter**: removed dedicated `instantiation` branch in BP adapter (abstraction factors are handled by the existing `infer`/`abstraction` branch)
- **Frontend**: updated `GraphViewer.tsx` to use `kind="abstraction"` for node styling

## Test plan

- [x] All 702 tests pass (including updated curation tests)
- [x] Ruff lint + format clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)