### PR TITLE
docs: LKM minimal pipeline spec and implementation plan

### DIFF
--- a/docs/plans/2026-03-25-lkm-minimal-pipeline.md
+++ b/docs/plans/2026-03-25-lkm-minimal-pipeline.md
@@ -2,21 +2,26 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build a minimal end-to-end pipeline under a new `gaia/` package: upload a `LocalCanonicalGraph` + `LocalParameterization` → persist → global canonicalization (with parameterization integration) → global BP → produce `BeliefState`.
+**Goal:** Build a minimal end-to-end pipeline under `gaia/`: upload `LocalCanonicalGraph` + `LocalParameterization` → persist → global canonicalization (with parameterization integration) → global BP → `BeliefState`.
 
-**Architecture:** New `gaia/` top-level package, completely independent of old `libs/`/`services/`/`scripts/`. Models rewritten from scratch per `docs/foundations/graph-ir/`. `KnowledgeNode` and `FactorNode` are unified data classes shared by local and global layers (distinguished by `id` prefix `lcn_`/`gcn_`). Storage on LanceDB (content+vector) + Neo4j (topology). Core algorithms in a shared `core/` layer. LKM entry points in `pipelines/` (batch) and `services/` (API), both thin orchestration layers.
+**Spec:** `docs/specs/2026-03-25-lkm-minimal-pipeline-spec.md` (v0.2)
 
-**Tech Stack:** Python 3.12+, Pydantic v2, LanceDB, Neo4j, NumPy, FastAPI
+**Architecture:** New `gaia/` package, independent of old code. Unified `KnowledgeNode` (`lcn_`/`gcn_`) and `FactorNode` (`lcf_`/`gcf_` + `scope`). All knowledge types participate in canonicalization. Embedding vector table (`node_embeddings`) for matching. BP bridged via `gaia.bp` → old `libs.inference`.
 
-**Spec:** `docs/specs/2026-03-25-lkm-minimal-pipeline-spec.md`
+**Fixtures:** galileo/newton/einstein from `tests/fixtures/`. No synthetic data.
 
-**Key foundation docs:**
-- `docs/foundations/graph-ir/` — Graph IR structural contract (all models derive from here)
-- `docs/foundations/lkm/` — Pipeline stages, storage schema, canonicalization, global inference
+---
 
-**BP engine:** `gaia/bp/` is a placeholder. `core/global_bp.py` imports from existing `libs.inference` via `gaia.bp` bridge.
+## PR Strategy
 
-**Fixtures:** Use existing galileo/newton/einstein examples from `tests/fixtures/`. Do not invent synthetic data.
+| PR | Scope | Verification |
+|----|-------|-------------|
+| **PR 1: Models + Fixtures** (Chunk 1) | `gaia/libs/models/`, `gaia/core/local_params.py`, `tests/gaia/fixtures/`, `tests/gaia/libs/models/` | `pytest tests/gaia/libs/models/ tests/gaia/fixtures/` 全绿 + owner review 模型 vs graph-ir 文档对齐 |
+| **PR 2: Storage** (Chunk 2) | `gaia/libs/storage/`, `gaia/libs/embedding.py`, `gaia/libs/llm.py`, `tests/gaia/libs/storage/` | `pytest tests/gaia/libs/storage/` 全绿（不含 neo4j）+ owner review 表结构 vs spec §2.5 |
+| **PR 3: Core Algorithms** (Chunk 3) | `gaia/core/`, `gaia/bp/__init__.py`, `tests/gaia/core/` | `pytest tests/gaia/core/` 全绿 + owner review canonicalize 决策规则 + 参数整合 + BP adapter |
+| **PR 4: LKM + E2E** (Chunk 4-5) | `gaia/lkm/`, `tests/gaia/lkm/`, `tests/gaia/test_e2e_pipeline.py` | `pytest tests/gaia/` 全部全绿 + E2E 3 包 pipeline 通过 + FastAPI smoke test |
+
+执行顺序严格 PR 1 → 2 → 3 → 4。
 
 ---
 
@@ -25,876 +30,239 @@
 ```
 gaia/
   __init__.py
-
   libs/
     __init__.py
     models/
-      __init__.py              # Re-exports all model classes
-      graph_ir.py              # KnowledgeNode, FactorNode, LocalCanonicalGraph, GlobalCanonicalGraph
+      __init__.py              # Re-exports
+      graph_ir.py              # KnowledgeNode (lcn_/gcn_), FactorNode (lcf_/gcf_ + scope),
+                               # LocalCanonicalGraph, GlobalCanonicalGraph
       parameterization.py      # PriorRecord, FactorParamRecord, ParameterizationSource, ResolutionPolicy
       belief_state.py          # BeliefState
-      binding.py               # CanonicalBinding
+      binding.py               # CanonicalBinding, BindingDecision
     storage/
       __init__.py
-      config.py                # StorageConfig (env → config)
+      config.py                # StorageConfig
       base.py                  # ABC: ContentStore, GraphStore
-      lance.py                 # LanceDB: content + vector + FTS
-      neo4j.py                 # Neo4j: topology
+      lance.py                 # LanceDB implementation (knowledge_nodes, factor_nodes,
+                               # canonical_bindings, prior_records, factor_param_records,
+                               # param_sources, belief_states, node_embeddings)
+      neo4j.py                 # Neo4j implementation
       manager.py               # StorageManager
-    embedding.py               # EmbeddingModel ABC + DPEmbeddingModel + StubEmbeddingModel
-    llm.py                     # LLM client (litellm wrapper)
-
+    embedding.py               # Port from libs/embedding.py
+    llm.py                     # Port from libs/llm.py
   core/
     __init__.py
-    local_params.py            # LocalParameterization (transient, not Graph IR contract)
-    matching.py                # Embedding cosine + TF-IDF similarity matching
-    canonicalize.py            # Global canonicalization + parameterization integration
-    global_bp.py               # Assemble Parameterization → run BP → produce BeliefState
-
+    local_params.py            # LocalParameterization (transient)
+    matching.py                # Similarity matching (queries node_embeddings table)
+    canonicalize.py            # Global canonicalization + param integration
+    global_bp.py               # Param assembly + BP orchestration + adapter (new→old models)
   lkm/
     __init__.py
     pipelines/
       __init__.py
-      run_ingest.py            # Orchestrate modules 1-3: persist_local → canonicalize → persist_global
-      run_global_bp.py         # Orchestrate module 4: global BP
-      run_full.py              # Full pipeline orchestrator
+      run_ingest.py            # Orchestrate: persist_local → canonicalize → persist_global
+      run_global_bp.py         # Orchestrate: global BP
+      run_full.py              # Full pipeline
     services/
       __init__.py
-      app.py                   # FastAPI app factory
-      deps.py                  # DI (StorageManager, EmbeddingModel)
+      app.py                   # FastAPI factory
+      deps.py                  # DI
       routes/
         __init__.py
-        packages.py            # POST /packages/ingest, GET /packages/{id}
-        knowledge.py           # GET /knowledge/{id}, GET /knowledge/{id}/beliefs
-        inference.py           # POST /inference/run, GET /beliefs/{run_id}
-
+        packages.py            # POST /api/packages/ingest
+        knowledge.py           # GET /api/knowledge/{id}
+        inference.py           # POST /api/inference/run
   bp/
-    __init__.py                # Placeholder — re-exports from libs.inference
-  review/
-    __init__.py                # Placeholder
-  cli/
-    __init__.py                # Placeholder
+    __init__.py                # Bridge: re-export libs.inference
+  review/__init__.py           # Placeholder
+  cli/__init__.py              # Placeholder
 
 tests/gaia/
-  __init__.py
-  libs/
-    __init__.py
-    models/
-      __init__.py
-      test_graph_ir.py
-      test_parameterization.py
-      test_belief_state.py
-      test_binding.py
-    storage/
-      __init__.py
-      test_lance.py
-      test_neo4j.py
-      test_manager.py
-  core/
-    __init__.py
-    test_matching.py
-    test_canonicalize.py
-    test_global_bp.py
-  lkm/
-    __init__.py
-    test_pipelines.py
-    services/
-      __init__.py
-      test_routes.py
-  fixtures/
-    __init__.py
-    graphs.py                  # Builder functions for test graphs (galileo, newton, einstein)
-    parameterizations.py       # Builder functions for LocalParameterization + expected params
+  libs/models/test_graph_ir.py, test_parameterization.py, test_belief_state.py, test_binding.py
+  libs/storage/test_lance.py, test_neo4j.py, test_manager.py
+  core/test_matching.py, test_canonicalize.py, test_global_bp.py
+  lkm/test_pipelines.py, services/test_routes.py
+  fixtures/graphs.py, parameterizations.py
+  test_e2e_pipeline.py
 ```
 
 ---
 
