### PR TITLE
feat(gaia-ir): structural validator (issue #233)

### DIFF
--- a/gaia/gaia_ir/binding.py
+++ b/gaia/gaia_ir/binding.py
@@ -1,6 +1,6 @@
 """CanonicalBinding model — local-to-global node mapping decision.
 
-Implements the schema defined in docs/foundations/graph-ir/graph-ir.md §3.4.
+Implements the schema defined in docs/foundations/gaia-ir/gaia-ir.md §4.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 
 class BindingDecision(StrEnum):
-    """Outcome of the canonicalization matching step (graph-ir.md §3.4)."""
+    """Outcome of the canonicalization matching step (gaia-ir.md §4)."""
 
     MATCH_EXISTING = "match_existing"
     CREATE_NEW = "create_new"
@@ -23,7 +23,7 @@ class CanonicalBinding(BaseModel):
 
     Created during ``canonicalize_package()`` for every local knowledge node.
     The ``decision`` field captures whether the node was merged with an existing
-    global node, created fresh, or linked via a candidate equivalent factor.
+    global node, created fresh, or linked via a candidate equivalence relation.
     """
 
     local_canonical_id: str

--- a/gaia/gaia_ir/graphs.py
+++ b/gaia/gaia_ir/graphs.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from typing import Any
 
 from pydantic import BaseModel, model_validator
 
@@ -15,16 +16,72 @@ from gaia.gaia_ir.operator import Operator
 from gaia.gaia_ir.strategy import Strategy
 
 
+def _json_sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)
+
+
+def _canonicalize_knowledge_dump(data: dict[str, Any]) -> dict[str, Any]:
+    canonical = dict(data)
+    canonical["parameters"] = sorted(canonical.get("parameters", []), key=_json_sort_key)
+    if canonical.get("provenance") is not None:
+        canonical["provenance"] = sorted(canonical["provenance"], key=_json_sort_key)
+    if canonical.get("local_members") is not None:
+        canonical["local_members"] = sorted(canonical["local_members"], key=_json_sort_key)
+    return canonical
+
+
+def _canonicalize_operator_dump(data: dict[str, Any]) -> dict[str, Any]:
+    canonical = dict(data)
+    variables = list(canonical.get("variables", []))
+    conclusion = canonical.get("conclusion")
+    operator = canonical.get("operator")
+    if operator in {"equivalence", "contradiction", "complement", "disjunction"}:
+        canonical["variables"] = sorted(variables)
+    elif operator == "conjunction" and conclusion is not None:
+        premises = sorted(v for v in variables if v != conclusion)
+        canonical["variables"] = premises + [conclusion]
+    return canonical
+
+
+def _canonicalize_strategy_dump(data: dict[str, Any]) -> dict[str, Any]:
+    canonical = dict(data)
+    canonical["premises"] = sorted(canonical.get("premises", []))
+    if canonical.get("background") is not None:
+        canonical["background"] = sorted(canonical["background"])
+    if canonical.get("sub_strategies") is not None:
+        canonical["sub_strategies"] = sorted(
+            [_canonicalize_strategy_dump(sub) for sub in canonical["sub_strategies"]],
+            key=_json_sort_key,
+        )
+    if canonical.get("formal_expr") is not None:
+        formal_expr = dict(canonical["formal_expr"])
+        formal_expr["operators"] = sorted(
+            [_canonicalize_operator_dump(op) for op in formal_expr.get("operators", [])],
+            key=_json_sort_key,
+        )
+        canonical["formal_expr"] = formal_expr
+    return canonical
+
+
 def _canonical_json(
     knowledges: list[Knowledge],
     operators: list[Operator],
     strategies: list[Strategy],
 ) -> str:
-    """Produce canonical JSON for hashing."""
+    """Produce canonical JSON for hashing — independent of insertion order."""
     data = {
-        "knowledges": [k.model_dump(mode="json") for k in knowledges],
-        "operators": [o.model_dump(mode="json") for o in operators],
-        "strategies": [s.model_dump(mode="json") for s in strategies],
+        "knowledges": sorted(
+            [_canonicalize_knowledge_dump(k.model_dump(mode="json")) for k in knowledges],
+            key=_json_sort_key,
+        ),
+        "operators": sorted(
+            [_canonicalize_operator_dump(o.model_dump(mode="json")) for o in operators],
+            key=_json_sort_key,
+        ),
+        "strategies": sorted(
+            [_canonicalize_strategy_dump(s.model_dump(mode="json")) for s in strategies],
+            key=_json_sort_key,
+        ),
     }
     return json.dumps(data, sort_keys=True, ensure_ascii=False)
 

--- a/gaia/gaia_ir/operator.py
+++ b/gaia/gaia_ir/operator.py
@@ -43,10 +43,18 @@ class Operator(BaseModel):
         if self.scope not in (None, "local", "global"):
             raise ValueError("scope must be one of: None, 'local', 'global'")
 
-        if self.scope == "local" and self.operator_id is not None and not self.operator_id.startswith("lco_"):
+        if (
+            self.scope == "local"
+            and self.operator_id is not None
+            and not self.operator_id.startswith("lco_")
+        ):
             raise ValueError("local operators must use an operator_id with lco_ prefix")
 
-        if self.scope == "global" and self.operator_id is not None and not self.operator_id.startswith("gco_"):
+        if (
+            self.scope == "global"
+            and self.operator_id is not None
+            and not self.operator_id.startswith("gco_")
+        ):
             raise ValueError("global operators must use an operator_id with gco_ prefix")
 
         # §2.4: conclusion rules by operator type

