### PR TITLE
docs(gaia-ir): realign v2/overview to theory layer

### DIFF
--- a/docs/foundations/gaia-ir/gaia-ir-v2-draft.md
+++ b/docs/foundations/gaia-ir/gaia-ir-v2-draft.md
@@ -1,49 +1,53 @@
 # Gaia IR — 结构定义（v2 草稿）
 
-> **Status:** Draft — 基于现有 gaia-ir.md 重构，整合 Issue #231（template → claim with parameters）
+> **Status:** Draft — 以 `theory/01`-`theory/05` 为语义边界重写
 >
 > **⚠️ Protected Contract Layer** — 本目录定义 CLI↔LKM 结构契约。变更需要独立 PR 并经负责人审查批准。
 
-Gaia IR 编码推理超图的拓扑结构——**什么连接什么**。它不包含任何概率值。
+Gaia IR 编码的是 **theory Layer 2 的命题网络结构**：图中有哪些对象、对象之间有哪些严格关系、哪些推理步骤仍停留在粗粒度 weakpoint/strategy 层。
 
-概率参数见 [parameterization.md](parameterization.md)。推理输出见 [belief-state.md](belief-state.md)。三者的关系见 [overview.md](overview.md)。具体的概率推理算法见 [bp/](../bp/) 层。
+Gaia IR **不**定义以下内容：
 
-Gaia IR 由三种实体构成：
+- 因子图、势函数、BP 或任何其他推理算法
+- 运行时如何折叠/展开同一条推理链
+- `Strategy.type` 对应哪一种 CPT / noisy-AND / 编译时执行模型
 
-| 实体 | 角色 | 语义 |
-|------|------|------|
-| **Knowledge** | 命题 | 表达科学断言、背景或问题 |
-| **Operator** | 确定性逻辑约束 | 表达命题间的逻辑关系（真值表完全确定） |
-| **Strategy** | 不确定推理声明 | 表达"前提以某种概率支持结论"的推理判断 |
+这些都属于 downstream 的计算层。Gaia IR 的职责只有一个：忠实表达 theory 文档中的**粗命题网络**与**细命题网络**。
 
-读者先理解图中有什么节点（Knowledge），再理解节点之间的确定性结构关系（Operator），最后理解不确定的推理如何建模（Strategy）。
+Gaia IR 由三类实体构成：
+
+| 实体 | 角色 | 语义边界 |
+|------|------|----------|
+| **Knowledge** | 节点 | 命题、背景或问题 |
+| **Operator** | 严格关系 | claim 之间的确定性逻辑约束 |
+| **Strategy** | 粗推理声明 | 尚未完全还原为严格关系的支撑步骤 |
 
 ---
 
 ## 1. Knowledge（知识）
 
-Knowledge 表示命题。**Claim 是唯一携带概率（prior + belief）的类型。**
+Knowledge 表示图中的对象。**只有 `claim` 是可判真的命题节点，也是唯一会在 downstream 概率层获得 prior / belief 的类型。**
 
 ### 1.1 Schema
 
 Local 和 global 使用同一个 data class，字段按层级使用：
 
-```
+```text
 Knowledge:
     id:                     str              # lcn_ 或 gcn_ 前缀
     type:                   str              # claim | setting | question
-    parameters:             list[Parameter]  # 全称命题的量化变量（封闭命题为空列表）
-    metadata:               dict | None      # 含 refs: list[str]（相关 Knowledge IDs、来源引用等）
+    parameters:             list[Parameter]  # 全称 claim 的量化变量；封闭命题为空
+    metadata:               dict | None
 
     # ── local 层 ──
-    content:                str | None       # 知识内容（local 层存储，global 层通常为 None）
+    content:                str | None       # local 层唯一正文存储位置
 
-    # ── 来源追溯 ──
-    provenance:             list[PackageRef] | None   # 贡献包列表
+    # ── 追溯 ──
+    provenance:             list[PackageRef] | None
 
     # ── global 层 ──
-    representative_lcn:     LocalCanonicalRef | None  # 代表性 local Knowledge（内容从此获取）
-    local_members:          list[LocalCanonicalRef] | None  # 所有映射到此的 local Knowledge
+    representative_lcn:     LocalCanonicalRef | None
+    local_members:          list[LocalCanonicalRef] | None
 ```
 
 **各层字段使用：**
@@ -51,571 +55,327 @@ Knowledge:
 | 字段 | Local | Global |
 |------|-------|--------|
 | `id` | `lcn_` 前缀，SHA-256 包+内容寻址 | `gcn_` 前缀，注册中心分配 |
-| `content` | 有值（唯一存储位置） | 通常为 None（LKM 直接创建的 Knowledge 例外，包括 FormalExpr 中间 Knowledge） |
-| `provenance` | 有值（来源包） | 有值（贡献包列表） |
-| `representative_lcn` | None | 有值（引用 local Knowledge 获取内容） |
-| `local_members` | None | 有值（所有映射到此的 local Knowledge） |
+| `content` | 有值（唯一正文存储位置） | 通常为 None，通过 `representative_lcn` 间接获取 |
+| `provenance` | 有值 | 有值 |
+| `representative_lcn` | None | 有值 |
+| `local_members` | None | 有值 |
 
-**身份规则**：local 层 `id = lcn_{SHA-256(package_id + type + content + sorted(parameters))[:16]}`。ID 包含 `package_id`，因此不同包中相同内容的节点有**不同的** lcn_id。跨包的语义等价由 global canonicalization 通过 embedding 相似度判定，而非 ID 相等。
+**身份规则**：local 层 `id = lcn_{SHA-256(package_id + type + content + sorted(parameters))[:16]}`。ID 中包含 `package_id`，因此不同包中相同内容的节点会有不同的 `lcn_id`；跨包身份统一由 canonicalization 决定，而不是由 local ID 决定。
 
-**内容存储**：所有知识内容存储在 local 层的 `content` 字段上。Global 层通过 `representative_lcn` 引用获取内容，不重复存储。LKM 服务器直接创建的 global Knowledge（包括 FormalExpr 展开的中间 Knowledge）无 local 来源，content 直接存在 global 层。
+### 1.2 三种 Knowledge 类型
 
-### 1.2 三种知识类型
+| type | 说明 | 是否真值对象 | 可作为 |
+|------|------|-------------|--------|
+| **claim** | 科学断言（封闭或全称） | 是 | premise, conclusion, refs |
+| **setting** | 背景设定 | 否 | background, refs |
+| **question** | 待研究问题 | 否 | background, refs |
 
-| type | 说明 | 携带概率 | 可作为 |
-|------|------|---------|--------|
-| **claim** | 科学断言（封闭或全称） | 是（唯一携带 prior + belief 的类型） | premise, background, conclusion, refs |
-| **setting** | 背景信息 | 否 | background, refs |
-| **question** | 待研究方向 | 否 | background, refs |
+`template` 不再是 Gaia IR 一等类型。模板概念仅保留在 Gaia Language 编写层；编译到 Gaia IR 时，按语义落到 `claim`、`setting` 或 `question`。
 
 #### claim（断言）
 
-具有真值的科学断言。唯一携带概率（prior + belief）的知识类型。
+具有真值的命题。唯一会进入命题网络计算语义的类型。
 
-Claim 分为两类，由 `parameters` 字段区分：
+Claim 分为两类，由 `parameters` 区分：
 
-- **封闭 claim**（`parameters=[]`）：所有变量已绑定的具体命题。如 "YBCO 在 90K 以下超导"。
-- **全称 claim**（`parameters` 非空）：含量化变量的通用定律。如 `∀{x}. superconductor({x}) → zero_resistance({x})`。全称 claim 有真值（可被反例推翻），携带概率，可通过 induction 获得支持，通过 deduction 实例化为封闭 claim。
+- **封闭 claim**：`parameters=[]`。例如 `"YBCO 在 90 K 以下超导"`
+- **全称 claim**：`parameters` 非空。例：`∀{x}. superconductor({x}) → zero_resistance({x})`
 
-> **设计决策（Issue #231）：** 原 `template` 类型统一为 claim with parameters。理由：全称命题天然具有真值，应携带概率。"template" 概念保留在 Gaia Language 编写层作为语法工具，编译到 Gaia IR 时按语义分流为 claim、setting 或 question。
+全称 claim 仍然是 claim，不是模板占位符。它有真值，可以被支持、反驳、实例化。
 
-Claim 可以携带描述其产生方式的结构化元数据（`metadata` 字段）。以下是概念性示例，不构成封闭分类。Gaia IR 层不限制 `metadata` 的结构。
+#### 显式命题规则
 
-```yaml
-# 观测
-content: "该样本在 90 K 以下表现出超导性"
-metadata: {schema: observation, instrument: "四探针电阻率测量"}
+Gaia IR 不允许“隐式中间 claim”：
 
-# 定量测量
-content: "YBa₂Cu₃O₇ 的超导转变温度为 92 ± 1 K"
-metadata: {schema: measurement, value: 92, unit: "K", uncertainty: 1}
+1. 任何被 `Operator.variables` 或 `Strategy.premises` / `Strategy.conclusion` 引用的 claim，都必须显式存在于顶层 `knowledges`
+2. 形式化过程中引入的 prediction、instance、bridge claim、continuity claim 等中间命题，必须作为独立的 self-contained claim 节点写入图中
+3. IR 不把中间 claim 视为服务器展开策略时临时生成的副产物
 