-## Chunk 1: Models — Graph IR Data Definitions
+## Chunk 1: Models + Fixtures (PR 1)
 
-All Pydantic v2 models mirroring `docs/foundations/graph-ir/`. **Key change from previous plan:** `KnowledgeNode` is a single unified data class for both local (`lcn_`) and global (`gcn_`) layers — no separate `GlobalCanonicalNode`.
+### Task 1.1: Scaffolding
 
-### Task 1.1: Project Scaffolding
+Create all directories and `__init__.py` files. `gaia/bp/__init__.py` bridges `libs.inference`.
 
-**Files:**
-- Create: all `__init__.py` files per file structure above
+### Task 1.2: KnowledgeNode + FactorNode + Graph Containers
 
-- [ ] **Step 1: Create package directory structure**
+**Files:** `gaia/libs/models/graph_ir.py`, `tests/gaia/libs/models/test_graph_ir.py`
 
-```bash
-mkdir -p gaia/libs/models gaia/libs/storage gaia/core gaia/lkm/pipelines gaia/lkm/services/routes gaia/bp gaia/review gaia/cli
-mkdir -p tests/gaia/libs/models tests/gaia/libs/storage tests/gaia/core tests/gaia/lkm/services tests/gaia/fixtures
-```
+**Spec:** graph-ir.md §1 (KnowledgeNode), §2 (FactorNode)
 
-- [ ] **Step 2: Create all `__init__.py` files**
+**Key design points for implementing agent:**
 
-Every directory gets an empty `__init__.py`, except `gaia/bp/__init__.py` which bridges old code:
+`KnowledgeNode`: unified data class.
+- If `id` not provided and `content` not None → compute `lcn_{sha256[:16]}`
+- If `id` provided (e.g., `gcn_*`) → use as-is
+- All fields from graph-ir.md §1.1: `id`, `type`, `parameters`, `source_refs`, `metadata`, `content`, `provenance`, `representative_lcn`, `member_local_nodes`
 
-```python
-# gaia/bp/__init__.py
-"""BP engine — placeholder, re-exports from libs.inference until migration."""
-from libs.inference.factor_graph import FactorGraph, CROMWELL_EPS
-from libs.inference.bp import BeliefPropagation, BPDiagnostics
-```
+`FactorNode`: unified data class with `scope` field.
+- `factor_id`: `lcf_{sha256[:16]}` (local) or `gcf_{sha256[:16]}` (global), computed from `scope + category + sorted(premises) + conclusion`
+- `scope`: `"local"` | `"global"` — required field
+- Invariants enforced via `@model_validator`: §2.3 invariant 1 (candidate/permanent infer needs reasoning_type), §2.3 invariant 6 (bilateral types need conclusion=None, premises>=2)
 
-- [ ] **Step 3: Verify import works**
+`LocalCanonicalGraph`: `scope="local"`, `graph_hash = sha256(canonical JSON)`, `knowledge_nodes`, `factor_nodes`
 
-```bash
-python -c "import gaia; print('gaia package OK')"
-```
+`GlobalCanonicalGraph`: `scope="global"`, `knowledge_nodes` (gcn_ prefixed), `factor_nodes` (gcf_ prefixed)
 
