### PR TITLE
feat(skill): add gaia-ir-authoring skill for constructing IR with existing APIs

### DIFF
--- a/.claude/skills/gaia-ir-authoring/SKILL.md
+++ b/.claude/skills/gaia-ir-authoring/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: gaia-ir-authoring
+description: "Use when constructing a Gaia IR LocalCanonicalGraph from source material — teaches how to build valid knowledge graphs using existing gaia.gaia_ir models, validate them, and run BP inference."
+---
+
+# Gaia IR Authoring
+
+Construct valid `LocalCanonicalGraph` instances using the existing data models in `gaia/gaia_ir/`, validate with `validate_local_graph`, and run inference via `gaia/bp/`.
+
+## When to use
+
+- Building **local** Gaia IR graphs for reasoning experiments, tests, or tooling.
+- Translating a scientific argument or knowledge structure into Gaia IR.
+- Running local BP inference on a hand-built graph.
+
+Do **not** use for: Typst package authoring (`gaia init` / `gaia build`), modifying core IR in `gaia/gaia_ir/` or BP in `gaia/bp/`, review workflows.
+
+## Imports
+
+```python
+from gaia.gaia_ir import (
+    Knowledge, KnowledgeType, Operator, OperatorType,
+    Strategy, StrategyType, LocalCanonicalGraph, make_qid,
+)
+from gaia.gaia_ir.validator import validate_local_graph
+from gaia.bp import lower_local_graph
+from gaia.bp.exact import exact_inference
+from gaia.bp.bp import BeliefPropagation
+```
+
+## Process
+
+### 1. Define identity
+
+Pick `namespace` and `package_name`. All Knowledge IDs use QID format: `{namespace}:{package_name}::{label}`.
+
+```python
+NS, PKG = "my_ns", "my_pkg"
+
+def qid(label: str) -> str:
+    return make_qid(NS, PKG, label)
+```
+
+### 2. Create Knowledge nodes
+
+Three types per `02-gaia-ir.md` §1.2:
+
+| Type | Role | Carries probability |
+|------|------|---------------------|
+| `claim` | Scientific assertions, hypotheses, observations | Yes (only type with prior + belief) |
+| `setting` | Background / frame assumptions | No |
+| `question` | Open problems | No |
+
+```python
+k1 = Knowledge(id=qid("observation_a"), type="claim", content="描述")
+k2 = Knowledge(id=qid("background"), type="setting", content="背景")
+k3 = Knowledge(id=qid("open_problem"), type="question", content="问题")
+```
+
+**Rules:**
+- Labels must be unique within the package (enforced by validator).
+- Labels must match `[a-z_][a-z0-9_]*` (lowercase + underscores).
+- `content` stores the proposition text (local layer).
+- `LocalCanonicalGraph` auto-assigns QIDs for nodes that have `label` but no `id`, but explicit `id=qid(...)` is recommended.
+
+### 3. Add Operators (structural constraints)
+
+Operators encode **deterministic** logical relations between claims. **No probability parameters.** Per `02-gaia-ir.md` §2:
+
+| Operator | Variables | Conclusion | Semantics |
+|----------|-----------|------------|-----------|
+| `implication` | `[A]` | `B` | A=1 → B=1 |
+| `conjunction` | `[A₁,...,Aₖ]` (≥2) | `M` | M = A₁ ∧ ... ∧ Aₖ |
+| `disjunction` | `[A₁,...,Aₖ]` (≥2) | helper | ¬(all=0) |
+| `equivalence` | `[A, B]` | helper | A=B |
+| `contradiction` | `[A, B]` | helper | ¬(A=1 ∧ B=1) |
+| `complement` | `[A, B]` | helper | A≠B (XOR) |
+
+**Top-level operators MUST have `operator_id` (prefix `lco_`) and `scope="local"`** — the validator rejects them otherwise:
+
+```python
+contra_helper = Knowledge(
+    id=qid("deflection_contradiction_h"), type="claim",
+    content="GR与牛顿预测矛盾",
+    metadata={
+        "helper_kind": "contradiction_result",
+        "helper_visibility": "top_level",
+        "canonical_name": "not_both_true(gr_deflection,soldner_deflection)",
+        "generated": True,
+        "generated_kind": "helper_claim",
+    },
+)
+contra_op = Operator(
+    operator_id="lco_001", scope="local",
+    operator="contradiction",
+    variables=[qid("gr_deflection"), qid("soldner_deflection")],
+    conclusion=contra_helper.id,
+)
+```
+
+**Helper claim metadata** per `04-helper-claims.md` §4–§5:
+
+| Field | Value |
+|-------|-------|
+| `helper_kind` | `conjunction_result` / `disjunction_result` / `equivalence_result` / `contradiction_result` / `complement_result` |
+| `helper_visibility` | `top_level` (for graph-level operators) or `formal_internal` (inside FormalExpr) |
+| `canonical_name` | Stable function-style name: `not_both_true(A,B)`, `same_truth(A,B)`, `all_true(A,B)`, `any_true(A,B,...)`, `opposite_truth(A,B)` |
+
+**Key invariant:** `conclusion` must NOT appear in `variables` — variables are inputs only.
+
+### 4. Add Strategies (reasoning declarations)
+
+Strategies carry **all probability** — per `02-gaia-ir.md` §3. Premises must reference `claim` Knowledge IDs.
+
+| Type | Use | Parameters |
+|------|-----|------------|
+| `noisy_and` | Premises jointly support conclusion | 1 float (strength p) |
+| `infer` | General CPT | 2^k floats |
+| `deduction` | Deterministic derivation | None (auto-formalized at lowering) |
+| `abduction` | Observation → hypothesis | None (auto-formalized) |
+| `analogy` | 2 premises → target | None |
+| `extrapolation` | 2 premises → target | None |
+| `elimination` | `[exhaustiveness, cand₁, ev₁, ...]` → conclusion | None |
+| `case_analysis` | `[exhaustiveness, case₁, sup₁, ...]` → conclusion | None |
+| `mathematical_induction` | 2 premises → law | None |
+
+```python
+s = Strategy(
+    scope="local", type="noisy_and",
+    premises=[qid("premise_a"), qid("premise_b")],
+    conclusion=qid("conclusion_c"),
+)
+```
+
+**Named strategies** (`deduction`, `abduction`, etc.) are stored as leaf `Strategy` and **auto-formalized** by `lower_local_graph` into `FormalStrategy` with generated intermediate claims — you do NOT need to build `FormalExpr` by hand.
+
+`setting` and `question` can appear in `background` but **not** in `premises` (validator rejects non-claim premises).
+
+### 5. Assemble the graph
+
+```python
+graph = LocalCanonicalGraph(
+    namespace=NS,
+    package_name=PKG,
+    knowledges=[k1, k2, ...],
+    operators=[op1, ...],       # may be empty
+    strategies=[s1, s2, ...],
+)
+```
+
+`ir_hash` is auto-computed (SHA-256 of canonical JSON).
+
+### 6. Validate
+
+```python
+from gaia.gaia_ir.validator import validate_local_graph
+
+result = validate_local_graph(graph)
+if not result.valid:
+    for err in result.errors:
+        print(f"ERROR: {err}")
+    raise SystemExit(1)
+```
+
+`validate_local_graph` checks (~80 rules per `08-validation.md`):
+- QID format, label uniqueness, type constraints
+- Operator variable/conclusion references exist and are claims
+- Strategy premises are claims, conclusion exists
+- No cycles in operator dependency graph
+- `ir_hash` consistency (if pre-set)
+
+### 7. Lower and run inference
+
+```python
+from gaia.bp import lower_local_graph
+from gaia.bp.exact import exact_inference
+
+fg = lower_local_graph(
+    graph,
+    node_priors={"ns:pkg::label": 0.9, ...},            # claim priors
+    strategy_conditional_params={s.strategy_id: [0.85]}, # noisy_and: 1 param
+)
+
+beliefs, _ = exact_inference(fg)
+for node, belief in sorted(beliefs.items()):
+    print(f"  {node}: {belief:.4f}")
+```
+
+For loopy BP (larger graphs):
+
+```python
+from gaia.bp.bp import BeliefPropagation
+
+bp = BeliefPropagation(damping=0.5, max_iterations=100)
+result = bp.run(fg)
+assert result.diagnostics.converged
+beliefs = result.beliefs
+```
+
+## Complete example — Galileo coarse
+
+```python
+from gaia.gaia_ir import Knowledge, Strategy, LocalCanonicalGraph, make_qid
+from gaia.gaia_ir.validator import validate_local_graph
+from gaia.bp import lower_local_graph
+from gaia.bp.exact import exact_inference
+
+NS, PKG = "reg", "galileo"
+def qid(label): return make_qid(NS, PKG, label)
+def claim(label, content): return Knowledge(id=qid(label), type="claim", content=content)
+
+tied = claim("tied_balls_contradiction", "绑球矛盾")
+air  = claim("air_resistance_is_confound", "介质阻力是混淆因素")
+inc  = claim("inclined_plane_observation", "斜面实验")
+venv = claim("vacuum_env", "真空环境设定")
+pred = claim("vacuum_prediction", "真空中等速下落")
+
+s = Strategy(
+    scope="local", type="noisy_and",
+    premises=[tied.id, air.id, inc.id, venv.id],
+    conclusion=pred.id,
+)
+
+graph = LocalCanonicalGraph(
+    namespace=NS, package_name=PKG,
+    knowledges=[tied, air, inc, venv, pred],
+    strategies=[s],
+)
+
+result = validate_local_graph(graph)
+assert result.valid, result.errors
+
+fg = lower_local_graph(graph, node_priors={
+    tied.id: 0.9, air.id: 0.85, inc.id: 0.95, venv.id: 0.99,
+}, strategy_conditional_params={s.strategy_id: [0.9]})
+
+beliefs, _ = exact_inference(fg)
+assert beliefs[pred.id] > 0.6
+```
+
+## Anti-patterns
+
+- **Omitting `operator_id` / `scope` on top-level Operators** — validator rejects them. Use `operator_id="lco_001"` (or any `lco_` prefix), `scope="local"`.
+- **Using `setting` or `question` as Strategy premise** — must be `claim`.
+- **Putting conclusion in variables** — variables are inputs only; conclusion is separate.
+- **Forgetting helper claims for relation operators** — `contradiction`, `equivalence`, `complement`, `disjunction` need a conclusion claim node in the graph.
+- **Manually building FormalExpr for named strategies** — `lower_local_graph` auto-formalizes `deduction`, `abduction`, etc. Just use leaf `Strategy`.
+- **Skipping validation** — always call `validate_local_graph` before lowering.
+
+## Spec pointers
+
+- `docs/foundations/gaia-ir/02-gaia-ir.md` — Knowledge / Operator / Strategy schemas and invariants
+- `docs/foundations/gaia-ir/04-helper-claims.md` — Helper claim metadata conventions
+- `docs/foundations/gaia-ir/08-validation.md` — Full validation rule set
+- `docs/foundations/gaia-ir/07-lowering.md` — Lowering contract (IR → FactorGraph)
+- `tests/test_science_examples.py` — Galileo / Newton / Einstein end-to-end references

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,12 @@ Usage notes:
 </skill>
 
 <skill>