-# 计算结果
-content: "DFT 计算预测该材料的带隙为 1.2 eV"
-metadata: {schema: computation, software: "VASP 6.4", functional: "PBE"}
-
-# 经验规律
-content: "金属的电阻率与温度成线性关系（Bloch-Grüneisen 高温极限）"
-metadata: {schema: empirical_law, domain: "固态物理", validity: "T >> Debye 温度"}
-
-# 全称 claim（原 template）
-content: "∀{x}. superconductor({x}) → zero_resistance({x})"
-parameters: [{name: "x", type: "material"}]
-metadata: {schema: universal_law, domain: "凝聚态物理"}
-```
+这是 `theory/05-formalization-methodology.md` 的直接要求：细命题网络中的所有承重对象都必须是显式 claim。
 
 #### 全称 claim 的实例化
 
-全称 claim 通过 deduction Strategy（条件概率=1.0）实例化为封闭 claim：
+实例化结果必须表现为**显式封闭 claim**，而不是“靠 background 绑定变量的隐式推导”。
 
+```text
+全称 claim:  "∀{x}. superconductor({x}) → zero_resistance({x})"
+实例 claim:  "superconductor(YBCO) → zero_resistance(YBCO)"
+
+Strategy(type=deduction):
+  premises   = [全称 claim]
+  conclusion = 实例 claim
+  metadata.binding = {x: "YBCO"}
 ```
-全称 claim:  "∀{x}. superconductor({x}) → zero_resistance({x})"  (claim, parameters=[x:material])
-绑定:        "x = YBCO"                                            (setting, background)
-                ↓ Strategy(type=deduction, p=1.0)
-封闭 claim:  "superconductor(YBCO) → zero_resistance(YBCO)"       (claim, parameters=[])
-```
 
-全称 claim 和封闭 claim 之间形成自然的归纳-演绎循环：
-
-- **归纳**：多个封闭实例通过 induction Strategy 支持全称 claim → 全称的 belief 上升
-- **演绎**：全称 claim 通过 deduction Strategy 预测新封闭实例 → 实例的 belief 跟随全称
-- **反例**：发现与全称矛盾的封闭 claim → contradiction Operator → 全称的 belief 下降
+绑定信息属于结构化 provenance，可放在 `metadata`，但 `YBCO` 绑定本身不是新的 claim，也不应被塞进 `background` 伪装成图语义的一部分。
 
 #### setting（背景设定）
 
-研究的背景信息或动机性叙述。不携带概率。可作为 Strategy 的 background（上下文依赖）或 refs（弱引用）。
-
-示例：某个领域的研究现状、实验动机、未解决挑战、近似方法或理论框架、全称 claim 实例化时的变量绑定（如 "x = YBCO"）。
+研究背景、适用语境、问题动机等非真值对象。不携带 prior，不直接进入命题网络运算。
 
 #### question（问题）
 
-探究制品，表达待研究的方向。不携带概率。可作为 Strategy 的 background 或 refs。
-
-示例：未解决的科学问题、后续调查目标。
+开放研究问题。不携带 prior，不直接进入命题网络运算。
 
 ---
 
-## 2. Operator（结构约束）
+## 2. Operator（严格关系）
 
-Operator 表示两个或多个 Knowledge 之间的**确定性逻辑关系**——真值表完全确定，无自由参数。
+Operator 表示 claim 之间的**确定性逻辑约束**。它们对应 theory 中的严格命题算子，不携带自由概率参数。
 
-theory 推导见 [命题算子](../theory/03-propositional-operators.md)。
+theory 推导见 [03-propositional-operators.md](../theory/03-propositional-operators.md)。
 
 ### 2.1 Schema
 
-```
+```text
 Operator:
-    operator_id:    str              # lco_ 或 gco_ 前缀（local/global canonical operator）
+    operator_id:    str              # lco_ 或 gco_ 前缀
     scope:          str              # "local" | "global"
 
-    operator:       str              # 算子类型（见 §2.2）
-    variables:      list[str]        # 连接的 Knowledge IDs（有序）
-    conclusion:     str | None       # 有向算子的输出（无向算子为 None）
+    operator:       str              # 见 §2.2
+    variables:      list[str]        # 有序 Knowledge IDs
+    conclusion:     str | None       # 有向算子的输出；无向算子为 None
 