-- [ ] **Step 4: Commit**
-
-```bash
-git add gaia/ tests/gaia/
-git commit -m "feat: scaffold gaia/ package structure with empty modules"
-```
-
-### Task 1.2: KnowledgeNode and FactorNode Models
-
-**Files:**
-- Create: `gaia/libs/models/graph_ir.py`
-- Create: `tests/gaia/libs/models/test_graph_ir.py`
-
-**Spec reference:** `docs/foundations/graph-ir/graph-ir.md` §1 (KnowledgeNode) and §2 (FactorNode)
-
-**Key design:** `KnowledgeNode` is the unified data class for both local and global layers. Local nodes have `content` filled and `id` starting with `lcn_`. Global nodes have `representative_lcn` filled, `content` usually None, and `id` starting with `gcn_`.
-
-- [ ] **Step 1: Write failing tests for KnowledgeNode**
-
-```python
-# tests/gaia/libs/models/test_graph_ir.py
-"""Tests for Graph IR models — locks down every constraint from graph-ir.md."""
-import pytest
-from gaia.libs.models.graph_ir import (
-    KnowledgeNode,
-    KnowledgeType,
-    FactorNode,
-    FactorCategory,
-    FactorStage,
-    ReasoningType,
-    Step,
-    SourceRef,
-    Parameter,
-    LocalCanonicalGraph,
-    GlobalCanonicalGraph,
-    LocalCanonicalRef,
-    PackageRef,
-)
-
-
-class TestKnowledgeNode:
-    """§1: Knowledge nodes represent propositions. Unified data class for local + global."""
-
-    def test_local_claim_node(self):
-        """Local layer: content filled, id starts with lcn_."""
-        node = KnowledgeNode(
-            type=KnowledgeType.CLAIM,
-            content="该样本在 90 K 以下表现出超导性",
-        )
-        assert node.type == KnowledgeType.CLAIM
-        assert node.id.startswith("lcn_")
-        assert node.content is not None
-
-    def test_global_claim_node(self):
-        """Global layer: id starts with gcn_, content usually None, has representative_lcn."""
-        node = KnowledgeNode(
-            id="gcn_abc123",
-            type=KnowledgeType.CLAIM,
-            representative_lcn=LocalCanonicalRef(
-                local_canonical_id="lcn_xyz", package_id="pkg1", version="1.0"
-            ),
-            member_local_nodes=[
-                LocalCanonicalRef(local_canonical_id="lcn_xyz", package_id="pkg1", version="1.0")
-            ],
-            provenance=[PackageRef(package_id="pkg1", version="1.0")],
-        )
-        assert node.id.startswith("gcn_")
-        assert node.content is None
-        assert node.representative_lcn is not None
-
-    def test_setting_node(self):
-        node = KnowledgeNode(
-            type=KnowledgeType.SETTING,
-            content="高温超导研究的当前进展",
-        )
-        assert node.type == KnowledgeType.SETTING
-
-    def test_template_node_with_parameters(self):
-        node = KnowledgeNode(
-            type=KnowledgeType.TEMPLATE,
-            content="∀{x}. superconductor({x}) → zero_resistance({x})",
-            parameters=[Parameter(name="x", type="material")],
-        )
-        assert len(node.parameters) == 1
-
-    def test_local_id_deterministic_sha256(self):
-        """§1.1: local id = SHA-256(type + content + sorted(parameters))."""
-        node_a = KnowledgeNode(type=KnowledgeType.CLAIM, content="X superconducts")
-        node_b = KnowledgeNode(type=KnowledgeType.CLAIM, content="X superconducts")
-        assert node_a.id == node_b.id
-        assert node_a.id.startswith("lcn_")
-
-    def test_different_content_different_id(self):
-        node_a = KnowledgeNode(type=KnowledgeType.CLAIM, content="A")
-        node_b = KnowledgeNode(type=KnowledgeType.CLAIM, content="B")
-        assert node_a.id != node_b.id
-
-    def test_different_type_different_id(self):
-        claim = KnowledgeNode(type=KnowledgeType.CLAIM, content="X")
-        setting = KnowledgeNode(type=KnowledgeType.SETTING, content="X")
-        assert claim.id != setting.id
-
-    def test_parameters_sorted_for_id(self):
-        node_a = KnowledgeNode(
-            type=KnowledgeType.TEMPLATE, content="f({x}, {y})",
-            parameters=[Parameter(name="x", type="int"), Parameter(name="y", type="str")],
-        )
-        node_b = KnowledgeNode(
-            type=KnowledgeType.TEMPLATE, content="f({x}, {y})",
-            parameters=[Parameter(name="y", type="str"), Parameter(name="x", type="int")],
-        )
-        assert node_a.id == node_b.id
-
-    def test_global_id_preserved_as_given(self):
-        """Global nodes get registry-allocated IDs, not computed."""
-        node = KnowledgeNode(id="gcn_registry_001", type=KnowledgeType.CLAIM)
-        assert node.id == "gcn_registry_001"
-
-    def test_serialization_roundtrip(self):
-        node = KnowledgeNode(
-            type=KnowledgeType.CLAIM,
-            content="该样本在 90 K 以下表现出超导性",
-            metadata={"schema": "observation", "instrument": "四探针电阻率测量"},
-            source_refs=[SourceRef(package="pkg1", version="1.0")],
-        )
-        roundtrip = KnowledgeNode.model_validate_json(node.model_dump_json())
-        assert roundtrip == node
-```
-
-- [ ] **Step 2: Write failing tests for FactorNode**
-
-```python
-class TestFactorNode:
-    """§2: Factor nodes — unified data class for local + global."""
-
-    def test_infer_factor_initial(self):
-        factor = FactorNode(
-            category=FactorCategory.INFER,
-            stage=FactorStage.INITIAL,
-            premises=["lcn_a"],
-            conclusion="lcn_b",
-            steps=[Step(reasoning="基于超导样品的电阻率骤降...")],
-        )
-        assert factor.factor_id.startswith("f_")
-        assert factor.reasoning_type is None  # initial can be None
-
-    def test_candidate_infer_requires_reasoning_type(self):
-        """§2.3 invariant 1."""
-        with pytest.raises(ValueError):
-            FactorNode(
-                category=FactorCategory.INFER,
-                stage=FactorStage.CANDIDATE,
-                reasoning_type=None,
-                premises=["lcn_a"],
-                conclusion="lcn_b",
-            )
-
-    def test_equivalent_has_no_conclusion_and_ge_2_premises(self):
-        """§2.3 invariant 6."""
-        factor = FactorNode(
-            category=FactorCategory.INFER,
-            stage=FactorStage.CANDIDATE,
-            reasoning_type=ReasoningType.EQUIVALENT,
-            premises=["lcn_a", "lcn_b"],
-            conclusion=None,
-        )
-        assert factor.conclusion is None
-
-    def test_bilateral_with_lt_2_premises_rejected(self):
-        with pytest.raises(ValueError):
-            FactorNode(
-                category=FactorCategory.INFER,
-                stage=FactorStage.CANDIDATE,
-                reasoning_type=ReasoningType.EQUIVALENT,
-                premises=["lcn_a"],
-                conclusion=None,
-            )
-
-    def test_global_factor_no_steps(self):
-        """Global layer: steps and weak_points are None."""
-        factor = FactorNode(
-            category=FactorCategory.INFER,
-            stage=FactorStage.PERMANENT,
-            reasoning_type=ReasoningType.ENTAILMENT,
-            premises=["gcn_a"],
-            conclusion="gcn_b",
-            steps=None,
-            weak_points=None,
-        )
-        assert factor.steps is None
-        assert factor.weak_points is None
-
-    def test_factor_id_deterministic(self):
-        f1 = FactorNode(
-            category=FactorCategory.INFER, stage=FactorStage.INITIAL,
-            premises=["lcn_a", "lcn_b"], conclusion="lcn_c",
-        )
-        f2 = FactorNode(
-            category=FactorCategory.INFER, stage=FactorStage.INITIAL,
-            premises=["lcn_a", "lcn_b"], conclusion="lcn_c",
-        )
-        assert f1.factor_id == f2.factor_id
-
-    def test_serialization_roundtrip(self):
-        factor = FactorNode(
-            category=FactorCategory.INFER,
-            stage=FactorStage.CANDIDATE,
-            reasoning_type=ReasoningType.ENTAILMENT,
-            premises=["lcn_a"], conclusion="lcn_b",
-            steps=[Step(reasoning="step 1")],
-            weak_points=["assumption may not hold"],
-        )
-        roundtrip = FactorNode.model_validate_json(factor.model_dump_json())
-        assert roundtrip == factor
-```
-
-- [ ] **Step 3: Write failing tests for graph containers**
-
-```python
-class TestLocalCanonicalGraph:
-    def test_graph_creation_and_hash(self):
-        claim = KnowledgeNode(type=KnowledgeType.CLAIM, content="A superconducts")
-        factor = FactorNode(
-            category=FactorCategory.INFER, stage=FactorStage.INITIAL,
-            premises=[claim.id], conclusion=claim.id,
-        )
-        graph = LocalCanonicalGraph(knowledge_nodes=[claim], factor_nodes=[factor])
-        assert graph.scope == "local"
-        assert graph.graph_hash.startswith("sha256:")
-
-    def test_hash_deterministic(self):
-        nodes = [KnowledgeNode(type=KnowledgeType.CLAIM, content="X")]
-        g1 = LocalCanonicalGraph(knowledge_nodes=nodes, factor_nodes=[])
-        g2 = LocalCanonicalGraph(knowledge_nodes=nodes, factor_nodes=[])
-        assert g1.graph_hash == g2.graph_hash
-
-
-class TestGlobalCanonicalGraph:
-    def test_global_graph_with_gcn_nodes(self):
-        gcn = KnowledgeNode(
-            id="gcn_abc", type=KnowledgeType.CLAIM,
-            representative_lcn=LocalCanonicalRef(
-                local_canonical_id="lcn_xyz", package_id="pkg1", version="1.0"
-            ),
-            member_local_nodes=[
-                LocalCanonicalRef(local_canonical_id="lcn_xyz", package_id="pkg1", version="1.0")
-            ],
-            provenance=[PackageRef(package_id="pkg1", version="1.0")],
-        )
-        graph = GlobalCanonicalGraph(knowledge_nodes=[gcn], factor_nodes=[])
-        assert graph.scope == "global"
-```
-
-- [ ] **Step 4: Run tests to verify they fail**
-
-```bash
-pytest tests/gaia/libs/models/test_graph_ir.py -v
-```
-
-- [ ] **Step 5: Implement `gaia/libs/models/graph_ir.py`**
-
-Unified `KnowledgeNode` class with all fields from graph-ir.md §1.1. Key behavior:
-- If `id` is not provided and `content` is not None → compute `lcn_` ID via SHA-256
-- If `id` is provided (e.g., `gcn_*`) → use as-is
-- `FactorNode` validation: §2.3 invariants enforced via `@model_validator`
-- Graph containers: `LocalCanonicalGraph` (auto-computes `graph_hash`), `GlobalCanonicalGraph`
-
-- [ ] **Step 6: Run tests, verify pass**
-- [ ] **Step 7: Commit**
-
-```bash
-git commit -m "feat(models): implement unified KnowledgeNode, FactorNode, graph containers"
-```
+**Tests must cover:** local/global node creation, deterministic ID, different content → different ID, type affects ID, parameter sort order, serialization roundtrip, all invariant violations.
 
 ### Task 1.3: Parameterization Models
 
-**Files:**
-- Create: `gaia/libs/models/parameterization.py`
-- Create: `tests/gaia/libs/models/test_parameterization.py`
+**Files:** `gaia/libs/models/parameterization.py`, `tests/gaia/libs/models/test_parameterization.py`
 
-**Spec reference:** `docs/foundations/graph-ir/parameterization.md`
+`PriorRecord`, `FactorParamRecord`: Cromwell clamping in `model_post_init`. `ResolutionPolicy`: validate `source_id` when `strategy="source"`. `ParameterizationSource`: model, policy, config.
 
-- [ ] **Step 1: Write failing tests**
+### Task 1.4: BeliefState + CanonicalBinding
 
