### PR TITLE
docs(ecosystem): add related systems survey

### DIFF
--- a/docs/foundations/ecosystem/07-related-systems.md
+++ b/docs/foundations/ecosystem/07-related-systems.md
@@ -1,0 +1,349 @@
+# Gaia 的相关系统与定位
+
+> **Status:** Current draft
+
+> 相关文档：
+> - [01-product-scope.md](01-product-scope.md)
+> - [../gaia-lang/spec.md](../gaia-lang/spec.md)
+> - [../gaia-ir/01-overview.md](../gaia-ir/01-overview.md)
+
+## 目的
+
+本文档回答一个经常会被问到的问题：
+
+> 在已有系统里，是否已经有一个和 Gaia 基本等价的语言或平台？
+
+简短答案是：**没有。**
+
+更准确的说法是，Gaia 不是单一前驱系统的复刻，而是把几条原本分离的传统拼接成了一个新的组合体：
+
+- 科学声明发布
+- 论证结构编著
+- 概率逻辑 / 概率图模型
+- 形式化知识管理
+- 图式知识表示
+
+因此，理解 Gaia 的最好方式不是去找一个一模一样的祖先，而是看它分别继承了哪些方向、又在哪些地方做了不同的组合。
+
+## 一句话定位
+
+Gaia 最接近的是：
+
+> **一个面向科学知识 formalization 的编著语言与中间表示系统，既不是单纯的 argument map，也不是单纯的 probabilistic logic language，也不是单纯的 nanopublication format。**
+
+它的核心组合是：
+
+- `Gaia Lang` 作为可编著包语言
+- `Gaia IR` 作为结构化 canonical contract
+- 在其上的概率语义与后续 lowering
+- review / publish / registry 作为工作流边界
+
+## 1. 科学声明发布：Nanopublications 与 Micropublications
+
+这一类系统最接近 Gaia 在“科学主张应当可引用、可追溯、可最小化发布”这一面。
+
+### 1.1 Nanopublications
+
+Nanopublication 的核心思想是：
+
+- 用一个最小 assertion 表达可发布的科学主张
+- 配套记录 provenance
+- 再附 publication info
+
+它与 Gaia 的相似点：
+
+- 都重视最小知识单元
+- 都重视 provenance / attribution
+- 都强调 machine-readable scientific publishing
+
+关键差异：
+
+- Nanopublication 更像**发布与交换格式**
+- 它不提供 Gaia 这样一层显式的 reasoning strategy
+- 也不提供 `Gaia Lang -> Gaia IR` 的结构化编译过程
+- 更不以内建的概率信念更新为中心
+
+### 1.2 Micropublications
+
+Micropublications 更接近科学论证图：
+
+- claim
+- evidence
+- challenge
+- support
+- provenance
+
+它与 Gaia 的相似点：
+
+- 都把科学文本理解为可败的论证网络
+- 都比简单三元组更接近真实论文结构
+- 都支持 claim-level representation
+
+关键差异：
+
+- Micropublications 更偏**科学论证语义模型**
+- Gaia 更进一步，把这些结构当成可 formalize、可 canonicalize、可 parameterize 的编著对象
+- Gaia 还额外引入了 package lifecycle、review 边界和后续推理语义
+
+### 小结
+
+如果只看“科学声明最小发布单元”，Gaia 和这一类系统是近亲。  
+但 Gaia 不止是 publication format，而是把 publication unit、reasoning structure 和 probabilistic semantics 放在了同一个体系里。
+
+## 2. 论证结构编著：Argdown 与 AIF
+
+这一类系统最接近 Gaia 在“人如何显式地写出论证结构”这一面。
+
+### 2.1 Argdown
+
+Argdown 提供：
+
+- 可读的 argument authoring syntax
+- statement / argument 的显式区分
+- premise / conclusion / attack / support 的结构表达
+- argument map 生成
+
+它与 Gaia Lang 的相似点：
+
+- 都关心 authoring surface
+- 都不满足于只存最终图，而强调“人如何写”
+- 都显式暴露 claim 和 argument structure
+
+关键差异：
+
+- Argdown 更偏 argument mapping 与可视化重建
+- Gaia Lang 的目标不是 argument map，而是 scientific knowledge package
+- Gaia 还要求编译到统一 IR，并继续进入 review / parameterization / inference 流程
+
+### 2.2 AIF
+
+Argument Interchange Format (AIF) 的价值在于：
+
+- 为论证图提供可交换的结构本体
+- 显式表示 inference、conflict、preference 等节点
+
+它与 Gaia 的相似点：
+
+- 都把“推理关系”提升为一等结构对象
+- 都不像普通知识图谱那样只把边当成简单关系
+- 都更接近 argument IR 而不是表层文本
+
+关键差异：
+
+- AIF 更像**交换格式 / 论证本体**
+- Gaia IR 更像**编译目标与运行边界**
+- Gaia 还要求 local/global identity、canonicalization、parameterization 和 lowering 契约
+
+### 小结
+
+如果只看“结构化论证编著”，Gaia 和 Argdown / AIF 很接近。  
+但 Gaia 的目标不是停在 argument interchange，而是继续向 scientific package 和 probabilistic reasoning 推进。
+
+## 3. 概率逻辑与建模语言：ProbLog、BLOG、MLN、PSL
+
+这一类系统最接近 Gaia 在“逻辑结构与不确定性如何统一”这一面。
+
+### 3.1 ProbLog
+
+ProbLog 把：
+
+- probabilistic facts
+- logical rules
+- query / evidence
+
+放进同一个 probabilistic logic programming language。
+
+它与 Gaia 的相似点：
+
+- 都试图统一逻辑结构与概率
+- 都不是纯数据库，也不是纯 theorem prover
+
+关键差异：
+
+- ProbLog 是**概率逻辑程序语言**
+- Gaia 不是通用概率逻辑编程语言，而是面向 scientific package formalization 的结构语言
+- Gaia 的基本对象是 knowledge package / claim / strategy / operator，而不是一般 Horn clause 程序
+
+### 3.2 BLOG
+
+BLOG 擅长表达：
+
+- 高层概率知识表示
+- identity uncertainty
+- unknown objects
+
+它与 Gaia 的相似点：
+
+- 都属于高层概率知识表示
+- 都不只是数值统计建模
+
+关键差异：
+
+- BLOG 更偏 generative probabilistic modeling
+- Gaia 更偏 claim-centered reasoning and package assembly
+
+### 3.3 MLN 与 PSL
+
+MLN 和 PSL 都试图把逻辑和概率统一起来：
+
+- MLN：逻辑公式 + 权重
+- PSL：连续真值 + 软逻辑约束
+
+它们与 Gaia 的相似点：
+
+- 都不把逻辑与概率完全分开
+- 都在处理“结构约束如何影响 belief”
+
+关键差异：
+
+- 它们更像**建模与推断框架**
+- Gaia 更像**编著语言 + IR + reviewable package workflow**
+- Gaia 还特别强调来自科学文本的结构降级与 package 生命周期
+
+### 小结
+
+如果只问“有没有把逻辑结构和概率统一的系统”，答案当然是有。  
+但 Gaia 的特殊性在于：它不是把科学知识塞进通用概率逻辑语言，而是为 scientific formalization 设计了自己的 authoring surface 与 IR contract。
+
+## 4. 形式化知识与证明管理：Lean、MMT / OMDoc
+
+这一类系统最接近 Gaia 在“作用域、结构显式性、模块化知识管理”这一面。
+
+### 4.1 Lean
+
+Lean 的价值不在概率，而在：
+
+- 严格的证明结构
+- 显式假设与作用域
+- 模块化形式化
+
+它和 Gaia 的相似点：
+
+- 都不满足于只保存文本结论
+- 都在意 structure-preserving representation
+- 都要求中间结构可被机器检查
+
+关键差异：
+
+- Lean 面向确定性 theorem proving
+- Gaia 面向可败、可更新、带信念度的科学知识图
+
+### 4.2 MMT / OMDoc
+
+MMT / OMDoc 更像是：
+
+- 统一的形式知识管理框架
+- 文档、理论、符号和模块的组织系统
+
+它与 Gaia 的相似点：
+
+- 都重视模块化知识表示
+- 都重视中间层 contract
+- 都不是只有最终显示层
+
+关键差异：
+
+- MMT / OMDoc 更偏 formal mathematics / logic knowledge management
+- Gaia 更偏 scientific claims、review workflow 与 probabilistic belief flow
+
+### 小结
+
+这条传统告诉我们：Gaia 不是凭空发明“结构化知识语言”这件事。  
+它站在 formal knowledge management 的脉络上，但把目标从确定性证明转向了可败科学信念。
+
+## 5. 图式符号 IR：Atomese / MeTTa
+
+这一类系统最接近 Gaia 在“知识是否应该以机器可操作图结构存储”这一面。
+
+它们与 Gaia 的相似点：
+
+- 都接受图 / 超图式知识表示
+- 都强调 machine-operable symbolic structure
+- 都希望知识不是只留在自然语言里
+
+关键差异：
+
+- Atomese / MeTTa 更 general-purpose，也更偏 AGI substrate
+- Gaia 更窄、更明确：面向 scientific claim、review、package、registry 和 probability-aware reasoning
+
+### 小结
+
+如果把 Gaia 放到更大的“symbolic substrate”语境里，它并不孤立。  
+但 Gaia 的特征是把问题收得足够窄，以便把 scientific formalization 做成一个清晰产品边界。
+
+## 6. Gaia 与这些系统的关系
+
+从组合角度看，Gaia 最像下面这个拼接：
+
+```text
+Nanopublication / Micropublication
+  + Argdown / AIF
+  + ProbLog / PSL / MLN / BLOG
+  + Lean / MMT
+  + graph-style symbolic IR
+  = Gaia
+```
+
+这不是说 Gaia 简单地把它们相加。  
+真正关键的是它做了一个不同的边界选择：
+
+- 输入边界：scientific authoring / package authoring
+- 中间边界：canonical Gaia IR
+- 工作流边界：review / publish / registry
+- 语义边界：belief-bearing scientific claims
+
+而多数已有系统通常只覆盖其中一块。
+
+## 7. 不应把 Gaia 误认成什么
+
+### 7.1 Gaia 不是 nanopublication 平台
+
+因为 Gaia 不只存 assertion + provenance；它还显式记录 reasoning structure，并要求编译到统一 IR。
+
+### 7.2 Gaia 不是 argument map 工具
+
+因为 Gaia 不满足于把论证“画出来”；它还要让结构进入 package workflow 和后续参数化/推理流程。
+
+### 7.3 Gaia 不是通用概率逻辑语言
+
+因为 Gaia 的核心单位不是任意逻辑程序，而是面向 scientific knowledge formalization 的 package、claim、strategy、operator。
+
+### 7.4 Gaia 不是 theorem prover
+
+因为 Gaia 面向的是可败知识与 belief update，而不是纯确定性证明闭包。
+
+## 8. 最终判断
+
+如果问题是：
+
+> “之前有没有一个和 Gaia Lang 几乎一样的系统？”
+
+那么当前判断是：
+
+> **没有。**
+
+如果问题是：
+
+> “Gaia 最接近哪些已有传统？”
+
+那么答案是：
+
+- 科学声明发布：Nanopublications、Micropublications
+- 论证编著：Argdown、AIF
+- 概率逻辑：ProbLog、BLOG、MLN、PSL
+- 形式化知识管理：Lean、MMT / OMDoc
+- 图式符号 IR：Atomese / MeTTa
+
+因此，Gaia 更适合被描述为：
+
+> **一个把科学声明发布、论证编著、概率逻辑、形式化知识管理和图式知识表示拼接起来的 scientific knowledge language stack。**
+
+## 9. 对后续文档的启示
+
+如果未来继续扩展这条文档线，最自然的方向是：
+
+1. 增加二维对比表：
+   `authoring language / IR / uncertainty / review workflow / publication unit`
+2. 补一篇更短的 visitor-facing 版本，放到 `for-visitors/`
+3. 单独解释：
+   “为什么 Gaia 不等同于 nanopublication / argument map / probabilistic logic program”


### PR DESCRIPTION
## Summary
- add a long-form ecosystem note on systems related to Gaia
- position Gaia relative to nanopublications, micropublications, Argdown/AIF, probabilistic logic systems, formal knowledge systems, and symbolic graph IRs
- keep this as a single long-form doc under docs/foundations/ecosystem/

## Testing
- not run (docs-only change)