### PR TITLE
refactor(gaia-ir): align code models with restructured design docs

### DIFF
--- a/gaia/gaia_ir/graphs.py
+++ b/gaia/gaia_ir/graphs.py
@@ -33,13 +33,11 @@ def _canonicalize_knowledge_dump(data: dict[str, Any]) -> dict[str, Any]:
 def _canonicalize_operator_dump(data: dict[str, Any]) -> dict[str, Any]:
     canonical = dict(data)
     variables = list(canonical.get("variables", []))
-    conclusion = canonical.get("conclusion")
     operator = canonical.get("operator")
-    if operator in {"equivalence", "contradiction", "complement", "disjunction"}:
+    # §2.4: variables are inputs only (conclusion is separate), sort for canonical order
+    if operator in {"equivalence", "contradiction", "complement", "disjunction", "conjunction"}:
         canonical["variables"] = sorted(variables)
-    elif operator == "conjunction" and conclusion is not None:
-        premises = sorted(v for v in variables if v != conclusion)
-        canonical["variables"] = premises + [conclusion]
+    # implication: single variable, no sorting needed
     return canonical
 
 
@@ -49,10 +47,8 @@ def _canonicalize_strategy_dump(data: dict[str, Any]) -> dict[str, Any]:
     if canonical.get("background") is not None:
         canonical["background"] = sorted(canonical["background"])
     if canonical.get("sub_strategies") is not None:
-        canonical["sub_strategies"] = sorted(
-            [_canonicalize_strategy_dump(sub) for sub in canonical["sub_strategies"]],
-            key=_json_sort_key,
-        )
+        # sub_strategies are now string IDs, not embedded dicts
+        canonical["sub_strategies"] = sorted(canonical["sub_strategies"])
     if canonical.get("formal_expr") is not None:
         formal_expr = dict(canonical["formal_expr"])
         formal_expr["operators"] = sorted(

--- a/gaia/gaia_ir/operator.py
+++ b/gaia/gaia_ir/operator.py
@@ -71,9 +71,7 @@ class Operator(BaseModel):
 
         elif self.operator == OperatorType.CONJUNCTION:
             if len(self.variables) < 2:
-                raise ValueError(
-                    "operator=conjunction requires at least 2 variables (inputs)"
-                )
+                raise ValueError("operator=conjunction requires at least 2 variables (inputs)")
 
         elif self.operator in (
             OperatorType.EQUIVALENCE,
@@ -81,14 +79,10 @@ class Operator(BaseModel):
             OperatorType.COMPLEMENT,
         ):
             if len(self.variables) != 2:
-                raise ValueError(
-                    f"operator={self.operator} requires exactly 2 variables"
-                )
+                raise ValueError(f"operator={self.operator} requires exactly 2 variables")
 
         elif self.operator == OperatorType.DISJUNCTION:
             if len(self.variables) < 2:
-                raise ValueError(
-                    "operator=disjunction requires at least 2 variables"
-                )
+                raise ValueError("operator=disjunction requires at least 2 variables")
 
         return self

--- a/gaia/gaia_ir/operator.py
+++ b/gaia/gaia_ir/operator.py
@@ -33,8 +33,8 @@ class Operator(BaseModel):
     scope: str | None = None  # "local" | "global" (None when embedded in FormalExpr)
 
     operator: OperatorType
-    variables: list[str]  # ordered Knowledge IDs
-    conclusion: str | None = None  # directed operators only
+    variables: list[str]  # ordered input Knowledge IDs (conclusion never appears here)
+    conclusion: str  # output Knowledge ID (separate from variables for all types)
 
     metadata: dict[str, Any] | None = None
 
@@ -57,44 +57,38 @@ class Operator(BaseModel):
         ):
             raise ValueError("global operators must use an operator_id with gco_ prefix")
 
-        # §2.4: conclusion rules by operator type
-        if self.operator in (
+        # §2.4: conclusion must NEVER appear in variables (inputs-only separation)
+        if self.conclusion in self.variables:
+            raise ValueError(
+                f"conclusion '{self.conclusion}' must not appear in variables "
+                f"(variables are inputs only)"
+            )
+
+        # §2.4: arity constraints per operator type
+        if self.operator == OperatorType.IMPLICATION:
+            if len(self.variables) != 1:
+                raise ValueError("operator=implication requires exactly 1 variable (input)")
+
+        elif self.operator == OperatorType.CONJUNCTION:
+            if len(self.variables) < 2:
+                raise ValueError(
+                    "operator=conjunction requires at least 2 variables (inputs)"
+                )
+
+        elif self.operator in (
             OperatorType.EQUIVALENCE,
             OperatorType.CONTRADICTION,
             OperatorType.COMPLEMENT,
-            OperatorType.DISJUNCTION,
         ):
-            if self.conclusion is not None:
-                raise ValueError(f"operator={self.operator} must have conclusion=None")
-
-        if self.operator == OperatorType.IMPLICATION:
-            if self.conclusion is None:
-                raise ValueError("operator=implication requires conclusion")
             if len(self.variables) != 2:
-                raise ValueError("operator=implication requires exactly 2 variables")
-            if self.conclusion not in self.variables:
-                raise ValueError(f"conclusion {self.conclusion} must appear in variables")
-            if self.conclusion != self.variables[-1]:
-                raise ValueError("operator=implication requires conclusion=variables[-1]")
+                raise ValueError(
+                    f"operator={self.operator} requires exactly 2 variables"
+                )
 
-        if self.operator == OperatorType.CONJUNCTION:
-            if self.conclusion is None:
-                raise ValueError("operator=conjunction requires conclusion (the conjunct M)")
-            if self.conclusion not in self.variables:
-                raise ValueError(f"conclusion {self.conclusion} must appear in variables")
-            if self.conclusion != self.variables[-1]:
-                raise ValueError("operator=conjunction requires conclusion=variables[-1]")
-
-        if self.operator in (OperatorType.EQUIVALENCE, OperatorType.COMPLEMENT):
-            if len(self.variables) != 2:
-                raise ValueError(f"operator={self.operator} requires exactly 2 variables")
-
-        # conclusion must be in variables (catch-all for future types)
-        if (
-            self.conclusion is not None
-            and self.operator not in (OperatorType.IMPLICATION, OperatorType.CONJUNCTION)
-            and self.conclusion not in self.variables
-        ):
-            raise ValueError(f"conclusion {self.conclusion} must appear in variables")
+        elif self.operator == OperatorType.DISJUNCTION:
+            if len(self.variables) < 2:
+                raise ValueError(
+                    "operator=disjunction requires at least 2 variables"
+                )
 
         return self

--- a/gaia/gaia_ir/parameterization.py
+++ b/gaia/gaia_ir/parameterization.py
@@ -39,11 +39,12 @@ class PriorRecord(BaseModel):
 class StrategyParamRecord(BaseModel):
     """Conditional probability parameters for a global Strategy.
 
-    Parameter count depends on Strategy type:
+    Only parameterized strategies need StrategyParamRecord:
     - infer: 2^k values (full CPT, one per premise truth-value combination)
     - noisy_and: 1 value (P(conclusion=true | all premises=true))
-    - named strategies: 1 value (folded conditional probability)
-    - toolcall/proof: defined separately
+
+    FormalStrategy types (deduction, abduction, etc.) derive behavior from
+    FormalExpr + claim priors — no independent StrategyParamRecord.
 
     All values are Cromwell-clamped.
     """

--- a/gaia/gaia_ir/strategy.py
+++ b/gaia/gaia_ir/strategy.py
@@ -76,13 +76,6 @@ def _compute_strategy_id(
     return f"{prefix}{_sha256_hex(payload)}"
 
 
-_LEAF_STRATEGY_TYPES = frozenset(
-    {
-        StrategyType.INFER,
-        StrategyType.NOISY_AND,
-    }
-)
-
 _FORMAL_STRATEGY_TYPES = frozenset(
     {
         StrategyType.DEDUCTION,

--- a/gaia/gaia_ir/strategy.py
+++ b/gaia/gaia_ir/strategy.py
@@ -99,16 +99,21 @@ _FORMAL_STRATEGY_TYPES = frozenset(
 
 
 def _canonical_formal_expr(formal_expr: FormalExpr) -> str:
-    """Canonical JSON representation of a FormalExpr for hashing."""
+    """Canonical JSON representation of a FormalExpr for hashing.
+
+    Operators are sorted by their JSON representation to ensure
+    order-independent deterministic serialization (spec §3.2).
+    """
     ops = []
     for op in formal_expr.operators:
         ops.append(
             {
                 "operator": op.operator.value,
-                "variables": op.variables,
+                "variables": sorted(op.variables),
                 "conclusion": op.conclusion,
             }
         )
+    ops.sort(key=lambda x: json.dumps(x, sort_keys=True))
     return json.dumps(ops, sort_keys=True, separators=(",", ":"))
 
 

--- a/gaia/gaia_ir/strategy.py
+++ b/gaia/gaia_ir/strategy.py
@@ -4,13 +4,14 @@ Implements docs/foundations/gaia-ir/gaia-ir.md §3.
 
 Three forms (class hierarchy):
 - Strategy: leaf reasoning (single ↝)
-- CompositeStrategy: contains sub-strategies, supports recursive nesting
+- CompositeStrategy: contains sub-strategies (by reference), supports recursive nesting
 - FormalStrategy: contains deterministic Operator expansion (FormalExpr)
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 from enum import StrEnum
 from typing import Any
 
@@ -32,15 +33,11 @@ class StrategyType(StrEnum):
     MATHEMATICAL_INDUCTION = "mathematical_induction"
     CASE_ANALYSIS = "case_analysis"
 
-    # Named strategies — non-deterministic (CompositeStrategy with FormalStrategy parts)
+    # Named strategies — non-deterministic (FormalStrategy)
     ABDUCTION = "abduction"
     INDUCTION = "induction"
     ANALOGY = "analogy"
     EXTRAPOLATION = "extrapolation"
-
-    # Special
-    TOOLCALL = "toolcall"
-    PROOF = "proof"
 
 
 class Step(BaseModel):
@@ -67,11 +64,15 @@ def _sha256_hex(data: str, length: int = 16) -> str:
 
 
 def _compute_strategy_id(
-    scope: str, type_: str, premises: list[str], conclusion: str | None
+    scope: str,
+    type_: str,
+    premises: list[str],
+    conclusion: str | None,
+    structure_hash: str = "",
 ) -> str:
-    """Deterministic strategy ID: {lcs_|gcs_}_{sha256(scope + type + sorted(premises) + conclusion)[:16]}."""
+    """Deterministic strategy ID: {lcs_|gcs_}_{sha256(scope + type + sorted(premises) + conclusion + structure_hash)[:16]}."""
     prefix = "lcs_" if scope == "local" else "gcs_"
-    payload = f"{scope}|{type_}|{sorted(premises)}|{conclusion}"
+    payload = f"{scope}|{type_}|{sorted(premises)}|{conclusion}|{structure_hash}"
     return f"{prefix}{_sha256_hex(payload)}"
 
 
@@ -79,17 +80,6 @@ _LEAF_STRATEGY_TYPES = frozenset(
     {
         StrategyType.INFER,
         StrategyType.NOISY_AND,
-        StrategyType.TOOLCALL,
-        StrategyType.PROOF,
-    }
-)
-
-_COMPOSITE_STRATEGY_TYPES = frozenset(
-    {
-        StrategyType.ABDUCTION,
-        StrategyType.INDUCTION,
-        StrategyType.ANALOGY,
-        StrategyType.EXTRAPOLATION,
     }
 )
 
@@ -100,14 +90,32 @@ _FORMAL_STRATEGY_TYPES = frozenset(
         StrategyType.ELIMINATION,
         StrategyType.MATHEMATICAL_INDUCTION,
         StrategyType.CASE_ANALYSIS,
+        StrategyType.ABDUCTION,
+        StrategyType.INDUCTION,
+        StrategyType.ANALOGY,
+        StrategyType.EXTRAPOLATION,
     }
 )
+
+
+def _canonical_formal_expr(formal_expr: FormalExpr) -> str:
+    """Canonical JSON representation of a FormalExpr for hashing."""
+    ops = []
+    for op in formal_expr.operators:
+        ops.append(
+            {
+                "operator": op.operator.value,
+                "variables": op.variables,
+                "conclusion": op.conclusion,
+            }
+        )
+    return json.dumps(ops, sort_keys=True, separators=(",", ":"))
 
 
 class Strategy(BaseModel):
     """Base strategy — leaf reasoning (single ↝).
 
-    Can be instantiated directly for basic strategies (infer, noisy_and, toolcall, proof).
+    Can be instantiated directly for basic strategies (infer, noisy_and).
     """
 
     strategy_id: str | None = None
@@ -124,6 +132,13 @@ class Strategy(BaseModel):
 
     # traceability
     metadata: dict[str, Any] | None = None
+
+    def _structure_hash(self) -> str:
+        """Compute the structure hash component for strategy ID.
+
+        Leaf strategies have empty structure hash.
+        """
+        return ""
 
     @model_validator(mode="after")
     def _compute_id_and_validate(self) -> Strategy:
@@ -142,7 +157,11 @@ class Strategy(BaseModel):
 
         if self.strategy_id is None:
             self.strategy_id = _compute_strategy_id(
-                self.scope, self.type, self.premises, self.conclusion
+                self.scope,
+                self.type,
+                self.premises,
+                self.conclusion,
+                structure_hash=self._structure_hash(),
             )
         return self
 
@@ -155,34 +174,39 @@ class Strategy(BaseModel):
 
 
 class CompositeStrategy(Strategy):
-    """Strategy with sub-strategies, supporting recursive nesting.
+    """Strategy with sub-strategies (by reference), supporting recursive nesting.
 
-    Used for non-deterministic named strategies (abduction, induction, analogy,
-    extrapolation) and for merging duplicate reasoning chains during canonicalization.
+    Generic container — any StrategyType is allowed. Sub-strategies are
+    referenced by strategy_id strings, not embedded objects.
     """
 
-    sub_strategies: list[Strategy]
+    sub_strategies: list[str]  # strategy_id references
+
+    def _structure_hash(self) -> str:
+        """SHA-256 of sorted sub_strategy IDs."""
+        payload = str(sorted(self.sub_strategies))
+        return _sha256_hex(payload)
 
     @model_validator(mode="after")
     def _validate_sub_strategies(self) -> CompositeStrategy:
         if not self.sub_strategies:
             raise ValueError("CompositeStrategy requires at least one sub_strategy")
-        if self.type not in _COMPOSITE_STRATEGY_TYPES:
-            allowed = ", ".join(sorted(t.value for t in _COMPOSITE_STRATEGY_TYPES))
-            raise ValueError(
-                f"CompositeStrategy form only allows types: {allowed}; got {self.type.value}"
-            )
         return self
 
 
 class FormalStrategy(Strategy):
     """Strategy with deterministic Operator expansion.
 
-    Used for deterministic named strategies (deduction, reductio, elimination,
-    mathematical_induction, case_analysis) and as sub-parts of CompositeStrategy.
+    Used for named strategies (deduction, reductio, elimination,
+    mathematical_induction, case_analysis, abduction, induction, analogy,
+    extrapolation) and as sub-parts of CompositeStrategy.
     """
 
     formal_expr: FormalExpr
+
+    def _structure_hash(self) -> str:
+        """SHA-256 of canonical formal expression."""
+        return _sha256_hex(_canonical_formal_expr(self.formal_expr))
 
     @model_validator(mode="after")
     def _validate_formal_expr(self) -> FormalStrategy:

--- a/gaia/gaia_ir/strategy.py
+++ b/gaia/gaia_ir/strategy.py
@@ -170,12 +170,8 @@ class Strategy(BaseModel):
             )
         return self
 
-    @model_validator(mode="after")
-    def _validate_leaf_form(self) -> Strategy:
-        if self.__class__ is Strategy and self.type not in _LEAF_STRATEGY_TYPES:
-            allowed = ", ".join(sorted(t.value for t in _LEAF_STRATEGY_TYPES))
-            raise ValueError(f"Strategy form only allows types: {allowed}; got {self.type.value}")
-        return self
+    # No leaf type restriction — per §3.5.1, named strategies (deduction, abduction,
+    # etc.) can exist as leaf Strategy before being formalized into FormalStrategy.
 
 
 class CompositeStrategy(Strategy):

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -325,13 +325,14 @@ def _validate_formal_expr_closure(
 
 def _validate_private_node_isolation(
     strategies: list[Strategy],
+    operators: list[Operator],
     result: ValidationResult,
 ) -> None:
-    """Validate that internal FormalExpr nodes are not referenced by other strategies.
+    """Validate that internal FormalExpr nodes are not referenced externally.
 
     A 'private' node is an operator conclusion in a FormalExpr that is NOT in
     the owning FormalStrategy's own premises/conclusion interface. Such nodes
-    must not be referenced by any other top-level strategy.
+    must not be referenced by any other top-level strategy or top-level operator.
     """
     # Collect private nodes per FormalStrategy: operator conclusions that are NOT
     # in the owning strategy's premises or conclusion
@@ -363,9 +364,25 @@ def _validate_private_node_isolation(
                     f"of FormalStrategy '{owner}'"
                 )
 
+    # Check: no top-level operator references a private node
+    for op in operators:
+        oid = op.operator_id or "<no-id>"
+        for var_id in op.variables:
+            if var_id in private_nodes:
+                result.error(
+                    f"Operator '{oid}': variable '{var_id}' is a private internal node "
+                    f"of FormalStrategy '{private_nodes[var_id]}'"
+                )
+        if op.conclusion in private_nodes:
+            result.error(
+                f"Operator '{oid}': conclusion '{op.conclusion}' is a private internal node "
+                f"of FormalStrategy '{private_nodes[op.conclusion]}'"
+            )
+
 
 def _validate_strategies(
     strategies: list[Strategy],
+    operators: list[Operator],
     knowledge_lookup: dict[str, Knowledge],
     scope: str,
     result: ValidationResult,
@@ -390,8 +407,8 @@ def _validate_strategies(
     # DAG check for CompositeStrategy references
     _validate_composite_dag(strategies, result)
 
-    # Private node isolation check
-    _validate_private_node_isolation(strategies, result)
+    # Private node isolation check (includes top-level operators)
+    _validate_private_node_isolation(strategies, operators, result)
 
 
 # ---------------------------------------------------------------------------
@@ -420,16 +437,25 @@ def _validate_scope_consistency(
                 f"Strategy '{s.strategy_id}': conclusion '{s.conclusion}' has wrong prefix for {scope} graph"
             )
 
-    for op in operators:
+    def _check_operator_prefix(op: Operator, context: str) -> None:
         for var_id in op.variables:
             if var_id and not var_id.startswith(prefix):
                 result.error(
-                    f"Operator '{op.operator_id}': variable '{var_id}' has wrong prefix for {scope} graph"
+                    f"{context} '{op.operator_id}': variable '{var_id}' has wrong prefix for {scope} graph"
                 )
         if op.conclusion and not op.conclusion.startswith(prefix):
             result.error(
-                f"Operator '{op.operator_id}': conclusion '{op.conclusion}' has wrong prefix for {scope} graph"
+                f"{context} '{op.operator_id}': conclusion '{op.conclusion}' has wrong prefix for {scope} graph"
             )
+
+    for op in operators:
+        _check_operator_prefix(op, "Operator")
+
+    # Also check FormalExpr-embedded operators
+    for s in strategies:
+        if isinstance(s, FormalStrategy):
+            for op in s.formal_expr.operators:
+                _check_operator_prefix(op, f"FormalStrategy '{s.strategy_id}' operator")
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +469,7 @@ def validate_local_graph(graph: LocalCanonicalGraph) -> ValidationResult:
 
     knowledge_lookup = _validate_knowledges(graph.knowledges, "local", result)
     _validate_operators(graph.operators, knowledge_lookup, "local", result)
-    _validate_strategies(graph.strategies, knowledge_lookup, "local", result)
+    _validate_strategies(graph.strategies, graph.operators, knowledge_lookup, "local", result)
     _validate_scope_consistency(
         knowledge_lookup, graph.operators, graph.strategies, "local", result
     )
@@ -468,7 +494,7 @@ def validate_global_graph(graph: GlobalCanonicalGraph) -> ValidationResult:
 
     knowledge_lookup = _validate_knowledges(graph.knowledges, "global", result)
     _validate_operators(graph.operators, knowledge_lookup, "global", result)
-    _validate_strategies(graph.strategies, knowledge_lookup, "global", result)
+    _validate_strategies(graph.strategies, graph.operators, knowledge_lookup, "global", result)
     _validate_scope_consistency(
         knowledge_lookup, graph.operators, graph.strategies, "global", result
     )

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -20,6 +20,9 @@ from gaia.gaia_ir.parameterization import (
 from gaia.gaia_ir.binding import CanonicalBinding
 
 
+_PARAMETERIZED_TYPES = {StrategyType.INFER, StrategyType.NOISY_AND}
+
+
 @dataclass
 class ValidationResult:
     valid: bool = True
@@ -105,7 +108,7 @@ def _validate_operators(
                 f"Operator '{op.operator_id}': scope '{op.scope}' incompatible with {scope} graph"
             )
 
-        # reference completeness
+        # reference completeness — variables (inputs only)
         for var_id in op.variables:
             if var_id not in knowledge_lookup:
                 result.error(f"Operator '{op.operator_id}': variable '{var_id}' not found in graph")
@@ -115,10 +118,21 @@ def _validate_operators(
                     f"'{knowledge_lookup[var_id].type}', must be claim"
                 )
 
-        # conclusion in variables (Pydantic also checks this, but belt-and-suspenders at graph level)
-        if op.conclusion is not None and op.conclusion not in op.variables:
+        # conclusion reference completeness (required str, always present)
+        if op.conclusion not in knowledge_lookup:
             result.error(
-                f"Operator '{op.operator_id}': conclusion '{op.conclusion}' not in variables"
+                f"Operator '{op.operator_id}': conclusion '{op.conclusion}' not found in graph"
+            )
+        elif knowledge_lookup[op.conclusion].type != KnowledgeType.CLAIM:
+            result.error(
+                f"Operator '{op.operator_id}': conclusion '{op.conclusion}' is "
+                f"'{knowledge_lookup[op.conclusion].type}', must be claim"
+            )
+
+        # conclusion must NOT be in variables (belt-and-suspenders, Pydantic also checks)
+        if op.conclusion in op.variables:
+            result.error(
+                f"Operator '{op.operator_id}': conclusion '{op.conclusion}' must not be in variables"
             )
 
 
@@ -132,6 +146,7 @@ def _validate_strategy(
     knowledge_lookup: dict[str, Knowledge],
     scope: str,
     result: ValidationResult,
+    strategy_lookup: dict[str, Strategy] | None = None,
 ) -> None:
     """Validate a single Strategy (any form) against the knowledge set."""
     sid = strategy.strategy_id or "<no-id>"
@@ -169,7 +184,7 @@ def _validate_strategy(
     if scope == "global" and strategy.steps is not None:
         result.error(f"Strategy '{sid}': global strategy must not have steps")
 
-    # scope/prefix checks (applied to nested strategies too, not just top-level)
+    # scope/prefix checks
     prefix = "lcs_" if scope == "local" else "gcs_"
     if strategy.scope != scope:
         result.error(f"Strategy '{sid}': scope '{strategy.scope}' incompatible with {scope} graph")
@@ -178,11 +193,143 @@ def _validate_strategy(
 
     # form-specific validation
     if isinstance(strategy, CompositeStrategy):
-        for sub in strategy.sub_strategies:
-            _validate_strategy(sub, knowledge_lookup, scope, result)
+        _validate_composite_sub_strategies(strategy, strategy_lookup, result)
 
     if isinstance(strategy, FormalStrategy):
         _validate_operators(strategy.formal_expr.operators, knowledge_lookup, scope, result)
+        _validate_formal_expr_closure(strategy, knowledge_lookup, result)
+
+
+def _validate_composite_sub_strategies(
+    strategy: CompositeStrategy,
+    strategy_lookup: dict[str, Strategy] | None,
+    result: ValidationResult,
+) -> None:
+    """Validate CompositeStrategy sub_strategy references exist."""
+    sid = strategy.strategy_id or "<no-id>"
+    if strategy_lookup is None:
+        return
+    for sub_id in strategy.sub_strategies:
+        if sub_id not in strategy_lookup:
+            result.error(
+                f"CompositeStrategy '{sid}': sub_strategy '{sub_id}' not found as top-level strategy"
+            )
+
+
+def _validate_composite_dag(
+    strategies: list[Strategy],
+    result: ValidationResult,
+) -> None:
+    """Check that CompositeStrategy sub_strategy references form a DAG (no cycles)."""
+    # Build adjacency: composite strategy_id -> list of sub_strategy_ids
+    adj: dict[str, list[str]] = {}
+    composite_ids: set[str] = set()
+    for s in strategies:
+        if isinstance(s, CompositeStrategy) and s.strategy_id:
+            adj[s.strategy_id] = list(s.sub_strategies)
+            composite_ids.add(s.strategy_id)
+
+    # DFS cycle detection
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = {sid: WHITE for sid in adj}
+
+    def dfs(node: str) -> bool:
+        """Returns True if cycle found."""
+        color[node] = GRAY
+        for nb in adj.get(node, []):
+            if nb not in color:
+                continue  # non-composite, leaf — no cycle through it
+            if color[nb] == GRAY:
+                result.error(f"CompositeStrategy cycle detected involving '{node}' -> '{nb}'")
+                return True
+            if color[nb] == WHITE:
+                if dfs(nb):
+                    return True
+        color[node] = BLACK
+        return False
+
+    for sid in adj:
+        if color[sid] == WHITE:
+            dfs(sid)
+
+
+def _validate_formal_expr_closure(
+    strategy: FormalStrategy,
+    knowledge_lookup: dict[str, Knowledge],
+    result: ValidationResult,
+) -> None:
+    """Validate FormalExpr reference closure (§5 of 08-validation.md).
+
+    Each Operator's variables/conclusion must reference one of:
+    - The FormalStrategy's premises (interface input)
+    - The FormalStrategy's conclusion (interface output)
+    - Another Operator's conclusion in the same FormalExpr (internal intermediate)
+    """
+    sid = strategy.strategy_id or "<no-id>"
+    allowed: set[str] = set(strategy.premises)
+    if strategy.conclusion is not None:
+        allowed.add(strategy.conclusion)
+
+    # Collect all operator conclusions in this FormalExpr as internal intermediates
+    operator_conclusions: set[str] = set()
+    for op in strategy.formal_expr.operators:
+        operator_conclusions.add(op.conclusion)
+
+    full_allowed = allowed | operator_conclusions
+
+    for op in strategy.formal_expr.operators:
+        for var_id in op.variables:
+            if var_id not in full_allowed:
+                result.error(
+                    f"FormalStrategy '{sid}': operator variable '{var_id}' not in "
+                    f"strategy premises/conclusion or operator conclusions (reference closure)"
+                )
+        if op.conclusion not in full_allowed:
+            result.error(
+                f"FormalStrategy '{sid}': operator conclusion '{op.conclusion}' not in "
+                f"strategy premises/conclusion or operator conclusions (reference closure)"
+            )
+
+
+def _validate_private_node_isolation(
+    strategies: list[Strategy],
+    result: ValidationResult,
+) -> None:
+    """Validate that internal FormalExpr nodes are not referenced by other strategies.
+
+    A 'private' node is an operator conclusion in a FormalExpr that is NOT in
+    the owning FormalStrategy's own premises/conclusion interface. Such nodes
+    must not be referenced by any other top-level strategy.
+    """
+    # Collect private nodes per FormalStrategy: operator conclusions that are NOT
+    # in the owning strategy's premises or conclusion
+    private_nodes: dict[str, str] = {}  # node_id -> owning strategy_id
+    for s in strategies:
+        if isinstance(s, FormalStrategy):
+            sid = s.strategy_id or "<no-id>"
+            own_interface: set[str] = set(s.premises)
+            if s.conclusion is not None:
+                own_interface.add(s.conclusion)
+            for op in s.formal_expr.operators:
+                if op.conclusion not in own_interface:
+                    private_nodes[op.conclusion] = sid
+
+    # Check: no other strategy references a private node
+    for s in strategies:
+        sid = s.strategy_id or "<no-id>"
+        for pid in s.premises:
+            if pid in private_nodes and private_nodes[pid] != sid:
+                result.error(
+                    f"Strategy '{sid}': premise '{pid}' is a private internal node "
+                    f"of FormalStrategy '{private_nodes[pid]}'"
+                )
+        if s.conclusion is not None and s.conclusion in private_nodes:
+            owner = private_nodes[s.conclusion]
+            if owner != sid:
+                result.error(
+                    f"Strategy '{sid}': conclusion '{s.conclusion}' is a private internal node "
+                    f"of FormalStrategy '{owner}'"
+                )
 
 
 def _validate_strategies(
@@ -193,6 +340,11 @@ def _validate_strategies(
 ) -> None:
     """Validate all top-level Strategies."""
     seen_ids: set[str] = set()
+    strategy_lookup: dict[str, Strategy] = {}
+
+    for s in strategies:
+        if s.strategy_id:
+            strategy_lookup[s.strategy_id] = s
 
     for s in strategies:
         # uniqueness (top-level only)
@@ -201,8 +353,13 @@ def _validate_strategies(
         if s.strategy_id:
             seen_ids.add(s.strategy_id)
 
-        # _validate_strategy handles scope, prefix, references, and recursion
-        _validate_strategy(s, knowledge_lookup, scope, result)
+        _validate_strategy(s, knowledge_lookup, scope, result, strategy_lookup)
+
+    # DAG check for CompositeStrategy references
+    _validate_composite_dag(strategies, result)
+
+    # Private node isolation check
+    _validate_private_node_isolation(strategies, result)
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +394,10 @@ def _validate_scope_consistency(
                 result.error(
                     f"Operator '{op.operator_id}': variable '{var_id}' has wrong prefix for {scope} graph"
                 )
+        if op.conclusion and not op.conclusion.startswith(prefix):
+            result.error(
+                f"Operator '{op.operator_id}': conclusion '{op.conclusion}' has wrong prefix for {scope} graph"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -296,19 +457,22 @@ def validate_parameterization(
     """Validate parameterization completeness before BP run.
 
     Checks that every claim Knowledge has at least one PriorRecord and every
-    Strategy has at least one StrategyParamRecord, and all values are within
-    Cromwell bounds.
+    parameterized Strategy (infer/noisy_and) has a StrategyParamRecord.
+    FormalStrategy types derive behavior from FormalExpr — no params needed.
     """
     result = ValidationResult()
 
     # collect claim gcn_ids
     claim_ids = {k.id for k in graph.knowledges if k.type == KnowledgeType.CLAIM and k.id}
 
-    # collect strategy ids
-    strategy_ids: set[str] = set()
+    # collect strategy ids, split by parameterized vs not
+    parameterized_ids: set[str] = set()
+    all_strategy_ids: set[str] = set()
     for s in graph.strategies:
         if s.strategy_id:
-            strategy_ids.add(s.strategy_id)
+            all_strategy_ids.add(s.strategy_id)
+            if s.type in _PARAMETERIZED_TYPES:
+                parameterized_ids.add(s.strategy_id)
 
     # check prior coverage
     prior_gcn_ids = {r.gcn_id for r in priors}
@@ -316,18 +480,29 @@ def validate_parameterization(
         if cid not in prior_gcn_ids:
             result.error(f"Claim '{cid}': missing PriorRecord")
 
-    # check strategy param coverage
+    # check strategy param coverage — only for parameterized types
     param_strategy_ids = {r.strategy_id for r in strategy_params}
-    for sid in strategy_ids:
+    for sid in parameterized_ids:
         if sid not in param_strategy_ids:
             result.error(f"Strategy '{sid}': missing StrategyParamRecord")
 
-    # check conditional_probabilities arity
+    # warn if StrategyParamRecord exists for non-parameterized type
+    non_parameterized_ids = all_strategy_ids - parameterized_ids
+    for r in strategy_params:
+        if r.strategy_id in non_parameterized_ids:
+            result.warn(
+                f"StrategyParamRecord '{r.strategy_id}': strategy type is not parameterized "
+                f"(only infer/noisy_and need params)"
+            )
+
+    # check conditional_probabilities arity — only for infer/noisy_and
     strategy_lookup = {s.strategy_id: s for s in graph.strategies if s.strategy_id}
     for r in strategy_params:
         s = strategy_lookup.get(r.strategy_id)
         if s is None:
             continue  # dangling ref handled below
+        if s.type not in _PARAMETERIZED_TYPES:
+            continue  # non-parameterized, already warned
         actual = len(r.conditional_probabilities)
         if s.type == StrategyType.INFER:
             expected = 2 ** len(s.premises)
@@ -341,13 +516,6 @@ def validate_parameterization(
             if actual != 1:
                 result.error(
                     f"StrategyParamRecord '{r.strategy_id}': noisy_and strategy "
-                    f"requires 1 conditional_probability, got {actual}"
-                )
-        else:
-            # named strategies (folded): 1 parameter
-            if actual != 1:
-                result.error(
-                    f"StrategyParamRecord '{r.strategy_id}': {s.type} strategy "
                     f"requires 1 conditional_probability, got {actual}"
                 )
 
@@ -376,7 +544,7 @@ def validate_parameterization(
 
     # dangling references: params for non-existent strategies
     for r in strategy_params:
-        if r.strategy_id not in strategy_ids:
+        if r.strategy_id not in all_strategy_ids:
             result.warn(f"StrategyParamRecord '{r.strategy_id}': references non-existent Strategy")
 
     return result

--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -258,12 +258,14 @@ def _validate_formal_expr_closure(
     knowledge_lookup: dict[str, Knowledge],
     result: ValidationResult,
 ) -> None:
-    """Validate FormalExpr reference closure (§5 of 08-validation.md).
+    """Validate FormalExpr reference closure and DAG (§5 of 08-validation.md).
 
     Each Operator's variables/conclusion must reference one of:
     - The FormalStrategy's premises (interface input)
     - The FormalStrategy's conclusion (interface output)
     - Another Operator's conclusion in the same FormalExpr (internal intermediate)
+
+    Operator conclusion dependencies must form a DAG (no cycles).
     """
     sid = strategy.strategy_id or "<no-id>"
     allowed: set[str] = set(strategy.premises)
@@ -289,6 +291,36 @@ def _validate_formal_expr_closure(
                 f"FormalStrategy '{sid}': operator conclusion '{op.conclusion}' not in "
                 f"strategy premises/conclusion or operator conclusions (reference closure)"
             )
+
+    # DAG check: operator conclusion dependencies must not cycle (§5.3)
+    # Build adjacency: conclusion -> set of conclusions it depends on (via variables)
+    conclusion_to_deps: dict[str, set[str]] = {}
+    for op in strategy.formal_expr.operators:
+        deps = {v for v in op.variables if v in operator_conclusions}
+        conclusion_to_deps[op.conclusion] = deps
+
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = {c: WHITE for c in conclusion_to_deps}
+
+    def dfs(node: str) -> bool:
+        color[node] = GRAY
+        for dep in conclusion_to_deps.get(node, set()):
+            if dep not in color:
+                continue
+            if color[dep] == GRAY:
+                result.error(
+                    f"FormalStrategy '{sid}': FormalExpr cycle detected "
+                    f"involving '{node}' -> '{dep}'"
+                )
+                return True
+            if color[dep] == WHITE and dfs(dep):
+                return True
+        color[node] = BLACK
+        return False
+
+    for c in conclusion_to_deps:
+        if color[c] == WHITE:
+            dfs(c)
 
 
 def _validate_private_node_isolation(
@@ -456,14 +488,28 @@ def validate_parameterization(
 ) -> ValidationResult:
     """Validate parameterization completeness before BP run.
 
-    Checks that every claim Knowledge has at least one PriorRecord and every
-    parameterized Strategy (infer/noisy_and) has a StrategyParamRecord.
+    Checks that every non-helper claim Knowledge has at least one PriorRecord
+    and every parameterized Strategy (infer/noisy_and) has a StrategyParamRecord.
     FormalStrategy types derive behavior from FormalExpr — no params needed.
+    Private helper claims (FormalExpr operator conclusions not in strategy interface)
+    are PROHIBITED from having independent PriorRecords (§4, §6 of spec).
     """
     result = ValidationResult()
 
     # collect claim gcn_ids
     claim_ids = {k.id for k in graph.knowledges if k.type == KnowledgeType.CLAIM and k.id}
+
+    # identify private helper claims: FormalExpr operator conclusions not in
+    # the owning FormalStrategy's premises/conclusion interface
+    private_helper_ids: set[str] = set()
+    for s in graph.strategies:
+        if isinstance(s, FormalStrategy):
+            own_interface: set[str] = set(s.premises)
+            if s.conclusion is not None:
+                own_interface.add(s.conclusion)
+            for op in s.formal_expr.operators:
+                if op.conclusion not in own_interface:
+                    private_helper_ids.add(op.conclusion)
 
     # collect strategy ids, split by parameterized vs not
     parameterized_ids: set[str] = set()
@@ -474,11 +520,21 @@ def validate_parameterization(
             if s.type in _PARAMETERIZED_TYPES:
                 parameterized_ids.add(s.strategy_id)
 
-    # check prior coverage
+    # check prior coverage (exclude private helper claims)
     prior_gcn_ids = {r.gcn_id for r in priors}
     for cid in claim_ids:
+        if cid in private_helper_ids:
+            continue  # private helpers don't need priors
         if cid not in prior_gcn_ids:
             result.error(f"Claim '{cid}': missing PriorRecord")
+
+    # private helper claims must NOT have PriorRecords (spec §4, §6)
+    for r_prior in priors:
+        if r_prior.gcn_id in private_helper_ids:
+            result.error(
+                f"PriorRecord '{r_prior.gcn_id}': private helper claim must not have "
+                f"independent PriorRecord (value determined by Operator constraints)"
+            )
 
     # check strategy param coverage — only for parameterized types
     param_strategy_ids = {r.strategy_id for r in strategy_params}

--- a/tests/gaia_ir/test_graphs.py
+++ b/tests/gaia_ir/test_graphs.py
@@ -37,9 +37,14 @@ class TestLocalCanonicalGraph:
             knowledges=[
                 Knowledge(id="lcn_a", type="claim"),
                 Knowledge(id="lcn_b", type="claim"),
+                Knowledge(id="lcn_eq", type="claim"),
             ],
             operators=[
-                Operator(operator="equivalence", variables=["lcn_a", "lcn_b"]),
+                Operator(
+                    operator="equivalence",
+                    variables=["lcn_a", "lcn_b"],
+                    conclusion="lcn_eq",
+                ),
             ],
         )
         assert len(g.operators) == 1
@@ -79,12 +84,22 @@ class TestGlobalCanonicalGraph:
 
     def test_three_entity_types(self):
         g = GlobalCanonicalGraph(
-            knowledges=[Knowledge(id="gcn_a", type="claim"), Knowledge(id="gcn_b", type="claim")],
-            operators=[Operator(operator="equivalence", variables=["gcn_a", "gcn_b"])],
+            knowledges=[
+                Knowledge(id="gcn_a", type="claim"),
+                Knowledge(id="gcn_b", type="claim"),
+                Knowledge(id="gcn_eq", type="claim"),
+            ],
+            operators=[
+                Operator(
+                    operator="equivalence",
+                    variables=["gcn_a", "gcn_b"],
+                    conclusion="gcn_eq",
+                )
+            ],
             strategies=[
                 Strategy(scope="global", type="infer", premises=["gcn_a"], conclusion="gcn_b")
             ],
         )
-        assert len(g.knowledges) == 2
+        assert len(g.knowledges) == 3
         assert len(g.operators) == 1
         assert len(g.strategies) == 1

--- a/tests/gaia_ir/test_operator.py
+++ b/tests/gaia_ir/test_operator.py
@@ -1,4 +1,4 @@
-"""Tests for Operator data model."""
+"""Tests for Operator data model — §2.4 inputs/conclusion separation."""
 
 import pytest
 from gaia.gaia_ir import Operator, OperatorType
@@ -17,82 +17,123 @@ class TestOperatorType:
 
 
 class TestOperatorCreation:
-    def test_equivalence(self):
-        op = Operator(operator="equivalence", variables=["gcn_a", "gcn_b"])
-        assert op.conclusion is None
-
-    def test_contradiction(self):
-        op = Operator(operator="contradiction", variables=["gcn_a", "gcn_b"])
-        assert op.conclusion is None
-
-    def test_complement(self):
-        op = Operator(operator="complement", variables=["gcn_a", "gcn_b"])
-        assert op.conclusion is None
+    """Valid construction for each operator type under the new contract."""
 
     def test_implication(self):
-        op = Operator(
-            operator="implication",
-            variables=["gcn_a", "gcn_b"],
-            conclusion="gcn_b",
-        )
+        op = Operator(operator="implication", variables=["gcn_a"], conclusion="gcn_b")
+        assert op.variables == ["gcn_a"]
         assert op.conclusion == "gcn_b"
 
     def test_conjunction(self):
         op = Operator(
             operator="conjunction",
-            variables=["gcn_a", "gcn_b", "gcn_m"],
+            variables=["gcn_a", "gcn_b"],
             conclusion="gcn_m",
         )
+        assert op.variables == ["gcn_a", "gcn_b"]
         assert op.conclusion == "gcn_m"
+
+    def test_equivalence(self):
+        op = Operator(operator="equivalence", variables=["gcn_a", "gcn_b"], conclusion="gcn_h")
+        assert op.conclusion == "gcn_h"
+
+    def test_contradiction(self):
+        op = Operator(
+            operator="contradiction", variables=["gcn_a", "gcn_b"], conclusion="gcn_h"
+        )
+        assert op.conclusion == "gcn_h"
+
+    def test_complement(self):
+        op = Operator(operator="complement", variables=["gcn_a", "gcn_b"], conclusion="gcn_h")
+        assert op.conclusion == "gcn_h"
 
     def test_disjunction(self):
         op = Operator(
             operator="disjunction",
             variables=["gcn_a", "gcn_b", "gcn_c"],
+            conclusion="gcn_h",
         )
-        assert op.conclusion is None
+        assert op.conclusion == "gcn_h"
+
+    def test_conjunction_many_inputs(self):
+        op = Operator(
+            operator="conjunction",
+            variables=["a", "b", "c", "d"],
+            conclusion="m",
+        )
+        assert len(op.variables) == 4
+
+    def test_disjunction_two_inputs(self):
+        op = Operator(operator="disjunction", variables=["a", "b"], conclusion="h")
+        assert len(op.variables) == 2
 
 
-class TestOperatorValidation:
-    def test_equivalence_rejects_conclusion(self):
-        with pytest.raises(ValueError, match="conclusion=None"):
+class TestConclusionSeparation:
+    """§2.4: conclusion must never appear in variables."""
+
+    def test_conclusion_in_variables_rejected(self):
+        with pytest.raises(ValueError, match="must not appear in variables"):
+            Operator(operator="implication", variables=["a"], conclusion="a")
+
+    def test_conjunction_conclusion_in_variables_rejected(self):
+        with pytest.raises(ValueError, match="must not appear in variables"):
+            Operator(operator="conjunction", variables=["a", "b", "m"], conclusion="m")
+
+    def test_equivalence_conclusion_in_variables_rejected(self):
+        with pytest.raises(ValueError, match="must not appear in variables"):
             Operator(operator="equivalence", variables=["a", "b"], conclusion="a")
 
-    def test_contradiction_rejects_conclusion(self):
-        with pytest.raises(ValueError, match="conclusion=None"):
-            Operator(operator="contradiction", variables=["a", "b"], conclusion="a")
+    def test_disjunction_conclusion_in_variables_rejected(self):
+        with pytest.raises(ValueError, match="must not appear in variables"):
+            Operator(operator="disjunction", variables=["a", "b"], conclusion="a")
 
-    def test_complement_rejects_three_variables(self):
-        with pytest.raises(ValueError, match="exactly 2"):
-            Operator(operator="complement", variables=["a", "b", "c"])
 
-    def test_implication_requires_conclusion(self):
-        with pytest.raises(ValueError, match="requires conclusion"):
-            Operator(operator="implication", variables=["a", "b"])
+class TestArityConstraints:
+    """§2.4: variable count constraints per operator type."""
 
-    def test_implication_requires_two_variables(self):
-        with pytest.raises(ValueError, match="exactly 2"):
-            Operator(operator="implication", variables=["a", "b", "c"], conclusion="c")
+    def test_implication_rejects_zero_variables(self):
+        with pytest.raises(ValueError, match="exactly 1 variable"):
+            Operator(operator="implication", variables=[], conclusion="b")
 
-    def test_implication_requires_conclusion_as_last_variable(self):
-        with pytest.raises(ValueError, match="variables\\[-1\\]"):
-            Operator(operator="implication", variables=["a", "b"], conclusion="a")
-
-    def test_conjunction_requires_conclusion(self):
-        with pytest.raises(ValueError, match="requires conclusion"):
-            Operator(operator="conjunction", variables=["a", "b", "m"])
-
-    def test_conjunction_requires_conclusion_as_last_variable(self):
-        with pytest.raises(ValueError, match="variables\\[-1\\]"):
-            Operator(operator="conjunction", variables=["a", "b", "m"], conclusion="a")
-
-    def test_conclusion_must_be_in_variables(self):
-        with pytest.raises(ValueError, match="must appear in variables"):
+    def test_implication_rejects_two_variables(self):
+        with pytest.raises(ValueError, match="exactly 1 variable"):
             Operator(operator="implication", variables=["a", "b"], conclusion="c")
 
-    def test_disjunction_rejects_conclusion(self):
-        with pytest.raises(ValueError, match="conclusion=None"):
-            Operator(operator="disjunction", variables=["a", "b"], conclusion="a")
+    def test_conjunction_rejects_one_variable(self):
+        with pytest.raises(ValueError, match="at least 2 variables"):
+            Operator(operator="conjunction", variables=["a"], conclusion="m")
+
+    def test_equivalence_rejects_three_variables(self):
+        with pytest.raises(ValueError, match="exactly 2 variables"):
+            Operator(operator="equivalence", variables=["a", "b", "c"], conclusion="h")
+
+    def test_equivalence_rejects_one_variable(self):
+        with pytest.raises(ValueError, match="exactly 2 variables"):
+            Operator(operator="equivalence", variables=["a"], conclusion="h")
+
+    def test_contradiction_rejects_three_variables(self):
+        with pytest.raises(ValueError, match="exactly 2 variables"):
+            Operator(operator="contradiction", variables=["a", "b", "c"], conclusion="h")
+
+    def test_complement_rejects_three_variables(self):
+        with pytest.raises(ValueError, match="exactly 2 variables"):
+            Operator(operator="complement", variables=["a", "b", "c"], conclusion="h")
+
+    def test_disjunction_rejects_one_variable(self):
+        with pytest.raises(ValueError, match="at least 2 variables"):
+            Operator(operator="disjunction", variables=["a"], conclusion="h")
+
+
+class TestConclusionRequired:
+    """conclusion is now a required field (str, not str | None)."""
+
+    def test_missing_conclusion_rejected(self):
+        with pytest.raises(Exception):
+            Operator(operator="implication", variables=["a"])
+
+    def test_missing_conclusion_equivalence_rejected(self):
+        with pytest.raises(Exception):
+            Operator(operator="equivalence", variables=["a", "b"])
 
 
 class TestOperatorScope:
@@ -102,19 +143,22 @@ class TestOperatorScope:
             scope="global",
             operator="equivalence",
             variables=["gcn_a", "gcn_b"],
+            conclusion="gcn_h",
         )
         assert op.operator_id == "gco_abc"
         assert op.scope == "global"
 
     def test_embedded_no_scope(self):
         """Operators inside FormalExpr don't need scope or id."""
-        op = Operator(operator="implication", variables=["a", "b"], conclusion="b")
+        op = Operator(operator="implication", variables=["a"], conclusion="b")
         assert op.scope is None
         assert op.operator_id is None
 
     def test_invalid_scope_rejected(self):
         with pytest.raises(ValueError, match="scope must be one of"):
-            Operator(scope="detached", operator="equivalence", variables=["a", "b"])
+            Operator(
+                scope="detached", operator="equivalence", variables=["a", "b"], conclusion="h"
+            )
 
     def test_local_scope_requires_lco_prefix(self):
         with pytest.raises(ValueError, match="lco_ prefix"):
@@ -123,6 +167,7 @@ class TestOperatorScope:
                 scope="local",
                 operator="equivalence",
                 variables=["a", "b"],
+                conclusion="h",
             )
 
     def test_global_scope_requires_gco_prefix(self):
@@ -132,4 +177,5 @@ class TestOperatorScope:
                 scope="global",
                 operator="equivalence",
                 variables=["a", "b"],
+                conclusion="h",
             )

--- a/tests/gaia_ir/test_operator.py
+++ b/tests/gaia_ir/test_operator.py
@@ -38,9 +38,7 @@ class TestOperatorCreation:
         assert op.conclusion == "gcn_h"
 
     def test_contradiction(self):
-        op = Operator(
-            operator="contradiction", variables=["gcn_a", "gcn_b"], conclusion="gcn_h"
-        )
+        op = Operator(operator="contradiction", variables=["gcn_a", "gcn_b"], conclusion="gcn_h")
         assert op.conclusion == "gcn_h"
 
     def test_complement(self):
@@ -156,9 +154,7 @@ class TestOperatorScope:
 
     def test_invalid_scope_rejected(self):
         with pytest.raises(ValueError, match="scope must be one of"):
-            Operator(
-                scope="detached", operator="equivalence", variables=["a", "b"], conclusion="h"
-            )
+            Operator(scope="detached", operator="equivalence", variables=["a", "b"], conclusion="h")
 
     def test_local_scope_requires_lco_prefix(self):
         with pytest.raises(ValueError, match="lco_ prefix"):

--- a/tests/gaia_ir/test_strategy.py
+++ b/tests/gaia_ir/test_strategy.py
@@ -13,14 +13,32 @@ from gaia.gaia_ir import (
 
 
 class TestStrategyType:
-    def test_thirteen_types(self):
-        assert len(StrategyType) == 13
-        assert "infer" in set(StrategyType)
-        assert "noisy_and" in set(StrategyType)
-        assert "deduction" in set(StrategyType)
-        assert "abduction" in set(StrategyType)
-        assert "induction" in set(StrategyType)
-        assert "toolcall" in set(StrategyType)
+    def test_eleven_types(self):
+        assert len(StrategyType) == 11
+        expected = {
+            "infer",
+            "noisy_and",
+            "deduction",
+            "reductio",
+            "elimination",
+            "mathematical_induction",
+            "case_analysis",
+            "abduction",
+            "induction",
+            "analogy",
+            "extrapolation",
+        }
+        assert set(StrategyType) == expected
+
+    def test_no_toolcall(self):
+        """toolcall is deferred per spec."""
+        with pytest.raises(ValueError):
+            StrategyType("toolcall")
+
+    def test_no_proof(self):
+        """proof is deferred per spec."""
+        with pytest.raises(ValueError):
+            StrategyType("proof")
 
     def test_no_soft_implication(self):
         """soft_implication merged into noisy_and per spec."""
@@ -91,19 +109,23 @@ class TestStrategyCreation:
         with pytest.raises(ValueError, match="Strategy form only allows types"):
             Strategy(scope="global", type="deduction", premises=["gcn_a"], conclusion="gcn_b")
 
+    def test_leaf_structure_hash_empty(self):
+        """Leaf strategies have empty structure hash."""
+        s = Strategy(scope="local", type="infer", premises=["a"], conclusion="b")
+        assert s._structure_hash() == ""
+
 
 class TestCompositeStrategy:
-    def test_creation(self):
-        sub1 = Strategy(scope="global", type="noisy_and", premises=["gcn_h"], conclusion="gcn_o")
-        sub2 = Strategy(scope="global", type="noisy_and", premises=["gcn_a"], conclusion="gcn_b")
+    def test_creation_with_string_refs(self):
         cs = CompositeStrategy(
             scope="global",
             type="abduction",
             premises=["gcn_obs"],
             conclusion="gcn_h",
-            sub_strategies=[sub1, sub2],
+            sub_strategies=["gcs_abc123", "gcs_def456"],
         )
         assert len(cs.sub_strategies) == 2
+        assert cs.sub_strategies[0] == "gcs_abc123"
         assert isinstance(cs, Strategy)
 
     def test_empty_sub_strategies_rejected(self):
@@ -116,63 +138,66 @@ class TestCompositeStrategy:
                 sub_strategies=[],
             )
 
-    def test_composite_rejects_leaf_type(self):
-        with pytest.raises(ValueError, match="CompositeStrategy form only allows types"):
-            CompositeStrategy(
+    def test_any_type_allowed(self):
+        """CompositeStrategy is a generic container -- any type is valid."""
+        for type_ in StrategyType:
+            cs = CompositeStrategy(
                 scope="global",
-                type="infer",
+                type=type_,
                 premises=["gcn_a"],
                 conclusion="gcn_b",
-                sub_strategies=[
-                    Strategy(scope="global", type="infer", premises=["gcn_a"], conclusion="gcn_b")
-                ],
+                sub_strategies=["gcs_abc123"],
             )
+            assert cs.type == type_
 
-    def test_nested_composite(self):
-        """CompositeStrategy can contain CompositeStrategy (recursive)."""
-        inner = CompositeStrategy(
+    def test_structure_hash_from_sorted_sub_strategies(self):
+        """structure_hash is based on sorted sub_strategy IDs."""
+        cs1 = CompositeStrategy(
             scope="global",
-            type="abduction",
+            type="infer",
             premises=["a"],
             conclusion="b",
-            sub_strategies=[
-                Strategy(scope="global", type="noisy_and", premises=["a"], conclusion="b")
-            ],
+            sub_strategies=["gcs_x", "gcs_y"],
         )
-        outer = CompositeStrategy(
+        cs2 = CompositeStrategy(
             scope="global",
-            type="induction",
+            type="infer",
             premises=["a"],
-            conclusion="c",
-            sub_strategies=[inner],
+            conclusion="b",
+            sub_strategies=["gcs_y", "gcs_x"],
         )
-        assert isinstance(outer.sub_strategies[0], CompositeStrategy)
+        # Same sorted sub_strategies => same ID
+        assert cs1.strategy_id == cs2.strategy_id
 
-    def test_mixed_sub_strategies(self):
-        """CompositeStrategy can mix Strategy and FormalStrategy."""
-        leaf = Strategy(scope="global", type="noisy_and", premises=["gcn_h"], conclusion="gcn_o")
-        formal = FormalStrategy(
+    def test_different_sub_strategies_different_id(self):
+        """Different sub_strategies produce different strategy IDs."""
+        cs1 = CompositeStrategy(
             scope="global",
-            type="deduction",
-            premises=["gcn_a"],
-            conclusion="gcn_b",
-            formal_expr=FormalExpr(
-                operators=[
-                    Operator(
-                        operator="implication", variables=["gcn_a", "gcn_b"], conclusion="gcn_b"
-                    ),
-                ]
-            ),
+            type="infer",
+            premises=["a"],
+            conclusion="b",
+            sub_strategies=["gcs_x"],
         )
-        cs = CompositeStrategy(
+        cs2 = CompositeStrategy(
             scope="global",
-            type="abduction",
-            premises=["gcn_obs"],
-            conclusion="gcn_h",
-            sub_strategies=[leaf, formal],
+            type="infer",
+            premises=["a"],
+            conclusion="b",
+            sub_strategies=["gcs_z"],
         )
-        assert isinstance(cs.sub_strategies[0], Strategy)
-        assert isinstance(cs.sub_strategies[1], FormalStrategy)
+        assert cs1.strategy_id != cs2.strategy_id
+
+    def test_structure_hash_affects_id(self):
+        """CompositeStrategy ID differs from leaf Strategy ID with same scope/type/premises/conclusion."""
+        leaf = Strategy(scope="local", type="infer", premises=["a"], conclusion="b")
+        comp = CompositeStrategy(
+            scope="local",
+            type="infer",
+            premises=["a"],
+            conclusion="b",
+            sub_strategies=["lcs_sub1"],
+        )
+        assert leaf.strategy_id != comp.strategy_id
 
 
 class TestFormalStrategy:
@@ -187,12 +212,10 @@ class TestFormalStrategy:
                 operators=[
                     Operator(
                         operator="conjunction",
-                        variables=["lcn_a", "lcn_b", "lcn_m"],
+                        variables=["lcn_a", "lcn_b"],
                         conclusion="lcn_m",
                     ),
-                    Operator(
-                        operator="implication", variables=["lcn_m", "lcn_c"], conclusion="lcn_c"
-                    ),
+                    Operator(operator="implication", variables=["lcn_m"], conclusion="lcn_c"),
                 ]
             ),
         )
@@ -209,16 +232,84 @@ class TestFormalStrategy:
             conclusion="lcn_not_p",
             formal_expr=FormalExpr(
                 operators=[
+                    Operator(operator="implication", variables=["lcn_p"], conclusion="lcn_q"),
                     Operator(
-                        operator="implication", variables=["lcn_p", "lcn_q"], conclusion="lcn_q"
+                        operator="contradiction",
+                        variables=["lcn_q", "lcn_r"],
+                        conclusion="lcn_contra",
                     ),
-                    Operator(operator="contradiction", variables=["lcn_q", "lcn_r"]),
-                    Operator(operator="complement", variables=["lcn_p", "lcn_not_p"]),
+                    Operator(
+                        operator="complement",
+                        variables=["lcn_p", "lcn_not_p"],
+                        conclusion="lcn_comp",
+                    ),
                 ]
             ),
         )
         assert fs.type == StrategyType.REDUCTIO
         assert len(fs.formal_expr.operators) == 3
+
+    def test_abduction_is_formal(self):
+        """Abduction is now a FormalStrategy type."""
+        fs = FormalStrategy(
+            scope="global",
+            type="abduction",
+            premises=["gcn_obs"],
+            conclusion="gcn_h",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(operator="implication", variables=["gcn_h"], conclusion="gcn_obs"),
+                ]
+            ),
+        )
+        assert fs.type == StrategyType.ABDUCTION
+
+    def test_induction_is_formal(self):
+        """Induction is now a FormalStrategy type."""
+        fs = FormalStrategy(
+            scope="global",
+            type="induction",
+            premises=["gcn_a"],
+            conclusion="gcn_b",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(operator="implication", variables=["gcn_a"], conclusion="gcn_b"),
+                ]
+            ),
+        )
+        assert fs.type == StrategyType.INDUCTION
+
+    def test_analogy_is_formal(self):
+        """Analogy is now a FormalStrategy type."""
+        fs = FormalStrategy(
+            scope="global",
+            type="analogy",
+            premises=["gcn_a"],
+            conclusion="gcn_b",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(
+                        operator="equivalence", variables=["gcn_a", "gcn_b"], conclusion="gcn_eq"
+                    ),
+                ]
+            ),
+        )
+        assert fs.type == StrategyType.ANALOGY
+
+    def test_extrapolation_is_formal(self):
+        """Extrapolation is now a FormalStrategy type."""
+        fs = FormalStrategy(
+            scope="global",
+            type="extrapolation",
+            premises=["gcn_a"],
+            conclusion="gcn_b",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(operator="implication", variables=["gcn_a"], conclusion="gcn_b"),
+                ]
+            ),
+        )
+        assert fs.type == StrategyType.EXTRAPOLATION
 
     def test_empty_formal_expr_rejected(self):
         with pytest.raises(ValueError, match="at least one operator"):
@@ -230,19 +321,80 @@ class TestFormalStrategy:
                 formal_expr=FormalExpr(operators=[]),
             )
 
-    def test_formal_rejects_composite_type(self):
+    def test_formal_rejects_leaf_type(self):
         with pytest.raises(ValueError, match="FormalStrategy form only allows types"):
             FormalStrategy(
                 scope="local",
-                type="induction",
+                type="infer",
                 premises=["a"],
                 conclusion="b",
                 formal_expr=FormalExpr(
                     operators=[
-                        Operator(operator="implication", variables=["a", "b"], conclusion="b"),
+                        Operator(operator="implication", variables=["a"], conclusion="b"),
                     ]
                 ),
             )
+
+    def test_structure_hash_from_formal_expr(self):
+        """FormalStrategy structure_hash is derived from canonical formal expression."""
+        fs = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["a"],
+            conclusion="b",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(operator="implication", variables=["a"], conclusion="b"),
+                ]
+            ),
+        )
+        assert fs._structure_hash() != ""
+
+    def test_different_formal_expr_different_id(self):
+        """Different formal expressions produce different strategy IDs."""
+        fs1 = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["a"],
+            conclusion="b",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(operator="implication", variables=["a"], conclusion="b"),
+                ]
+            ),
+        )
+        fs2 = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["a"],
+            conclusion="b",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(operator="implication", variables=["a"], conclusion="b"),
+                    Operator(operator="implication", variables=["b"], conclusion="c"),
+                ]
+            ),
+        )
+        assert fs1.strategy_id != fs2.strategy_id
+
+    def test_structure_hash_affects_id_vs_leaf(self):
+        """FormalStrategy ID differs from hypothetical leaf with same scope/type/premises/conclusion."""
+        fs = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["a"],
+            conclusion="b",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(operator="implication", variables=["a"], conclusion="b"),
+                ]
+            ),
+        )
+        # A leaf with same inputs but empty structure_hash would get a different ID
+        from gaia.gaia_ir.strategy import _compute_strategy_id
+
+        leaf_id = _compute_strategy_id("local", "deduction", ["a"], "b", structure_hash="")
+        assert fs.strategy_id != leaf_id
 
 
 class TestStrategyNoLifecycleStages:

--- a/tests/gaia_ir/test_strategy.py
+++ b/tests/gaia_ir/test_strategy.py
@@ -105,9 +105,11 @@ class TestStrategyCreation:
                 steps=[Step(reasoning="should stay local")],
             )
 
-    def test_leaf_rejects_named_strategy_type(self):
-        with pytest.raises(ValueError, match="Strategy form only allows types"):
-            Strategy(scope="global", type="deduction", premises=["gcn_a"], conclusion="gcn_b")
+    def test_leaf_allows_named_strategy_type(self):
+        """Per §3.5.1, named strategies can exist as leaf before formalization."""
+        s = Strategy(scope="global", type="deduction", premises=["gcn_a"], conclusion="gcn_b")
+        assert s.type == StrategyType.DEDUCTION
+        assert s.strategy_id.startswith("gcs_")
 
     def test_leaf_structure_hash_empty(self):
         """Leaf strategies have empty structure hash."""

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -139,37 +139,97 @@ class TestKnowledgeValidation:
 
 
 class TestOperatorValidation:
-    def test_valid_operator(self):
+    def test_valid_operator_equivalence(self):
+        """Equivalence: 2 variables + conclusion (helper claim)."""
         g = _local_graph(
-            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
-            operators=[Operator(operator="equivalence", variables=["lcn_a", "lcn_b"])],
+            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_h")],
+            operators=[
+                Operator(operator="equivalence", variables=["lcn_a", "lcn_b"], conclusion="lcn_h")
+            ],
         )
         r = validate_local_graph(g)
         assert r.valid
 