--- a/gaia/gaia_ir/operator.py
+++ b/gaia/gaia_ir/operator.py
@@ -40,6 +40,15 @@ class Operator(BaseModel):
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> Operator:
+        if self.scope not in (None, "local", "global"):
+            raise ValueError("scope must be one of: None, 'local', 'global'")
+
+        if self.scope == "local" and self.operator_id is not None and not self.operator_id.startswith("lco_"):
+            raise ValueError("local operators must use an operator_id with lco_ prefix")
+
+        if self.scope == "global" and self.operator_id is not None and not self.operator_id.startswith("gco_"):
+            raise ValueError("global operators must use an operator_id with gco_ prefix")
+
         # §2.4: conclusion rules by operator type
         if self.operator in (
             OperatorType.EQUIVALENCE,
@@ -55,17 +64,29 @@ class Operator(BaseModel):
                 raise ValueError("operator=implication requires conclusion")
             if len(self.variables) != 2:
                 raise ValueError("operator=implication requires exactly 2 variables")
+            if self.conclusion not in self.variables:
+                raise ValueError(f"conclusion {self.conclusion} must appear in variables")
+            if self.conclusion != self.variables[-1]:
+                raise ValueError("operator=implication requires conclusion=variables[-1]")
 
         if self.operator == OperatorType.CONJUNCTION:
             if self.conclusion is None:
                 raise ValueError("operator=conjunction requires conclusion (the conjunct M)")
+            if self.conclusion not in self.variables:
+                raise ValueError(f"conclusion {self.conclusion} must appear in variables")
+            if self.conclusion != self.variables[-1]:
+                raise ValueError("operator=conjunction requires conclusion=variables[-1]")
 
         if self.operator in (OperatorType.EQUIVALENCE, OperatorType.COMPLEMENT):
             if len(self.variables) != 2:
                 raise ValueError(f"operator={self.operator} requires exactly 2 variables")
 
-        # conclusion must be in variables
-        if self.conclusion is not None and self.conclusion not in self.variables:
+        # conclusion must be in variables (catch-all for future types)
+        if (
+            self.conclusion is not None
+            and self.operator not in (OperatorType.IMPLICATION, OperatorType.CONJUNCTION)
+            and self.conclusion not in self.variables
+        ):
             raise ValueError(f"conclusion {self.conclusion} must appear in variables")
 
         return self

--- a/gaia/gaia_ir/strategy.py
+++ b/gaia/gaia_ir/strategy.py
@@ -75,6 +75,23 @@ def _compute_strategy_id(
     return f"{prefix}{_sha256_hex(payload)}"
 
 
+_LEAF_STRATEGY_TYPES = frozenset({
+    StrategyType.INFER, StrategyType.NOISY_AND,
+    StrategyType.TOOLCALL, StrategyType.PROOF,
+})
+
+_COMPOSITE_STRATEGY_TYPES = frozenset({
+    StrategyType.ABDUCTION, StrategyType.INDUCTION,
+    StrategyType.ANALOGY, StrategyType.EXTRAPOLATION,
+})
+
+_FORMAL_STRATEGY_TYPES = frozenset({
+    StrategyType.DEDUCTION, StrategyType.REDUCTIO,
+    StrategyType.ELIMINATION, StrategyType.MATHEMATICAL_INDUCTION,
+    StrategyType.CASE_ANALYSIS,
+})
+
+
 class Strategy(BaseModel):
     """Base strategy — leaf reasoning (single ↝).
 
@@ -98,9 +115,31 @@ class Strategy(BaseModel):
 
     @model_validator(mode="after")
     def _compute_id_and_validate(self) -> Strategy:
+        if self.scope not in {"local", "global"}:
+            raise ValueError("scope must be one of: 'local', 'global'")
+
+        if self.scope == "global" and self.steps is not None:
+            raise ValueError("global Strategy must not carry steps")
+
+        if self.strategy_id is not None:
+            expected_prefix = "lcs_" if self.scope == "local" else "gcs_"
+            if not self.strategy_id.startswith(expected_prefix):
+                raise ValueError(
+                    f"{self.scope} strategies must use a strategy_id with {expected_prefix} prefix"
+                )
+
         if self.strategy_id is None:
             self.strategy_id = _compute_strategy_id(
                 self.scope, self.type, self.premises, self.conclusion
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_leaf_form(self) -> Strategy:
+        if self.__class__ is Strategy and self.type not in _LEAF_STRATEGY_TYPES:
+            allowed = ", ".join(sorted(t.value for t in _LEAF_STRATEGY_TYPES))
+            raise ValueError(
+                f"Strategy form only allows types: {allowed}; got {self.type.value}"
             )
         return self
 
@@ -118,6 +157,11 @@ class CompositeStrategy(Strategy):
     def _validate_sub_strategies(self) -> CompositeStrategy:
         if not self.sub_strategies:
             raise ValueError("CompositeStrategy requires at least one sub_strategy")
+        if self.type not in _COMPOSITE_STRATEGY_TYPES:
+            allowed = ", ".join(sorted(t.value for t in _COMPOSITE_STRATEGY_TYPES))
+            raise ValueError(
+                f"CompositeStrategy form only allows types: {allowed}; got {self.type.value}"
+            )
         return self
 
 
@@ -134,4 +178,9 @@ class FormalStrategy(Strategy):
     def _validate_formal_expr(self) -> FormalStrategy:
         if not self.formal_expr.operators:
             raise ValueError("FormalStrategy requires at least one operator in formal_expr")
+        if self.type not in _FORMAL_STRATEGY_TYPES:
+            allowed = ", ".join(sorted(t.value for t in _FORMAL_STRATEGY_TYPES))
+            raise ValueError(
+                f"FormalStrategy form only allows types: {allowed}; got {self.type.value}"
+            )
         return self

--- a/gaia/gaia_ir/strategy.py
+++ b/gaia/gaia_ir/strategy.py
@@ -75,21 +75,33 @@ def _compute_strategy_id(
     return f"{prefix}{_sha256_hex(payload)}"
 
 
-_LEAF_STRATEGY_TYPES = frozenset({
-    StrategyType.INFER, StrategyType.NOISY_AND,
-    StrategyType.TOOLCALL, StrategyType.PROOF,
-})
+_LEAF_STRATEGY_TYPES = frozenset(
+    {
+        StrategyType.INFER,
+        StrategyType.NOISY_AND,
+        StrategyType.TOOLCALL,
+        StrategyType.PROOF,
+    }
+)
 
-_COMPOSITE_STRATEGY_TYPES = frozenset({
-    StrategyType.ABDUCTION, StrategyType.INDUCTION,
-    StrategyType.ANALOGY, StrategyType.EXTRAPOLATION,
-})
+_COMPOSITE_STRATEGY_TYPES = frozenset(
+    {
+        StrategyType.ABDUCTION,
+        StrategyType.INDUCTION,
+        StrategyType.ANALOGY,
+        StrategyType.EXTRAPOLATION,
+    }
+)
 
-_FORMAL_STRATEGY_TYPES = frozenset({
-    StrategyType.DEDUCTION, StrategyType.REDUCTIO,
-    StrategyType.ELIMINATION, StrategyType.MATHEMATICAL_INDUCTION,
-    StrategyType.CASE_ANALYSIS,
-})
+_FORMAL_STRATEGY_TYPES = frozenset(
+    {
+        StrategyType.DEDUCTION,
+        StrategyType.REDUCTIO,
+        StrategyType.ELIMINATION,
+        StrategyType.MATHEMATICAL_INDUCTION,
+        StrategyType.CASE_ANALYSIS,
+    }
+)
 
 
 class Strategy(BaseModel):
@@ -138,9 +150,7 @@ class Strategy(BaseModel):
     def _validate_leaf_form(self) -> Strategy:
         if self.__class__ is Strategy and self.type not in _LEAF_STRATEGY_TYPES:
             allowed = ", ".join(sorted(t.value for t in _LEAF_STRATEGY_TYPES))
-            raise ValueError(
-                f"Strategy form only allows types: {allowed}; got {self.type.value}"
-            )
+            raise ValueError(f"Strategy form only allows types: {allowed}; got {self.type.value}")
         return self
 
 

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -102,8 +102,7 @@ def _validate_operators(
         # operator scope must be compatible with graph scope
         if op.scope is not None and op.scope != scope:
             result.error(
-                f"Operator '{op.operator_id}': scope '{op.scope}' incompatible "
-                f"with {scope} graph"
+                f"Operator '{op.operator_id}': scope '{op.scope}' incompatible with {scope} graph"
             )
 
         # reference completeness
@@ -203,8 +202,7 @@ def _validate_strategies(
         # strategy scope must match graph scope
         if s.scope != scope:
             result.error(
-                f"Strategy '{s.strategy_id}': scope '{s.scope}' incompatible "
-                f"with {scope} graph"
+                f"Strategy '{s.strategy_id}': scope '{s.scope}' incompatible with {scope} graph"
             )
 
         _validate_strategy(s, knowledge_lookup, scope, result)

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -94,10 +94,18 @@ def _validate_knowledges(
 def _validate_operators(
     operators: list[Operator],
     knowledge_lookup: dict[str, Knowledge],
+    scope: str,
     result: ValidationResult,
 ) -> None:
     """Validate top-level Operators against the knowledge set."""
     for op in operators:
+        # operator scope must be compatible with graph scope
+        if op.scope is not None and op.scope != scope:
+            result.error(
+                f"Operator '{op.operator_id}': scope '{op.scope}' incompatible "
+                f"with {scope} graph"
+            )
+
         # reference completeness
         for var_id in op.variables:
             if var_id not in knowledge_lookup:
@@ -168,7 +176,7 @@ def _validate_strategy(
             _validate_strategy(sub, knowledge_lookup, scope, result)
 
     if isinstance(strategy, FormalStrategy):
-        _validate_operators(strategy.formal_expr.operators, knowledge_lookup, result)
+        _validate_operators(strategy.formal_expr.operators, knowledge_lookup, scope, result)
 
 
 def _validate_strategies(
@@ -239,7 +247,7 @@ def validate_local_graph(graph: LocalCanonicalGraph) -> ValidationResult:
     result = ValidationResult()
 
     knowledge_lookup = _validate_knowledges(graph.knowledges, "local", result)
-    _validate_operators(graph.operators, knowledge_lookup, result)
+    _validate_operators(graph.operators, knowledge_lookup, "local", result)
     _validate_strategies(graph.strategies, knowledge_lookup, "local", result)
     _validate_scope_consistency(
         knowledge_lookup, graph.operators, graph.strategies, "local", result
@@ -264,7 +272,7 @@ def validate_global_graph(graph: GlobalCanonicalGraph) -> ValidationResult:
     result = ValidationResult()
 
     knowledge_lookup = _validate_knowledges(graph.knowledges, "global", result)
-    _validate_operators(graph.operators, knowledge_lookup, result)
+    _validate_operators(graph.operators, knowledge_lookup, "global", result)
     _validate_strategies(graph.strategies, knowledge_lookup, "global", result)
     _validate_scope_consistency(
         knowledge_lookup, graph.operators, graph.strategies, "global", result

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from gaia.gaia_ir.knowledge import Knowledge, KnowledgeType
-from gaia.gaia_ir.operator import Operator, OperatorType
+from gaia.gaia_ir.operator import Operator
 from gaia.gaia_ir.strategy import Strategy, CompositeStrategy, FormalStrategy
 from gaia.gaia_ir.graphs import LocalCanonicalGraph, GlobalCanonicalGraph, _canonical_json
 from gaia.gaia_ir.parameterization import (
@@ -72,9 +72,7 @@ def _validate_knowledges(
         # claim content completeness
         if k.type == KnowledgeType.CLAIM:
             if k.content is None and k.representative_lcn is None:
-                result.error(
-                    f"Knowledge '{k.id}': claim must have content or representative_lcn"
-                )
+                result.error(f"Knowledge '{k.id}': claim must have content or representative_lcn")
 
     return lookup
 
@@ -94,9 +92,7 @@ def _validate_operators(
         # reference completeness
         for var_id in op.variables:
             if var_id not in knowledge_lookup:
-                result.error(
-                    f"Operator '{op.operator_id}': variable '{var_id}' not found in graph"
-                )
+                result.error(f"Operator '{op.operator_id}': variable '{var_id}' not found in graph")
             elif knowledge_lookup[var_id].type != KnowledgeType.CLAIM:
                 result.error(
                     f"Operator '{op.operator_id}': variable '{var_id}' is "
@@ -136,9 +132,7 @@ def _validate_strategy(
     # conclusion reference + type
     if strategy.conclusion is not None:
         if strategy.conclusion not in knowledge_lookup:
-            result.error(
-                f"Strategy '{sid}': conclusion '{strategy.conclusion}' not found in graph"
-            )
+            result.error(f"Strategy '{sid}': conclusion '{strategy.conclusion}' not found in graph")
         elif knowledge_lookup[strategy.conclusion].type != KnowledgeType.CLAIM:
             result.error(
                 f"Strategy '{sid}': conclusion '{strategy.conclusion}' is "
@@ -181,9 +175,7 @@ def _validate_strategies(
     for s in strategies:
         # ID prefix
         if s.strategy_id and not s.strategy_id.startswith(prefix):
-            result.error(
-                f"Strategy '{s.strategy_id}': expected {prefix} prefix in {scope} graph"
-            )
+            result.error(f"Strategy '{s.strategy_id}': expected {prefix} prefix in {scope} graph")
 
         # uniqueness
         if s.strategy_id and s.strategy_id in seen_ids:
@@ -240,15 +232,20 @@ def validate_local_graph(graph: LocalCanonicalGraph) -> ValidationResult:
     knowledge_lookup = _validate_knowledges(graph.knowledges, "local", result)
     _validate_operators(graph.operators, knowledge_lookup, result)
     _validate_strategies(graph.strategies, knowledge_lookup, "local", result)
-    _validate_scope_consistency(knowledge_lookup, graph.operators, graph.strategies, "local", result)
+    _validate_scope_consistency(
+        knowledge_lookup, graph.operators, graph.strategies, "local", result
+    )
 
     # hash consistency
     if graph.ir_hash is not None:
         recomputed = _canonical_json(graph.knowledges, graph.operators, graph.strategies)
         import hashlib
+
         expected = f"sha256:{hashlib.sha256(recomputed.encode()).hexdigest()}"
         if graph.ir_hash != expected:
-            result.error(f"LocalCanonicalGraph ir_hash mismatch: stored={graph.ir_hash}, computed={expected}")
+            result.error(
+                f"LocalCanonicalGraph ir_hash mismatch: stored={graph.ir_hash}, computed={expected}"
+            )
 
     return result
 
@@ -260,7 +257,9 @@ def validate_global_graph(graph: GlobalCanonicalGraph) -> ValidationResult:
     knowledge_lookup = _validate_knowledges(graph.knowledges, "global", result)
     _validate_operators(graph.operators, knowledge_lookup, result)
     _validate_strategies(graph.strategies, knowledge_lookup, "global", result)
-    _validate_scope_consistency(knowledge_lookup, graph.operators, graph.strategies, "global", result)
+    _validate_scope_consistency(
+        knowledge_lookup, graph.operators, graph.strategies, "global", result
+    )
 
     return result
 
@@ -330,9 +329,7 @@ def validate_parameterization(
     # dangling references: params for non-existent strategies
     for r in strategy_params:
         if r.strategy_id not in strategy_ids:
-            result.warn(
-                f"StrategyParamRecord '{r.strategy_id}': references non-existent Strategy"
-            )
+            result.warn(f"StrategyParamRecord '{r.strategy_id}': references non-existent Strategy")
 
     return result
 

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -1,0 +1,259 @@
+"""Gaia IR validator — structural validation on every IR update.
+
+Implements issue #233. Validates Knowledge, Operator, Strategy, and graph-level
+invariants as defined in docs/foundations/gaia-ir/gaia-ir.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from gaia.gaia_ir.knowledge import Knowledge, KnowledgeType
+from gaia.gaia_ir.operator import Operator, OperatorType
+from gaia.gaia_ir.strategy import Strategy, CompositeStrategy, FormalStrategy
+from gaia.gaia_ir.graphs import LocalCanonicalGraph, GlobalCanonicalGraph, _canonical_json
+
+
+@dataclass
+class ValidationResult:
+    valid: bool = True
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+        self.valid = False
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def merge(self, other: ValidationResult) -> None:
+        self.errors.extend(other.errors)
+        self.warnings.extend(other.warnings)
+        if not other.valid:
+            self.valid = False
+
+
+# ---------------------------------------------------------------------------
+# 1. Knowledge validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_knowledges(
+    knowledges: list[Knowledge],
+    scope: str,
+    result: ValidationResult,
+) -> dict[str, Knowledge]:
+    """Validate Knowledge nodes and return id→Knowledge lookup."""
+    prefix = "lcn_" if scope == "local" else "gcn_"
+    lookup: dict[str, Knowledge] = {}
+
+    for k in knowledges:
+        # ID prefix
+        if k.id and not k.id.startswith(prefix):
+            result.error(f"Knowledge '{k.id}': expected {prefix} prefix in {scope} graph")
+
+        # uniqueness
+        if k.id in lookup:
+            result.error(f"Knowledge '{k.id}': duplicate ID")
+        if k.id:
+            lookup[k.id] = k
+
+        # type
+        if k.type not in set(KnowledgeType):
+            result.error(f"Knowledge '{k.id}': invalid type '{k.type}'")
+
+        # claim content completeness
+        if k.type == KnowledgeType.CLAIM:
+            if k.content is None and k.representative_lcn is None:
+                result.error(
+                    f"Knowledge '{k.id}': claim must have content or representative_lcn"
+                )
+
+    return lookup
+
+
+# ---------------------------------------------------------------------------
+# 2. Operator validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_operators(
+    operators: list[Operator],
+    knowledge_lookup: dict[str, Knowledge],
+    result: ValidationResult,
+) -> None:
+    """Validate top-level Operators against the knowledge set."""
+    for op in operators:
+        # reference completeness
+        for var_id in op.variables:
+            if var_id not in knowledge_lookup:
+                result.error(
+                    f"Operator '{op.operator_id}': variable '{var_id}' not found in graph"
+                )
+            elif knowledge_lookup[var_id].type != KnowledgeType.CLAIM:
+                result.error(
+                    f"Operator '{op.operator_id}': variable '{var_id}' is "
+                    f"'{knowledge_lookup[var_id].type}', must be claim"
+                )
+
+        # conclusion in variables (Pydantic also checks this, but belt-and-suspenders at graph level)
+        if op.conclusion is not None and op.conclusion not in op.variables:
+            result.error(
+                f"Operator '{op.operator_id}': conclusion '{op.conclusion}' not in variables"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Strategy validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_strategy(
+    strategy: Strategy,
+    knowledge_lookup: dict[str, Knowledge],
+    scope: str,
+    result: ValidationResult,
+) -> None:
+    """Validate a single Strategy (any form) against the knowledge set."""
+    sid = strategy.strategy_id or "<no-id>"
+
+    # premise reference + type
+    for pid in strategy.premises:
+        if pid not in knowledge_lookup:
+            result.error(f"Strategy '{sid}': premise '{pid}' not found in graph")
+        elif knowledge_lookup[pid].type != KnowledgeType.CLAIM:
+            result.error(
+                f"Strategy '{sid}': premise '{pid}' is '{knowledge_lookup[pid].type}', must be claim"
+            )
+
+    # conclusion reference + type
+    if strategy.conclusion is not None:
+        if strategy.conclusion not in knowledge_lookup:
+            result.error(
+                f"Strategy '{sid}': conclusion '{strategy.conclusion}' not found in graph"
+            )
+        elif knowledge_lookup[strategy.conclusion].type != KnowledgeType.CLAIM:
+            result.error(
+                f"Strategy '{sid}': conclusion '{strategy.conclusion}' is "
+                f"'{knowledge_lookup[strategy.conclusion].type}', must be claim"
+            )
+
+    # no self-loop
+    if strategy.conclusion is not None and strategy.conclusion in strategy.premises:
+        result.error(f"Strategy '{sid}': conclusion in premises (self-loop)")
+
+    # background reference (any type OK, just must exist)
+    if strategy.background:
+        for bid in strategy.background:
+            if bid not in knowledge_lookup:
+                result.warn(f"Strategy '{sid}': background '{bid}' not found in graph")
+
+    # global strategies must not have steps
+    if scope == "global" and strategy.steps is not None:
+        result.error(f"Strategy '{sid}': global strategy must not have steps")
+
+    # form-specific validation
+    if isinstance(strategy, CompositeStrategy):
+        for sub in strategy.sub_strategies:
+            _validate_strategy(sub, knowledge_lookup, scope, result)
+
+    if isinstance(strategy, FormalStrategy):
+        _validate_operators(strategy.formal_expr.operators, knowledge_lookup, result)
+
+
+def _validate_strategies(
+    strategies: list[Strategy],
+    knowledge_lookup: dict[str, Knowledge],
+    scope: str,
+    result: ValidationResult,
+) -> None:
+    """Validate all top-level Strategies."""
+    prefix = "lcs_" if scope == "local" else "gcs_"
+    seen_ids: set[str] = set()
+
+    for s in strategies:
+        # ID prefix
+        if s.strategy_id and not s.strategy_id.startswith(prefix):
+            result.error(
+                f"Strategy '{s.strategy_id}': expected {prefix} prefix in {scope} graph"
+            )
+
+        # uniqueness
+        if s.strategy_id and s.strategy_id in seen_ids:
+            result.error(f"Strategy '{s.strategy_id}': duplicate ID")
+        if s.strategy_id:
+            seen_ids.add(s.strategy_id)
+
+        _validate_strategy(s, knowledge_lookup, scope, result)
+
+
+# ---------------------------------------------------------------------------
+# 4. Graph-level validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_scope_consistency(
+    knowledge_lookup: dict[str, Knowledge],
+    operators: list[Operator],
+    strategies: list[Strategy],
+    scope: str,
+    result: ValidationResult,
+) -> None:
+    """Ensure all references use the correct ID prefix for the scope."""
+    prefix = "lcn_" if scope == "local" else "gcn_"
+
+    for s in strategies:
+        for pid in s.premises:
+            if pid and not pid.startswith(prefix):
+                result.error(
+                    f"Strategy '{s.strategy_id}': premise '{pid}' has wrong prefix for {scope} graph"
+                )
+        if s.conclusion and not s.conclusion.startswith(prefix):
+            result.error(
+                f"Strategy '{s.strategy_id}': conclusion '{s.conclusion}' has wrong prefix for {scope} graph"
+            )
+
+    for op in operators:
+        for var_id in op.variables:
+            if var_id and not var_id.startswith(prefix):
+                result.error(
+                    f"Operator '{op.operator_id}': variable '{var_id}' has wrong prefix for {scope} graph"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_local_graph(graph: LocalCanonicalGraph) -> ValidationResult:
+    """Validate a LocalCanonicalGraph."""
+    result = ValidationResult()
+
+    knowledge_lookup = _validate_knowledges(graph.knowledges, "local", result)
+    _validate_operators(graph.operators, knowledge_lookup, result)
+    _validate_strategies(graph.strategies, knowledge_lookup, "local", result)
+    _validate_scope_consistency(knowledge_lookup, graph.operators, graph.strategies, "local", result)
+
+    # hash consistency
+    if graph.ir_hash is not None:
+        recomputed = _canonical_json(graph.knowledges, graph.operators, graph.strategies)
+        import hashlib
+        expected = f"sha256:{hashlib.sha256(recomputed.encode()).hexdigest()}"
+        if graph.ir_hash != expected:
+            result.error(f"LocalCanonicalGraph ir_hash mismatch: stored={graph.ir_hash}, computed={expected}")
+
+    return result
+
+
+def validate_global_graph(graph: GlobalCanonicalGraph) -> ValidationResult:
+    """Validate a GlobalCanonicalGraph."""
+    result = ValidationResult()
+
+    knowledge_lookup = _validate_knowledges(graph.knowledges, "global", result)
+    _validate_operators(graph.operators, knowledge_lookup, result)
+    _validate_strategies(graph.strategies, knowledge_lookup, "global", result)
+    _validate_scope_consistency(knowledge_lookup, graph.operators, graph.strategies, "global", result)
+
+    return result

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 
 from gaia.gaia_ir.knowledge import Knowledge, KnowledgeType
 from gaia.gaia_ir.operator import Operator
-from gaia.gaia_ir.strategy import Strategy, CompositeStrategy, FormalStrategy
+from gaia.gaia_ir.strategy import Strategy, CompositeStrategy, FormalStrategy, StrategyType
 from gaia.gaia_ir.graphs import LocalCanonicalGraph, GlobalCanonicalGraph, _canonical_json
 from gaia.gaia_ir.parameterization import (
     CROMWELL_EPS,
@@ -169,6 +169,13 @@ def _validate_strategy(
     if scope == "global" and strategy.steps is not None:
         result.error(f"Strategy '{sid}': global strategy must not have steps")
 
+    # scope/prefix checks (applied to nested strategies too, not just top-level)
+    prefix = "lcs_" if scope == "local" else "gcs_"
+    if strategy.scope != scope:
+        result.error(f"Strategy '{sid}': scope '{strategy.scope}' incompatible with {scope} graph")
+    if strategy.strategy_id and not strategy.strategy_id.startswith(prefix):
+        result.error(f"Strategy '{sid}': expected {prefix} prefix in {scope} graph")
+
     # form-specific validation
     if isinstance(strategy, CompositeStrategy):
         for sub in strategy.sub_strategies:
@@ -185,26 +192,16 @@ def _validate_strategies(
     result: ValidationResult,
 ) -> None:
     """Validate all top-level Strategies."""
-    prefix = "lcs_" if scope == "local" else "gcs_"
     seen_ids: set[str] = set()
 
     for s in strategies:
-        # ID prefix
-        if s.strategy_id and not s.strategy_id.startswith(prefix):
-            result.error(f"Strategy '{s.strategy_id}': expected {prefix} prefix in {scope} graph")
-
-        # uniqueness
+        # uniqueness (top-level only)
         if s.strategy_id and s.strategy_id in seen_ids:
             result.error(f"Strategy '{s.strategy_id}': duplicate ID")
         if s.strategy_id:
             seen_ids.add(s.strategy_id)
 
-        # strategy scope must match graph scope
-        if s.scope != scope:
-            result.error(
-                f"Strategy '{s.strategy_id}': scope '{s.scope}' incompatible with {scope} graph"
-            )
-
+        # _validate_strategy handles scope, prefix, references, and recursion
         _validate_strategy(s, knowledge_lookup, scope, result)
 
 
@@ -325,6 +322,35 @@ def validate_parameterization(
         if sid not in param_strategy_ids:
             result.error(f"Strategy '{sid}': missing StrategyParamRecord")
 
+    # check conditional_probabilities arity
+    strategy_lookup = {s.strategy_id: s for s in graph.strategies if s.strategy_id}
+    for r in strategy_params:
+        s = strategy_lookup.get(r.strategy_id)
+        if s is None:
+            continue  # dangling ref handled below
+        actual = len(r.conditional_probabilities)
+        if s.type == StrategyType.INFER:
+            expected = 2 ** len(s.premises)
+            if actual != expected:
+                result.error(
+                    f"StrategyParamRecord '{r.strategy_id}': infer strategy with "
+                    f"{len(s.premises)} premises requires 2^{len(s.premises)}={expected} "
+                    f"conditional_probabilities, got {actual}"
+                )
+        elif s.type == StrategyType.NOISY_AND:
+            if actual != 1:
+                result.error(
+                    f"StrategyParamRecord '{r.strategy_id}': noisy_and strategy "
+                    f"requires 1 conditional_probability, got {actual}"
+                )
+        else:
+            # named strategies (folded): 1 parameter
+            if actual != 1:
+                result.error(
+                    f"StrategyParamRecord '{r.strategy_id}': {s.type} strategy "
+                    f"requires 1 conditional_probability, got {actual}"
+                )
+
     # Cromwell bounds on priors
     for r in priors:
         if r.value < CROMWELL_EPS or r.value > 1 - CROMWELL_EPS:
@@ -401,11 +427,5 @@ def validate_bindings(
                 f"CanonicalBinding: global_canonical_id '{b.global_canonical_id}' "
                 f"not found in global graph"
             )
-
-    # bindings for IDs not in local graph
-    for b in bindings:
-        if b.local_canonical_id not in local_ids:
-            # already reported above, skip duplicate
-            pass
 
     return result

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -74,6 +74,15 @@ def _validate_knowledges(
             if k.content is None and k.representative_lcn is None:
                 result.error(f"Knowledge '{k.id}': claim must have content or representative_lcn")
 
+        # local-layer shape rules
+        if scope == "local":
+            if k.content is None:
+                result.error(f"Knowledge '{k.id}': local layer requires content")
+            if k.representative_lcn is not None:
+                result.error(f"Knowledge '{k.id}': local layer must not set representative_lcn")
+            if k.local_members is not None:
+                result.error(f"Knowledge '{k.id}': local layer must not set local_members")
+
     return lookup
 
 

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -200,6 +200,13 @@ def _validate_strategies(
         if s.strategy_id:
             seen_ids.add(s.strategy_id)
 
+        # strategy scope must match graph scope
+        if s.scope != scope:
+            result.error(
+                f"Strategy '{s.strategy_id}': scope '{s.scope}' incompatible "
+                f"with {scope} graph"
+            )
+
         _validate_strategy(s, knowledge_lookup, scope, result)
 
 

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -12,6 +12,12 @@ from gaia.gaia_ir.knowledge import Knowledge, KnowledgeType
 from gaia.gaia_ir.operator import Operator, OperatorType
 from gaia.gaia_ir.strategy import Strategy, CompositeStrategy, FormalStrategy
 from gaia.gaia_ir.graphs import LocalCanonicalGraph, GlobalCanonicalGraph, _canonical_json
+from gaia.gaia_ir.parameterization import (
+    CROMWELL_EPS,
+    PriorRecord,
+    StrategyParamRecord,
+)
+from gaia.gaia_ir.binding import CanonicalBinding
 
 
 @dataclass
@@ -255,5 +261,132 @@ def validate_global_graph(graph: GlobalCanonicalGraph) -> ValidationResult:
     _validate_operators(graph.operators, knowledge_lookup, result)
     _validate_strategies(graph.strategies, knowledge_lookup, "global", result)
     _validate_scope_consistency(knowledge_lookup, graph.operators, graph.strategies, "global", result)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 5. Parameterization completeness (pre-BP)
+# ---------------------------------------------------------------------------
+
+
+def validate_parameterization(
+    graph: GlobalCanonicalGraph,
+    priors: list[PriorRecord],
+    strategy_params: list[StrategyParamRecord],
+) -> ValidationResult:
+    """Validate parameterization completeness before BP run.
+
+    Checks that every claim Knowledge has at least one PriorRecord and every
+    Strategy has at least one StrategyParamRecord, and all values are within
+    Cromwell bounds.
+    """
+    result = ValidationResult()
+
+    # collect claim gcn_ids
+    claim_ids = {k.id for k in graph.knowledges if k.type == KnowledgeType.CLAIM and k.id}
+
+    # collect strategy ids
+    strategy_ids: set[str] = set()
+    for s in graph.strategies:
+        if s.strategy_id:
+            strategy_ids.add(s.strategy_id)
+
+    # check prior coverage
+    prior_gcn_ids = {r.gcn_id for r in priors}
+    for cid in claim_ids:
+        if cid not in prior_gcn_ids:
+            result.error(f"Claim '{cid}': missing PriorRecord")
+
+    # check strategy param coverage
+    param_strategy_ids = {r.strategy_id for r in strategy_params}
+    for sid in strategy_ids:
+        if sid not in param_strategy_ids:
+            result.error(f"Strategy '{sid}': missing StrategyParamRecord")
+
+    # Cromwell bounds on priors
+    for r in priors:
+        if r.value < CROMWELL_EPS or r.value > 1 - CROMWELL_EPS:
+            result.error(
+                f"PriorRecord '{r.gcn_id}': value {r.value} outside Cromwell bounds "
+                f"[{CROMWELL_EPS}, {1 - CROMWELL_EPS}]"
+            )
+
+    # Cromwell bounds on strategy params
+    for r in strategy_params:
+        for i, p in enumerate(r.conditional_probabilities):
+            if p < CROMWELL_EPS or p > 1 - CROMWELL_EPS:
+                result.error(
+                    f"StrategyParamRecord '{r.strategy_id}': "
+                    f"conditional_probabilities[{i}]={p} outside Cromwell bounds"
+                )
+
+    # dangling references: priors for non-existent claims
+    all_knowledge_ids = {k.id for k in graph.knowledges if k.id}
+    for r in priors:
+        if r.gcn_id not in all_knowledge_ids:
+            result.warn(f"PriorRecord '{r.gcn_id}': references non-existent Knowledge")
+
+    # dangling references: params for non-existent strategies
+    for r in strategy_params:
+        if r.strategy_id not in strategy_ids:
+            result.warn(
+                f"StrategyParamRecord '{r.strategy_id}': references non-existent Strategy"
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 6. CanonicalBinding validation
+# ---------------------------------------------------------------------------
+
+
+def validate_bindings(
+    bindings: list[CanonicalBinding],
+    local_graph: LocalCanonicalGraph,
+    global_graph: GlobalCanonicalGraph,
+) -> ValidationResult:
+    """Validate CanonicalBindings between local and global graphs.
+
+    Checks completeness (every local Knowledge has exactly one binding) and
+    reference validity (both local and global IDs exist).
+    """
+    result = ValidationResult()
+
+    local_ids = {k.id for k in local_graph.knowledges if k.id}
+    global_ids = {k.id for k in global_graph.knowledges if k.id}
+
+    # track which local IDs have bindings
+    bound_local_ids: dict[str, int] = {}
+    for b in bindings:
+        bound_local_ids[b.local_canonical_id] = bound_local_ids.get(b.local_canonical_id, 0) + 1
+
+    # every local Knowledge must have exactly one binding
+    for lid in local_ids:
+        count = bound_local_ids.get(lid, 0)
+        if count == 0:
+            result.error(f"Knowledge '{lid}': no CanonicalBinding")
+        elif count > 1:
+            result.error(f"Knowledge '{lid}': {count} bindings (expected exactly 1)")
+
+    # binding references must be valid
+    for b in bindings:
+        if b.local_canonical_id not in local_ids:
+            result.error(
+                f"CanonicalBinding: local_canonical_id '{b.local_canonical_id}' "
+                f"not found in local graph"
+            )
+        if b.global_canonical_id not in global_ids:
+            result.error(
+                f"CanonicalBinding: global_canonical_id '{b.global_canonical_id}' "
+                f"not found in global graph"
+            )
+
+    # bindings for IDs not in local graph
+    for b in bindings:
+        if b.local_canonical_id not in local_ids:
+            # already reported above, skip duplicate
+            pass
 
     return result

--- a/tests/gaia_ir/test_graphs.py
+++ b/tests/gaia_ir/test_graphs.py
@@ -48,6 +48,16 @@ class TestLocalCanonicalGraph:
         g = LocalCanonicalGraph(knowledges=[])
         assert g.scope == "local"
 
+    def test_hash_independent_of_entity_order(self):
+        k1 = Knowledge(id="lcn_1", type="claim", content="A")
+        k2 = Knowledge(id="lcn_2", type="claim", content="B")
+        s = Strategy(scope="local", type="infer", premises=["lcn_1"], conclusion="lcn_2")
+
+        g1 = LocalCanonicalGraph(knowledges=[k1, k2], strategies=[s])
+        g2 = LocalCanonicalGraph(knowledges=[k2, k1], strategies=[s])
+
+        assert g1.ir_hash == g2.ir_hash
+
 
 class TestGlobalCanonicalGraph:
     def test_no_hash(self):

--- a/tests/gaia_ir/test_operator.py
+++ b/tests/gaia_ir/test_operator.py
@@ -74,9 +74,17 @@ class TestOperatorValidation:
         with pytest.raises(ValueError, match="exactly 2"):
             Operator(operator="implication", variables=["a", "b", "c"], conclusion="c")
 
+    def test_implication_requires_conclusion_as_last_variable(self):
+        with pytest.raises(ValueError, match="variables\\[-1\\]"):
+            Operator(operator="implication", variables=["a", "b"], conclusion="a")
+
     def test_conjunction_requires_conclusion(self):
         with pytest.raises(ValueError, match="requires conclusion"):
             Operator(operator="conjunction", variables=["a", "b", "m"])
+
+    def test_conjunction_requires_conclusion_as_last_variable(self):
+        with pytest.raises(ValueError, match="variables\\[-1\\]"):
+            Operator(operator="conjunction", variables=["a", "b", "m"], conclusion="a")
 
     def test_conclusion_must_be_in_variables(self):
         with pytest.raises(ValueError, match="must appear in variables"):
@@ -103,3 +111,21 @@ class TestOperatorScope:
         op = Operator(operator="implication", variables=["a", "b"], conclusion="b")
         assert op.scope is None
         assert op.operator_id is None
+
+    def test_invalid_scope_rejected(self):
+        with pytest.raises(ValueError, match="scope must be one of"):
+            Operator(scope="detached", operator="equivalence", variables=["a", "b"])
+
+    def test_local_scope_requires_lco_prefix(self):
+        with pytest.raises(ValueError, match="lco_ prefix"):
+            Operator(
+                operator_id="gco_wrong", scope="local",
+                operator="equivalence", variables=["a", "b"],
+            )
+
+    def test_global_scope_requires_gco_prefix(self):
+        with pytest.raises(ValueError, match="gco_ prefix"):
+            Operator(
+                operator_id="lco_wrong", scope="global",
+                operator="equivalence", variables=["a", "b"],
+            )

--- a/tests/gaia_ir/test_operator.py
+++ b/tests/gaia_ir/test_operator.py
@@ -119,13 +119,17 @@ class TestOperatorScope:
     def test_local_scope_requires_lco_prefix(self):
         with pytest.raises(ValueError, match="lco_ prefix"):
             Operator(
-                operator_id="gco_wrong", scope="local",
-                operator="equivalence", variables=["a", "b"],
+                operator_id="gco_wrong",
+                scope="local",
+                operator="equivalence",
+                variables=["a", "b"],
             )
 
     def test_global_scope_requires_gco_prefix(self):
         with pytest.raises(ValueError, match="gco_ prefix"):
             Operator(
-                operator_id="lco_wrong", scope="global",
-                operator="equivalence", variables=["a", "b"],
+                operator_id="lco_wrong",
+                scope="global",
+                operator="equivalence",
+                variables=["a", "b"],
             )

--- a/tests/gaia_ir/test_strategy.py
+++ b/tests/gaia_ir/test_strategy.py
@@ -73,6 +73,24 @@ class TestStrategyCreation:
         )
         assert len(s.steps) == 1
 
+    def test_invalid_scope_rejected(self):
+        with pytest.raises(ValueError, match="scope must be one of"):
+            Strategy(scope="detached", type="infer", premises=["a"], conclusion="b")
+
+    def test_global_steps_rejected(self):
+        with pytest.raises(ValueError, match="must not carry steps"):
+            Strategy(
+                scope="global",
+                type="infer",
+                premises=["gcn_a"],
+                conclusion="gcn_b",
+                steps=[Step(reasoning="should stay local")],
+            )
+
+    def test_leaf_rejects_named_strategy_type(self):
+        with pytest.raises(ValueError, match="Strategy form only allows types"):
+            Strategy(scope="global", type="deduction", premises=["gcn_a"], conclusion="gcn_b")
+
 
 class TestCompositeStrategy:
     def test_creation(self):
@@ -98,11 +116,21 @@ class TestCompositeStrategy:
                 sub_strategies=[],
             )
 
+    def test_composite_rejects_leaf_type(self):
+        with pytest.raises(ValueError, match="CompositeStrategy form only allows types"):
+            CompositeStrategy(
+                scope="global",
+                type="infer",
+                premises=["gcn_a"],
+                conclusion="gcn_b",
+                sub_strategies=[Strategy(scope="global", type="infer", premises=["gcn_a"], conclusion="gcn_b")],
+            )
+
     def test_nested_composite(self):
         """CompositeStrategy can contain CompositeStrategy (recursive)."""
         inner = CompositeStrategy(
             scope="global",
-            type="infer",
+            type="abduction",
             premises=["a"],
             conclusion="b",
             sub_strategies=[
@@ -198,6 +226,18 @@ class TestFormalStrategy:
                 premises=["a"],
                 conclusion="b",
                 formal_expr=FormalExpr(operators=[]),
+            )
+
+    def test_formal_rejects_composite_type(self):
+        with pytest.raises(ValueError, match="FormalStrategy form only allows types"):
+            FormalStrategy(
+                scope="local",
+                type="induction",
+                premises=["a"],
+                conclusion="b",
+                formal_expr=FormalExpr(operators=[
+                    Operator(operator="implication", variables=["a", "b"], conclusion="b"),
+                ]),
             )
 
 

--- a/tests/gaia_ir/test_strategy.py
+++ b/tests/gaia_ir/test_strategy.py
@@ -123,7 +123,9 @@ class TestCompositeStrategy:
                 type="infer",
                 premises=["gcn_a"],
                 conclusion="gcn_b",
-                sub_strategies=[Strategy(scope="global", type="infer", premises=["gcn_a"], conclusion="gcn_b")],
+                sub_strategies=[
+                    Strategy(scope="global", type="infer", premises=["gcn_a"], conclusion="gcn_b")
+                ],
             )
 
     def test_nested_composite(self):
@@ -235,9 +237,11 @@ class TestFormalStrategy:
                 type="induction",
                 premises=["a"],
                 conclusion="b",
-                formal_expr=FormalExpr(operators=[
-                    Operator(operator="implication", variables=["a", "b"], conclusion="b"),
-                ]),
+                formal_expr=FormalExpr(
+                    operators=[
+                        Operator(operator="implication", variables=["a", "b"], conclusion="b"),
+                    ]
+                ),
             )
 
 

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -104,7 +104,9 @@ class TestKnowledgeValidation:
         from gaia.gaia_ir import LocalCanonicalRef
 
         k = Knowledge(
-            id="lcn_a", type=KnowledgeType.CLAIM, content="test",
+            id="lcn_a",
+            type=KnowledgeType.CLAIM,
+            content="test",
             representative_lcn=LocalCanonicalRef(
                 local_canonical_id="lcn_x", package_id="pkg", version="1"
             ),
@@ -118,10 +120,12 @@ class TestKnowledgeValidation:
         from gaia.gaia_ir import LocalCanonicalRef
 
         k = Knowledge(
-            id="lcn_a", type=KnowledgeType.CLAIM, content="test",
-            local_members=[LocalCanonicalRef(
-                local_canonical_id="lcn_x", package_id="pkg", version="1"
-            )],
+            id="lcn_a",
+            type=KnowledgeType.CLAIM,
+            content="test",
+            local_members=[
+                LocalCanonicalRef(local_canonical_id="lcn_x", package_id="pkg", version="1")
+            ],
         )
         g = _local_graph(knowledges=[k])
         r = validate_local_graph(g)
@@ -164,7 +168,9 @@ class TestOperatorValidation:
     def test_local_graph_rejects_global_scoped_operator(self):
         g = _local_graph(
             knowledges=[_claim("lcn_a"), _claim("lcn_b")],
-            operators=[Operator(scope="global", operator="equivalence", variables=["lcn_a", "lcn_b"])],
+            operators=[
+                Operator(scope="global", operator="equivalence", variables=["lcn_a", "lcn_b"])
+            ],
         )
         r = validate_local_graph(g)
         assert not r.valid
@@ -173,7 +179,9 @@ class TestOperatorValidation:
     def test_global_graph_rejects_local_scoped_operator(self):
         g = _global_graph(
             knowledges=[_claim("gcn_a"), _claim("gcn_b")],
-            operators=[Operator(scope="local", operator="equivalence", variables=["gcn_a", "gcn_b"])],
+            operators=[
+                Operator(scope="local", operator="equivalence", variables=["gcn_a", "gcn_b"])
+            ],
         )
         r = validate_global_graph(g)
         assert not r.valid
@@ -298,7 +306,9 @@ class TestStrategyValidation:
     def test_local_graph_rejects_global_scoped_strategy(self):
         g = _local_graph(
             knowledges=[_claim("lcn_a"), _claim("lcn_b")],
-            strategies=[Strategy(scope="global", type="infer", premises=["lcn_a"], conclusion="lcn_b")],
+            strategies=[
+                Strategy(scope="global", type="infer", premises=["lcn_a"], conclusion="lcn_b")
+            ],
         )
         r = validate_local_graph(g)
         assert not r.valid
@@ -307,7 +317,9 @@ class TestStrategyValidation:
     def test_global_graph_rejects_local_scoped_strategy(self):
         g = _global_graph(
             knowledges=[_claim("gcn_a"), _claim("gcn_b")],
-            strategies=[Strategy(scope="local", type="infer", premises=["gcn_a"], conclusion="gcn_b")],
+            strategies=[
+                Strategy(scope="local", type="infer", premises=["gcn_a"], conclusion="gcn_b")
+            ],
         )
         r = validate_global_graph(g)
         assert not r.valid

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -161,6 +161,24 @@ class TestOperatorValidation:
         assert not r.valid
         assert any("must be claim" in e for e in r.errors)
 
+    def test_local_graph_rejects_global_scoped_operator(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            operators=[Operator(scope="global", operator="equivalence", variables=["lcn_a", "lcn_b"])],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("scope" in e.lower() for e in r.errors)
+
+    def test_global_graph_rejects_local_scoped_operator(self):
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b")],
+            operators=[Operator(scope="local", operator="equivalence", variables=["gcn_a", "gcn_b"])],
+        )
+        r = validate_global_graph(g)
+        assert not r.valid
+        assert any("scope" in e.lower() for e in r.errors)
+
 
 # ---------------------------------------------------------------------------
 # 3. Strategy validation
@@ -251,40 +269,31 @@ class TestStrategyValidation:
         assert any("background" in w for w in r.warnings)
 
     def test_global_strategy_rejects_steps(self):
+        """Pydantic model validation rejects steps on global Strategy at construction time."""
+        import pytest
         from gaia.gaia_ir import Step
 
-        g = _global_graph(
-            knowledges=[_claim("gcn_a"), _claim("gcn_b")],
-            strategies=[
-                Strategy(
-                    scope="global",
-                    type="infer",
-                    premises=["gcn_a"],
-                    conclusion="gcn_b",
-                    steps=[Step(reasoning="should not be here")],
-                )
-            ],
-        )
-        r = validate_global_graph(g)
-        assert not r.valid
-        assert any("steps" in e for e in r.errors)
+        with pytest.raises(Exception, match="global Strategy must not carry steps"):
+            Strategy(
+                scope="global",
+                type="infer",
+                premises=["gcn_a"],
+                conclusion="gcn_b",
+                steps=[Step(reasoning="should not be here")],
+            )
 
     def test_strategy_prefix_check(self):
-        g = _local_graph(
-            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
-            strategies=[
-                Strategy(
-                    strategy_id="gcs_wrong",
-                    scope="local",
-                    type="infer",
-                    premises=["lcn_a"],
-                    conclusion="lcn_b",
-                )
-            ],
-        )
-        r = validate_local_graph(g)
-        assert not r.valid
-        assert any("prefix" in e for e in r.errors)
+        """Pydantic model validation rejects wrong ID prefix at construction time."""
+        import pytest
+
+        with pytest.raises(Exception, match="lcs_ prefix"):
+            Strategy(
+                strategy_id="gcs_wrong",
+                scope="local",
+                type="infer",
+                premises=["lcn_a"],
+                conclusion="lcn_b",
+            )
 
 
 class TestCompositeStrategyValidation:

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -13,7 +13,12 @@ from gaia.gaia_ir import (
     LocalCanonicalGraph,
     GlobalCanonicalGraph,
 )
-from gaia.gaia_ir.validator import validate_local_graph, validate_global_graph
+from gaia.gaia_ir.validator import (
+    validate_local_graph,
+    validate_global_graph,
+    validate_parameterization,
+    validate_bindings,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -355,4 +360,225 @@ class TestGraphLevelValidation:
 
     def test_empty_global_valid(self):
         r = validate_global_graph(_global_graph())
+        assert r.valid
+
+
+# ---------------------------------------------------------------------------
+# 5. Parameterization completeness
+# ---------------------------------------------------------------------------
+
+
+class TestParameterizationValidation:
+    def _graph(self):
+        return _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b"), _setting("gcn_s")],
+            strategies=[
+                Strategy(scope="global", type="noisy_and", premises=["gcn_a"], conclusion="gcn_b"),
+            ],
+        )
+
+    def test_complete_parameterization(self):
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+        g = self._graph()
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.7, source_id="s"),
+            ],
+            strategy_params=[
+                StrategyParamRecord(strategy_id=sid, conditional_probabilities=[0.85], source_id="s"),
+            ],
+        )
+        assert r.valid
+
+    def test_missing_prior(self):
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+        g = self._graph()
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s")],
+            strategy_params=[
+                StrategyParamRecord(strategy_id=sid, conditional_probabilities=[0.85], source_id="s"),
+            ],
+        )
+        assert not r.valid
+        assert any("gcn_b" in e and "missing PriorRecord" in e for e in r.errors)
+
+    def test_missing_strategy_param(self):
+        from gaia.gaia_ir import PriorRecord
+        g = self._graph()
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.7, source_id="s"),
+            ],
+            strategy_params=[],
+        )
+        assert not r.valid
+        assert any("missing StrategyParamRecord" in e for e in r.errors)
+
+    def test_setting_does_not_need_prior(self):
+        """Settings don't carry probability — no PriorRecord needed."""
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+        g = self._graph()
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.7, source_id="s"),
+            ],
+            strategy_params=[
+                StrategyParamRecord(strategy_id=sid, conditional_probabilities=[0.85], source_id="s"),
+            ],
+        )
+        assert r.valid  # gcn_s (setting) doesn't need a prior
+
+    def test_cromwell_bounds_on_priors(self):
+        """PriorRecord auto-clamps, so raw values within bounds should pass."""
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+        g = _global_graph(
+            knowledges=[_claim("gcn_a")],
+            strategies=[],
+        )
+        r = validate_parameterization(
+            g,
+            priors=[PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s")],
+            strategy_params=[],
+        )
+        assert r.valid
+
+    def test_dangling_prior_warning(self):
+        from gaia.gaia_ir import PriorRecord
+        g = _global_graph(knowledges=[_claim("gcn_a")])
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_nonexistent", value=0.5, source_id="s"),
+            ],
+            strategy_params=[],
+        )
+        assert r.valid  # warning, not error
+        assert any("non-existent" in w for w in r.warnings)
+
+    def test_dangling_strategy_param_warning(self):
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+        g = _global_graph(knowledges=[_claim("gcn_a")])
+        r = validate_parameterization(
+            g,
+            priors=[PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s")],
+            strategy_params=[
+                StrategyParamRecord(strategy_id="gcs_ghost", conditional_probabilities=[0.5], source_id="s"),
+            ],
+        )
+        assert r.valid
+        assert any("non-existent" in w for w in r.warnings)
+
+    def test_empty_graph_no_requirements(self):
+        r = validate_parameterization(_global_graph(), [], [])
+        assert r.valid
+
+
+# ---------------------------------------------------------------------------
+# 6. CanonicalBinding validation
+# ---------------------------------------------------------------------------
+
+
+class TestBindingValidation:
+    def test_valid_bindings(self):
+        from gaia.gaia_ir import CanonicalBinding, BindingDecision
+        local = _local_graph(knowledges=[_claim("lcn_a"), _claim("lcn_b")])
+        global_ = _global_graph(knowledges=[_claim("gcn_x"), _claim("gcn_y")])
+        bindings = [
+            CanonicalBinding(
+                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
+                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                reason="similarity 0.95",
+            ),
+            CanonicalBinding(
+                local_canonical_id="lcn_b", global_canonical_id="gcn_y",
+                package_id="pkg", version="1", decision=BindingDecision.CREATE_NEW,
+                reason="no match",
+            ),
+        ]
+        r = validate_bindings(bindings, local, global_)
+        assert r.valid
+
+    def test_missing_binding(self):
+        from gaia.gaia_ir import CanonicalBinding, BindingDecision
+        local = _local_graph(knowledges=[_claim("lcn_a"), _claim("lcn_b")])
+        global_ = _global_graph(knowledges=[_claim("gcn_x")])
+        bindings = [
+            CanonicalBinding(
+                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
+                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                reason="match",
+            ),
+        ]
+        r = validate_bindings(bindings, local, global_)
+        assert not r.valid
+        assert any("lcn_b" in e and "no CanonicalBinding" in e for e in r.errors)
+
+    def test_duplicate_binding(self):
+        from gaia.gaia_ir import CanonicalBinding, BindingDecision
+        local = _local_graph(knowledges=[_claim("lcn_a")])
+        global_ = _global_graph(knowledges=[_claim("gcn_x"), _claim("gcn_y")])
+        bindings = [
+            CanonicalBinding(
+                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
+                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                reason="first",
+            ),
+            CanonicalBinding(
+                local_canonical_id="lcn_a", global_canonical_id="gcn_y",
+                package_id="pkg", version="1", decision=BindingDecision.CREATE_NEW,
+                reason="second",
+            ),
+        ]
+        r = validate_bindings(bindings, local, global_)
+        assert not r.valid
+        assert any("2 bindings" in e for e in r.errors)
+
+    def test_binding_dangling_local(self):
+        from gaia.gaia_ir import CanonicalBinding, BindingDecision
+        local = _local_graph(knowledges=[_claim("lcn_a")])
+        global_ = _global_graph(knowledges=[_claim("gcn_x")])
+        bindings = [
+            CanonicalBinding(
+                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
+                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                reason="ok",
+            ),
+            CanonicalBinding(
+                local_canonical_id="lcn_ghost", global_canonical_id="gcn_x",
+                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                reason="dangling",
+            ),
+        ]
+        r = validate_bindings(bindings, local, global_)
+        assert not r.valid
+        assert any("not found in local" in e for e in r.errors)
+
+    def test_binding_dangling_global(self):
+        from gaia.gaia_ir import CanonicalBinding, BindingDecision
+        local = _local_graph(knowledges=[_claim("lcn_a")])
+        global_ = _global_graph(knowledges=[])
+        bindings = [
+            CanonicalBinding(
+                local_canonical_id="lcn_a", global_canonical_id="gcn_ghost",
+                package_id="pkg", version="1", decision=BindingDecision.CREATE_NEW,
+                reason="dangling global",
+            ),
+        ]
+        r = validate_bindings(bindings, local, global_)
+        assert not r.valid
+        assert any("not found in global" in e for e in r.errors)
+
+    def test_empty_bindings_for_empty_graph(self):
+        r = validate_bindings([], _local_graph(), _global_graph())
         assert r.valid

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -347,6 +347,30 @@ class TestCompositeStrategyValidation:
         r = validate_local_graph(g)
         assert r.valid
 
+    def test_nested_scope_mismatch_rejected(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_c")],
+            strategies=[
+                CompositeStrategy(
+                    scope="local",
+                    type="abduction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
+                    sub_strategies=[
+                        Strategy(
+                            scope="global",
+                            type="noisy_and",
+                            premises=["lcn_a"],
+                            conclusion="lcn_b",
+                        ),
+                    ],
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("scope" in e.lower() and "incompatible" in e.lower() for e in r.errors)
+
     def test_sub_strategy_dangling_ref(self):
         g = _local_graph(
             knowledges=[_claim("lcn_a"), _claim("lcn_c")],
@@ -607,6 +631,93 @@ class TestParameterizationValidation:
 
     def test_empty_graph_no_requirements(self):
         r = validate_parameterization(_global_graph(), [], [])
+        assert r.valid
+
+    def test_noisy_and_wrong_arity_rejected(self):
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
+        g = self._graph()
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.7, source_id="s"),
+            ],
+            strategy_params=[
+                StrategyParamRecord(
+                    strategy_id=sid,
+                    conditional_probabilities=[0.2, 0.3, 0.4, 0.5],
+                    source_id="s",
+                ),
+            ],
+        )
+        assert not r.valid
+        assert any("noisy_and" in e and "requires 1" in e for e in r.errors)
+
+    def test_infer_wrong_arity_rejected(self):
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b"), _claim("gcn_c")],
+            strategies=[
+                Strategy(
+                    scope="global",
+                    type="infer",
+                    premises=["gcn_a", "gcn_b"],
+                    conclusion="gcn_c",
+                ),
+            ],
+        )
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_c", value=0.5, source_id="s"),
+            ],
+            strategy_params=[
+                StrategyParamRecord(
+                    strategy_id=sid,
+                    conditional_probabilities=[0.8, 0.9],  # needs 2^2=4
+                    source_id="s",
+                ),
+            ],
+        )
+        assert not r.valid
+        assert any("2^2=4" in e for e in r.errors)
+
+    def test_infer_correct_arity_passes(self):
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b"), _claim("gcn_c")],
+            strategies=[
+                Strategy(
+                    scope="global",
+                    type="infer",
+                    premises=["gcn_a", "gcn_b"],
+                    conclusion="gcn_c",
+                ),
+            ],
+        )
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_c", value=0.5, source_id="s"),
+            ],
+            strategy_params=[
+                StrategyParamRecord(
+                    strategy_id=sid,
+                    conditional_probabilities=[0.8, 0.7, 0.6, 0.9],
+                    source_id="s",
+                ),
+            ],
+        )
         assert r.valid
 
 

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -1,0 +1,358 @@
+"""Tests for Gaia IR validator."""
+
+import pytest
+from gaia.gaia_ir import (
+    Knowledge,
+    KnowledgeType,
+    Operator,
+    Strategy,
+    CompositeStrategy,
+    FormalStrategy,
+    FormalExpr,
+    StrategyType,
+    LocalCanonicalGraph,
+    GlobalCanonicalGraph,
+)
+from gaia.gaia_ir.validator import validate_local_graph, validate_global_graph
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _claim(id: str, content: str = "test") -> Knowledge:
+    return Knowledge(id=id, type=KnowledgeType.CLAIM, content=content)
+
+
+def _setting(id: str) -> Knowledge:
+    return Knowledge(id=id, type=KnowledgeType.SETTING)
+
+
+def _local_graph(**kwargs) -> LocalCanonicalGraph:
+    defaults = {"knowledges": [], "operators": [], "strategies": []}
+    defaults.update(kwargs)
+    return LocalCanonicalGraph(**defaults)
+
+
+def _global_graph(**kwargs) -> GlobalCanonicalGraph:
+    defaults = {"knowledges": [], "operators": [], "strategies": []}
+    defaults.update(kwargs)
+    return GlobalCanonicalGraph(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. Knowledge validation
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeValidation:
+    def test_valid_local(self):
+        g = _local_graph(knowledges=[_claim("lcn_a")])
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_wrong_prefix_local(self):
+        g = _local_graph(knowledges=[_claim("gcn_wrong")])
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("prefix" in e for e in r.errors)
+
+    def test_wrong_prefix_global(self):
+        g = _global_graph(knowledges=[_claim("lcn_wrong")])
+        r = validate_global_graph(g)
+        assert not r.valid
+
+    def test_duplicate_id(self):
+        g = _local_graph(knowledges=[_claim("lcn_a"), _claim("lcn_a", "other")])
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("duplicate" in e for e in r.errors)
+
+    def test_claim_without_content_or_repr(self):
+        k = Knowledge(id="gcn_bad", type=KnowledgeType.CLAIM)
+        g = _global_graph(knowledges=[k])
+        r = validate_global_graph(g)
+        assert not r.valid
+        assert any("content or representative_lcn" in e for e in r.errors)
+
+    def test_claim_with_representative_lcn_ok(self):
+        from gaia.gaia_ir import LocalCanonicalRef
+        k = Knowledge(
+            id="gcn_ok",
+            type=KnowledgeType.CLAIM,
+            representative_lcn=LocalCanonicalRef(
+                local_canonical_id="lcn_x", package_id="pkg", version="1"
+            ),
+        )
+        g = _global_graph(knowledges=[k])
+        r = validate_global_graph(g)
+        assert r.valid
+
+
+# ---------------------------------------------------------------------------
+# 2. Operator validation
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorValidation:
+    def test_valid_operator(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            operators=[Operator(operator="equivalence", variables=["lcn_a", "lcn_b"])],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_dangling_reference(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a")],
+            operators=[Operator(operator="equivalence", variables=["lcn_a", "lcn_missing"])],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("not found" in e for e in r.errors)
+
+    def test_operator_on_non_claim(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _setting("lcn_s")],
+            operators=[Operator(operator="equivalence", variables=["lcn_a", "lcn_s"])],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("must be claim" in e for e in r.errors)
+
+
+# ---------------------------------------------------------------------------
+# 3. Strategy validation
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyValidation:
+    def test_valid_strategy(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            strategies=[
+                Strategy(scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_dangling_premise(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_b")],
+            strategies=[
+                Strategy(scope="local", type="infer", premises=["lcn_missing"], conclusion="lcn_b")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("premise" in e and "not found" in e for e in r.errors)
+
+    def test_dangling_conclusion(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a")],
+            strategies=[
+                Strategy(scope="local", type="infer", premises=["lcn_a"], conclusion="lcn_missing")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("conclusion" in e and "not found" in e for e in r.errors)
+
+    def test_premise_must_be_claim(self):
+        g = _local_graph(
+            knowledges=[_setting("lcn_s"), _claim("lcn_b")],
+            strategies=[
+                Strategy(scope="local", type="infer", premises=["lcn_s"], conclusion="lcn_b")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("premise" in e and "must be claim" in e for e in r.errors)
+
+    def test_conclusion_must_be_claim(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _setting("lcn_s")],
+            strategies=[
+                Strategy(scope="local", type="infer", premises=["lcn_a"], conclusion="lcn_s")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("conclusion" in e and "must be claim" in e for e in r.errors)
+
+    def test_self_loop_rejected(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a")],
+            strategies=[
+                Strategy(scope="local", type="infer", premises=["lcn_a"], conclusion="lcn_a")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("self-loop" in e for e in r.errors)
+
+    def test_background_warning_if_missing(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            strategies=[
+                Strategy(
+                    scope="local", type="noisy_and",
+                    premises=["lcn_a"], conclusion="lcn_b",
+                    background=["lcn_nonexistent"],
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid  # warning, not error
+        assert any("background" in w for w in r.warnings)
+
+    def test_global_strategy_rejects_steps(self):
+        from gaia.gaia_ir import Step
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b")],
+            strategies=[
+                Strategy(
+                    scope="global", type="infer",
+                    premises=["gcn_a"], conclusion="gcn_b",
+                    steps=[Step(reasoning="should not be here")],
+                )
+            ],
+        )
+        r = validate_global_graph(g)
+        assert not r.valid
+        assert any("steps" in e for e in r.errors)
+
+    def test_strategy_prefix_check(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            strategies=[
+                Strategy(
+                    strategy_id="gcs_wrong",
+                    scope="local", type="infer",
+                    premises=["lcn_a"], conclusion="lcn_b",
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("prefix" in e for e in r.errors)
+
+
+class TestCompositeStrategyValidation:
+    def test_valid_composite(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_c")],
+            strategies=[
+                CompositeStrategy(
+                    scope="local", type="abduction",
+                    premises=["lcn_a"], conclusion="lcn_c",
+                    sub_strategies=[
+                        Strategy(scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b"),
+                    ],
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_sub_strategy_dangling_ref(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_c")],
+            strategies=[
+                CompositeStrategy(
+                    scope="local", type="induction",
+                    premises=["lcn_a"], conclusion="lcn_c",
+                    sub_strategies=[
+                        Strategy(scope="local", type="noisy_and", premises=["lcn_missing"], conclusion="lcn_c"),
+                    ],
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+
+
+class TestFormalStrategyValidation:
+    def test_valid_formal(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_m"), _claim("lcn_c")],
+            strategies=[
+                FormalStrategy(
+                    scope="local", type="deduction",
+                    premises=["lcn_a", "lcn_b"], conclusion="lcn_c",
+                    formal_expr=FormalExpr(operators=[
+                        Operator(operator="conjunction", variables=["lcn_a", "lcn_b", "lcn_m"], conclusion="lcn_m"),
+                        Operator(operator="implication", variables=["lcn_m", "lcn_c"], conclusion="lcn_c"),
+                    ]),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_formal_expr_dangling_ref(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_c")],
+            strategies=[
+                FormalStrategy(
+                    scope="local", type="deduction",
+                    premises=["lcn_a"], conclusion="lcn_c",
+                    formal_expr=FormalExpr(operators=[
+                        Operator(operator="implication", variables=["lcn_missing", "lcn_c"], conclusion="lcn_c"),
+                    ]),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+
+
+# ---------------------------------------------------------------------------
+# 4. Graph-level validation
+# ---------------------------------------------------------------------------
+
+
+class TestGraphLevelValidation:
+    def test_scope_consistency_local(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            strategies=[
+                Strategy(scope="local", type="infer", premises=["gcn_wrong"], conclusion="lcn_b")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("wrong prefix" in e for e in r.errors)
+
+    def test_scope_consistency_global(self):
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b")],
+            strategies=[
+                Strategy(scope="global", type="infer", premises=["lcn_wrong"], conclusion="gcn_b")
+            ],
+        )
+        r = validate_global_graph(g)
+        assert not r.valid
+
+    def test_hash_consistency(self):
+        g = _local_graph(knowledges=[_claim("lcn_a")])
+        r = validate_local_graph(g)
+        assert r.valid  # auto-computed hash should match
+
+    def test_hash_mismatch(self):
+        g = _local_graph(knowledges=[_claim("lcn_a")])
+        g.ir_hash = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("ir_hash mismatch" in e for e in r.errors)
+
+    def test_empty_graph_valid(self):
+        r = validate_local_graph(_local_graph())
+        assert r.valid
+
+    def test_empty_global_valid(self):
+        r = validate_global_graph(_global_graph())
+        assert r.valid

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -93,6 +93,41 @@ class TestKnowledgeValidation:
         r = validate_global_graph(g)
         assert r.valid
 
+    def test_local_knowledge_must_have_content(self):
+        k = Knowledge(id="lcn_a", type=KnowledgeType.CLAIM)
+        g = _local_graph(knowledges=[k])
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("content" in e for e in r.errors)
+
+    def test_local_knowledge_must_not_have_representative_lcn(self):
+        from gaia.gaia_ir import LocalCanonicalRef
+
+        k = Knowledge(
+            id="lcn_a", type=KnowledgeType.CLAIM, content="test",
+            representative_lcn=LocalCanonicalRef(
+                local_canonical_id="lcn_x", package_id="pkg", version="1"
+            ),
+        )
+        g = _local_graph(knowledges=[k])
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("representative_lcn" in e for e in r.errors)
+
+    def test_local_knowledge_must_not_have_local_members(self):
+        from gaia.gaia_ir import LocalCanonicalRef
+
+        k = Knowledge(
+            id="lcn_a", type=KnowledgeType.CLAIM, content="test",
+            local_members=[LocalCanonicalRef(
+                local_canonical_id="lcn_x", package_id="pkg", version="1"
+            )],
+        )
+        g = _local_graph(knowledges=[k])
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("local_members" in e for e in r.errors)
+
 
 # ---------------------------------------------------------------------------
 # 2. Operator validation

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -295,6 +295,24 @@ class TestStrategyValidation:
                 conclusion="lcn_b",
             )
 
+    def test_local_graph_rejects_global_scoped_strategy(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            strategies=[Strategy(scope="global", type="infer", premises=["lcn_a"], conclusion="lcn_b")],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("scope" in e.lower() for e in r.errors)
+
+    def test_global_graph_rejects_local_scoped_strategy(self):
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b")],
+            strategies=[Strategy(scope="local", type="infer", premises=["gcn_a"], conclusion="gcn_b")],
+        )
+        r = validate_global_graph(g)
+        assert not r.valid
+        assert any("scope" in e.lower() for e in r.errors)
+
 
 class TestCompositeStrategyValidation:
     def test_valid_composite(self):

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -1,6 +1,5 @@
 """Tests for Gaia IR validator."""
 
-import pytest
 from gaia.gaia_ir import (
     Knowledge,
     KnowledgeType,
@@ -9,7 +8,6 @@ from gaia.gaia_ir import (
     CompositeStrategy,
     FormalStrategy,
     FormalExpr,
-    StrategyType,
     LocalCanonicalGraph,
     GlobalCanonicalGraph,
 )
@@ -83,6 +81,7 @@ class TestKnowledgeValidation:
 
     def test_claim_with_representative_lcn_ok(self):
         from gaia.gaia_ir import LocalCanonicalRef
+
         k = Knowledge(
             id="gcn_ok",
             type=KnowledgeType.CLAIM,
@@ -204,8 +203,10 @@ class TestStrategyValidation:
             knowledges=[_claim("lcn_a"), _claim("lcn_b")],
             strategies=[
                 Strategy(
-                    scope="local", type="noisy_and",
-                    premises=["lcn_a"], conclusion="lcn_b",
+                    scope="local",
+                    type="noisy_and",
+                    premises=["lcn_a"],
+                    conclusion="lcn_b",
                     background=["lcn_nonexistent"],
                 )
             ],
@@ -216,12 +217,15 @@ class TestStrategyValidation:
 
     def test_global_strategy_rejects_steps(self):
         from gaia.gaia_ir import Step
+
         g = _global_graph(
             knowledges=[_claim("gcn_a"), _claim("gcn_b")],
             strategies=[
                 Strategy(
-                    scope="global", type="infer",
-                    premises=["gcn_a"], conclusion="gcn_b",
+                    scope="global",
+                    type="infer",
+                    premises=["gcn_a"],
+                    conclusion="gcn_b",
                     steps=[Step(reasoning="should not be here")],
                 )
             ],
@@ -236,8 +240,10 @@ class TestStrategyValidation:
             strategies=[
                 Strategy(
                     strategy_id="gcs_wrong",
-                    scope="local", type="infer",
-                    premises=["lcn_a"], conclusion="lcn_b",
+                    scope="local",
+                    type="infer",
+                    premises=["lcn_a"],
+                    conclusion="lcn_b",
                 )
             ],
         )
@@ -252,10 +258,14 @@ class TestCompositeStrategyValidation:
             knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_c")],
             strategies=[
                 CompositeStrategy(
-                    scope="local", type="abduction",
-                    premises=["lcn_a"], conclusion="lcn_c",
+                    scope="local",
+                    type="abduction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
                     sub_strategies=[
-                        Strategy(scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b"),
+                        Strategy(
+                            scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b"
+                        ),
                     ],
                 )
             ],
@@ -268,10 +278,17 @@ class TestCompositeStrategyValidation:
             knowledges=[_claim("lcn_a"), _claim("lcn_c")],
             strategies=[
                 CompositeStrategy(
-                    scope="local", type="induction",
-                    premises=["lcn_a"], conclusion="lcn_c",
+                    scope="local",
+                    type="induction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
                     sub_strategies=[
-                        Strategy(scope="local", type="noisy_and", premises=["lcn_missing"], conclusion="lcn_c"),
+                        Strategy(
+                            scope="local",
+                            type="noisy_and",
+                            premises=["lcn_missing"],
+                            conclusion="lcn_c",
+                        ),
                     ],
                 )
             ],
@@ -286,12 +303,24 @@ class TestFormalStrategyValidation:
             knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_m"), _claim("lcn_c")],
             strategies=[
                 FormalStrategy(
-                    scope="local", type="deduction",
-                    premises=["lcn_a", "lcn_b"], conclusion="lcn_c",
-                    formal_expr=FormalExpr(operators=[
-                        Operator(operator="conjunction", variables=["lcn_a", "lcn_b", "lcn_m"], conclusion="lcn_m"),
-                        Operator(operator="implication", variables=["lcn_m", "lcn_c"], conclusion="lcn_c"),
-                    ]),
+                    scope="local",
+                    type="deduction",
+                    premises=["lcn_a", "lcn_b"],
+                    conclusion="lcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="conjunction",
+                                variables=["lcn_a", "lcn_b", "lcn_m"],
+                                conclusion="lcn_m",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_m", "lcn_c"],
+                                conclusion="lcn_c",
+                            ),
+                        ]
+                    ),
                 )
             ],
         )
@@ -303,11 +332,19 @@ class TestFormalStrategyValidation:
             knowledges=[_claim("lcn_a"), _claim("lcn_c")],
             strategies=[
                 FormalStrategy(
-                    scope="local", type="deduction",
-                    premises=["lcn_a"], conclusion="lcn_c",
-                    formal_expr=FormalExpr(operators=[
-                        Operator(operator="implication", variables=["lcn_missing", "lcn_c"], conclusion="lcn_c"),
-                    ]),
+                    scope="local",
+                    type="deduction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_missing", "lcn_c"],
+                                conclusion="lcn_c",
+                            ),
+                        ]
+                    ),
                 )
             ],
         )
@@ -379,6 +416,7 @@ class TestParameterizationValidation:
 
     def test_complete_parameterization(self):
         from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
         g = self._graph()
         sid = g.strategies[0].strategy_id
         r = validate_parameterization(
@@ -388,20 +426,25 @@ class TestParameterizationValidation:
                 PriorRecord(gcn_id="gcn_b", value=0.7, source_id="s"),
             ],
             strategy_params=[
-                StrategyParamRecord(strategy_id=sid, conditional_probabilities=[0.85], source_id="s"),
+                StrategyParamRecord(
+                    strategy_id=sid, conditional_probabilities=[0.85], source_id="s"
+                ),
             ],
         )
         assert r.valid
 
     def test_missing_prior(self):
         from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
         g = self._graph()
         sid = g.strategies[0].strategy_id
         r = validate_parameterization(
             g,
             priors=[PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s")],
             strategy_params=[
-                StrategyParamRecord(strategy_id=sid, conditional_probabilities=[0.85], source_id="s"),
+                StrategyParamRecord(
+                    strategy_id=sid, conditional_probabilities=[0.85], source_id="s"
+                ),
             ],
         )
         assert not r.valid
@@ -409,6 +452,7 @@ class TestParameterizationValidation:
 
     def test_missing_strategy_param(self):
         from gaia.gaia_ir import PriorRecord
+
         g = self._graph()
         r = validate_parameterization(
             g,
@@ -424,6 +468,7 @@ class TestParameterizationValidation:
     def test_setting_does_not_need_prior(self):
         """Settings don't carry probability — no PriorRecord needed."""
         from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
         g = self._graph()
         sid = g.strategies[0].strategy_id
         r = validate_parameterization(
@@ -433,14 +478,17 @@ class TestParameterizationValidation:
                 PriorRecord(gcn_id="gcn_b", value=0.7, source_id="s"),
             ],
             strategy_params=[
-                StrategyParamRecord(strategy_id=sid, conditional_probabilities=[0.85], source_id="s"),
+                StrategyParamRecord(
+                    strategy_id=sid, conditional_probabilities=[0.85], source_id="s"
+                ),
             ],
         )
         assert r.valid  # gcn_s (setting) doesn't need a prior
 
     def test_cromwell_bounds_on_priors(self):
         """PriorRecord auto-clamps, so raw values within bounds should pass."""
-        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+        from gaia.gaia_ir import PriorRecord
+
         g = _global_graph(
             knowledges=[_claim("gcn_a")],
             strategies=[],
@@ -454,6 +502,7 @@ class TestParameterizationValidation:
 
     def test_dangling_prior_warning(self):
         from gaia.gaia_ir import PriorRecord
+
         g = _global_graph(knowledges=[_claim("gcn_a")])
         r = validate_parameterization(
             g,
@@ -468,12 +517,15 @@ class TestParameterizationValidation:
 
     def test_dangling_strategy_param_warning(self):
         from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
         g = _global_graph(knowledges=[_claim("gcn_a")])
         r = validate_parameterization(
             g,
             priors=[PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s")],
             strategy_params=[
-                StrategyParamRecord(strategy_id="gcs_ghost", conditional_probabilities=[0.5], source_id="s"),
+                StrategyParamRecord(
+                    strategy_id="gcs_ghost", conditional_probabilities=[0.5], source_id="s"
+                ),
             ],
         )
         assert r.valid
@@ -492,17 +544,24 @@ class TestParameterizationValidation:
 class TestBindingValidation:
     def test_valid_bindings(self):
         from gaia.gaia_ir import CanonicalBinding, BindingDecision
+
         local = _local_graph(knowledges=[_claim("lcn_a"), _claim("lcn_b")])
         global_ = _global_graph(knowledges=[_claim("gcn_x"), _claim("gcn_y")])
         bindings = [
             CanonicalBinding(
-                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
-                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                local_canonical_id="lcn_a",
+                global_canonical_id="gcn_x",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.MATCH_EXISTING,
                 reason="similarity 0.95",
             ),
             CanonicalBinding(
-                local_canonical_id="lcn_b", global_canonical_id="gcn_y",
-                package_id="pkg", version="1", decision=BindingDecision.CREATE_NEW,
+                local_canonical_id="lcn_b",
+                global_canonical_id="gcn_y",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.CREATE_NEW,
                 reason="no match",
             ),
         ]
@@ -511,12 +570,16 @@ class TestBindingValidation:
 
     def test_missing_binding(self):
         from gaia.gaia_ir import CanonicalBinding, BindingDecision
+
         local = _local_graph(knowledges=[_claim("lcn_a"), _claim("lcn_b")])
         global_ = _global_graph(knowledges=[_claim("gcn_x")])
         bindings = [
             CanonicalBinding(
-                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
-                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                local_canonical_id="lcn_a",
+                global_canonical_id="gcn_x",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.MATCH_EXISTING,
                 reason="match",
             ),
         ]
@@ -526,17 +589,24 @@ class TestBindingValidation:
 
     def test_duplicate_binding(self):
         from gaia.gaia_ir import CanonicalBinding, BindingDecision
+
         local = _local_graph(knowledges=[_claim("lcn_a")])
         global_ = _global_graph(knowledges=[_claim("gcn_x"), _claim("gcn_y")])
         bindings = [
             CanonicalBinding(
-                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
-                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                local_canonical_id="lcn_a",
+                global_canonical_id="gcn_x",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.MATCH_EXISTING,
                 reason="first",
             ),
             CanonicalBinding(
-                local_canonical_id="lcn_a", global_canonical_id="gcn_y",
-                package_id="pkg", version="1", decision=BindingDecision.CREATE_NEW,
+                local_canonical_id="lcn_a",
+                global_canonical_id="gcn_y",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.CREATE_NEW,
                 reason="second",
             ),
         ]
@@ -546,17 +616,24 @@ class TestBindingValidation:
 
     def test_binding_dangling_local(self):
         from gaia.gaia_ir import CanonicalBinding, BindingDecision
+
         local = _local_graph(knowledges=[_claim("lcn_a")])
         global_ = _global_graph(knowledges=[_claim("gcn_x")])
         bindings = [
             CanonicalBinding(
-                local_canonical_id="lcn_a", global_canonical_id="gcn_x",
-                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                local_canonical_id="lcn_a",
+                global_canonical_id="gcn_x",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.MATCH_EXISTING,
                 reason="ok",
             ),
             CanonicalBinding(
-                local_canonical_id="lcn_ghost", global_canonical_id="gcn_x",
-                package_id="pkg", version="1", decision=BindingDecision.MATCH_EXISTING,
+                local_canonical_id="lcn_ghost",
+                global_canonical_id="gcn_x",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.MATCH_EXISTING,
                 reason="dangling",
             ),
         ]
@@ -566,12 +643,16 @@ class TestBindingValidation:
 
     def test_binding_dangling_global(self):
         from gaia.gaia_ir import CanonicalBinding, BindingDecision
+
         local = _local_graph(knowledges=[_claim("lcn_a")])
         global_ = _global_graph(knowledges=[])
         bindings = [
             CanonicalBinding(
-                local_canonical_id="lcn_a", global_canonical_id="gcn_ghost",
-                package_id="pkg", version="1", decision=BindingDecision.CREATE_NEW,
+                local_canonical_id="lcn_a",
+                global_canonical_id="gcn_ghost",
+                package_id="pkg",
+                version="1",
+                decision=BindingDecision.CREATE_NEW,
                 reason="dangling global",
             ),
         ]


### PR DESCRIPTION
## Summary

Implements #233 — Gaia IR validator for structural validation on every IR update.

Six validation layers, matching the spec in `docs/foundations/gaia-ir/`:

1. **Knowledge**: ID prefix, uniqueness, type, claim content completeness
2. **Operator**: reference completeness, variables must be claims
3. **Strategy**: premise/conclusion refs + types, self-loop, no steps at global, CompositeStrategy/FormalStrategy recursion
4. **Graph-level**: scope consistency (lcn_/gcn_ prefix), ir_hash consistency
5. **Parameterization**: every claim has PriorRecord, every Strategy has StrategyParamRecord, Cromwell bounds
6. **CanonicalBinding**: every local Knowledge has exactly one binding, reference validity

Public API:
```python
validate_local_graph(graph) -> ValidationResult
validate_global_graph(graph) -> ValidationResult
validate_parameterization(graph, priors, strategy_params) -> ValidationResult
validate_bindings(bindings, local_graph, global_graph) -> ValidationResult
```

Depends on #255 (gaia-ir data model rewrite).

## Test plan
- [x] 42 tests covering all validation layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #233