### PR TITLE
docs(graph-ir): lcn_id includes package_id in hash

### DIFF
--- a/docs/foundations/graph-ir/graph-ir.md
+++ b/docs/foundations/graph-ir/graph-ir.md
@@ -41,13 +41,13 @@ KnowledgeNode:
 
 | 字段 | Local | Global |
 |------|-------|--------|
-| `id` | `lcn_` 前缀，SHA-256 内容寻址 | `gcn_` 前缀，注册中心分配 |
+| `id` | `lcn_` 前缀，SHA-256 包+内容寻址 | `gcn_` 前缀，注册中心分配 |
 | `content` | 有值（唯一存储位置） | 通常为 None（subgraph 中间节点例外） |
 | `provenance` | 有值（来源包） | 有值（贡献包列表） |
 | `representative_lcn` | None | 有值（引用 local 节点获取内容） |
 | `member_local_nodes` | None | 有值（所有映射到此的 local 节点） |
 
-**身份规则**：local 层 `id = SHA-256(type + content + sorted(parameters))`，相同类型、内容和参数的声明共享同一 ID。
+**身份规则**：local 层 `id = lcn_{SHA-256(package_id + type + content + sorted(parameters))[:16]}`。ID 包含 `package_id`，因此不同包中相同内容的节点有**不同的** lcn_id。跨包的语义等价由 global canonicalization 通过 embedding 相似度判定，而非 ID 相等。
 
 **内容存储**：所有知识内容存储在 local 层的 `content` 字段上。Global 层通过 `representative_lcn` 引用获取内容，不重复存储。唯一例外是 subgraph 展开时新创建的中间节点（无 local 来源，content 直接存在 global 节点上）。
 


### PR DESCRIPTION
## Summary

Graph IR 契约变更：local canonical node ID 的 hash 输入增加 `package_id`。

**Before:** `lcn_{SHA-256(type + content + sorted(parameters))[:16]}`
- 不同包中相同内容 → 相同 lcn_id → 存储层出现重复行

**After:** `lcn_{SHA-256(package_id + type + content + sorted(parameters))[:16]}`
- 不同包中相同内容 → 不同 lcn_id → 无重复
- 跨包语义等价由 global canonicalization 通过 embedding 相似度判定

**动机：** 在实际测试中发现，Newton 的 `inverse_square_law` 和 Einstein 的 `newton_gravity` 有相同内容，产生相同 lcn_id，导致存储层出现重复行和查询混乱。

## Impact

需要同步更新 `gaia/libs/models/graph_ir.py` 的 `_compute_knowledge_id()` 函数（在 PR #223 中）。

## Test plan

- [ ] 确认 graph-ir.md 身份规则描述一致
- [ ] 合并后更新 gaia/ 代码中的 ID 计算

🤖 Generated with [Claude Code](https://claude.com/claude-code)