### PR TITLE
fix: include gaia package in setuptools find config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["libs*", "services*", "cli*"]
+include = ["gaia*", "libs*", "services*", "cli*"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary
- `gaia/` directory was missing from `[tool.setuptools.packages.find]` include list in `pyproject.toml`
- This caused `import gaia` to fail when the package was installed by downstream repos
- Added `"gaia*"` to the include list to fix the issue

## Test plan
- [x] Verified `import gaia` works from outside the project directory after `pip install -e .`
- [x] Verified subpackage imports (`gaia.gaia_ir`, `gaia.bp`) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)