### PR TITLE
add exact enumeration and BP comparison   scripts for coarse graph

### DIFF
--- a/tests/galileo_exact_simple.py
+++ b/tests/galileo_exact_simple.py
@@ -1,0 +1,125 @@
+"""Galileo 落体 — 精确枚举计算 belief.
+
+不依赖任何库，纯 Python 实现。
+枚举所有 2^10 = 1024 种状态，直接算每个命题为真的概率。
+"""
+
+from itertools import product
+
+# ============================================================
+# 1. 定义变量（10 个二值命题）
+# ============================================================
+VARS = ["A", "V", "O_daily", "O_media", "O_air", "T1", "T2", "A_vac", "S_vac", "E"]
+
+# 先验：观测到的事实 = 0.95，未知命题 = 0.5
+PRIOR = {
+    "A": 0.5,  # 重者更快（待定）
+    "V": 0.5,  # 真空等速（待定）
+    "O_daily": 0.95,  # 日常观测（已观测）
+    "O_media": 0.95,  # 介质观测（已观测）
+    "O_air": 0.95,  # 空气观测（已观测）
+    "T1": 0.5,  # 拖拽论证（待定）
+    "T2": 0.5,  # 总重论证（待定）
+    "A_vac": 0.5,  # 真空中重者更快（待定）
+    "S_vac": 0.95,  # 真空=零密度（定义性）
+    "E": 0.95,  # 斜面实验（已观测）
+}
+
+
+# ============================================================
+# 2. 定义因子（8 条规则）
+# ============================================================
+# 每个因子是一个函数：接收所有变量的取值，返回一个分数
+
+
+def ent(s, premises, conclusion, p=0.99):
+    """Entailment: 前提全真时，结论应为真。"""
+    print("premises, conclusion", premises, conclusion)
+    if all(s[v] == 1 for v in premises):
+        return p if s[conclusion] == 1 else (1 - p)
+    return 1.0
+
+
+def contradiction(s, a, b, p=0.95):
+    """Contradiction: 两个不能同时为真。"""
+    if s[a] == 1 and s[b] == 1:
+        return 1 - p  # 惩罚
+    return 1.0
+
+
+FACTORS = [
+    lambda s: ent(s, ["O_daily"], "A", p=0.70),  # W1: 日常观测→重者更快
+    lambda s: ent(s, ["A"], "T1"),  # A→T1 (蕴含)
+    lambda s: ent(s, ["A"], "T2"),  # A→T2 (蕴含)
+    lambda s: contradiction(s, "T1", "T2"),  # T1⊗T2 (矛盾)
+    lambda s: ent(s, ["A", "S_vac"], "A_vac"),  # A+S_vac→A_vac (蕴含)
+    lambda s: contradiction(s, "A_vac", "V"),  # A_vac⊗V (矛盾)
+    lambda s: ent(s, ["O_media", "O_air"], "V", p=0.70),  # W2: 介质观测→真空等速
+    lambda s: ent(s, ["E"], "V", p=0.75),  # W3: 斜面实验→等速下落
+]
+
+
+# ============================================================
+# 3. 对每个状态打分
+# ============================================================
+# 一个"状态"就是 10 个变量各取 0 或 1 的一种组合
+# 分数 = 所有变量的先验 × 所有因子的打分
+
+scores = {}  # state_tuple -> score
+
+for vals in product([0, 1], repeat=len(VARS)):
+    print("vals", vals)
+    state = dict(zip(VARS, vals))
+    print("state", state)
+
+    # 先验贡献
+    score = 1.0
+    for var in VARS:
+        pi = PRIOR[var]
+        score *= pi if state[var] == 1 else (1 - pi)
+
+    # 因子贡献
+    for factor in FACTORS:
+        score *= factor(state)
+
+    scores[vals] = score
+
+# ============================================================
+# 4. 归一化 → 概率分布
+# ============================================================
+Z = sum(scores.values())  # 配分函数
+
+# ============================================================
+# 5. 算边缘概率（belief）
+# ============================================================
+# 对每个变量，把它=1 的所有状态的概率加起来
+
+belief = {}
+for vi, var in enumerate(VARS):
+    print("vi, var", vi, var)
+    total = 0.0
+    for vals, score in scores.items():
+        if vals[vi] == 1:
+            total += score / Z
+    belief[var] = total
+
+# ============================================================
+# 6. 输出
+# ============================================================
+print(f"总状态数: {len(scores)}")
+print(f"配分函数 Z = {Z:.6e}")
+print()
+print(f"{'变量':<15} {'先验':>8} {'Belief':>10}")
+print("-" * 35)
+for var in VARS:
+    arrow = (
+        "↑"
+        if belief[var] > PRIOR[var] + 0.01
+        else ("↓" if belief[var] < PRIOR[var] - 0.01 else "→")
+    )
+    print(f"{var:<15} {PRIOR[var]:>8.3f} {belief[var]:>10.6f}  {arrow}")
+
+print()
+print("关键结论:")
+print(f"  A(重者更快)  = {belief['A']:.4f}  ← 被压到很低")
+print(f"  V(真空等速)  = {belief['V']:.4f}  ← 被推到很高")