+<name>gaia-ir-authoring</name>
+<description>Use when constructing a Gaia IR LocalCanonicalGraph from source material — teaches how to build valid knowledge graphs using existing gaia.gaia_ir models, validate them, and run BP inference</description>
+<location>project</location>
+</skill>
+
+<skill>
 <name>meeting</name>
 <description>Use when a decision needs structured multi-party deliberation with external AI agents before the user decides. Triggers include architecture discussions, design trade-offs, naming decisions, or any topic where independent perspectives improve decision quality.</description>
 <location>project</location>

--- a/tests/test_science_examples.py
+++ b/tests/test_science_examples.py
@@ -1,0 +1,413 @@
+"""End-to-end examples: Galileo, Newton, Einstein — coarse & fine graphs.
+
+Builds Gaia IR LocalCanonicalGraphs by hand, lowers them to FactorGraphs,
+and runs BP to verify belief propagation produces sensible posteriors.
+"""
+
+from __future__ import annotations
+
+from gaia.bp import lower_local_graph
+from gaia.bp.bp import BeliefPropagation
+from gaia.bp.exact import exact_inference
+from gaia.gaia_ir import Knowledge, Operator, Strategy, LocalCanonicalGraph
+
+
+NS, PKG_G, PKG_N, PKG_E = "reg", "galileo", "newton", "einstein"
+
+
+def _qid(pkg: str, label: str) -> str:
+    return f"{NS}:{pkg}::{label}"
+
+
+def _claim(pkg: str, label: str, content: str) -> Knowledge:
+    return Knowledge(id=_qid(pkg, label), type="claim", content=content)
+
+
+def _lg(pkg: str, **kw) -> LocalCanonicalGraph:
+    kw.setdefault("namespace", NS)
+    kw.setdefault("package_name", pkg)
+    return LocalCanonicalGraph(**kw)
+
+
+# ============================================================================
+# Galileo — Falling Bodies
+# ============================================================================
+
+
+class TestGalileoCoarse:
+    """Coarse graph: 4 premises → noisy_and → vacuum_prediction."""
+
+    def _build(self):
+        tied_balls = _claim("galileo", "tied_balls_contradiction", "绑球矛盾")
+        air_resist = _claim("galileo", "air_resistance_is_confound", "介质阻力是混淆因素")
+        inclined = _claim("galileo", "inclined_plane_observation", "斜面实验")
+        vacuum_env = _claim("galileo", "vacuum_env", "真空环境设定")
+        vacuum_pred = _claim("galileo", "vacuum_prediction", "真空中等速下落")
+
+        s = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=[tied_balls.id, air_resist.id, inclined.id, vacuum_env.id],
+            conclusion=vacuum_pred.id,
+        )
+        return _lg(
+            "galileo",
+            knowledges=[tied_balls, air_resist, inclined, vacuum_env, vacuum_pred],
+            strategies=[s],
+        ), s
+
+    def test_builds_and_validates(self):
+        g, s = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("galileo", "tied_balls_contradiction"): 0.9,
+                _qid("galileo", "air_resistance_is_confound"): 0.85,
+                _qid("galileo", "inclined_plane_observation"): 0.95,
+                _qid("galileo", "vacuum_env"): 0.99,
+            },
+            strategy_conditional_params={s.strategy_id: [0.9]},
+        )
+        assert not fg.validate()
+        beliefs, _ = exact_inference(fg)
+        vp = beliefs[_qid("galileo", "vacuum_prediction")]
+        assert vp > 0.6, f"vacuum_prediction belief too low: {vp:.4f}"
+
+    def test_strong_premises_raise_conclusion(self):
+        g, s = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("galileo", "tied_balls_contradiction"): 0.95,
+                _qid("galileo", "air_resistance_is_confound"): 0.95,
+                _qid("galileo", "inclined_plane_observation"): 0.98,
+                _qid("galileo", "vacuum_env"): 0.99,
+            },
+            strategy_conditional_params={s.strategy_id: [0.95]},
+        )
+        beliefs, _ = exact_inference(fg)
+        vp = beliefs[_qid("galileo", "vacuum_prediction")]
+        assert vp > 0.8, f"Expected high belief, got {vp:.4f}"
+
+
+class TestGalileoFine:
+    """Fine graph: decomposed tied-ball argument with contradiction operator."""
+
+    def _build(self):
+        heavier_faster = _claim("galileo", "heavier_falls_faster", "重者下落更快")
+        thought_exp = _claim("galileo", "thought_experiment_env", "思想实验环境")
+        composite_slower = _claim("galileo", "composite_is_slower", "HL慢于H")
+        composite_faster = _claim("galileo", "composite_is_faster", "HL快于H")
+        contra_helper = _claim("galileo", "tied_balls_contra_h", "矛盾helper")
+        medium_obs = _claim("galileo", "medium_density_observation", "介质密度观察")
+        inclined_obs = _claim("galileo", "inclined_plane_observation", "斜面观察")
+        air_resist = _claim("galileo", "air_resistance_is_confound", "介质阻力")
+        vacuum_env = _claim("galileo", "vacuum_env", "真空环境")
+        vacuum_pred = _claim("galileo", "vacuum_prediction", "真空中等速下落")
+
+        # composite_is_slower: noisy_and from heavier_faster + thought_exp
+        s1 = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=[heavier_faster.id, thought_exp.id],
+            conclusion=composite_slower.id,
+        )
+        # composite_is_faster: noisy_and from heavier_faster + thought_exp
+        s2 = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=[heavier_faster.id, thought_exp.id],
+            conclusion=composite_faster.id,
+        )
+        contra_op = Operator(
+            operator_id="lco_001",
+            scope="local",
+            operator="contradiction",
+            variables=[composite_slower.id, composite_faster.id],
+            conclusion=contra_helper.id,
+        )
+        # air_resistance from medium_density_observation
+        s3 = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=[medium_obs.id],
+            conclusion=air_resist.id,
+        )
+        # vacuum_prediction from all evidence
+        s4 = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=[contra_helper.id, air_resist.id, inclined_obs.id, vacuum_env.id],
+            conclusion=vacuum_pred.id,
+        )
+
+        g = _lg(
+            "galileo",
+            knowledges=[
+                heavier_faster,
+                thought_exp,
+                composite_slower,
+                composite_faster,
+                contra_helper,
+                medium_obs,
+                inclined_obs,
+                air_resist,
+                vacuum_env,
+                vacuum_pred,
+            ],
+            operators=[contra_op],
+            strategies=[s1, s2, s3, s4],
+        )
+        return g, {
+            s1.strategy_id: [0.95],
+            s2.strategy_id: [0.95],
+            s3.strategy_id: [0.85],
+            s4.strategy_id: [0.9],
+        }
+
+    def test_contradiction_suppresses_premise(self):
+        g, sp = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("galileo", "heavier_falls_faster"): 0.7,
+                _qid("galileo", "thought_experiment_env"): 0.99,
+                _qid("galileo", "medium_density_observation"): 0.95,
+                _qid("galileo", "inclined_plane_observation"): 0.95,
+                _qid("galileo", "vacuum_env"): 0.99,
+            },
+            strategy_conditional_params=sp,
+        )
+        assert not fg.validate()
+        beliefs, _ = exact_inference(fg)
+        # Contradiction between composite_slower and composite_faster suppresses
+        # the shared premise heavier_falls_faster
+        hff = beliefs[_qid("galileo", "heavier_falls_faster")]
+        assert hff < 0.7, f"heavier_falls_faster should decrease, got {hff:.4f}"
+        # vacuum_prediction should still be supported
+        vp = beliefs[_qid("galileo", "vacuum_prediction")]
+        assert vp > 0.5, f"vacuum_prediction too low: {vp:.4f}"
+
+    def test_bp_converges_on_fine_graph(self):
+        g, sp = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("galileo", "heavier_falls_faster"): 0.7,
+                _qid("galileo", "thought_experiment_env"): 0.99,
+                _qid("galileo", "medium_density_observation"): 0.95,
+                _qid("galileo", "inclined_plane_observation"): 0.95,
+                _qid("galileo", "vacuum_env"): 0.99,
+            },
+            strategy_conditional_params=sp,
+        )
+        bp = BeliefPropagation(damping=0.5, max_iterations=100)
+        result = bp.run(fg)
+        assert result.diagnostics.converged
+
+
+# ============================================================================
+# Newton — Principia derivation chain
+# ============================================================================
+
+
+class TestNewtonCoarse:
+    """Coarse graph: deduction chain to freefall_acceleration."""
+
+    def _build(self):
+        kepler = _claim("newton", "kepler_third_law", "开普勒第三定律")
+        second_law = _claim("newton", "second_law", "牛顿第二定律")
+        third_law = _claim("newton", "third_law", "牛顿第三定律")
+        pendulum = _claim("newton", "pendulum_experiment", "摆锤实验")
+        near_earth = _claim("newton", "near_earth_surface", "近地表面条件")
+
+        inverse_sq = _claim("newton", "inverse_square_force", "反平方力")
+        gravity_law = _claim("newton", "law_of_gravity", "万有引力定律")
+        mass_eq = _claim("newton", "mass_equivalence", "质量等价")
+        freefall = _claim("newton", "freefall_acceleration", "自由落体加速度")
+
+        # deduction: kepler + second_law → inverse_square
+        s1 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=[kepler.id, second_law.id],
+            conclusion=inverse_sq.id,
+        )
+        # deduction: inverse_square + third_law → law_of_gravity
+        s2 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=[inverse_sq.id, third_law.id],
+            conclusion=gravity_law.id,
+        )
+        # deduction: pendulum + second_law + gravity_law → mass_equivalence
+        s3 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=[pendulum.id, second_law.id, gravity_law.id],
+            conclusion=mass_eq.id,
+        )
+        # deduction: second_law + gravity_law + mass_eq + near_earth → freefall
+        s4 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=[second_law.id, gravity_law.id, mass_eq.id, near_earth.id],
+            conclusion=freefall.id,
+        )
+
+        return _lg(
+            "newton",
+            knowledges=[
+                kepler,
+                second_law,
+                third_law,
+                pendulum,
+                near_earth,
+                inverse_sq,
+                gravity_law,
+                mass_eq,
+                freefall,
+            ],
+            strategies=[s1, s2, s3, s4],
+        )
+
+    def test_deduction_chain_propagates(self):
+        g = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("newton", "kepler_third_law"): 0.95,
+                _qid("newton", "second_law"): 0.99,
+                _qid("newton", "third_law"): 0.99,
+                _qid("newton", "pendulum_experiment"): 0.95,
+                _qid("newton", "near_earth_surface"): 0.99,
+            },
+        )
+        assert not fg.validate()
+        beliefs, _ = exact_inference(fg)
+        ff = beliefs[_qid("newton", "freefall_acceleration")]
+        assert ff > 0.7, f"freefall belief too low: {ff:.4f}"
+        # Each deduction step with high-prior premises should produce high belief
+        isq = beliefs[_qid("newton", "inverse_square_force")]
+        assert isq > 0.7, f"inverse_square belief: {isq:.4f}"
+
+    def test_weakening_premise_cascades(self):
+        """Lower Kepler's prior → inverse_square drops → downstream drops."""
+        g = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("newton", "kepler_third_law"): 0.3,
+                _qid("newton", "second_law"): 0.99,
+                _qid("newton", "third_law"): 0.99,
+                _qid("newton", "pendulum_experiment"): 0.95,
+                _qid("newton", "near_earth_surface"): 0.99,
+            },
+        )
+        beliefs, _ = exact_inference(fg)
+        isq = beliefs[_qid("newton", "inverse_square_force")]
+        assert isq < 0.6, f"inverse_square should be lower with weak Kepler: {isq:.4f}"
+
+
+# ============================================================================
+# Einstein — GR light deflection + contradiction with Soldner
+# ============================================================================
+
+
+class TestEinsteinContradiction:
+    """Einstein graph: GR vs Soldner contradiction on light deflection."""
+
+    def _build(self):
+        equiv_principle = _claim("einstein", "light_bends_in_gravity", "光在引力场中弯曲")
+        field_eqs = _claim("einstein", "einstein_field_equations", "爱因斯坦场方程")
+        gr_deflect = _claim("einstein", "gr_light_deflection", "GR预测1.75角秒")
+        soldner = _claim("einstein", "soldner_deflection", "牛顿微粒说预测0.87角秒")
+        contra_h = _claim("einstein", "deflection_contradiction_h", "矛盾helper")
+        mercury_obs = _claim("einstein", "mercury_perihelion", "水星进动观测")
+        mercury_gr = _claim("einstein", "gr_mercury_precession", "GR解释水星进动")
+
+        # GR deflection from equivalence_principle + field_equations
+        s1 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=[equiv_principle.id, field_eqs.id],
+            conclusion=gr_deflect.id,
+        )
+        contra_op = Operator(
+            operator_id="lco_001",
+            scope="local",
+            operator="contradiction",
+            variables=[gr_deflect.id, soldner.id],
+            conclusion=contra_h.id,
+        )
+        # Mercury precession from field_equations + observation
+        s2 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=[field_eqs.id, mercury_obs.id],
+            conclusion=mercury_gr.id,
+        )
+
+        return _lg(
+            "einstein",
+            knowledges=[
+                equiv_principle,
+                field_eqs,
+                gr_deflect,
+                soldner,
+                contra_h,
+                mercury_obs,
+                mercury_gr,
+            ],
+            operators=[contra_op],
+            strategies=[s1, s2],
+        )
+
+    def test_contradiction_suppresses_soldner(self):
+        g = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("einstein", "light_bends_in_gravity"): 0.9,
+                _qid("einstein", "einstein_field_equations"): 0.95,
+                _qid("einstein", "soldner_deflection"): 0.6,
+                _qid("einstein", "mercury_perihelion"): 0.98,
+            },
+        )
+        assert not fg.validate()
+        beliefs, _ = exact_inference(fg)
+        gr = beliefs[_qid("einstein", "gr_light_deflection")]
+        sol = beliefs[_qid("einstein", "soldner_deflection")]
+        # GR supported by deduction; Soldner suppressed by contradiction
+        assert gr > sol, f"GR ({gr:.4f}) should dominate Soldner ({sol:.4f})"
+
+    def test_mercury_independent_support(self):
+        """Mercury precession deduction: high field_eqs prior → high mercury_gr belief."""
+        g = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("einstein", "light_bends_in_gravity"): 0.9,
+                _qid("einstein", "einstein_field_equations"): 0.95,
+                _qid("einstein", "soldner_deflection"): 0.5,
+                _qid("einstein", "mercury_perihelion"): 0.98,
+            },
+        )
+        beliefs, _ = exact_inference(fg)
+        mgr = beliefs[_qid("einstein", "gr_mercury_precession")]
+        assert mgr > 0.7, f"mercury GR belief should be high: {mgr:.4f}"
+
+    def test_bp_converges(self):
+        g = self._build()
+        fg = lower_local_graph(
+            g,
+            node_priors={
+                _qid("einstein", "light_bends_in_gravity"): 0.9,
+                _qid("einstein", "einstein_field_equations"): 0.95,
+                _qid("einstein", "soldner_deflection"): 0.6,
+                _qid("einstein", "mercury_perihelion"): 0.98,
+            },
+        )
+        bp = BeliefPropagation(damping=0.5, max_iterations=100)
+        result = bp.run(fg)
+        assert result.diagnostics.converged


### PR DESCRIPTION
## Summary

- `.claude/skills/gaia-ir-authoring/SKILL.md` — self-contained agent skill teaching
  construction of valid `LocalCanonicalGraph` using existing `gaia.gaia_ir` models,
  validation, and BP inference. No new SDK — pure documentation.
- `tests/test_science_examples.py` — Galileo/Newton/Einstein end-to-end IR tests
- `AGENTS.md` — registered skill

## Test plan

- [x] `ruff check` + `ruff format` — passed
- [x] `test_science_examples.py` — 9/9 passed
- [x] Test assertions verified against theory (contradiction §2.4, deduction §3.3, soft entailment §4)
- [x] Fresh agent reads only SKILL.md → builds novel IR → validate + infer succeeds