-```python
-# tests/gaia/libs/models/test_parameterization.py
-import pytest
-from gaia.libs.models.parameterization import (
-    PriorRecord, FactorParamRecord, ParameterizationSource,
-    ResolutionPolicy, CROMWELL_EPS,
-)
+**Files:** `gaia/libs/models/belief_state.py`, `gaia/libs/models/binding.py`, tests for both.
 
+Straightforward Pydantic models. `BindingDecision` enum: `match_existing`, `create_new`, `equivalent_candidate`.
 
-class TestPriorRecord:
-    def test_creation(self):
-        r = PriorRecord(gcn_id="gcn_x", value=0.7, source_id="src_001")
-        assert r.value == 0.7
+### Task 1.5: Re-exports + LocalParameterization
 
-    def test_cromwell_clamp_zero(self):
-        r = PriorRecord(gcn_id="gcn_x", value=0.0, source_id="s")
-        assert r.value == CROMWELL_EPS
+**Files:** `gaia/libs/models/__init__.py`, `gaia/core/local_params.py`
 
-    def test_cromwell_clamp_one(self):
-        r = PriorRecord(gcn_id="gcn_x", value=1.0, source_id="s")
-        assert r.value == 1.0 - CROMWELL_EPS
+`LocalParameterization` is transient — `graph_hash`, `node_priors: dict[str, float]`, `factor_parameters: dict[str, float]`. Lives in `core/`, not `libs/models/`.
 
+### Task 1.6: Fixtures
 
-class TestFactorParamRecord:
-    def test_cromwell_clamp(self):
-        r = FactorParamRecord(factor_id="f_x", probability=0.0, source_id="s")
-        assert r.probability == CROMWELL_EPS
+**Files:** `tests/gaia/fixtures/graphs.py`, `tests/gaia/fixtures/parameterizations.py`, `tests/gaia/fixtures/test_fixtures.py`
 
+`make_galileo_falling_bodies()`, `make_newton_gravity()`, `make_einstein_equivalence()`, `make_minimal_claim_pair()` — all return `LocalCanonicalGraph`. `make_default_local_params(graph)` returns `LocalParameterization`.
 
-class TestResolutionPolicy:
-    def test_latest(self):
-        p = ResolutionPolicy(strategy="latest")
-        assert p.strategy == "latest"
-
-    def test_source_without_id_rejected(self):
-        with pytest.raises(ValueError):
-            ResolutionPolicy(strategy="source", source_id=None)
-```
-
-- [ ] **Step 2: Run to verify fail**
-- [ ] **Step 3: Implement** — Same as before: `CROMWELL_EPS = 1e-3`, clamping in `model_post_init`, `ResolutionPolicy` with validation.
-- [ ] **Step 4: Run, verify pass**
-- [ ] **Step 5: Commit**
-
-### Task 1.4: BeliefState Model
-
-**Files:**
-- Create: `gaia/libs/models/belief_state.py`
-- Create: `tests/gaia/libs/models/test_belief_state.py`
-
-- [ ] **Step 1: Write failing tests** — creation, serialization roundtrip, empty beliefs edge case.
-- [ ] **Step 2: Implement** — Straightforward Pydantic model per `belief-state.md`.
-- [ ] **Step 3: Run, verify pass**
-- [ ] **Step 4: Commit**
-
-### Task 1.5: CanonicalBinding Model
-
-**Files:**
-- Create: `gaia/libs/models/binding.py`
-- Create: `tests/gaia/libs/models/test_binding.py`
-
-- [ ] **Step 1: Write failing tests** — `match_existing`, `create_new`, `equivalent_candidate` decisions.
-- [ ] **Step 2: Implement** — `BindingDecision` enum + `CanonicalBinding` model per graph-ir.md §3.4.
-- [ ] **Step 3: Run, verify pass**
-- [ ] **Step 4: Commit**
-
-### Task 1.6: Models `__init__.py` Re-exports + LocalParameterization
-
-**Files:**
-- Modify: `gaia/libs/models/__init__.py`
-- Create: `gaia/core/local_params.py`
-
-- [ ] **Step 1: Write models `__init__.py` re-exports** — all public types from graph_ir, parameterization, belief_state, binding.
-
-- [ ] **Step 2: Write `gaia/core/local_params.py`**
-
-```python
-# gaia/core/local_params.py
-"""LocalParameterization — transient container, not part of Graph IR contract."""
-from pydantic import BaseModel
-
-
-class LocalParameterization(BaseModel):
-    """Temporary parameter container from CLI build/review. Not persisted."""
-    graph_hash: str
-    node_priors: dict[str, float] = {}       # lcn_id → prior
-    factor_parameters: dict[str, float] = {} # factor_id → conditional_probability
-```
-
-- [ ] **Step 3: Verify imports**
-
-```bash
-python -c "from gaia.libs.models import KnowledgeNode, BeliefState, CanonicalBinding; print('OK')"
-python -c "from gaia.core.local_params import LocalParameterization; print('OK')"
-```
-
-- [ ] **Step 4: Run all model tests**
-- [ ] **Step 5: Commit**
-
-### Task 1.7: Test Fixtures — Galileo/Newton/Einstein Graphs
-
-**Files:**
-- Create: `tests/gaia/fixtures/graphs.py`
-- Create: `tests/gaia/fixtures/parameterizations.py`
-- Create: `tests/gaia/fixtures/test_fixtures.py`
-
-- [ ] **Step 1: Write fixture graph builders**
-
-Build `make_galileo_falling_bodies()`, `make_newton_gravity()`, `make_einstein_equivalence()`, `make_minimal_claim_pair()` returning `LocalCanonicalGraph` instances from real scientific examples (see `tests/fixtures/examples/`).
-
-Key: galileo's "vacuum prediction" and newton's reference to the same claim use identical `content` → same `lcn_` ID → cross-package match candidate.
-
-- [ ] **Step 2: Write fixture parameterization builders**
-
-```python
-# tests/gaia/fixtures/parameterizations.py
-from gaia.core.local_params import LocalParameterization
-from gaia.libs.models import LocalCanonicalGraph, KnowledgeType
-
-
-def make_default_local_params(graph: LocalCanonicalGraph, prior: float = 0.5, factor_prob: float = 0.8) -> LocalParameterization:
-    """Create default LocalParameterization for a graph."""
-    node_priors = {
-        n.id: prior for n in graph.knowledge_nodes if n.type == KnowledgeType.CLAIM
-    }
-    factor_params = {f.factor_id: factor_prob for f in graph.factor_nodes}
-    return LocalParameterization(
-        graph_hash=graph.graph_hash,
-        node_priors=node_priors,
-        factor_parameters=factor_params,
-    )
-```
-
-- [ ] **Step 3: Write smoke tests for fixtures**
-
-Verify each builder produces valid graphs with expected node/factor counts and cross-package content matching.
-
-- [ ] **Step 4: Run tests, commit**
+Key: galileo "vacuum prediction" content == newton's same claim → same `lcn_` ID → cross-package match.
 
 ---
 
-## Chunk 2: Storage Layer
+## Chunk 2: Storage (PR 2)
 
-Unified tables for `knowledge_nodes` and `factor_nodes` (local + global in same table, filtered by `id` prefix).
+### Task 2.1: Config + ABCs
 
-### Task 2.1: StorageConfig
+**Files:** `gaia/libs/storage/config.py`, `gaia/libs/storage/base.py`
 
-**Files:**
-- Create: `gaia/libs/storage/config.py`
+`ContentStore` ABC operates on unified `KnowledgeNode` and `FactorNode`:
+- `write_knowledge_nodes(nodes)`, `get_knowledge_nodes(prefix=None)` — prefix filter `lcn_`/`gcn_`
+- `write_factor_nodes(factors)`, `get_factor_nodes(scope=None)` — filter by `scope` field
+- `write_node_embeddings(gcn_id, vector)`, `get_node_embedding(gcn_id)`, `search_similar_nodes(query_vector, top_k, type_filter)`
+- Standard CRUD for bindings, prior_records, factor_param_records, param_sources, belief_states
 
