### PR TITLE
fix(gaia-ir): validate local content_hash consistency

### DIFF
--- a/gaia/gaia_ir/knowledge.py
+++ b/gaia/gaia_ir/knowledge.py
@@ -92,9 +92,18 @@ class Knowledge(BaseModel):
 
     @model_validator(mode="after")
     def _compute_derived_fields(self) -> Knowledge:
-        # Auto-compute content_hash when content is available
-        if self.content_hash is None and self.content is not None:
-            self.content_hash = _compute_content_hash(self.type, self.content, self.parameters)
+        # Local content_hash is a derived fingerprint and must stay consistent
+        # with the node's actual content.
+        if self.content is not None:
+            expected_content_hash = _compute_content_hash(self.type, self.content, self.parameters)
+            if self.package_id is not None:
+                if self.content_hash is not None and self.content_hash != expected_content_hash:
+                    raise ValueError(
+                        "local content_hash must match the derived content fingerprint"
+                    )
+                self.content_hash = expected_content_hash
+            elif self.content_hash is None:
+                self.content_hash = expected_content_hash
 
         # Auto-compute ID for local nodes
         if self.id is None:

--- a/tests/gaia_ir/test_knowledge.py
+++ b/tests/gaia_ir/test_knowledge.py
@@ -47,6 +47,15 @@ class TestKnowledgeCreation:
         assert k.content_hash is not None
         assert len(k.content_hash) == 64  # full SHA-256 hex
 
+    def test_local_explicit_wrong_content_hash_rejected(self):
+        with pytest.raises(ValueError, match="content_hash"):
+            Knowledge(
+                type="claim",
+                content="test",
+                package_id="pkg",
+                content_hash="0" * 64,
+            )
+
     def test_different_content_different_content_hash(self):
         k1 = Knowledge(type="claim", content="A", package_id="pkg")
         k2 = Knowledge(type="claim", content="B", package_id="pkg")


### PR DESCRIPTION
## Summary

- reject mismatched explicit `content_hash` on local `Knowledge` nodes
- keep auto-derived local `content_hash` behavior
- preserve existing global explicit `content_hash` behavior
- add regression coverage for bogus local `content_hash` input

Closes #262

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pytest -q tests/gaia_ir/test_knowledge.py`