-    def test_dangling_reference(self):
+    def test_valid_operator_implication(self):
+        """Implication: 1 variable + conclusion."""
         g = _local_graph(
-            knowledges=[_claim("lcn_a")],
-            operators=[Operator(operator="equivalence", variables=["lcn_a", "lcn_missing"])],
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            operators=[Operator(operator="implication", variables=["lcn_a"], conclusion="lcn_b")],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_valid_operator_conjunction(self):
+        """Conjunction: >=2 variables + conclusion."""
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_m")],
+            operators=[
+                Operator(operator="conjunction", variables=["lcn_a", "lcn_b"], conclusion="lcn_m")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_dangling_variable_reference(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_h")],
+            operators=[
+                Operator(
+                    operator="equivalence",
+                    variables=["lcn_a", "lcn_missing"],
+                    conclusion="lcn_h",
+                )
+            ],
         )
         r = validate_local_graph(g)
         assert not r.valid
         assert any("not found" in e for e in r.errors)
 
-    def test_operator_on_non_claim(self):
+    def test_dangling_conclusion_reference(self):
         g = _local_graph(
-            knowledges=[_claim("lcn_a"), _setting("lcn_s")],
-            operators=[Operator(operator="equivalence", variables=["lcn_a", "lcn_s"])],
+            knowledges=[_claim("lcn_a")],
+            operators=[
+                Operator(operator="implication", variables=["lcn_a"], conclusion="lcn_missing")
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("conclusion" in e and "not found" in e for e in r.errors)
+
+    def test_operator_variable_on_non_claim(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _setting("lcn_s"), _claim("lcn_h")],
+            operators=[
+                Operator(
+                    operator="equivalence",
+                    variables=["lcn_a", "lcn_s"],
+                    conclusion="lcn_h",
+                )
+            ],
         )
         r = validate_local_graph(g)
         assert not r.valid
         assert any("must be claim" in e for e in r.errors)
 
+    def test_operator_conclusion_on_non_claim(self):
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _setting("lcn_s")],
+            operators=[Operator(operator="implication", variables=["lcn_a"], conclusion="lcn_s")],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("conclusion" in e and "must be claim" in e for e in r.errors)
+
     def test_local_graph_rejects_global_scoped_operator(self):
         g = _local_graph(
             knowledges=[_claim("lcn_a"), _claim("lcn_b")],
             operators=[
-                Operator(scope="global", operator="equivalence", variables=["lcn_a", "lcn_b"])
+                Operator(
+                    scope="global",
+                    operator="implication",
+                    variables=["lcn_a"],
+                    conclusion="lcn_b",
+                )
             ],
         )
         r = validate_local_graph(g)
@@ -180,12 +240,33 @@ class TestOperatorValidation:
         g = _global_graph(
             knowledges=[_claim("gcn_a"), _claim("gcn_b")],
             operators=[
-                Operator(scope="local", operator="equivalence", variables=["gcn_a", "gcn_b"])
+                Operator(
+                    scope="local",
+                    operator="implication",
+                    variables=["gcn_a"],
+                    conclusion="gcn_b",
+                )
             ],
         )
         r = validate_global_graph(g)
         assert not r.valid
         assert any("scope" in e.lower() for e in r.errors)
+
+    def test_operator_conclusion_scope_prefix_check(self):
+        """Operator conclusion should have correct scope prefix."""
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            operators=[
+                Operator(
+                    operator="implication",
+                    variables=["lcn_a"],
+                    conclusion="gcn_wrong",
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("wrong prefix" in e or "not found" in e for e in r.errors)
 
 
 # ---------------------------------------------------------------------------
@@ -327,51 +408,27 @@ class TestStrategyValidation:
 
 
 class TestCompositeStrategyValidation:
-    def test_valid_composite(self):
+    def test_valid_composite_with_string_refs(self):
+        """CompositeStrategy with sub_strategies as string references."""
+        sub = Strategy(scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b")
         g = _local_graph(
             knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_c")],
             strategies=[
+                sub,
                 CompositeStrategy(
                     scope="local",
                     type="abduction",
                     premises=["lcn_a"],
                     conclusion="lcn_c",
-                    sub_strategies=[
-                        Strategy(
-                            scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b"
-                        ),
-                    ],
-                )
+                    sub_strategies=[sub.strategy_id],
+                ),
             ],
         )
         r = validate_local_graph(g)
         assert r.valid
 
-    def test_nested_scope_mismatch_rejected(self):
-        g = _local_graph(
-            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_c")],
-            strategies=[
-                CompositeStrategy(
-                    scope="local",
-                    type="abduction",
-                    premises=["lcn_a"],
-                    conclusion="lcn_c",
-                    sub_strategies=[
-                        Strategy(
-                            scope="global",
-                            type="noisy_and",
-                            premises=["lcn_a"],
-                            conclusion="lcn_b",
-                        ),
-                    ],
-                )
-            ],
-        )
-        r = validate_local_graph(g)
-        assert not r.valid
-        assert any("scope" in e.lower() and "incompatible" in e.lower() for e in r.errors)
-
-    def test_sub_strategy_dangling_ref(self):
+    def test_sub_strategy_ref_not_found(self):
+        """CompositeStrategy referencing a non-existent sub_strategy ID."""
         g = _local_graph(
             knowledges=[_claim("lcn_a"), _claim("lcn_c")],
             strategies=[
@@ -380,19 +437,61 @@ class TestCompositeStrategyValidation:
                     type="induction",
                     premises=["lcn_a"],
                     conclusion="lcn_c",
-                    sub_strategies=[
-                        Strategy(
-                            scope="local",
-                            type="noisy_and",
-                            premises=["lcn_missing"],
-                            conclusion="lcn_c",
-                        ),
-                    ],
-                )
+                    sub_strategies=["lcs_nonexistent"],
+                ),
             ],
         )
         r = validate_local_graph(g)
         assert not r.valid
+        assert any("sub_strategy" in e and "not found" in e for e in r.errors)
+
+    def test_composite_cycle_detected(self):
+        """CompositeStrategy cycle: A references B, B references A."""
+        # We need to manually construct IDs to create a cycle
+        # Build two composites that reference each other
+        # First create a leaf strategy for valid sub_strategies
+        leaf = Strategy(scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b")
+
+        comp_a = CompositeStrategy(
+            strategy_id="lcs_comp_a",
+            scope="local",
+            type="abduction",
+            premises=["lcn_a"],
+            conclusion="lcn_b",
+            sub_strategies=["lcs_comp_b"],
+        )
+        comp_b = CompositeStrategy(
+            strategy_id="lcs_comp_b",
+            scope="local",
+            type="induction",
+            premises=["lcn_a"],
+            conclusion="lcn_b",
+            sub_strategies=["lcs_comp_a"],
+        )
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            strategies=[leaf, comp_a, comp_b],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("cycle" in e.lower() for e in r.errors)
+
+    def test_composite_no_cycle_valid(self):
+        """CompositeStrategy DAG (no cycle) should pass."""
+        leaf = Strategy(scope="local", type="noisy_and", premises=["lcn_a"], conclusion="lcn_b")
+        comp = CompositeStrategy(
+            scope="local",
+            type="abduction",
+            premises=["lcn_a"],
+            conclusion="lcn_b",
+            sub_strategies=[leaf.strategy_id],
+        )
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            strategies=[leaf, comp],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
 
 
 class TestFormalStrategyValidation:
@@ -409,12 +508,12 @@ class TestFormalStrategyValidation:
                         operators=[
                             Operator(
                                 operator="conjunction",
-                                variables=["lcn_a", "lcn_b", "lcn_m"],
+                                variables=["lcn_a", "lcn_b"],
                                 conclusion="lcn_m",
                             ),
                             Operator(
                                 operator="implication",
-                                variables=["lcn_m", "lcn_c"],
+                                variables=["lcn_m"],
                                 conclusion="lcn_c",
                             ),
                         ]
@@ -438,7 +537,7 @@ class TestFormalStrategyValidation:
                         operators=[
                             Operator(
                                 operator="implication",
-                                variables=["lcn_missing", "lcn_c"],
+                                variables=["lcn_missing"],
                                 conclusion="lcn_c",
                             ),
                         ]
@@ -448,6 +547,138 @@ class TestFormalStrategyValidation:
         )
         r = validate_local_graph(g)
         assert not r.valid
+
+    def test_formal_expr_reference_closure_valid(self):
+        """All operator refs within premises/conclusion/other operator conclusions."""
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_m"), _claim("lcn_c")],
+            strategies=[
+                FormalStrategy(
+                    scope="local",
+                    type="deduction",
+                    premises=["lcn_a", "lcn_b"],
+                    conclusion="lcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="conjunction",
+                                variables=["lcn_a", "lcn_b"],
+                                conclusion="lcn_m",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_m"],
+                                conclusion="lcn_c",
+                            ),
+                        ]
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_formal_expr_reference_closure_violation(self):
+        """Operator variable not in premises/conclusion/operator conclusions."""
+        g = _local_graph(
+            knowledges=[
+                _claim("lcn_a"),
+                _claim("lcn_c"),
+                _claim("lcn_outside"),
+            ],
+            strategies=[
+                FormalStrategy(
+                    scope="local",
+                    type="deduction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_outside"],
+                                conclusion="lcn_c",
+                            ),
+                        ]
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("reference closure" in e for e in r.errors)
+
+    def test_formal_expr_private_node_isolation(self):
+        """Private internal node must not be referenced by another strategy."""
+        # lcn_m is a private intermediate in the FormalStrategy
+        # Another strategy should not reference it
+        formal = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["lcn_a"],
+            conclusion="lcn_c",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(
+                        operator="implication",
+                        variables=["lcn_a"],
+                        conclusion="lcn_m",
+                    ),
+                    Operator(
+                        operator="implication",
+                        variables=["lcn_m"],
+                        conclusion="lcn_c",
+                    ),
+                ]
+            ),
+        )
+        # lcn_m is private: it's an operator conclusion but NOT in any top-level
+        # strategy's premises/conclusion. Another strategy references it — violation.
+        other = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=["lcn_m"],
+            conclusion="lcn_c",
+        )
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_c"), _claim("lcn_m")],
+            strategies=[formal, other],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("private internal node" in e for e in r.errors)
+
+    def test_formal_expr_non_private_node_ok(self):
+        """An operator conclusion that IS in the owning strategy's interface is not private."""
+        # lcn_c is both an operator conclusion and the FormalStrategy's conclusion,
+        # so it's NOT private. Another strategy can reference it freely.
+        formal = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["lcn_a"],
+            conclusion="lcn_c",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(
+                        operator="implication",
+                        variables=["lcn_a"],
+                        conclusion="lcn_c",
+                    ),
+                ]
+            ),
+        )
+        other = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=["lcn_c"],
+            conclusion="lcn_d",
+        )
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_c"), _claim("lcn_d")],
+            strategies=[formal, other],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +707,23 @@ class TestGraphLevelValidation:
         )
         r = validate_global_graph(g)
         assert not r.valid