-- [ ] **Step 1: Implement** — Port from `libs/storage/config.py`, Pydantic settings with `GAIA_` prefix.
-- [ ] **Step 2: Commit**
+`GraphStore` ABC: `write_nodes`, `write_factors`, `get_neighbors`, `get_subgraph`, `clean_all`
 
-### Task 2.2: Storage ABCs
+### Task 2.2: LanceDB Content Store
 
-**Files:**
-- Create: `gaia/libs/storage/base.py`
+**Files:** `gaia/libs/storage/lance.py`, `tests/gaia/libs/storage/test_lance.py`
 
-- [ ] **Step 1: Define ContentStore and GraphStore interfaces**
+8 tables: `knowledge_nodes`, `factor_nodes`, `canonical_bindings`, `prior_records`, `factor_param_records`, `param_sources`, `belief_states`, `node_embeddings`.
 
-`ContentStore` methods operate on unified `KnowledgeNode` (not separate local/global types):
+`node_embeddings` table: `gcn_id (str)`, `vector (list[float])`, `content_preview (str)`. Used by `matching.py` for similarity search.
 
-```python
-class ContentStore(ABC):
-    async def write_knowledge_nodes(self, nodes: list[KnowledgeNode]) -> None: ...
-    async def write_factor_nodes(self, factors: list[FactorNode]) -> None: ...
-    async def write_bindings(self, bindings: list[CanonicalBinding]) -> None: ...
-    async def write_prior_records(self, records: list[PriorRecord]) -> None: ...
-    async def write_factor_param_records(self, records: list[FactorParamRecord]) -> None: ...
-    async def write_param_source(self, source: ParameterizationSource) -> None: ...
-    async def write_belief_state(self, state: BeliefState) -> None: ...
+Tests: write+read roundtrip per table, prefix filtering for knowledge nodes, scope filtering for factors, embedding vector write+search, clean_all.
 
-    async def get_node(self, node_id: str) -> KnowledgeNode | None: ...
-    async def get_knowledge_nodes(self, prefix: str | None = None) -> list[KnowledgeNode]: ...
-    async def get_factor_nodes(self, prefix: str | None = None) -> list[FactorNode]: ...
-    async def get_bindings(self, package_id: str | None = None) -> list[CanonicalBinding]: ...
-    async def get_prior_records(self, gcn_id: str | None = None) -> list[PriorRecord]: ...
-    async def get_factor_param_records(self, factor_id: str | None = None) -> list[FactorParamRecord]: ...
-    async def get_belief_states(self, limit: int = 10) -> list[BeliefState]: ...
-    async def clean_all(self) -> None: ...
+### Task 2.3: Neo4j Graph Store
 
-class GraphStore(ABC):
-    async def write_nodes(self, nodes: list[KnowledgeNode]) -> None: ...
-    async def write_factors(self, factors: list[FactorNode]) -> None: ...
-    async def get_neighbors(self, node_id: str) -> list[str]: ...
-    async def get_subgraph(self, node_ids: list[str], depth: int = 1) -> tuple[list[str], list[str]]: ...
-    async def clean_all(self) -> None: ...
-```
+**Files:** `gaia/libs/storage/neo4j.py`, `tests/gaia/libs/storage/test_neo4j.py`
 
-Note: `get_knowledge_nodes(prefix="gcn_")` returns global nodes; `get_knowledge_nodes(prefix="lcn_")` returns local.
+Tests marked `@pytest.mark.neo4j`. Nodes as `(:KnowledgeNode {id, type})`, factors via `:PREMISE`/`:CONCLUSION` edges.
 
-- [ ] **Step 2: Commit**
+### Task 2.4: StorageManager
 
-### Task 2.3: LanceDB Content Store
+**Files:** `gaia/libs/storage/manager.py`, `tests/gaia/libs/storage/test_manager.py`
 
-**Files:**
-- Create: `gaia/libs/storage/lance.py`
-- Create: `tests/gaia/libs/storage/test_lance.py`
+Delegates to content store + optional graph store. No three-write atomicity in MVP (deferred, see spec §6).
 
-- [ ] **Step 1: Write failing tests**
+### Task 2.5: Port Embedding + LLM
 
-Test write + read roundtrip for each table: knowledge_nodes (both lcn_ and gcn_), factor_nodes, bindings, prior_records, factor_param_records, belief_states. Test prefix filtering. Test `clean_all`.
+**Files:** `gaia/libs/embedding.py`, `gaia/libs/llm.py`
 
-- [ ] **Step 2: Implement LanceContentStore**
-
-Unified `knowledge_nodes` table with columns: `id`, `type`, `content`, `parameters_json`, `source_refs_json`, `metadata_json`, `representative_lcn_json`, `member_local_nodes_json`, `provenance_json`, `package_id`, `version`. Query by prefix: `WHERE id LIKE 'gcn_%'`.
-
-Similarly unified `factor_nodes` table.
-
-- [ ] **Step 3: Run, verify pass**
-- [ ] **Step 4: Commit**
-
-### Task 2.4: Neo4j Graph Store
-
-**Files:**
-- Create: `gaia/libs/storage/neo4j.py`
-- Create: `tests/gaia/libs/storage/test_neo4j.py`
-
-- [ ] **Step 1: Write failing tests** (marked `@pytest.mark.neo4j`)
-- [ ] **Step 2: Implement Neo4jGraphStore** — nodes as `(:KnowledgeNode {id, type})`, factors create `:PREMISE`/`:CONCLUSION` edges.
-- [ ] **Step 3: Run (with Neo4j), commit**
-
-### Task 2.5: StorageManager
-
-**Files:**
-- Create: `gaia/libs/storage/manager.py`
-- Create: `tests/gaia/libs/storage/test_manager.py`
-
-- [ ] **Step 1: Write failing tests** — init, write+read through manager, graph store optional.
-- [ ] **Step 2: Implement** — delegates to content store + optional graph store.
-- [ ] **Step 3: Run, commit**
-
-### Task 2.6: Port Embedding and LLM
-
-**Files:**
-- Create: `gaia/libs/embedding.py` (port from `libs/embedding.py`)
-- Create: `gaia/libs/llm.py` (port from `libs/llm.py`)
-
-- [ ] **Step 1: Port, verify imports**
-- [ ] **Step 2: Commit**
+Port from old code. Logic unchanged.
 
 ---
 
-## Chunk 3: Core Algorithms
+## Chunk 3: Core Algorithms (PR 3)
 
-### Task 3.1: Matching — Similarity Engine
+### Task 3.1: Matching
 
-**Files:**
-- Create: `gaia/core/matching.py`
-- Create: `tests/gaia/core/test_matching.py`
+**Files:** `gaia/core/matching.py`, `tests/gaia/core/test_matching.py`
 
-- [ ] **Step 1: Write failing tests** — identical content matches, different type never matches, below threshold returns None, TF-IDF fallback.
-- [ ] **Step 2: Implement** — `find_best_match(query: KnowledgeNode, candidates: list[KnowledgeNode], ...) → KnowledgeNode | None`. Type filter first, then embedding cosine / TF-IDF.
-- [ ] **Step 3: Run, commit**
+`find_best_match(query_node, embedding_model, storage, threshold=0.90) → KnowledgeNode | None`
 
-### Task 3.2: Global Canonicalization
+Approach:
+1. Embed query node content
+2. Search `node_embeddings` table via `storage.search_similar_nodes(vector, top_k, type_filter=query_node.type)`
+3. Return best match above threshold, or None
+4. TF-IDF fallback when no embedding model
 
-**Files:**
-- Create: `gaia/core/canonicalize.py`
-- Create: `tests/gaia/core/test_canonicalize.py`
+Tests: identical content matches, different type never matches, below threshold returns None.
 
-**Spec reference:** spec §3.2 (module 2), graph-ir.md §3.1–§3.6
+### Task 3.2: Canonicalization
 