-    metadata:       dict | None      # 含 refs: list[str] 等
-```
-
-### 2.2 算子类型与真值表
-
-| operator | 符号 | variables | conclusion | 真值约束 | 说明 |
-|----------|------|-----------|------------|---------|------|
-| **implication** | → | [A, B] | B | A=1 时 B 必须=1 | A 成立则 B 必须成立 |
-| **equivalence** | ↔ | [A, B] | None | A=B | 真值必须一致 |
-| **contradiction** | ⊗ | [A, B] | None | ¬(A=1 ∧ B=1) | 不能同时为真 |
-| **complement** | ⊕ | [A, B] | None | A≠B | 真值必须相反（XOR） |
-| **disjunction** | ∨ | [A₁,...,Aₖ] | None | ¬(all Aᵢ=0) | 至少一个为真 |
-| **conjunction** | ∧ | [A₁,...,Aₖ,M] | M | M=(A₁∧...∧Aₖ) | M 等于所有 Aᵢ 的合取 |
-
-**关键性质：** Operator 没有概率参数——它编码的是逻辑结构（"A 和 B 矛盾"），不是推理判断（"作者认为 A 蕴含 B"）。后者由 Strategy 承载。
-
-### 2.3 存在位置
-
-Operator 可以出现在两个位置：
-
-- **顶层 `operators` 数组**：独立的结构关系。例如：
-  - 人工标注的 contradiction（"GR 预测 1.75 角秒"⊗"牛顿预测 0.87 角秒"）
-  - 规范化确认的 equivalence（跨包同义命题）
-  - Review 发现的 implication
-
-- **FormalStrategy 内部的 `formal_expr.operators`**：FormalExpr 展开产生的算子，嵌入在 FormalStrategy 中，不独立存在。
-
-位置即来源，不需要额外的 `source` 字段。
-
-### 2.4 不变量
-
-1. `variables` 中的所有 ID 必须引用同 graph 中存在的 Knowledge
-2. `variables` 中的 Knowledge 类型必须是 `claim`（Operator 只连接有真值的命题）
-3. `conclusion`（如非 None）必须在 `variables` 中
-4. `equivalence`、`contradiction`、`complement`：`conclusion = None`（无向）
-5. `implication`：`conclusion` 必填（有向，`conclusion = variables[-1]`）
-6. `conjunction`：`conclusion` 必填（`conclusion = variables[-1]` = M）
-7. `disjunction`：`conclusion = None`（无向约束）
-
----
-
-## 3. Strategy（推理声明）
-
-Strategy 表示推理声明——前提通过某种推理支持结论。Strategy 是不确定性的载体：**所有概率参数都在 Strategy 层**（通过 [parameterization](parameterization.md)），Operator 层纯确定性。
-
-### 3.1 基本概念
-
-一个基本 Strategy 表达一条概率性推理：
-
-```
-premises  ——↝(p)——→  conclusion
-```
-
-其中 ↝ 表示"前提以条件概率 p 支持结论"。
-
-Strategy 有三种形态（类层级），支持多分辨率推理——同一图可在不同粒度上做概率推理：
-
-| 形态 | 说明 | 独有字段 |
-|------|------|---------|
-| **Strategy**（基类，可实例化） | 叶子推理（单条 ↝） | — |
-| **CompositeStrategy**(Strategy) | 含子策略，可递归嵌套 | `sub_strategies` |
-| **FormalStrategy**(Strategy) | 含确定性 Operator 展开 | `formal_expr` |
-
-所有形态折叠时均表达为单条 ↝（参数来自 parameterization 层）。展开时进入内部结构。
-
-### 3.2 Schema
-
-**Strategy（基类）**：
-
-```
-Strategy:
-    strategy_id:    str              # lcs_ 或 gcs_ 前缀
-    scope:          str              # "local" | "global"
-    type:           str              # 见 §3.3
-
-    # ── 连接 ──
-    premises:       list[str]        # claim Knowledge IDs（参与概率推理）
-    conclusion:     str | None       # 单个输出 Knowledge（必须是 claim）
-    background:     list[str] | None # 上下文 Knowledge IDs（任意类型，不参与概率推理）
-
-    # ── local 层 ──
-    steps:          list[Step] | None  # 推理过程的分步描述
-
-    # ── 追溯 ──
     metadata:       dict | None
 ```
 
-**CompositeStrategy(Strategy)**——新增：
+### 2.2 算子类型
 
+| operator | 符号 | variables | conclusion | 真值约束 | 说明 |
+|----------|------|-----------|------------|---------|------|
+| **entailment** | → | [A, B] | B | A=1 时 B 必须=1 | theory 中的严格蕴含 |
+| **equivalence** | ↔ | [A, B] | None | A=B | 真值一致 |
+| **contradiction** | ⊗ | [A, B] | None | ¬(A=1 ∧ B=1) | 不能同真 |
+| **negation** | ⊕ | [A, B] | None | A≠B | 真值互补 |
+| **conjunction** | ∧ | [A1,...,Ak,M] | M | M=(A1∧...∧Ak) | 生成显式合取 claim |
+| **disjunction** | ∨ | [A1,...,Ak] | None | ¬(all Ai=0) | 至少一个为真 |
+
+说明：
+
+- `entailment` 是 IR 对 theory 中严格蕴含 `A→B` 的命名
+- `conjunction` 的输出 `M` 必须是一个显式 claim，用来承接多前提推理中的中间命题
+- `equivalence` / `contradiction` / `negation` 是真正的命题关系，不是 dedupe 补丁
+
+### 2.3 不变量
+
+1. `variables` 中的所有 ID 必须引用同 graph 中存在的 Knowledge
+2. `variables` 中的 Knowledge 类型必须全部是 `claim`
+3. `conclusion` 如非 None，必须在 `variables` 中
+4. `equivalence`、`contradiction`、`negation`、`disjunction` 的 `conclusion = None`
+5. `entailment` 的 `conclusion = variables[-1]`
+6. `conjunction` 的 `conclusion = variables[-1]`
+
+---
+
+## 3. Strategy（粗推理声明）
+
+Strategy 记录**尚未完全还原为严格关系的推理步骤**。它处在 theory 的 coarse network 层，不是 BP/factor-graph 的执行单元。
+
+一个 Strategy 表达的是：
+
+```text
+premises   --(某种推理模式 / weakpoint)-->   conclusion
 ```
-CompositeStrategy(Strategy):
-    sub_strategies:  list[Strategy]  # 子策略（可包含 Strategy / CompositeStrategy / FormalStrategy）
+
+它说明“这些 claim 以某种推理方式支撑那个 claim”，但尚未把该支撑完整写成显式 claim + strict operator 子网络。
+
+### 3.1 Schema
+
+```text
+Strategy:
+    strategy_id:    str              # lcs_ 或 gcs_ 前缀
+    scope:          str              # "local" | "global"
+    type:           str              # 见 §3.2
+
+    premises:       list[str]        # claim Knowledge IDs
+    conclusion:     str              # claim Knowledge ID
+    background:     list[str] | None # setting/question IDs；不参与命题网络运算
+
+    # ── local 层 ──
+    steps:          list[Step] | None
+
+    # ── 追溯 ──
+    metadata:       dict | None      # 可含 refs、binding、review 注释等
 ```
-
-**FormalStrategy(Strategy)**——新增：
-
-```
-FormalStrategy(Strategy):
-    formal_expr:     FormalExpr      # 确定性 Operator 展开（必填）
-
-FormalExpr:
-    operators:       list[Operator]  # 只包含确定性 Operator
-```
-
-FormalExpr 中的中间 Knowledge 不需要显式列出——从 operators 的 variables 推导：`{所有 Knowledge ID} - {premises} - {conclusion}`。
 
 **各层字段使用：**
 
 | 字段 | Local | Global |
 |------|-------|--------|
 | `strategy_id` | `lcs_` 前缀 | `gcs_` 前缀 |
-| `premises`/`conclusion` | `lcn_` ID | `gcn_` ID |
-| `steps` | 有值 | None（保留在 local 层） |
+| `premises` / `conclusion` | `lcn_` ID | `gcn_` ID |
+| `steps` | 有值 | None |
 
-**身份规则**：`strategy_id = {lcs_|gcs_}_{SHA-256(scope + type + sorted(premises) + conclusion)[:16]}`。
+### 3.2 Strategy 类型
 
-### 3.3 类型字段
+`type` 表示**语义分类**，不是运行时参数模型：
 
-| type | 参数化模型 | 形态 |
-|------|-----------|------|
-| **`infer`** | 完整条件概率表（CPT）：2^k 参数（默认 MaxEnt 0.5） | Strategy |
-| **`noisy_and`** | ∧ + 单参数 p | Strategy |
-| **`deduction`** | 确定性（p=1） | FormalStrategy |
-| **`abduction`** | 非确定性 | CompositeStrategy（含 FormalStrategy 子部分） |
-| **`induction`** | 非确定性 | CompositeStrategy（含 FormalStrategy 子部分） |
-| **`analogy`** | 非确定性 | CompositeStrategy（含 FormalStrategy 子部分） |
-| **`extrapolation`** | 非确定性 | CompositeStrategy（含 FormalStrategy 子部分） |
-| **`reductio`** | 确定性（p=1） | FormalStrategy |
-| **`elimination`** | 确定性（p=1） | FormalStrategy |
-| **`mathematical_induction`** | 确定性（p=1） | FormalStrategy |
-| **`case_analysis`** | 确定性（p=1） | FormalStrategy |
-| **`toolcall`** | 另行定义 | Strategy |
-| **`proof`** | 另行定义 | Strategy |
+| type | 含义 | 对应 theory |
+|------|------|-------------|
+| **soft_implication** | 未进一步分类的粗 weakpoint | `03-propositional-operators.md` 的 ↝ |
+| **deduction** | 演绎 | `04` §2.1 |
+| **abduction** | 溯因 | `04` §2.2 |
+| **induction** | 归纳 | `04` §2.3 |
+| **analogy** | 类比 | `04` §2.4 |
+| **extrapolation** | 外推 | `04` §2.5 |
+| **reductio** | 归谬 | `04` §2.6 |
+| **elimination** | 排除 | `04` §2.7 |
+| **mathematical_induction** | 数学归纳 | `04` §2.8 |
+| **case_analysis** | 分情况讨论 | `04` §2.9 |
 
-> **设计决策：** `independent_evidence` 和 `contradiction` 不作为 Strategy 类型——它们是结构关系，直接用 Operator（equivalence / contradiction）表达。原 `soft_implication` 合并到 `noisy_and`（k=1 的特例）。原 `None` 合并到 `infer`。
+`toolcall`、`proof` 等工作流/执行态概念不属于 Gaia IR 核心 contract；如需记录，应放在更上层的 authoring / workflow schema，而不是混入命题网络本体。
 
-### 3.4 参数化语义
+### 3.3 参数语义边界
 
-Strategy 的参数化模型由 `type` 决定。概率参数存储在 [parameterization](parameterization.md) 层，不在 IR 中。
+Gaia IR 自身**不存储任何概率值**。它只保留 strategy 的结构和语义分类。
 
-#### `infer`（通用条件概率表）
+与参数相关的边界如下：
 
-未分类的通用推理。k 个前提需要 2^k 个条件概率参数——每种前提真值组合对应一个 P(conclusion | 前提组合)。按最大熵原则，默认值全为 0.5（无信息先验）。
+1. claim 的 prior 属于 downstream 参数层
+2. `soft_implication` 之类的 coarse weakpoint，如要赋 `(p1, p2)`，也属于 downstream 参数层
+3. theory 当前只显式给出了二值接口 `A ↝ B` 的 `(p1, p2)` 语义；多前提策略的推广形式尚未在 theory 中定稿
 
-实践中很少使用——大多数推理会被分类为 `noisy_and` 或命名策略。`StrategyParamRecord.conditional_probabilities: list[float]` 已支持变长列表，可存储 2^k 参数。
+因此，Gaia IR 允许 `premises: list[str]`，但**不在 IR 层强行绑定某一种 generalized CPT / noisy-AND 参数模型**。IR 只负责记录结构；参数推广如何做，是 theory 与 downstream parameterization 的问题，不是 IR contract 的问题。
 
-#### `noisy_and`（∧ + 单参数 p）
+### 3.4 粗命题网络与细命题网络
 
-**最常用的 Strategy 类型。** 所有前提先 AND（联合必要条件），再以条件概率 p 推出结论：
+Gaia IR 支持两种合法表达：
 
-```
-P(conclusion=true | all premises=true) = p
-P(conclusion=true | any premise=false) = ε    （Cromwell leak）
-```
+#### 粗命题网络
 
-单参数 p 表达推理本身的可信度，前提的可信度由各自的 prior 表达。
+使用 `Strategy` 记录尚未展开的支撑步骤：
 
-**适用范围：前提是联合必要条件的推理。** 包括演绎（所有前提必须成立）、类比（source + bridge 都必须成立）等。
-
-**不适用于归纳和溯因**——它们的前提是独立贡献的，不是全有全无。少一个实例/证据不会让支持归零。这些策略必须用 CompositeStrategy 分解为并行子结构（见 §3.6）。
-
-### 3.5 三种形态
-
-#### 3.5.1 基本 Strategy（叶子 ↝）
-
-最简单的形态——表达单条条件概率关系。参数化模型取决于 type（`infer` → 2^k 参数 CPT，`noisy_and` → 单参数 p）。
-
-#### 3.5.2 CompositeStrategy（嵌套子策略）
-
-将一个推理分解为多个子策略。`sub_strategies` 可以包含任意形态（Strategy / CompositeStrategy / FormalStrategy），支持递归嵌套。
-
-折叠时（不展开）：表达为单条 ↝。展开时：递归进入每个子策略的内部结构。
-
-#### 3.5.3 FormalStrategy + FormalExpr（确定性展开）
-
-用于有已知确定性微观结构的命名策略。`formal_expr` 只包含 Operator（确定性），不包含不确定的 ↝。
-
-**关键约束：FormalExpr 内部没有概率参数——不确定性转移到中间 Knowledge 的先验 π 上。**
-
-### 3.6 命名策略的组装方式
-
-#### 确定性策略 → 纯 FormalStrategy
-
-前提联合必要，推理过程确定性。
-
-**演绎（deduction）**：`premises=[A₁,...,Aₖ], conclusion=C`
-```
-FormalStrategy(type=deduction):
-  formal_expr:
-    - conjunction([A₁,...,Aₖ, M], conclusion=M)
-    - implication([M, C], conclusion=C)
+```text
+Obs1, Obs2  --induction-->  Law
 ```
 
-**数学归纳（mathematical_induction）**：`premises=[Base, Step], conclusion=Law`
-```
-FormalStrategy(type=mathematical_induction):
-  formal_expr:
-    - conjunction([Base, Step, M], conclusion=M)
-    - implication([M, Law], conclusion=Law)
-```
-结构与演绎相同。语义区分：Base=P(0), Step=∀n(P(n)→P(n+1)), Law=∀n.P(n)。
+#### 细命题网络
 
-**归谬（reductio）**：`premises=[R], conclusion=¬P`
-```
-FormalStrategy(type=reductio):
-  formal_expr:
-    - implication([P, Q], conclusion=Q)
-    - contradiction([Q, R])
-    - complement([P, ¬P])
+把原 strategy 进一步形式化为显式 claim + Operator；若仍有未消去的 weakpoint，再用新的下层 Strategy 表示：
+
+```text
+Law  --entailment-->  Instance1  --equivalence-->  Obs1
+Law  --entailment-->  Instance2  --equivalence-->  Obs2
 ```
 
-**排除（elimination）**：`premises=[E₁, E₂, Exhaustiveness], conclusion=H₃`
-```
-FormalStrategy(type=elimination):
-  formal_expr:
-    - contradiction([H₁, E₁])
-    - contradiction([H₂, E₂])
-    - complement([H₁, ¬H₁])
-    - complement([H₂, ¬H₂])
-    - conjunction([¬H₁, ¬H₂, M], conclusion=M)
-    - implication([M, H₃], conclusion=H₃)
-```
+关键规则：
 
-**分情况讨论（case_analysis）**：`premises=[Exhaustiveness, P₁,...,Pₖ], conclusion=C`
-```
-FormalStrategy(type=case_analysis):
-  formal_expr:
-    - disjunction([A₁,...,Aₖ])
-    - conjunction([A₁, P₁, M₁], conclusion=M₁), implication([M₁, C], conclusion=C)
-    - conjunction([A₂, P₂, M₂], conclusion=M₂), implication([M₂, C], conclusion=C)
-    - ...（每个 case 一对 conjunction + implication）
-```
+1. **细化是图重写，不是 IR 内置的运行时折叠/展开协议**
+2. 同一条活跃推理步骤在同一张图里应当选择一个分辨率表达
+3. 如果同时保留 coarse summary 和其完整 refined subnetwork，并把二者都当作独立证据参与运算，会导致重复计数
 
-#### 非确定性策略 → CompositeStrategy（含 FormalStrategy 子部分）
+如果工作流需要保留“这张细网络来源于哪条 coarse strategy”的追溯关系，应写入 `metadata` / review 层，而不是把双分辨率执行语义塞进 IR contract。
 
-前提独立贡献或推理过程非确定性。不确定的 ↝ 部分用 Strategy 子节点表达，确定的结构用 FormalStrategy 子节点表达。
+### 3.5 命名策略的标准细化方向
 
-**溯因（abduction）**：`premises=[supporting_knowledge], conclusion=H`
+命名策略的意义，是告诉 reviewer / compiler / agent：这条 coarse step 在 theory 中通常应往什么形式化方向细化。
 
-溯因的不确定性在于"假说是否是最佳解释"。确定部分是 H→O 和 O↔Obs 的逻辑结构。
+| type | 典型细化骨架 |
+|------|--------------|
+| `deduction` | `conjunction` + `entailment` |
+| `abduction` | `Hypothesis → Prediction`，再 `Prediction ↔ Observation` |
+| `induction` | 多组 `Law → Instance_i` 与 `Instance_i ↔ Obs_i` |
+| `analogy` | 显式 bridge claim + source law + target entailment |
+| `extrapolation` | 显式 continuity claim + known law + target entailment |
+| `reductio` | 假设导出结果，再与已知 claim 构成 `contradiction` / `negation` |
+| `elimination` | 通过互斥关系逐步排除候选，再 `entailment` 到剩余结论 |
+| `mathematical_induction` | base + step 的 `conjunction`，再 `entailment` 到一般命题 |
+| `case_analysis` | case 的 `disjunction`，各 case 到结论的 `entailment` |
 
-```
-CompositeStrategy(type=abduction, premises=[supporting_knowledge], conclusion=H):
-  sub_strategies:
-    - Strategy(type=noisy_and, premises=[H], conclusion=O)        ← 不确定的 ↝
-    - FormalStrategy(formal_expr:
-        - implication([H, O], conclusion=O)
-        - equivalence([O, Obs])
-      )                                                            ← 确定的结构
-```
+这些是**形式化方法论的方向约束**，不是嵌入式执行 AST。
 
-**归纳（induction）**：`premises=[Obs₁,...,Obsₙ], conclusion=Law`
+### 3.6 Premise / Background / Refs
 
-归纳的每个实例独立贡献支持——不是联合必要。分解为并行的子推理，每个都是确定性的 implication + equivalence 结构。
+| 字段 | 类型约束 | 是否进入命题网络 | 说明 |
+|------|---------|------------------|------|
+| **premises** | 仅 `claim` | 是 | 这条推理真正依赖的真值对象 |
+| **background** | 仅 `setting` / `question` | 否 | 背景语境、研究动机、适用范围 |
+| **refs**（`metadata.refs`） | 任意 | 否 | 追溯引用 |
 
-```
-CompositeStrategy(type=induction, premises=[Obs₁,...,Obsₙ], conclusion=Law):
-  sub_strategies:
-    - FormalStrategy(formal_expr:
-        - implication([Law, Instance₁], conclusion=Instance₁)
-        - equivalence([Instance₁, Obs₁])
-      )
-    - FormalStrategy(formal_expr:
-        - implication([Law, Instance₂], conclusion=Instance₂)
-        - equivalence([Instance₂, Obs₂])
-      )
-    - ...（每个观测一组 implication + equivalence）
-```
+规则：
 
-累积效应由多条独立证据的概率在 Law 节点上汇聚实现——更多一致的观测 → Law 的 belief 自然上升。单个反例（Obs 与 Instance 不一致）通过 equivalence Operator 传播，削弱 Law 的 belief。
+- 任意**承重假设**，只要它有真值、可支持、可反驳，就必须写成 `claim`
+- 这种 claim 必须进入 `premises`、`conclusion` 或显式 Operator 网络
+- 不能把 claim 藏在 `background` 里逃避结构化
 
-**类比（analogy）**：`premises=[SourceLaw, BridgeClaim], conclusion=Target`
+### 3.7 不变量
 
-前提联合必要（source 和 bridge 都要成立），但 bridge 的可信度本身是不确定的。
-
-```
-CompositeStrategy(type=analogy, premises=[SourceLaw, BridgeClaim], conclusion=Target):
-  sub_strategies:
-    - Strategy(type=noisy_and, premises=[SourceLaw, BridgeClaim], conclusion=Target)
-    - FormalStrategy(formal_expr:
-        - conjunction([SourceLaw, BridgeClaim, M], conclusion=M)
-        - implication([M, Target], conclusion=Target)
-      )
-```
-
-不确定性集中在 BridgeClaim 的先验 π(BridgeClaim)。
-
-**外推（extrapolation）**：`premises=[KnownLaw, ContinuityClaim], conclusion=Extended`
-
-与类比结构相同。不确定性在 ContinuityClaim 的先验。
-
-```
-CompositeStrategy(type=extrapolation, premises=[KnownLaw, ContinuityClaim], conclusion=Extended):
-  sub_strategies:
-    - Strategy(type=noisy_and, premises=[KnownLaw, ContinuityClaim], conclusion=Extended)
-    - FormalStrategy(formal_expr:
-        - conjunction([KnownLaw, ContinuityClaim, M], conclusion=M)
-        - implication([M, Extended], conclusion=Extended)
-      )
-```
-
-### 3.7 多分辨率展开
-
-Strategy 的三种形态支持同一图在不同粒度上推理。给定一个"展开集合"（需要进入内部结构的 Strategy ID 集合），推理引擎可以选择：
-
-- **不展开**：将 Strategy 视为单条 ↝，使用 parameterization 层的条件概率参数
-- **展开 CompositeStrategy**：递归进入子策略
-- **展开 FormalStrategy**：进入 FormalExpr 内的确定性 Operator 结构
-
-具体的推理算法实现见 [bp/](../bp/) 层。
-
-### 3.8 Lifecycle
-
-Strategy 的形态即状态——不需要 `initial` / `candidate` / `permanent` 阶段标签：
-
-```
-Strategy(type=infer)                          ← 初始：通用推理
-  ├── reviewer 分类为命名策略 → CompositeStrategy / FormalStrategy
-  ├── reviewer 确认为 noisy_and → type=noisy_and
-  ├── reviewer 分解 → CompositeStrategy + sub_strategies
-  └── 保持 type=infer
-```
-
-IR 中所有 Strategy 都是已确认的结构——候选项由 review 层管理。
-
-### 3.9 Premise / Background / Refs
-
-| 字段 | 类型约束 | 参与概率推理 | 说明 |
-|------|---------|-------------|------|
-| **premises** | 仅 claim | 是 | 推理的形式前提，条件概率的输入变量 |
-| **background** | 任意类型 | 否 | 上下文依赖（setting、全称 claim 实例化的绑定等） |
-| **refs** (metadata) | 任意 | 否 | 弱相关来源引用 |
-
-- **Premise**：推理成立的必要条件，必须是 claim。Review 在评估 Strategy 条件概率时应同时考虑 premises 和 background 的内容。
-- **Background**：上下文依赖，任意类型。不参与概率推理。
-- **Refs**：存储在 `metadata.refs` 中的 ID 列表。不参与图结构。
-
-### 3.10 不变量
-
-1. `premises` 中的 Knowledge 类型必须是 `claim`
-2. `conclusion` 的 Knowledge 类型必须是 `claim`（如果非 None）
-3. `background` 中的 Knowledge 类型可以是任意（claim / setting / question）
-4. FormalStrategy 的 `formal_expr` 必填；CompositeStrategy 的 `sub_strategies` 必填且非空
-5. `sub_strategies` 和 `formal_expr` 不同时出现（形态互斥由类层级保证）
-6. FormalExpr 只包含 Operator（不包含 Strategy）
-7. `noisy_and` 仅用于前提联合必要的场景；归纳/溯因必须用 CompositeStrategy 分解
+1. `premises` 中的 Knowledge 类型必须全部为 `claim`
+2. `conclusion` 引用的 Knowledge 类型必须为 `claim`
+3. `background` 中的 Knowledge 类型只能是 `setting` 或 `question`
+4. Strategy 至少有一个 premise
+5. `strategy_id` 只标识这条 coarse 推理声明，不暗含任何运行时展开策略
 
 ---
 
 ## 4. 规范化（Canonicalization）
 
-规范化是将 local canonical 实体映射到 global canonical 实体的过程——从包内身份到跨包身份。
+规范化将 local canonical 实体映射为 global canonical 实体。核心原则是：**按命题身份做映射，而不是按该命题在局部图里的修辞角色做映射。**
 
-### 4.1 映射决策：身份映射与等价声明
+### 4.1 CanonicalBinding 与 Equivalence 的区别
 
-规范化中存在两种本质不同的关系：
+规范化中存在两类完全不同的关系：
 
-- **CanonicalBinding（身份映射）**：local Knowledge 和 global Knowledge 是**同一个命题**的不同表示。纯引用关系，不提供新证据，不创建图结构。
-- **Equivalence Operator（等价声明）**：两个独立的 global Knowledge 被声明为**等价**。两条独立推理链得出相同结论——这本身是新证据，概率推理会在两者之间传播 belief。
+- **CanonicalBinding（身份映射）**：local Knowledge 与 global Knowledge 是同一个命题的不同出现
+- **Equivalence Operator（等价关系）**：两个 global claim 是独立命题，但被判断为等价
 
-Gaia IR 提供这种区分的结构基础。具体的匹配判定和等价确认由 review 服务和 agent 实现——IR 层不规定判定策略。
+前者是身份统一，后者是图中的真实结构关系。`equivalence` 不是为了解决“结论节点不能 merge”的技术补丁，而是命题层面的关系声明。
 
-当新包中的 local Knowledge 与全局图中已有 Knowledge 语义匹配时，处理方式取决于**该 Knowledge 在 local 图中的角色**：
+### 4.2 映射决策
 
-**作为 premise 的 Knowledge → CanonicalBinding（身份映射，无新证据）**
+当 local Knowledge 与已有 global Knowledge 语义匹配时：
 
-如果 local Knowledge 在 local 图中仅作为 premise（或 background）使用，且与已有 global Knowledge 匹配，则直接绑定到该 global Knowledge。全局图上的 prior 和 belief 保持不变。
+1. **同一命题** → 直接 CanonicalBinding 到该 global Knowledge
+2. **不是同一命题，但 reviewer 认为两者等价** → 创建新的 global Knowledge，并在两者之间提议 `equivalence`
+3. **无匹配** → 创建新的 global Knowledge
 
-**作为 conclusion 的 Knowledge → Equivalence candidate（等价声明，新证据）**
+局部角色（premise / conclusion / background）可以作为 reviewer 判断的辅助信号，但**不能**作为 IR contract 中的规范化规则。
 
-如果 local Knowledge 在 local 图中作为某个 Strategy 的 conclusion，且与已有 global Knowledge 匹配，**不**直接 merge 为同一个 global Knowledge。而是：
+### 4.3 参与规范化的类型
 
-1. 为 local conclusion 创建新的 global Knowledge
-2. 在新旧两个 global Knowledge 之间提议一个 equivalence Operator（候选项由 review 层管理，确认后写入 IR）
+所有 Knowledge 类型都可以规范化：
 
-理由：两个不同包独立得出的结论语义相似，不代表它们是同一个命题。等价关系一旦确认，概率推理会在两者之间传播 belief——这是新证据，不是简单的身份合并。
+- `claim`：按命题身份统一
+- `setting`：按背景对象身份统一
+- `question`：按问题身份统一
 
-Canonicalization 同时创建 placeholder 参数记录：新 global claim Knowledge 的 PriorRecord（placeholder prior）。具体值由后续 review 步骤确定。
+其中 `claim` 的 canonicalization 最关键，因为它决定全局命题网络的节点集合。
 
-**同时作为 premise 和 conclusion → 走 conclusion 路径**
+### 4.4 匹配策略
 
-理由：该 Knowledge 有独立的推理来源，不应静默合并。
+IR 层不规定具体判定算法，但推荐约束如下：
 
-**无匹配 → create_new**
-
-为前所未见的命题创建新的 global Knowledge。
-
-### 4.2 参与规范化的 Knowledge 类型
-
-**所有知识类型都参与全局规范化：** claim（含全称 claim）、setting、question。
-
-- **claim**：跨包身份统一是概率推理的基础。全称 claim（parameters 非空）跨包共享同一通用定律
-- **setting**：不同包可能描述相同背景，统一后可被多个推理引用
-- **question**：同一科学问题可被多个包提出
-
-### 4.3 匹配策略
-
-**Embedding 相似度（主要）**：余弦相似度，阈值 0.90。
-
-**TF-IDF 回退**：无 embedding 模型时使用。
-
-**过滤规则：**
-
-- 仅相同 `type` 的候选者才有资格
-- 含 `parameters` 的 claim 额外比较参数结构：count + types 按序匹配，忽略 name（α-equivalence，见 Issue #234）
-
-### 4.4 CanonicalBinding
-
-```
-CanonicalBinding:
-    local_canonical_id:     str
-    global_canonical_id:    str
-    package_id:             str
-    version:                str
-    decision:               str    # "match_existing" | "create_new" | "equivalent_candidate"
-    reason:                 str    # 匹配原因（如 "cosine similarity 0.95"）
-```
+- 仅同 `type` 候选可比较
+- `claim(parameters != [])` 需要额外比较参数结构（count + types 按序匹配，忽略变量名）
+- embedding / lexical / symbolic matching 都是实现细节，不属于 IR contract
 
 ### 4.5 Strategy 提升
 
-Knowledge 规范化完成后，local Strategy 提升到全局图：
+Knowledge 规范化完成后，local Strategy 提升到 global：
 
-1. 从 CanonicalBinding 构建 `lcn_ → gcn_` 映射
-2. 从全局 Knowledge 元数据构建 `ext: → gcn_` 映射（跨包引用解析）
-3. 对每个 local Strategy，解析所有 premise、conclusion 和 background ID
-4. 含未解析引用的 Strategy 被丢弃（记录在 `unresolved_cross_refs` 中）
+1. 基于 CanonicalBinding 构造 `lcn_ → gcn_` 映射
+2. 解析 Strategy 的 `premises`、`conclusion`、`background`
+3. 若存在未解析引用，则该 Strategy 不能被提升为有效 global Strategy
 
-**Global Strategy 不携带 steps。** Local Strategy 的 `steps`（推理过程文本）保留在 local canonical 层。Global Strategy 只保留结构信息（type、premises、conclusion、形态及其字段），不复制推理内容。需要查看推理细节时，通过 CanonicalBinding 回溯到 local 层。
+Global Strategy 不携带 `steps`。推理文本保留在 local 层。
 
-### 4.6 Global 层的内容引用
+### 4.6 显式内容与中间 claim
 
-Global 层**通常不存储内容**：
+Global 层通常通过 `representative_lcn` 间接获得内容；但如果 review / LKM 在 global 层新增了一个 claim，它也必须作为**显式 Knowledge 实体**写入图中，并具备可追溯 content。
 
-- **Global Knowledge** 通过 `representative_lcn` 引用 local canonical Knowledge 获取 content。当多个 local Knowledge 映射到同一 global Knowledge 时，选择一个作为代表，所有映射记录在 `local_members` 中。
-- **Global Strategy** 不携带 `steps`。推理过程的文本保留在 local 层。
-
-**例外：** LKM 服务器直接创建的 Knowledge（包括 FormalExpr 展开的中间 Knowledge）没有 local 来源，其 content 直接存储在 global Knowledge 上。
-
-Global 层是**结构索引**，local 层是**内容仓库**。
-
-### 4.7 Strategy 形态与层级规则
-
-**三种形态均可出现在 local 和 global 层：**
-
-- **基本 Strategy**：local 层（compiler 产出）和 global 层（提升后）均可。
-- **CompositeStrategy**：local 层（作者在包内构造层次化论证）和 global 层（reviewer/agent 分解）均可。
-- **FormalStrategy**：local 层（compiler 识别 type 后自动生成 FormalExpr）和 global 层（reviewer/agent 分类后生成）均可。
-
-**中间 Knowledge 的归属：**
-
-- FormalExpr 展开时可能创建中间 Knowledge（FormalExpr 中引用但不在 premises/conclusion 中的 Knowledge ID）。
-- Local 层的中间 Knowledge 获得 `lcn_` ID，归属于当前包。
-- Global 层的中间 Knowledge 获得 `gcn_` ID，由 LKM 直接创建，content 存在 global Knowledge 上（§4.6 的例外情况）。
-
-**FormalExpr 的生成方式：**
-
-- **确定性策略**（deduction, reductio, elimination, mathematical_induction, case_analysis）：FormalExpr 由 type 唯一确定，可在分类确认时**自动生成**（compiler 或 reviewer 均可触发）。
-- **非确定性策略**（abduction, induction, analogy, extrapolation）：表达为 CompositeStrategy，其 sub_strategies 中的 FormalStrategy 子部分可自动生成，但 CompositeStrategy 的整体分解结构（哪些子策略、哪些中间 Knowledge）需要 reviewer/agent 判断。中间 Knowledge 的先验概率通过 parameterization 层的 PriorRecord 赋值，不在 IR 中指定。
+系统永远不应把某个 claim 当作“展开 strategy 时隐式出现，但不需要进入 `knowledges`”。
 
 ---
 
-## 5. 关于撤回（Retraction）
+## 5. 关于细化（Refinement）
 
-Gaia IR 中没有 retraction 类型。撤回是一个**操作**：为目标 Knowledge 关联的所有 Strategy 添加新的 StrategyParamRecord，将 `conditional_probabilities` 中的所有条目设为 Cromwell 下界 ε。该 Knowledge 实质上变成孤岛，belief 回到 prior。图结构不变——图是不可变的。
+Gaia IR 的细化原则来自 `theory/05-formalization-methodology.md`：
+
+1. 先允许 coarse network 诚实记录 weakpoint
+2. 再逐步把 weakpoint 重写为显式 claim + strict operator 子网络
+3. 当某条路径已被充分细化后，剩余自由度应尽量收缩到 claim 的 prior，而不是继续塞在边的黑箱参数里
+
+Gaia IR 负责承载这个过程的**结果**，不负责定义运行时如何在同一条路径上来回折叠/展开。
 
 ---
 
@@ -623,41 +383,18 @@ Gaia IR 中没有 retraction 类型。撤回是一个**操作**：为目标 Know
 
 | 决策 | 理由 |
 |------|------|
-| Knowledge 三种类型（删除 template） | Issue #231：全称命题（∀{x}.P({x})）有真值，应携带概率。统一为 claim with parameters。Template 概念保留在 Gaia Language 编写层 |
-| Operator 从 Strategy 分离 | ↔/⊗/⊕ 是确定性命题算子，不是推理声明。Operator 无概率参数，Strategy 有 |
-| independent_evidence / contradiction 用 Operator 表达 | 它们是结构关系，不是推理判断。直接用 equivalence / contradiction Operator |
-| Strategy type 合并 | 原 None 合并到 infer，原 soft_implication 合并到 noisy_and（k=1 特例） |
-| infer vs noisy_and 区分 | infer = 完整 CPT（2^k 参数），noisy_and = ∧ + 单参数 p。大多数推理使用 noisy_and |
-| noisy_and 仅限联合必要场景 | 归纳/溯因的前提是独立贡献的，不能用 noisy_and。必须用 CompositeStrategy 分解为并行子结构 |
-| Strategy 三形态类层级 | Strategy（叶子 ↝）、CompositeStrategy（递归嵌套）、FormalStrategy（确定性展开）——形态由结构决定，type 与形态正交 |
-| FormalExpr 只包含 Operator | 不确定部分留在 CompositeStrategy 的 sub_strategies 中，FormalExpr 纯确定性 |
-| FormalExpr 作为 FormalStrategy 的嵌入字段 | 1:1 关系，不需要独立实体；FormalExpr 无独立 ID 和 lifecycle |
-| conditional_probabilities 在 parameterization 层 | 概率参数不属于图结构；通过 StrategyParamRecord 存储。type 决定参数数量 |
-| 多分辨率展开 | 任何 Strategy 折叠时均表达为单条 ↝；展开时进入内部结构。具体推理算法由 bp/ 层定义 |
-| 图的不可变性 | 撤回通过参数操作（conditional_probabilities → ε）实现，不删除图结构 |
+| 删除 `template` 作为 IR 一等类型 | 全称命题本身是 claim；模板只属于 authoring 语法层 |
+| `Operator` 只保留 theory 层严格关系 | 这些关系是命题网络本体，不是 downstream factor/BP object |
+| `Strategy.type` 改为语义分类 | `infer` / `noisy_and` / CPT 是参数模型，不是 ontology 层类型 |
+| 不再以 `CompositeStrategy` / `FormalStrategy` 作为核心 contract | 那是执行/展开视角；theory 层要表达的是 coarse graph 与 explicit refined graph |
+| 中间 claim 必须显式存在 | theory/05 要求 self-contained claim；不能依赖隐式节点 |
+| `background` 禁止 claim | 承重真值对象必须进入 proposition network |
+| canonicalization 按命题身份，不按局部角色 | 命题身份与其在一条局部推理中的修辞位置无关 |
 
-### 已知 Future Work
+### 已知开放点
 
-| 缺口 | 说明 | 影响 |
-|------|------|------|
-| **α-equivalence（Issue #234）** | 含 parameters 的 claim 匹配时需要忽略变量名 | Canonicalization 精度 |
-| **Gaia IR Validator（Issue #233）** | 每次 IR 更新时的结构验证 | 数据完整性 |
-| **Compiler dispatch（Issue #236）** | Gaia Language template → IR 知识类型的编译规则 | CLI 端实现 |
-
----
-
-## 与原 Gaia IR 的概念映射
-
-| 原概念 | 新概念 | 变更说明 |
-|--------|--------|---------|
-| KnowledgeNode | **Knowledge** | 去掉 Node 后缀；删除 template 类型，统一为 claim with parameters |
-| FactorNode | **Strategy** | 改名 + 重构（统一 type，三形态类层级） |
-| FactorNode.category + reasoning_type | Strategy.type | 合并为单一字段 |
-| FactorNode.subgraph | **FormalExpr**（FormalStrategy 嵌入字段） | 从 FactorNode 字段提取为 data class |
-| reasoning_type=equivalent | **Operator**(operator=equivalence) | 从推理声明移为结构约束 |
-| reasoning_type=contradict | **Operator**(operator=contradiction) | 从推理声明移为结构约束 |
-| — | **Operator**(operator=complement, disjunction, conjunction, implication) | 新增 |
-| soft_implication | 合并到 noisy_and | k=1 的 noisy_and 特例 |
-| None (type) | 合并到 infer | 未分类推理统一用 infer |
-| independent_evidence (Strategy type) | 直接用 Operator(equivalence) | 结构关系，不是推理声明 |
-| contradiction (Strategy type) | 直接用 Operator(contradiction) | 结构关系，不是推理声明 |
+| 主题 | 当前状态 |
+|------|----------|
+| `↝` 的多前提参数推广 | theory 尚未定稿；IR 保持结构中立 |
+| claim 的 α-equivalence | 仍需单独定义匹配规则 |
+| downstream parameterization 与 belief engine | 属于 Layer 3，不在本文定义 |

--- a/docs/foundations/gaia-ir/overview.md
+++ b/docs/foundations/gaia-ir/overview.md
@@ -1,309 +1,219 @@
 # Gaia IR 概述
 
-> **Status:** Target design — 基于 [06-factor-graphs.md](../theory/06-factor-graphs.md) 和 [04-reasoning-strategies.md](../theory/04-reasoning-strategies.md) 设计
+> **Status:** Target design — 以 `theory/01`-`theory/05` 为语义边界
 >
 > **⚠️ Protected Contract Layer** — 本目录定义 CLI↔LKM 结构契约。变更需要独立 PR 并经负责人审查批准。详见 [documentation-policy.md](../../documentation-policy.md#12-变更控制)。
 
 ## 目的
 
-Gaia IR 是 Gaia 推理超图的完备数据表示。读完本文档，你应当知道一个完整的 Gaia 知识体系由哪几部分信息构成。
+Gaia IR 是 Gaia 在 **theory Layer 2** 上的命题网络表示。它回答的是：
 
-Gaia 的数据由三个独立对象组成：
+- 图里有哪些对象？
+- 哪些对象是可判真的 claim？
+- 哪些关系是严格逻辑关系？
+- 哪些推理步骤仍然是尚未完全形式化的 coarse strategy / weakpoint？
 
+Gaia IR **不**回答：
+
+- 如何编译成因子图
+- 如何给某条边挑选 noisy-AND / CPT 参数模型
+- 如何运行 BP 或其他推理算法
+
+这些属于 downstream 计算层。
+
+## 一、Gaia IR 的三个对象
+
+Gaia IR 由三种对象组成：
+
+```text
+Knowledge   +   Operator   +   Strategy
+节点            严格关系        粗推理声明
 ```
-Gaia IR（结构）    ×    Parameterization（参数）    →    BeliefState（信念）
-什么连接什么               每个 Knowledge/Strategy 多可信     BP 计算的后验信念
-编译时确定                  review 产出                     BP 产出
-```
 
-三者严格分离。Gaia IR 有 local 和 global 两层。Parameterization 和 BeliefState 只作用在 GlobalCanonicalGraph 上。
+| 对象 | 作用 | theory 对齐点 |
+|------|------|---------------|
+| **Knowledge** | 表示命题、背景或问题 | `04-reasoning-strategies.md` 的知识类型 |
+| **Operator** | 表示 claim 之间的严格关系 | `03-propositional-operators.md` 的严格算子 |
+| **Strategy** | 表示尚未充分展开的推理步骤 | `03` 的 ↝ 与 `04` 的命名推理策略 |
 
-## 一、Gaia IR — 结构
+### Knowledge
 
-Gaia IR 编码**什么连接什么**——推理超图的拓扑结构。它不包含任何概率值。
+Knowledge 有三种类型：
 
-Gaia IR 由三种实体构成：**Knowledge**（命题）、**Strategy**（推理声明）、**Operator**（结构约束）。Strategy 有三种形态：基础 Strategy（↝ 叶子）、CompositeStrategy（含子策略，可递归嵌套）和 FormalStrategy（含确定性展开 FormalExpr）。
+| type | 是否真值对象 | 说明 |
+|------|-------------|------|
+| **claim** | 是 | 科学断言，唯一会在 downstream 获得 prior / belief |
+| **setting** | 否 | 背景设定、适用语境 |
+| **question** | 否 | 待研究问题 |
 
-### 整体结构
+`template` 不再是 Gaia IR 一等类型。全称命题直接作为 `claim(parameters != [])` 表达。
 
-**Local 层示例**（包内，存储完整内容）：
+### Operator
+
+Operator 是 claim 之间的**确定性逻辑约束**。当前核心类型包括：
+
+- `entailment`
+- `equivalence`
+- `contradiction`
+- `negation`
+- `conjunction`
+- `disjunction`
+
+这些对象定义命题网络的严格结构，不携带自由概率参数。
+
+### Strategy
+
+Strategy 是**粗推理声明**。它说明某些 claim 通过某种 reasoning pattern 支撑另一个 claim，但尚未完全还原成显式 claim + strict operator 子网络。
+
+`Strategy.type` 是语义分类，不是运行时参数模型。典型类型包括：
+
+- `soft_implication`
+- `deduction`
+- `abduction`
+- `induction`
+- `analogy`
+- `extrapolation`
+- `reductio`
+- `elimination`
+- `mathematical_induction`
+- `case_analysis`
+
+## 二、粗命题网络与细命题网络
+
+Gaia IR 允许图停留在不同形式化层级，但**同一条推理步骤在同一张活跃图里应只选择一个分辨率表达**。
+
+### 粗命题网络
+
+当某条推理还没有被完全分析时，用 Strategy 诚实记录 weakpoint：
 
 ```json
 {
   "scope": "local",
-  "ir_hash": "sha256:...",
   "knowledges": [
-    {
-      "id": "lcn_a3f2...",
-      "type": "claim",
-      "content": "该样本在 90 K 以下表现出超导性"
-    },
-    {
-      "id": "lcn_b7e1...",
-      "type": "claim",
-      "content": "YBa₂Cu₃O₇ 的超导转变温度为 92 ± 1 K"
-    },
-    {
-      "id": "lcn_c9a0...",
-      "type": "setting",
-      "content": "高温超导研究的当前进展"
-    },
-    {
-      "_comment": "全称 claim（原 template）— 通用定律，含量化变量，参与 BP",
-      "id": "lcn_e4b7...",
-      "type": "claim",
-      "content": "∀{x}. superconductor({x}) → zero_resistance({x})",
-      "parameters": [{"name": "x", "type": "material"}]
-    },
-    {
-      "_comment": "绑定 setting — 实例化时提供具体参数值",
-      "id": "lcn_f5c8...",
-      "type": "setting",
-      "content": "x = YBa₂Cu₃O₇（YBCO）"
-    },
-    {
-      "_comment": "实例化后的封闭 claim",
-      "id": "lcn_g6d9...",
-      "type": "claim",
-      "content": "superconductor(YBCO) → zero_resistance(YBCO)"
-    }
+    {"id": "lcn_obs1", "type": "claim", "content": "Obs1"},
+    {"id": "lcn_obs2", "type": "claim", "content": "Obs2"},
+    {"id": "lcn_law", "type": "claim", "content": "Law"}
   ],
   "strategies": [
     {
-      "strategy_id": "lcs_d2c8...",
-      "type": "infer",
-      "premises": ["lcn_a3f2..."],
-      "conclusion": "lcn_b7e1...",
-      "background": ["lcn_c9a0..."],
-      "steps": [{"reasoning": "基于超导样品的电阻率骤降..."}]
-    },
-    {
-      "_comment": "全称 claim 的实例化 — deduction, p₁=1.0",
-      "strategy_id": "lcs_h7ea...",
-      "type": "deduction",
-      "premises": ["lcn_e4b7..."],
-      "conclusion": "lcn_g6d9...",
-      "background": ["lcn_f5c8..."]
+      "strategy_id": "lcs_1",
+      "type": "induction",
+      "premises": ["lcn_obs1", "lcn_obs2"],
+      "conclusion": "lcn_law"
     }
   ],
   "operators": []
 }
 ```
 