+
+    def test_operator_conclusion_scope_prefix(self):
+        """Operator conclusion with wrong prefix is caught in scope consistency."""
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b")],
+            operators=[
+                Operator(
+                    operator="implication",
+                    variables=["lcn_a"],
+                    conclusion="gcn_wrong",
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        # Should have wrong prefix error for conclusion
+        assert any("wrong prefix" in e or "not found" in e for e in r.errors)
 
     def test_hash_consistency(self):
         g = _local_graph(knowledges=[_claim("lcn_a")])
@@ -548,7 +796,7 @@ class TestParameterizationValidation:
         assert not r.valid
         assert any("gcn_b" in e and "missing PriorRecord" in e for e in r.errors)
 
-    def test_missing_strategy_param(self):
+    def test_missing_strategy_param_for_parameterized(self):
         from gaia.gaia_ir import PriorRecord
 
         g = self._graph()
@@ -562,6 +810,81 @@ class TestParameterizationValidation:
         )
         assert not r.valid
         assert any("missing StrategyParamRecord" in e for e in r.errors)
+
+    def test_formal_strategy_without_params_passes(self):
+        """FormalStrategy types do not need StrategyParamRecord."""
+        from gaia.gaia_ir import PriorRecord
+
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b"), _claim("gcn_m")],
+            strategies=[
+                FormalStrategy(
+                    scope="global",
+                    type="deduction",
+                    premises=["gcn_a"],
+                    conclusion="gcn_b",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_a"],
+                                conclusion="gcn_b",
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+        )
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_m", value=0.5, source_id="s"),
+            ],
+            strategy_params=[],  # no params needed for deduction
+        )
+        assert r.valid
+
+    def test_param_for_non_parameterized_type_warns(self):
+        """StrategyParamRecord for a FormalStrategy type should warn."""
+        from gaia.gaia_ir import PriorRecord, StrategyParamRecord
+
+        g = _global_graph(
+            knowledges=[_claim("gcn_a"), _claim("gcn_b")],
+            strategies=[
+                FormalStrategy(
+                    scope="global",
+                    type="deduction",
+                    premises=["gcn_a"],
+                    conclusion="gcn_b",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_a"],
+                                conclusion="gcn_b",
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+        )
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.5, source_id="s"),
+            ],
+            strategy_params=[
+                StrategyParamRecord(
+                    strategy_id=sid, conditional_probabilities=[0.5], source_id="s"
+                ),
+            ],
+        )
+        assert r.valid  # warning, not error
+        assert any("not parameterized" in w for w in r.warnings)
 
     def test_setting_does_not_need_prior(self):
         """Settings don't carry probability — no PriorRecord needed."""

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -741,6 +741,94 @@ class TestFormalStrategyValidation:
         r = validate_local_graph(g)
         assert r.valid
 