-**Key change from previous plan:** canonicalize now takes `LocalParameterization` as input and outputs `PriorRecord`/`FactorParamRecord` (parameterization integration).
-
-- [ ] **Step 1: Write failing tests**
-
-```python
-# tests/gaia/core/test_canonicalize.py
-import pytest
-from gaia.core.canonicalize import canonicalize_package, CanonicalizationResult
-from gaia.core.local_params import LocalParameterization
-from gaia.libs.models import GlobalCanonicalGraph, KnowledgeType
-from gaia.libs.models.binding import BindingDecision
-from gaia.libs.embedding import StubEmbeddingModel
-from tests.gaia.fixtures.graphs import make_galileo_falling_bodies, make_newton_gravity, make_minimal_claim_pair
-from tests.gaia.fixtures.parameterizations import make_default_local_params
-
-
-@pytest.fixture
-def embedding_model():
-    return StubEmbeddingModel(dim=64)
-
-
-class TestCanonicalizeFirstPackage:
-    async def test_all_create_new(self, embedding_model):
-        graph = make_galileo_falling_bodies()
-        params = make_default_local_params(graph)
-        result = await canonicalize_package(
-            local_graph=graph, local_params=params,
-            global_graph=GlobalCanonicalGraph(),
-            package_id="galileo", version="1.0",
-            embedding_model=embedding_model,
-        )
-        assert isinstance(result, CanonicalizationResult)
-        for b in result.bindings:
-            assert b.decision == BindingDecision.CREATE_NEW
-        # Parameterization records created
-        assert len(result.prior_records) > 0
-        assert len(result.factor_param_records) > 0
-        # Global factors have gcn_ IDs, no steps
-        for f in result.global_factors:
-            assert f.steps is None
-            for p in f.premises:
-                assert p.startswith("gcn_")
-
-
-class TestCanonicalizeParamIntegration:
-    async def test_local_priors_converted_to_prior_records(self, embedding_model):
-        """LocalParameterization node_priors → PriorRecord with gcn_ IDs."""
-        graph = make_minimal_claim_pair()
-        params = make_default_local_params(graph, prior=0.7, factor_prob=0.9)
-        result = await canonicalize_package(
-            local_graph=graph, local_params=params,
-            global_graph=GlobalCanonicalGraph(),
-            package_id="test", version="1.0",
-            embedding_model=embedding_model,
-        )
-        # Prior records should reference gcn_ IDs, not lcn_
-        for pr in result.prior_records:
-            assert pr.gcn_id.startswith("gcn_")
-        # Factor params should reference global factor IDs
-        for fp in result.factor_param_records:
-            assert fp.factor_id.startswith("f_")
-        # Values should match input (modulo Cromwell clamping)
-        assert any(abs(pr.value - 0.7) < 0.01 for pr in result.prior_records)
-
-
-class TestFactorLifting:
-    async def test_global_factors_drop_steps_and_weak_points(self, embedding_model):
-        graph = make_galileo_falling_bodies()
-        params = make_default_local_params(graph)
-        result = await canonicalize_package(
-            local_graph=graph, local_params=params,
-            global_graph=GlobalCanonicalGraph(),
-            package_id="galileo", version="1.0",
-            embedding_model=embedding_model,
-        )
-        for f in result.global_factors:
-            assert f.steps is None
-            assert f.weak_points is None
-```
-
-- [ ] **Step 2: Implement `gaia/core/canonicalize.py`**
+**Files:** `gaia/core/canonicalize.py`, `tests/gaia/core/test_canonicalize.py`
 
 ```python
 async def canonicalize_package(
-    local_graph: LocalCanonicalGraph,
-    local_params: LocalParameterization,
-    global_graph: GlobalCanonicalGraph,
-    package_id: str,
-    version: str,
-    embedding_model: EmbeddingModel | None = None,
-    threshold: float = 0.90,
-) -> CanonicalizationResult:
-    ...
+    local_graph, local_params, global_graph,
+    package_id, version, embedding_model, storage, threshold=0.90
+) -> CanonicalizationResult
 ```
 
-Key steps:
-1. Classify local nodes (premise-only / conclusion / both)
-2. Match against global graph via `matching.find_best_match()`
-3. Apply §3.1 rules → bindings + new global nodes
-4. Factor lifting: lcn→gcn, drop steps/weak_points
-5. **Parameterization integration:** convert `local_params.node_priors` to `PriorRecord` (lcn→gcn mapped), convert `local_params.factor_parameters` to `FactorParamRecord`, generate placeholders for equivalent_candidate
+**All knowledge types** (claim, setting, question, template) participate — per graph-ir.md §3.2.
 
-- [ ] **Step 3: Run, commit**
+Key steps per spec §3.2:
+1. Classify nodes (premise-only / conclusion / both)
+2. Match each against global graph via `matching.find_best_match()`
+3. Apply §3.1 decision rules
+4. Factor lifting: lcn→gcn ID rewrite, `scope="local"` → `scope="global"`, drop steps/weak_points, prefix `lcf_` → `gcf_`
+5. Parameterization integration: convert `local_params` to `PriorRecord`/`FactorParamRecord` with gcn_/gcf_ IDs
+6. Write new node embeddings for newly created gcn_ nodes
 
-### Task 3.3: Global BP Orchestration
+Tests: first package all create_new, param conversion lcn→gcn, factor lifting drops steps, global factors have gcf_ prefix.
 
-**Files:**
-- Create: `gaia/core/global_bp.py`
-- Create: `tests/gaia/core/test_global_bp.py`
+### Task 3.3: Global BP + Adapter
 
-- [ ] **Step 1: Write failing tests**
+**Files:** `gaia/core/global_bp.py`, `tests/gaia/core/test_global_bp.py`
 
-Test `assemble_parameterization` (latest policy, source policy, prior_cutoff filtering). Test `run_global_bp` end-to-end: canonicalize minimal graph → assemble → BP → verify BeliefState has beliefs only for claim nodes.
+Two responsibilities:
 
-- [ ] **Step 2: Implement**
+**1. Parameter assembly** (`assemble_parameterization`): apply ResolutionPolicy to select per-node/factor values from atomic records. Tests: latest picks newest, source filters, prior_cutoff filters.
 
-`assemble_parameterization(prior_records, factor_records, policy) → dict` and `run_global_bp(global_graph, prior_records, factor_records, policy) → BeliefState`. Bridge to old BP via `from gaia.bp import FactorGraph, BeliefPropagation`.
+**2. BP adapter + execution** (`run_global_bp`): convert new `GlobalCanonicalGraph` + assembled params → old `FactorGraph` format → run `BeliefPropagation` → wrap in `BeliefState`.
 
-- [ ] **Step 3: Run, commit**
+Adapter mapping (new → old):
+- `KnowledgeNode` (type=claim, gcn_ prefix) → `FactorGraph.add_variable(int_id, prior)`
+- Non-claim premises skipped (no BP edge)
+- `FactorNode` → `FactorGraph.add_factor(...)` with edge_type mapped from `ReasoningType`
+- `ReasoningType.ENTAILMENT` → old `"deduction"`, `CONTRADICT` → `"contradiction"`, etc.
+
+Tests: minimal graph produces valid BeliefState, only claim nodes have beliefs, galileo contradiction affects values.
 
 ---
 
-## Chunk 4: LKM Entry Points
+## Chunk 4: LKM + E2E (PR 4)
 
-All orchestration in `lkm/pipelines/`. No `lkm/ingest.py` — per spec §3.5.
+### Task 4.1: Pipelines
 
-### Task 4.1: Pipeline — run_ingest
+**Files:** `gaia/lkm/pipelines/run_ingest.py`, `run_global_bp.py`, `run_full.py`, `tests/gaia/lkm/test_pipelines.py`
 
