### PR TITLE
fix(gaia-ir): extend PriorRecord prohibition to all FormalExpr private nodes

### DIFF
--- a/gaia/gaia_ir/validator.py
+++ b/gaia/gaia_ir/validator.py
@@ -535,33 +535,47 @@ def validate_parameterization(
 ) -> ValidationResult:
     """Validate parameterization completeness before BP run.
 
-    Checks that every non-helper claim Knowledge has at least one PriorRecord
+    Checks that every non-private claim Knowledge has at least one PriorRecord
     and every parameterized Strategy (infer/noisy_and) has a StrategyParamRecord.
     FormalStrategy types derive behavior from FormalExpr — no params needed.
-    Structural helper claims (top-level or FormalExpr operator conclusions produced
-    by conjunction/disjunction/equivalence/contradiction/complement) are PROHIBITED
-    from having independent PriorRecords (§4, §6 of spec). Generated public
-    interface claims (for example abduction's alternative explanation claim)
-    remain ordinary claim inputs and therefore still require PriorRecord.
+
+    Two categories of claims are excluded from PriorRecord requirements and
+    PROHIBITED from having independent PriorRecords:
+    1. Top-level structural helper claims — conclusions of top-level Operators
+       with structural types (conjunction/disjunction/equivalence/contradiction/
+       complement). Their truth value is fully determined by the Operator.
+    2. FormalExpr private nodes — ANY operator conclusion inside a FormalExpr
+       that is NOT in the owning FormalStrategy's premises/conclusion interface.
+       Per spec §4 of 04-helper-claims.md, private nodes must not carry
+       independent PriorRecord regardless of the operator type.
+
+    Generated public interface claims (e.g. abduction's AlternativeExplanationForObs)
+    are part of the strategy interface, so they remain ordinary claim inputs and
+    still require PriorRecord.
     """
     result = ValidationResult()
 
     # collect claim gcn_ids
     claim_ids = {k.id for k in graph.knowledges if k.type == KnowledgeType.CLAIM and k.id}
 
-    # identify structural helper claims. These are deterministic operator results
-    # that are not free probability inputs, regardless of whether they are top-level
-    # or internal to a FormalStrategy.
-    helper_claim_ids: set[str] = set()
+    # identify claims that must not have independent PriorRecords:
+
+    # (a) top-level structural helper claims — conclusions of structural operators
+    no_prior_ids: set[str] = set()
     for op in graph.operators:
         if op.operator in _STRUCTURAL_HELPER_OPERATOR_TYPES:
-            helper_claim_ids.add(op.conclusion)
+            no_prior_ids.add(op.conclusion)
 
+    # (b) FormalExpr private nodes — ALL operator conclusions inside FormalExpr
+    #     that are NOT in the owning strategy's premises/conclusion interface
     for s in graph.strategies:
         if isinstance(s, FormalStrategy):
+            own_interface: set[str] = set(s.premises)
+            if s.conclusion is not None:
+                own_interface.add(s.conclusion)
             for op in s.formal_expr.operators:
-                if op.operator in _STRUCTURAL_HELPER_OPERATOR_TYPES:
-                    helper_claim_ids.add(op.conclusion)
+                if op.conclusion not in own_interface:
+                    no_prior_ids.add(op.conclusion)
 
     # collect strategy ids, split by parameterized vs not
     parameterized_ids: set[str] = set()
@@ -572,20 +586,20 @@ def validate_parameterization(
             if s.type in _PARAMETERIZED_TYPES:
                 parameterized_ids.add(s.strategy_id)
 
-    # check prior coverage (exclude structural helper claims)
+    # check prior coverage (exclude private/helper claims)
     prior_gcn_ids = {r.gcn_id for r in priors}
     for cid in claim_ids:
-        if cid in helper_claim_ids:
-            continue  # helper claims don't need priors
+        if cid in no_prior_ids:
+            continue  # private or structural helper — no prior needed
         if cid not in prior_gcn_ids:
             result.error(f"Claim '{cid}': missing PriorRecord")
 
-    # structural helper claims must NOT have PriorRecords (spec §4, §6)
+    # private/helper claims must NOT have PriorRecords (spec §4 of 04-helper-claims.md)
     for r_prior in priors:
-        if r_prior.gcn_id in helper_claim_ids:
+        if r_prior.gcn_id in no_prior_ids:
             result.error(
-                f"PriorRecord '{r_prior.gcn_id}': structural helper claim must not have "
-                f"independent PriorRecord (value determined by Operator constraints)"
+                f"PriorRecord '{r_prior.gcn_id}': private or structural helper claim "
+                f"must not have independent PriorRecord"
             )
 
     # check strategy param coverage — only for parameterized types

--- a/tests/gaia_ir/test_validator.py
+++ b/tests/gaia_ir/test_validator.py
@@ -1175,7 +1175,101 @@ class TestParameterizationValidation:
             strategy_params=[],
         )
         assert not r.valid