+    def test_private_node_referenced_by_top_level_operator_variable(self):
+        """Top-level operator referencing a FormalExpr private node as variable is an error."""
+        formal = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["lcn_a", "lcn_b"],
+            conclusion="lcn_c",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(
+                        operator="conjunction",
+                        variables=["lcn_a", "lcn_b"],
+                        conclusion="lcn_m",
+                    ),
+                    Operator(
+                        operator="implication",
+                        variables=["lcn_m"],
+                        conclusion="lcn_c",
+                    ),
+                ]
+            ),
+        )
+        # Top-level operator uses private node lcn_m as a variable
+        top_op = Operator(
+            operator_id="lco_bad",
+            scope="local",
+            operator="implication",
+            variables=["lcn_m"],
+            conclusion="lcn_c",
+        )
+        g = _local_graph(
+            knowledges=[
+                _claim("lcn_a"),
+                _claim("lcn_b"),
+                _claim("lcn_c"),
+                _claim("lcn_m"),
+            ],
+            operators=[top_op],
+            strategies=[formal],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("private internal node" in e for e in r.errors)
+
+    def test_private_node_referenced_by_top_level_operator_conclusion(self):
+        """Top-level operator using a FormalExpr private node as conclusion is an error."""
+        formal = FormalStrategy(
+            scope="local",
+            type="deduction",
+            premises=["lcn_a", "lcn_b"],
+            conclusion="lcn_c",
+            formal_expr=FormalExpr(
+                operators=[
+                    Operator(
+                        operator="conjunction",
+                        variables=["lcn_a", "lcn_b"],
+                        conclusion="lcn_m",
+                    ),
+                    Operator(
+                        operator="implication",
+                        variables=["lcn_m"],
+                        conclusion="lcn_c",
+                    ),
+                ]
+            ),
+        )
+        # Top-level operator outputs to private node lcn_m
+        top_op = Operator(
+            operator_id="lco_bad",
+            scope="local",
+            operator="implication",
+            variables=["lcn_a"],
+            conclusion="lcn_m",
+        )
+        g = _local_graph(
+            knowledges=[
+                _claim("lcn_a"),
+                _claim("lcn_b"),
+                _claim("lcn_c"),
+                _claim("lcn_m"),
+            ],
+            operators=[top_op],
+            strategies=[formal],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("private internal node" in e for e in r.errors)
+
 
 # ---------------------------------------------------------------------------
 # 4. Graph-level validation
@@ -785,6 +873,39 @@ class TestGraphLevelValidation:
         assert not r.valid
         # Should have wrong prefix error for conclusion
         assert any("wrong prefix" in e or "not found" in e for e in r.errors)
+
+    def test_formal_expr_operator_scope_prefix(self):
+        """FormalExpr-embedded operators with wrong prefix are caught in scope consistency."""
+        # lcn_a and lcn_c exist in local graph, but FormalExpr internally
+        # references gcn_wrong which has a global prefix in a local graph.
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_c"), _claim("lcn_m")],
+            strategies=[
+                FormalStrategy(
+                    scope="local",
+                    type="deduction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_a"],
+                                conclusion="lcn_m",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_wrong"],
+                                conclusion="lcn_c",
+                            ),
+                        ]
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("wrong prefix" in e and "FormalStrategy" in e for e in r.errors)
 
     def test_hash_consistency(self):
         g = _local_graph(knowledges=[_claim("lcn_a")])

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -680,6 +680,67 @@ class TestFormalStrategyValidation:
         r = validate_local_graph(g)
         assert r.valid
 
+    def test_formal_expr_cycle_detected(self):
+        """FormalExpr operators that form a cycle: A->B and B->A."""
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_b"), _claim("lcn_c")],
+            strategies=[
+                FormalStrategy(
+                    scope="local",
+                    type="deduction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_b"],
+                                conclusion="lcn_c",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_c"],
+                                conclusion="lcn_b",
+                            ),
+                        ]
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("cycle" in e.lower() for e in r.errors)
+
+    def test_formal_expr_no_cycle_valid(self):
+        """Linear chain A->M->C has no cycle."""
+        g = _local_graph(
+            knowledges=[_claim("lcn_a"), _claim("lcn_m"), _claim("lcn_c")],
+            strategies=[
+                FormalStrategy(
+                    scope="local",
+                    type="deduction",
+                    premises=["lcn_a"],
+                    conclusion="lcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_a"],
+                                conclusion="lcn_m",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["lcn_m"],
+                                conclusion="lcn_c",
+                            ),
+                        ]
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
 
 # ---------------------------------------------------------------------------
 # 4. Graph-level validation