-**Global 层示例**（跨包，展示三种 Strategy 形态）：
+### 细命题网络
+
+当同一条推理被进一步形式化时，应把中间命题写成显式 claim，再用 Operator 连接：
 
 ```json
 {
-  "scope": "global",
+  "scope": "local",
   "knowledges": [
-    {"id": "gcn_a1...", "type": "claim"},
-    {"id": "gcn_b2...", "type": "claim"},
-    {"id": "gcn_d4...", "type": "claim"},
-    {"id": "gcn_m1...", "type": "claim", "content": "gcn_a1 ∧ gcn_b2"}
+    {"id": "lcn_law", "type": "claim", "content": "Law"},
+    {"id": "lcn_inst1", "type": "claim", "content": "Instance1"},
+    {"id": "lcn_obs1", "type": "claim", "content": "Obs1"},
+    {"id": "lcn_inst2", "type": "claim", "content": "Instance2"},
+    {"id": "lcn_obs2", "type": "claim", "content": "Obs2"}
   ],
-  "strategies": [
-    {
-      "_comment": "Strategy（叶子 ↝）",
-      "strategy_id": "gcs_s1...",
-      "type": "infer",
-      "premises": ["gcn_a1..."],
-      "conclusion": "gcn_b2..."
-    },
-    {
-      "_comment": "CompositeStrategy（含子策略）",
-      "strategy_id": "gcs_s2...",
-      "type": "infer",
-      "premises": ["gcn_a1...", "gcn_b2..."],
-      "conclusion": "gcn_d4...",
-      "sub_strategies": ["gcs_s1...", "gcs_s3..."]
-    },
-    {
-      "_comment": "FormalStrategy（确定性展开）",
-      "strategy_id": "gcs_s3...",
-      "type": "deduction",
-      "premises": ["gcn_a1...", "gcn_b2..."],
-      "conclusion": "gcn_d4...",
-      "formal_expr": {
-        "operators": [
-          {"operator_id": "gco_1...", "operator": "conjunction",
-           "variables": ["gcn_a1...", "gcn_b2...", "gcn_m1..."], "conclusion": "gcn_m1..."},
-          {"operator_id": "gco_2...", "operator": "implication",
-           "variables": ["gcn_m1...", "gcn_d4..."], "conclusion": "gcn_d4..."}
-        ]
-      }
-    }
-  ],
+  "strategies": [],
   "operators": [
     {
-      "_comment": "standalone Operator（规范化产生的等价候选，位置即来源——顶层 = 独立结构关系）",
-      "operator_id": "gco_e1...",
+      "operator_id": "lco_1",
+      "operator": "entailment",
+      "variables": ["lcn_law", "lcn_inst1"],
+      "conclusion": "lcn_inst1"
+    },
+    {
+      "operator_id": "lco_2",
       "operator": "equivalence",
-      "variables": ["gcn_a1...", "gcn_x9..."],
+      "variables": ["lcn_inst1", "lcn_obs1"],
+      "conclusion": null
+    },
+    {
+      "operator_id": "lco_3",
+      "operator": "entailment",
+      "variables": ["lcn_law", "lcn_inst2"],
+      "conclusion": "lcn_inst2"
+    },
+    {
+      "operator_id": "lco_4",
+      "operator": "equivalence",
+      "variables": ["lcn_inst2", "lcn_obs2"],
       "conclusion": null
     }
   ]
 }
 ```
 
-Global 层 Knowledge 通常不存储 content（通过 `representative_lcn` 引用 local 层）。LKM 服务器直接创建的 Knowledge（包括 FormalExpr 中间 Knowledge 如 `gcn_m1`）无 local 来源，content 直接存在 global 层。
+这里的关键不是“给 BP 一个可折叠/可展开的 AST”，而是：**细命题网络中的每个承重对象都必须是显式 claim。**
 
-### Knowledge（命题）
+如果某条路径已经被细化成显式子网络，就不应再把对应 coarse strategy 作为另一条独立证据同时激活，否则会重复计数。细化是 graph rewrite / graph replacement，不是 IR 内置的 dual-resolution runtime。
 
-表示命题。四种类型：
+## 三、显式 claim 规则
 
-| type | 说明 | 参与 BP | 可作为 |
-|------|------|---------|--------|
-| **claim** | 科学断言（封闭或全称） | 是（唯一 BP 承载者） | premise, background, conclusion, refs |
-| **setting** | 背景信息 | 否 | background, refs |
-| **question** | 待研究方向 | 否 | background, refs |
+Gaia IR 不允许隐式中间命题：
 
-详细 schema 见 [gaia-ir.md](gaia-ir.md) §1。
+- 任何被 `Operator` 或 `Strategy` 引用的 claim，都必须出现在顶层 `knowledges`
+- prediction、instance、bridge claim、continuity claim 等必须写成 self-contained claim
+- 不能依赖“服务器展开 strategy 时临时创建一个看不见的 claim”
 
-### Strategy（推理声明）
+这点直接对齐 [05-formalization-methodology.md](../theory/05-formalization-methodology.md)。
 
-表示推理算子，连接 Knowledge。Strategy 有三种形态（类层级）：
+## 四、Background 的边界
 
-| 形态 | 说明 | 独有字段 |
-|------|------|---------|
-| **Strategy**（基类，可实例化） | 叶子推理，编译为 ↝ | — |
-| **CompositeStrategy**(Strategy) | 含子策略，可递归嵌套 | `sub_strategies: list[str]` |
-| **FormalStrategy**(Strategy) | 含确定性 Operator 展开 | `formal_expr: FormalExpr` |
+`background` 只承载 `setting` / `question`，不承载 claim。
 
-所有形态折叠时均编译为 ↝（概率参数来自 [parameterization](parameterization.md) 层）。展开时进入内部结构（子策略或确定性 Operator）。这支持**多分辨率 BP**——同一图在不同粒度做推理。
+原因很简单：只要一个对象有真值、可被支持或反驳、会影响结论是否成立，它就应该进入 proposition network 成为显式 claim，而不是被藏进 `background`。
 
-统一 `type` 字段（与形态正交）：
+例如全称命题实例化中的变量绑定，应该写进结构化 `metadata.binding`，同时把实例化结果写成显式封闭 claim；而不是把 `"x = YBCO"` 作为一个假的图节点去承担推理语义。
 
-| type | 参数化模型 | 经历 lifecycle | 形态 |
-|------|-----------|---------------|------|
-| **None** | 通用 CPT: 2^K（默认 MaxEnt 0.5） | 是 | Strategy 或 CompositeStrategy |
-| **infer** | noisy-AND: [q]（单参数） | 是 | Strategy 或 CompositeStrategy |
-| **soft_implication** | [p₁, p₂] | 是 | Strategy 或 CompositeStrategy |
-| **deduction** | — | 是 | FormalStrategy |
-| **abduction** | — | 是 | FormalStrategy |
-| **induction** | — | 是 | FormalStrategy |
-| **analogy** | — | 是 | FormalStrategy |
-| **extrapolation** | — | 是 | FormalStrategy |
-| **reductio** | — | 是 | FormalStrategy |
-| **elimination** | — | 是 | FormalStrategy |
-| **mathematical_induction** | — | 是 | FormalStrategy |
-| **case_analysis** | — | 是 | FormalStrategy |
-| **independent_evidence** | [q] | 是 | Strategy（conclusion=None） |
-| **contradiction** | [q] | 是 | Strategy（conclusion=None） |
-| **toolcall** | 另行定义 | 否 | Strategy |
-| **proof** | 另行定义 | 否 | Strategy |
+## 五、Canonicalization 原则
 