-**Files:**
-- Create: `gaia/lkm/pipelines/run_ingest.py`
-- Create: `tests/gaia/lkm/test_pipelines.py`
-
-- [ ] **Step 1: Write failing tests**
-
+`run_ingest` orchestrates spec modules 1-3:
 ```python
-# tests/gaia/lkm/test_pipelines.py
-import pytest
-from gaia.lkm.pipelines.run_ingest import run_ingest
-from gaia.libs.storage.manager import StorageManager
-from gaia.libs.storage.config import StorageConfig
-from gaia.libs.embedding import StubEmbeddingModel
-from tests.gaia.fixtures.graphs import make_galileo_falling_bodies, make_newton_gravity
-from tests.gaia.fixtures.parameterizations import make_default_local_params
-
-
-@pytest.fixture
-async def storage(tmp_path):
-    config = StorageConfig(lancedb_path=str(tmp_path / "test.lance"))
-    mgr = StorageManager(config)
-    await mgr.initialize()
-    return mgr
-
-@pytest.fixture
-def embedding_model():
-    return StubEmbeddingModel(dim=64)
-
-
-class TestRunIngest:
-    async def test_first_package(self, storage, embedding_model):
-        graph = make_galileo_falling_bodies()
-        params = make_default_local_params(graph)
-        result = await run_ingest(
-            local_graph=graph, local_params=params,
-            package_id="galileo", version="1.0",
-            storage=storage, embedding_model=embedding_model,
-        )
-        assert len(result.bindings) > 0
-        # Verify persisted
-        global_nodes = await storage.get_knowledge_nodes(prefix="gcn_")
-        assert len(global_nodes) > 0
-        prior_records = await storage.get_prior_records()
-        assert len(prior_records) > 0
-
-    async def test_second_package(self, storage, embedding_model):
-        g1 = make_galileo_falling_bodies()
-        await run_ingest(
-            local_graph=g1, local_params=make_default_local_params(g1),
-            package_id="galileo", version="1.0",
-            storage=storage, embedding_model=embedding_model,
-        )
-        g2 = make_newton_gravity()
-        result = await run_ingest(
-            local_graph=g2, local_params=make_default_local_params(g2),
-            package_id="newton", version="1.0",
-            storage=storage, embedding_model=embedding_model,
-        )
-        assert len(result.bindings) > 0
-```
-
-- [ ] **Step 2: Implement `run_ingest`**
-
-Orchestrates spec modules 1-3:
-
-```python
-# gaia/lkm/pipelines/run_ingest.py
 async def run_ingest(local_graph, local_params, package_id, version, storage, embedding_model):
     # Module 1: persist local
     await storage.write_knowledge_nodes(local_graph.knowledge_nodes)
     await storage.write_factor_nodes(local_graph.factor_nodes)
-
-    # Module 2: canonicalize
-    existing_nodes = await storage.get_knowledge_nodes(prefix="gcn_")
-    existing_factors = await storage.get_factor_nodes(prefix="gcn_")  # global factors
-    global_graph = GlobalCanonicalGraph(knowledge_nodes=existing_nodes, factor_nodes=existing_factors)
-    result = await canonicalize_package(local_graph, local_params, global_graph, package_id, version, embedding_model)
-
+    # Module 2: canonicalize (loads global graph from storage internally)
+    result = await canonicalize_package(local_graph, local_params, ..., storage, embedding_model)
     # Module 3: persist global
     await storage.write_knowledge_nodes(result.new_global_nodes)
     await storage.write_factor_nodes(result.global_factors)
@@ -902,99 +270,21 @@ async def run_ingest(local_graph, local_params, package_id, version, storage, em
     await storage.write_prior_records(result.prior_records)
     await storage.write_factor_param_records(result.factor_param_records)
     await storage.write_param_source(result.param_source)
-
     return result
 ```
 
-- [ ] **Step 3: Run, commit**
+`run_global_bp`: load global graph + params from storage, call `core.global_bp.run_global_bp()`, persist BeliefState.
 
-### Task 4.2: Pipeline — run_global_bp and run_full
+`run_full`: CLI entry with `--input-dir`, `--lancedb-path`, `--clean`.
 
-**Files:**
-- Create: `gaia/lkm/pipelines/run_global_bp.py`
-- Create: `gaia/lkm/pipelines/run_full.py`
+### Task 4.2: FastAPI Services
 
-- [ ] **Step 1: Implement `run_global_bp.py`** — loads global graph + param records from storage, calls `core.global_bp.run_global_bp()`, persists BeliefState.
+**Files:** `gaia/lkm/services/app.py`, `deps.py`, `routes/packages.py`, `knowledge.py`, `inference.py`, `tests/gaia/lkm/services/test_routes.py`
 
-- [ ] **Step 2: Implement `run_full.py`** — CLI entry: `--input-dir`, `--lancedb-path`, `--clean`. Loops over packages calling `run_ingest`, then `run_global_bp`.
+`POST /api/packages/ingest` → calls `run_ingest`. `POST /api/inference/run` → calls `run_global_bp`. Read endpoints for knowledge and beliefs.
 
-- [ ] **Step 3: Commit**
+### Task 4.3: E2E Test
 
-### Task 4.3: FastAPI Services
+**Files:** `tests/gaia/test_e2e_pipeline.py`
 
-**Files:**
-- Create: `gaia/lkm/services/app.py`
-- Create: `gaia/lkm/services/deps.py`
-- Create: `gaia/lkm/services/routes/packages.py`
-- Create: `gaia/lkm/services/routes/knowledge.py`
-- Create: `gaia/lkm/services/routes/inference.py`
-- Create: `tests/gaia/lkm/services/test_routes.py`
-
-- [ ] **Step 1: Implement deps.py** — `Dependencies` class with `storage: StorageManager`, `embedding: EmbeddingModel | None`.
-
-- [ ] **Step 2: Implement app.py** — FastAPI factory with lifespan, CORS, health endpoint, route includes.
-
-- [ ] **Step 3: Implement routes**
-
-`packages.py`: `POST /api/packages/ingest` accepts `{package_id, version, local_graph, local_params}`, calls `run_ingest()`.
-
-`knowledge.py`: `GET /api/knowledge/{node_id}`, `GET /api/knowledge/{node_id}/beliefs`.
-
-`inference.py`: `POST /api/inference/run` triggers global BP, `GET /api/beliefs` lists belief states.
-
-- [ ] **Step 4: Write API tests** — health, ingest roundtrip, knowledge retrieval after ingest.
-
-- [ ] **Step 5: Run, commit**
-
----
-
-## Chunk 5: Integration Test — End-to-End Pipeline
-
-### Task 5.1: Full Pipeline Integration Test
-
-**Files:**
-- Create: `tests/gaia/test_e2e_pipeline.py`
-
-- [ ] **Step 1: Write integration test**
-
-```python
-# tests/gaia/test_e2e_pipeline.py
-"""E2E: ingest galileo + newton + einstein → global BP → verify beliefs."""
-
-class TestEndToEndPipeline:
-    async def test_three_package_pipeline(self, storage, embedding_model):
-        # Stage 1: Ingest all three
-        for pkg_id, graph in [("galileo", galileo), ("newton", newton), ("einstein", einstein)]:
-            params = make_default_local_params(graph)
-            await run_ingest(local_graph=graph, local_params=params, ...)
-
-        # Stage 2: Verify global graph
-        global_nodes = await storage.get_knowledge_nodes(prefix="gcn_")
-        assert len(global_nodes) > 0
-        claim_nodes = [n for n in global_nodes if n.type == KnowledgeType.CLAIM]
-
-        # Stage 3: Run global BP
-        belief_state = await run_global_bp(storage, ResolutionPolicy(strategy="latest"))
-
-        # Stage 4: Verify
-        assert belief_state.converged
-        assert len(belief_state.beliefs) == len(claim_nodes)
-        for v in belief_state.beliefs.values():
-            assert CROMWELL_EPS <= v <= 1.0 - CROMWELL_EPS
-```
-
-- [ ] **Step 2: Run, commit**
-
----
-
-## Summary
-
-| Chunk | Tasks | Focus |
-|-------|-------|-------|
-| 1. Models | 1.1–1.7 | Unified KnowledgeNode/FactorNode, parameterization, fixtures |
-| 2. Storage | 2.1–2.6 | LanceDB (unified tables) + Neo4j + StorageManager |
-| 3. Core | 3.1–3.3 | Matching, canonicalize (with param integration), global BP |
-| 4. LKM | 4.1–4.3 | Pipelines (run_ingest, run_global_bp, run_full) + FastAPI |
-| 5. E2E | 5.1 | Integration test: 3 packages → global BP → beliefs |
-
-Execution order: Chunk 1 → 2 → 3 → 4 → 5 (strict sequential).
+Ingest galileo + newton + einstein → verify global graph → run global BP → verify BeliefState has beliefs for all claim nodes, all values in Cromwell bounds.