@@ -835,6 +896,7 @@ class TestParameterizationValidation:
                 ),
             ],
         )
+        # gcn_m is not referenced by any FormalExpr operator, so it's a regular claim
         r = validate_parameterization(
             g,
             priors=[
@@ -845,6 +907,101 @@ class TestParameterizationValidation:
             strategy_params=[],  # no params needed for deduction
         )
         assert r.valid
+
+    def test_private_helper_claim_no_prior_needed(self):
+        """Private helper claims (FormalExpr internal) don't need PriorRecord."""
+        from gaia.gaia_ir import PriorRecord
+
+        g = _global_graph(
+            knowledges=[
+                _claim("gcn_a"),
+                _claim("gcn_b"),
+                _claim("gcn_m"),  # private helper: conjunction result
+                _claim("gcn_c"),
+            ],
+            strategies=[
+                FormalStrategy(
+                    scope="global",
+                    type="deduction",
+                    premises=["gcn_a", "gcn_b"],
+                    conclusion="gcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="conjunction",
+                                variables=["gcn_a", "gcn_b"],
+                                conclusion="gcn_m",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_m"],
+                                conclusion="gcn_c",
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+        )
+        # gcn_m is private (operator conclusion, not in premises/conclusion)
+        # → no PriorRecord needed
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_c", value=0.5, source_id="s"),
+                # no prior for gcn_m
+            ],
+            strategy_params=[],
+        )
+        assert r.valid
+
+    def test_private_helper_claim_prior_prohibited(self):
+        """Providing PriorRecord for a private helper claim is an error."""
+        from gaia.gaia_ir import PriorRecord
+
+        g = _global_graph(
+            knowledges=[
+                _claim("gcn_a"),
+                _claim("gcn_b"),
+                _claim("gcn_m"),
+                _claim("gcn_c"),
+            ],
+            strategies=[
+                FormalStrategy(
+                    scope="global",
+                    type="deduction",
+                    premises=["gcn_a", "gcn_b"],
+                    conclusion="gcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="conjunction",
+                                variables=["gcn_a", "gcn_b"],
+                                conclusion="gcn_m",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_m"],
+                                conclusion="gcn_c",
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+        )
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_b", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_c", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_m", value=0.5, source_id="s"),  # prohibited!
+            ],
+            strategy_params=[],
+        )
+        assert not r.valid
+        assert any("private helper claim" in e for e in r.errors)
 
     def test_param_for_non_parameterized_type_warns(self):
         """StrategyParamRecord for a FormalStrategy type should warn."""


### PR DESCRIPTION
## Summary

- **Operator §2.4**: `variables` now inputs-only, `conclusion` is a separate required field for all operator types (including relation operators which get helper claim conclusions). Implication takes 1 variable, conjunction takes ≥2.
- **Strategy §3.2–3.6**: Removed deferred `toolcall`/`proof` types. Moved abduction/induction/analogy/extrapolation from CompositeStrategy to FormalStrategy. CompositeStrategy is now a generic container with `list[str]` sub_strategies (ID refs, not embedded objects). Strategy ID computation includes `structure_hash`.
- **Parameterization §3.4**: Only `infer`/`noisy_and` require `StrategyParamRecord`. FormalStrategy types derive behavior from FormalExpr + claim priors.
- **Validator §5**: Added FormalExpr reference closure validation, private node isolation checks, CompositeStrategy DAG cycle detection, operator conclusion scope prefix checks.

## Test Plan

- [x] 185 gaia_ir unit tests pass (28 operator + 34 strategy + 10 graph + 16 parameterization + 7 binding + 7 belief_state + 17 knowledge + 66 validator)
- [x] 763 total project tests pass, 0 failures
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)