### PR TITLE
docs: graph-ir fixups — template braces + provenance + created_at

### DIFF
--- a/docs/foundations/graph-ir/belief-state.md
+++ b/docs/foundations/graph-ir/belief-state.md
@@ -11,7 +11,7 @@ Graph IR 结构定义见 [graph-ir.md](graph-ir.md)。概率参数见 [parameter
 ```
 BeliefState:
     bp_run_id:            str              # 唯一运行 ID
-    timestamp:            str              # ISO 8601
+    created_at:           str              # ISO 8601
 
     # ── 重现条件 ──
     resolution_policy:    str              # "latest" | "source:<source_id>"

--- a/docs/foundations/graph-ir/graph-ir.md
+++ b/docs/foundations/graph-ir/graph-ir.md
@@ -27,10 +27,12 @@ KnowledgeNode:
     # ── local 层使用 ──
     content:                str | None       # 知识内容（local 层存储，global 层通常为 None）
 
+    # ── 来源追溯 ──
+    provenance:             list[PackageRef] | None   # 贡献包列表
+
     # ── global 层使用 ──
     representative_lcn:     LocalCanonicalRef | None  # 代表性 local 节点（内容从此获取）
     member_local_nodes:     list[LocalCanonicalRef] | None  # 所有映射到此的 local 节点
-    provenance:             list[PackageRef] | None   # 贡献包列表
 ```
 
 **各层字段使用：**
@@ -39,9 +41,9 @@ KnowledgeNode:
 |------|-------|--------|
 | `id` | `lcn_` 前缀，SHA-256 内容寻址 | `gcn_` 前缀，注册中心分配 |
 | `content` | 有值（唯一存储位置） | 通常为 None（subgraph 中间节点例外） |
+| `provenance` | 有值（来源包） | 有值（贡献包列表） |
 | `representative_lcn` | None | 有值（引用 local 节点获取内容） |
 | `member_local_nodes` | None | 有值（所有映射到此的 local 节点） |
-| `provenance` | None | 有值（贡献包列表） |
 
 **身份规则**：local 层 `id = SHA-256(type + content + sorted(parameters))`，相同类型、内容和参数的声明共享同一 ID。
 

--- a/docs/foundations/graph-ir/overview.md
+++ b/docs/foundations/graph-ir/overview.md
@@ -165,7 +165,7 @@ BeliefState 是 BP 在 GlobalCanonicalGraph 上的纯输出——后验信念值
 ```json
 {
   "bp_run_id": "uuid-...",
-  "timestamp": "2026-03-24T12:00:00Z",
+  "created_at": "2026-03-24T12:00:00Z",
   "resolution_policy": "latest",
   "prior_cutoff": "2026-03-24T12:00:00Z",
   "beliefs": {


### PR DESCRIPTION
## Summary

Two fixups that were pushed to the PR #205 branch after it was merged:

- Template free variables use `{x}` brace syntax (not bare `x`)
- `provenance` field used by both local and global layers
- `timestamp` → `created_at` in BeliefState, consistent with other schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)