--- a/docs/specs/2026-03-25-lkm-minimal-pipeline-spec.md
+++ b/docs/specs/2026-03-25-lkm-minimal-pipeline-spec.md
@@ -2,9 +2,9 @@
 
 | 文档属性 | 值 |
 |---------|---|
-| 版本 | 0.1 (draft) |
+| 版本 | 0.2 |
 | 日期 | 2026-03-25 |
-| 状态 | **Proposal** — 待 review |
+| 状态 | **Proposal** — review 后更新 |
 | 关联文档 | [graph-ir/overview.md](../foundations/graph-ir/overview.md), [lkm/overview.md](../foundations/lkm/overview.md), [lkm/pipeline.md](../foundations/lkm/pipeline.md) |
 
 ## 1. 目标
@@ -109,14 +109,17 @@ lkm/services/  ──┘       ↓
 | 表 | 内容 | 对应 Graph IR 对象 |
 |---|------|-------------------|
 | `knowledge_nodes` | knowledge 节点（local + global 共用） | KnowledgeNode，以 `id` 前缀区分 (`lcn_` / `gcn_`) |
-| `factor_nodes` | factor 节点（local + global 共用） | FactorNode，global 层 `steps`/`weak_points` 为 None |
+| `factor_nodes` | factor 节点（local + global 共用） | FactorNode，以 `factor_id` 前缀区分 (`lcf_` / `gcf_`)，含 `scope` 字段 |
 | `canonical_bindings` | lcn → gcn 映射 | CanonicalBinding |
 | `prior_records` | claim 先验（原子记录） | PriorRecord |
 | `factor_param_records` | factor 概率（原子记录） | FactorParamRecord |
 | `param_sources` | review 来源 | ParameterizationSource |
 | `belief_states` | BP 输出 | BeliefState |
+| `node_embeddings` | gcn_ 节点的 embedding 向量 | gcn_id → vector（representative content 的向量化） |
 
-> **注意：** graph-ir.md §1.1 规定 local 和 global knowledge node 使用同一个 data class（`KnowledgeNode`），通过 `id` 前缀（`lcn_` vs `gcn_`）和字段填充（`content` vs `representative_lcn`）区分层级。Factor 节点同理。因此存储层不再按 local/global 拆分表，而是统一存储，查询时按前缀过滤。
+> **Embedding 向量表：** `node_embeddings` 是专门的向量表，只存 global canonical node 的 representative content 的向量化。Canonicalize 匹配时直接查这个表，不需要 dereference `representative_lcn` 再去取 content。新 gcn 节点创建时写入对应 embedding。
+
+> **注意：** KnowledgeNode 通过 `id` 前缀（`lcn_` vs `gcn_`）和字段填充区分层级。FactorNode 通过 `factor_id` 前缀（`lcf_` vs `gcf_`）和 `scope` 字段区分层级。两者结构完全对偶（见 graph-ir.md §2.1）。存储层统一表，查询时按前缀过滤。
 
 **旧表（Knowledge, Chain, Module, Package 等）全部废弃。**
 
@@ -147,15 +150,17 @@ lkm/services/  ──┘       ↓
 | `BeliefState` | `belief_state.py` | belief-state.md |
 | `CanonicalBinding` | `binding.py` | graph-ir.md §3.4 |
 
-> **注意：** `KnowledgeNode` 是 local 和 global 共用的唯一 data class。Local 层 `id` 以 `lcn_` 开头（content-addressed），global 层以 `gcn_` 开头（registry-allocated）。字段填充按层级不同：local 层有 `content`，global 层通常 `content=None` 但有 `representative_lcn`。不再有独立的 `GlobalCanonicalNode` class。`FactorNode` 同理。
+> **注意：** `KnowledgeNode` 是 local 和 global 共用的唯一 data class。Local 层 `id` 以 `lcn_` 开头（content-addressed），global 层以 `gcn_` 开头（registry-allocated）。`FactorNode` 同理：`lcf_`（local）/ `gcf_`（global）前缀 + `scope` 字段。
 
 **关键约束（来自 graph-ir 文档）：**
 - KnowledgeNode ID: local 层 `SHA-256(type + content + sorted(parameters))`，前缀 `lcn_`；global 层注册分配，前缀 `gcn_`
+- FactorNode ID: `{prefix}_{sha256[:16]}`，local 层前缀 `lcf_`，global 层前缀 `gcf_`；含 `scope` 字段
 - Cromwell's rule: 所有概率 clamp 到 `[ε, 1-ε]`，ε = 1e-3
 - 只有 `type=claim` 的节点参与 BP、有 prior 和 belief
 - `stage=candidate|permanent` + `category=infer` → `reasoning_type` 必填
 - `equivalent`/`contradict` → `conclusion=None`，`premises >= 2`
 - Global factor 不携带 `steps` 和 `weak_points`
+- **所有知识类型（claim, setting, question, template）都参与全局规范化**（graph-ir.md §3.2）
 
 ## 3. Pipeline 流程
 
@@ -173,7 +178,6 @@ lkm/services/  ──┘       ↓
 ```
 输入:
   - LocalCanonicalGraph
-  - LocalParameterization（node_priors + factor_params，来自 CLI build/review）
   - package_id + version
 
 操作:
@@ -336,8 +340,9 @@ gaia/
 
   core/
     __init__.py
-    matching.py                # Embedding cosine + TF-IDF
-    canonicalize.py            # Global canonicalization
+    local_params.py            # LocalParameterization（临时容器，非 Graph IR 契约）
+    matching.py                # Embedding cosine + TF-IDF（查 node_embeddings 表）
+    canonicalize.py            # Global canonicalization + 参数整合
     global_bp.py               # 参数组装 + BP 编排
 
   lkm/
@@ -383,7 +388,7 @@ tests/gaia/
 | 层 | 测试类型 | 依赖 | 重点 |
 |----|---------|------|------|
 | models | 单元测试 | 无 | 锁定 Graph IR spec 的每个约束 |
-| storage | 集成测试 | LanceDB (tmp_path)，Neo4j (标记跳过) | 读写 roundtrip，三写入原子性 |
+| storage | 集成测试 | LanceDB (tmp_path)，Neo4j (标记跳过) | 读写 roundtrip，前缀过滤 |
 | core | 单元+集成 | fixtures，StubEmbeddingModel | §3.1 决策规则、BP 正确性 |
 | lkm/ingest | 集成测试 | storage + core | 端到端写入路径 |
 | lkm/services | E2E | 全栈 (httpx + ASGITransport) | HTTP roundtrip smoke test |
@@ -410,6 +415,7 @@ tests/gaia/
 | CLI 迁移 | 合作者 scope |
 | BP 迁移 | 桥接即可，独立 plan |
 | 前端 | 后续 plan |
+| 三写入原子性 | MVP 不做，创建 issue 跟踪（preparing→committed 可见性门控）|
 | 旧代码删除 | 新 pipeline 跑通后再统一清理 |
 
 ## 7. 验收标准


### PR DESCRIPTION
## Summary

- **Spec** (`docs/specs/2026-03-25-lkm-minimal-pipeline-spec.md`): 设计文档，包含 7 个核心决策（新旧代码分离、代码组织、shared layer、LKM 双入口、存储重写、BP 桥接、模型重写）+ pipeline 流程 + 目录结构 + 测试策略 + 验收标准
- **Plan** (`docs/plans/2026-03-25-lkm-minimal-pipeline.md`): 5 个 Chunk、17 个 Task 的实现计划，含完整代码和测试

## Scope

最小闭环 pipeline：`LocalCanonicalGraph → 持久化 → Global Canonicalization → Global BP → BeliefState`

全部在新 `gaia/` 包下从零构建，不动旧代码。

## Test plan

- [ ] Review spec 设计决策
- [ ] Review plan 与 spec 对齐
- [ ] 确认目录结构合理
- [ ] Spec 批准后开始执行 plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)