-        assert any("structural helper claim" in e for e in r.errors)
+        assert any("private or structural helper claim" in e for e in r.errors)
+
+    def test_implication_private_node_prior_prohibited(self):
+        """Any FormalExpr private node (not just structural helpers) must not have PriorRecord."""
+        from gaia.gaia_ir import PriorRecord
+
+        # gcn_mid is an implication conclusion inside FormalExpr, NOT in the
+        # strategy's interface (premises/conclusion). Even though implication is
+        # not a "structural helper" operator type, gcn_mid is still private.
+        g = _global_graph(
+            knowledges=[
+                _claim("gcn_a"),
+                _claim("gcn_mid"),
+                _claim("gcn_final"),
+                _claim("gcn_c"),
+            ],
+            strategies=[
+                FormalStrategy(
+                    scope="global",
+                    type="deduction",
+                    premises=["gcn_a"],
+                    conclusion="gcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_a"],
+                                conclusion="gcn_mid",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_mid"],
+                                conclusion="gcn_c",
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+        )
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_c", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_final", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_mid", value=0.5, source_id="s"),  # prohibited!
+            ],
+            strategy_params=[],
+        )
+        assert not r.valid
+        assert any("gcn_mid" in e and "private or structural helper" in e for e in r.errors)
+
+    def test_implication_private_node_no_prior_needed(self):
+        """FormalExpr private implication nodes don't need PriorRecord."""
+        from gaia.gaia_ir import PriorRecord
+
+        g = _global_graph(
+            knowledges=[
+                _claim("gcn_a"),
+                _claim("gcn_mid"),
+                _claim("gcn_c"),
+            ],
+            strategies=[
+                FormalStrategy(
+                    scope="global",
+                    type="deduction",
+                    premises=["gcn_a"],
+                    conclusion="gcn_c",
+                    formal_expr=FormalExpr(
+                        operators=[
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_a"],
+                                conclusion="gcn_mid",
+                            ),
+                            Operator(
+                                operator="implication",
+                                variables=["gcn_mid"],
+                                conclusion="gcn_c",
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+        )
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(gcn_id="gcn_a", value=0.5, source_id="s"),
+                PriorRecord(gcn_id="gcn_c", value=0.5, source_id="s"),
+                # gcn_mid is private — no prior needed
+            ],
+            strategy_params=[],
+        )
+        assert r.valid
 
     def test_abduction_generated_interface_claim_requires_prior(self):
         """Auto-generated alternative explanations are public interface claims with priors."""
@@ -1334,7 +1428,7 @@ class TestParameterizationValidation:
             strategy_params=[],
         )
         assert not r.valid
-        assert any("gcn_eq" in e and "structural helper claim" in e for e in r.errors)
+        assert any("gcn_eq" in e and "private or structural helper claim" in e for e in r.errors)
 
     def test_param_for_non_parameterized_type_warns(self):
         """StrategyParamRecord for a FormalStrategy type should warn."""


### PR DESCRIPTION
## Summary
- Extend `validate_parameterization` to prohibit PriorRecord on **all** FormalExpr private nodes, not just structural helper operator types
- Previously only conclusions of conjunction/disjunction/equivalence/contradiction/complement operators were blocked; now any operator conclusion inside FormalExpr that is not in the owning strategy's premises/conclusion interface is treated as private

## Motivation
Per spec §4 of `04-helper-claims.md`: "私有节点不得承载独立 PriorRecord". The old code only checked operator type, missing private nodes from `implication` operators. While current formalize templates don't produce such nodes (implication always targets the strategy conclusion), the validator should match the spec.

## Testing
- Added `test_implication_private_node_prior_prohibited` — verifies that a PriorRecord targeting a private implication conclusion inside FormalExpr is rejected
- Added `test_implication_private_node_no_prior_needed` — verifies that private implication nodes don't require PriorRecord
- Updated 2 existing test assertions to match refined error message
- `python -m pytest tests/gaia_ir -q` → 219 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)