--- a/tests/galileo_exact_vs_bp.py
+++ b/tests/galileo_exact_vs_bp.py
@@ -1,0 +1,191 @@
+"""Galileo coarse graph: exact enumeration vs BP.
+
+Enumerate all 2^10 = 1024 states, compute exact marginals,
+and compare with BP results.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np
+from itertools import product as cartesian_product
+
+from libs.inference.factor_graph import FactorGraph
+from libs.inference.bp import BeliefPropagation
+
+# ============================================================
+# Variable IDs (same as galileo_bp_demo.py coarse graph)
+# ============================================================
+A = 1
+V = 2
+O_DAILY = 10
+O_MEDIA = 11
+O_AIR = 12
+T1 = 20
+T2 = 21
+A_VAC = 22
+S_VAC = 41
+E_EXP = 83
+
+ALL_VARS = [A, V, O_DAILY, O_MEDIA, O_AIR, T1, T2, A_VAC, S_VAC, E_EXP]
+NAMES = {
+    A: "A(重者更快)",
+    V: "V(真空等速)",
+    O_DAILY: "O_daily",
+    O_MEDIA: "O_media",
+    O_AIR: "O_air",
+    T1: "T₁(拖拽)",
+    T2: "T₂(总重)",
+    A_VAC: "A_vac",
+    S_VAC: "S_vac",
+    E_EXP: "E_θᵢ",
+}
+
+# ============================================================
+# Priors
+# ============================================================
+priors = {
+    A: 0.5,
+    V: 0.5,
+    O_DAILY: 0.95,
+    O_MEDIA: 0.95,
+    O_AIR: 0.95,
+    T1: 0.5,
+    T2: 0.5,
+    A_VAC: 0.5,
+    S_VAC: 0.95,
+    E_EXP: 0.95,
+}
+
+# Cromwell clamp
+EPS = 1e-3
+for k in priors:
+    priors[k] = max(EPS, min(1 - EPS, priors[k]))
+
+# ============================================================
+# Factors (same as coarse graph)
+# ============================================================
+factors = [
+    # (premises, conclusions, p, edge_type)
+    ([O_DAILY], [A], 0.7, "deduction"),  # W1
+    ([A], [T1], 0.99, "deduction"),  # f1: A->T1
+    ([A], [T2], 0.99, "deduction"),  # f2: A->T2
+    ([T1, T2], [], 0.95, "relation_contradiction"),  # T1 ⊗ T2
+    ([A, S_VAC], [A_VAC], 0.99, "deduction"),  # f3: A+S_vac->A_vac
+    ([A_VAC, V], [], 0.95, "relation_contradiction"),  # A_vac ⊗ V
+    ([O_MEDIA, O_AIR], [V], 0.7, "deduction"),  # W2
+    ([E_EXP], [V], 0.75, "deduction"),  # W3
+]
+
+# Cromwell clamp factor probs
+for i, (prem, conc, p, etype) in enumerate(factors):
+    factors[i] = (prem, conc, max(EPS, min(1 - EPS, p)), etype)
+
+
+def evaluate_potential(premises, conclusions, assignment, prob, edge_type):
+    """Same logic as bp.py _evaluate_potential."""
+    if edge_type == "relation_contradiction":
+        all_true = all(assignment[p] == 1 for p in premises)
+        return (1.0 - prob) if all_true else 1.0
+
+    if edge_type == "relation_equivalence":
+        a_val = assignment[premises[0]]
+        b_val = assignment[premises[1]]
+        return prob if a_val == b_val else (1.0 - prob)
+
+    all_premises_true = all(assignment[p] == 1 for p in premises)
+    if not all_premises_true:
+        return 1.0
+
+    pot = 1.0
+    for h in conclusions:
+        h_val = assignment[h]
+        pot *= prob if h_val == 1 else (1.0 - prob)
+    return pot
+
+
+# ============================================================
+# Exact enumeration: 2^10 = 1024 states
+# ============================================================
+n = len(ALL_VARS)
+print(f"Enumerating all 2^{n} = {2**n} states...")
+
+# For each state, compute unnormalized probability
+unnorm = np.zeros(2**n)
+
+for state_idx, vals in enumerate(cartesian_product([0, 1], repeat=n)):
+    assignment = {var: val for var, val in zip(ALL_VARS, vals)}
+
+    # Prior contribution
+    p_state = 1.0
+    for var in ALL_VARS:
+        pi = priors[var]
+        p_state *= pi if assignment[var] == 1 else (1 - pi)
+
+    # Factor contribution
+    for premises, conclusions, prob, edge_type in factors:
+        p_state *= evaluate_potential(premises, conclusions, assignment, prob, edge_type)
+
+    unnorm[state_idx] = p_state
+
+# Normalize
+Z = unnorm.sum()
+prob_dist = unnorm / Z
+
+# Compute exact marginals
+exact_beliefs = {}
+for vi, var in enumerate(ALL_VARS):
+    # Sum over all states where var=1
+    marginal = 0.0
+    for state_idx, vals in enumerate(cartesian_product([0, 1], repeat=n)):
+        if list(vals)[vi] == 1:
+            marginal += prob_dist[state_idx]
+    exact_beliefs[var] = marginal
+
+# ============================================================
+# BP computation (same graph)
+# ============================================================
+fg = FactorGraph()
+for var in ALL_VARS:
+    fg.add_variable(var, priors[var])
+
+for fid, (premises, conclusions, prob, edge_type) in enumerate(factors):
+    fg.add_factor(fid, premises, conclusions, prob, edge_type)
+
+bp = BeliefPropagation(damping=0.5, max_iterations=200, convergence_threshold=1e-8)
+bp_beliefs, diag = bp.run_with_diagnostics(fg)
+
+print("diag", diag)
+
+# ============================================================
+# Compare
+# ============================================================
+print()
+print("=" * 75)
+print(f"{'Variable':<20} {'Exact':>10} {'BP':>10} {'Diff':>10} {'Match?':>8}")
+print("=" * 75)
+
+all_match = True
+for var in ALL_VARS:
+    exact = exact_beliefs[var]
+    bp_val = bp_beliefs[var]
+    diff = abs(exact - bp_val)
+    match = diff < 0.01
+    if not match:
+        all_match = False
+    print(
+        f"{NAMES[var]:<20} {exact:>10.6f} {bp_val:>10.6f} {diff:>10.6f} {'✓' if match else '✗':>8}"
+    )
+
+print("=" * 75)
+print(f"BP converged: {diag.converged} | Iterations: {diag.iterations_run}")
+print(f"Z (partition function): {Z:.6e}")
+print()
+
+if all_match:
+    print("✓ All beliefs match within 0.01 tolerance!")
+else:
+    print("✗ Some beliefs differ — expected for loopy BP on graphs with cycles.")
+    print("  (BP is exact on trees, approximate on graphs with loops)")


### PR DESCRIPTION
  ## Summary
  - Add galileo_exact_simple.py: pure Python exact enumeration of all
  2^10 states
  - Add galileo_exact_vs_bp.py: compares exact marginals with loopy BP
  results, validates BP accuracy

  ## Test plan
  - [x] `uv run python tests/galileo_exact_vs_bp.py` runs successfully