-详细 schema 见 [gaia-ir.md](gaia-ir.md) §2。
+规范化按**命题身份**进行，而不是按“它在 local 图里是 premise 还是 conclusion”进行。
 
-### Operator（结构约束）
+三种情况必须分开：
 
-确定性逻辑关系（equivalence, contradiction, complement, implication, disjunction, conjunction）。对应 theory Layer 3 的势函数，所有算子均确定性（ψ ∈ {0, 1}，无自由参数）。Schema 见 [gaia-ir.md](gaia-ir.md) §3。
+1. local 与已有 global 是**同一命题**：直接 CanonicalBinding
+2. 两者不是同一命题，但 reviewer 认为它们**等价**：保留为两个 global claim，再加 `equivalence`
+3. 没有匹配：创建新 global claim
 
-### FormalExpr（data class，非顶层实体）
+因此，`equivalence` 是命题层关系，不是为了解决“结论节点不能 merge”而引入的技术补丁。
 
-FormalStrategy 的确定性展开结构——由 Operator 列表构成。中间 Knowledge 从 operators 推导（不显式列出）。不是独立实体，而是 FormalStrategy 的嵌入字段。9 种命名策略自带 FormalExpr 模板，确定性策略可自动生成，非确定性策略需 reviewer 手动创建。Schema 见 [gaia-ir.md](gaia-ir.md) §4。
+## 六、Local / Global 两层
 
-### 两层身份
+Gaia IR 仍然有 local / global 两层：
 
-两个 ID 命名空间，schema 有差异（global 层不存储 content 和 steps）：
+| 层 | 范围 | 作用 |
+|----|------|------|
+| **LocalCanonicalGraph** | 单个包内 | 存储正文 content、local strategy steps、作者局部结构 |
+| **GlobalCanonicalGraph** | 跨包 | 统一命题身份，承载全局 proposition network |
 
-| 层 | 范围 | ID 前缀 | 内容 |
-|----|------|---------|------|
-| **LocalCanonicalGraph** | 单个包 | `lcn_`, `lcs_`, `lco_` | 存储完整 content + Strategy steps（内容仓库） |
-| **GlobalCanonicalGraph** | 跨包 | `gcn_`, `gcs_`, `gco_` | 引用 representative lcn，Strategy 无 steps（结构索引）+ Operator |
+Global 层通常通过 `representative_lcn` 引用 local content，但如果 review / LKM 在 global 层新增 claim，它也必须作为**显式 Knowledge** 写入图中，而不是作为隐式展开副产物存在。
 
-规范化（lcn → gcn 映射）见 [gaia-ir.md](gaia-ir.md) §5。
+## 七、下游对象
 
-### 图哈希
+Gaia IR 之外还有两个 downstream 对象：
 
-LocalCanonicalGraph 有确定性哈希 `ir_hash = SHA-256(canonical JSON)`，用于编译完整性校验——审查引擎重新编译并验证匹配。GlobalCanonicalGraph 是增量变化的，不使用整体哈希。
-
-## 二、Parameterization — 参数
-
-Parameterization 是 GlobalCanonicalGraph 上的概率参数层。它由**原子记录**构成，不同 review 来源（不同模型、不同策略）产出不同的记录。
-
-### 存储层
-
-```json
-// PriorRecord（每条一个 Knowledge）
-{"gcn_id": "gcn_8b1c...", "value": 0.7, "source_id": "src_001", "created_at": "..."}
-{"gcn_id": "gcn_8b1c...", "value": 0.8, "source_id": "src_002", "created_at": "..."}
-
-// StrategyParamRecord（每条一个 Strategy）
-{"strategy_id": "gcs_d2c8...", "conditional_probabilities": [0.85], "source_id": "src_001", "created_at": "..."}
-
-// ParameterizationSource（记录产出上下文）
-{"source_id": "src_001", "model": "gpt-5-mini", "policy": "conservative", "created_at": "..."}
-{"source_id": "src_002", "model": "claude-opus", "policy": null, "created_at": "..."}
+```text
+Gaia IR          ->   Parameterization          ->   BeliefState
+命题网络结构          参数层 / 输入记录               推理输出
 ```
 
-### BP 运行时组装
+它们的边界应该这样理解：
 
-BP 运行前按 resolution policy 从原子记录中选择每个 Knowledge/Strategy 的值，**现算不持久化**：
+- **Gaia IR**：theory 层的结构 contract
+- **Parameterization**：给 claim 和 coarse strategy 附加参数的下游层
+- **BeliefState**：任一推理引擎产出的后验结果
 
-| policy | 说明 |
-|--------|------|
-| `latest` | 每个 Knowledge/Strategy 取最新记录 |
-| `source:<source_id>` | 指定使用某个 source 的记录 |
+Parameterization 和 BeliefState 可以只作用于 global graph，但它们都**不是** Gaia IR 语义的一部分。Gaia IR 不应反向依赖某个具体推理引擎的实现选择。
 
-关键规则：
+## 八、进一步阅读
 
-- **claim_priors**：只有 `type=claim` 的 Knowledge 有记录。
-- **strategy_params**：所有推理类 Strategy 都有 conditional_probabilities（参数数量由 type 决定：None=2^K, infer=[q], soft_implication=[p₁,p₂]）。
-- **Cromwell's rule**：所有概率钳制到 `[ε, 1-ε]`，ε = 1e-3。
-- 组装时使用 `prior_cutoff` 时间戳过滤记录，确保可重现。
-- 组装结果必须覆盖所有 claim Knowledge 和所有 Strategy，否则 BP 拒绝运行。
-
-详细设计见 [parameterization.md](parameterization.md)。
-
-## 三、BeliefState — 信念
-
-BeliefState 是 BP 在 GlobalCanonicalGraph 上的纯输出——后验信念值。它记录 resolution policy 使结果可重现。
-
-### 整体结构
-
-```json
-{
-  "bp_run_id": "uuid-...",
-  "created_at": "2026-03-24T12:00:00Z",
-  "resolution_policy": "latest",
-  "prior_cutoff": "2026-03-24T12:00:00Z",
-  "beliefs": {
-    "gcn_8b1c...": 0.82,
-    "gcn_9d2a...": 0.71
-  },
-  "converged": true,
-  "iterations": 23,
-  "max_residual": 4.2e-7
-}
-```
-
-关键规则：
-
-- **beliefs**：只有 `type=claim` 的 Knowledge 有 belief。
-- **可重现**：`resolution_policy` + `prior_cutoff` 完整定义参数组装条件，可重跑 BP。
-- **可多次运行**：同一 resolution policy 可以有多次 BP 运行。
-
-详细设计见 [belief-state.md](belief-state.md)。
-
-## 完备性
-
-一个完整的 Gaia 知识体系需要以下信息：
-
-| 对象 | 内容 | 变化频率 |
-|------|------|---------|
-| **LocalCanonicalGraph** | 包内 Knowledge + Strategy（含 steps）+ 完整文本 | 每次 build 更新 |
-| **GlobalCanonicalGraph** | 跨包 Knowledge（引用 lcn）+ 全局 Strategy（无 steps，FormalStrategy 含 FormalExpr）+ Operator | 每次 ingest/curation 更新 |
-| **CanonicalBinding** | lcn → gcn 映射记录 | 每次 ingest 更新 |
-| **PriorRecord** | 全局 claim 的 prior（每条记录携带 source） | 每次 review 追加 |
-| **StrategyParamRecord** | 全局 Strategy 的 conditional_probabilities（每条记录携带 source） | 每次 review 追加 |
-| **ParameterizationSource** | review 来源信息（模型、策略、配置） | 每次 review 创建 |
-| **BeliefState** | 全局 claim 的后验信念 + resolution policy | 每次 global BP 创建 |
-
-## 源代码
-
-- `libs/graph_ir/models.py` -- `LocalCanonicalGraph`, `Knowledge`, `Strategy`
-- `libs/storage/models.py` -- global `Knowledge`, `CanonicalBinding`, `BeliefSnapshot`
-- `libs/global_graph/canonicalize.py` -- `canonicalize_package()`
-- `libs/global_graph/similarity.py` -- `find_best_match()`
-- *Future:* `libs/graph_ir/operator.py` -- `Operator`
-- *Future:* `libs/graph_ir/strategy.py` -- `CompositeStrategy`, `FormalStrategy`, `FormalExpr`
+- 详细 schema： [gaia-ir-v2-draft.md](gaia-ir-v2-draft.md)
+- theory 边界： [03-propositional-operators.md](../theory/03-propositional-operators.md), [04-reasoning-strategies.md](../theory/04-reasoning-strategies.md), [05-formalization-methodology.md](../theory/05-formalization-methodology.md)
+- downstream docs： [parameterization.md](parameterization.md), [belief-state.md](belief-state.md)


### PR DESCRIPTION
## Summary
- rewrite `gaia-ir-v2-draft.md` as a theory-layer proposition-network contract
- rewrite `overview.md` to lead with coarse/fine proposition networks instead of BP/runtime semantics
- remove role-based canonicalization, hidden intermediate claims, and claim-valued background from the v2 contract

## What Changed
- `Strategy.type` is now documented as a semantic classification rather than a CPT / noisy-AND runtime model
- coarse-to-fine refinement is described as graph rewriting, not multi-resolution execution semantics inside the IR
- intermediate claims introduced during formalization must be explicit top-level `Knowledge`
- canonicalization now keys off proposition identity instead of `premise`/`conclusion` role
- `background` is restricted to `setting` / `question`
- note explicitly that multi-premise `↝` parameterization is still a theory-layer open issue, not an IR contract decision

## Validation
- `git diff --check`
