### PR TITLE
Add review sidecar infer pipeline

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
-from gaia.lang.runtime import Knowledge
+from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
 
@@ -54,6 +54,7 @@ def _import_fresh(import_name: str) -> ModuleType:
 
 def _assign_labels(module: ModuleType, pkg: CollectedPackage) -> None:
     local_knowledge_ids = {id(k) for k in pkg.knowledge}
+    local_strategy_ids = {id(s) for s in pkg.strategies}
     export_names = getattr(module, "__all__", None)
     if isinstance(export_names, list) and all(isinstance(name, str) for name in export_names):
         names = export_names
@@ -62,6 +63,10 @@ def _assign_labels(module: ModuleType, pkg: CollectedPackage) -> None:
     for attr in names:
         obj = getattr(module, attr, None)
         if isinstance(obj, Knowledge) and id(obj) in local_knowledge_ids and obj.label is None:
+            obj.label = attr
+    for attr in [name for name in dir(module) if not name.startswith("_")]:
+        obj = getattr(module, attr, None)
+        if isinstance(obj, Strategy) and id(obj) in local_strategy_ids and obj.label is None:
             obj.label = attr
 
 
@@ -138,6 +143,13 @@ def compile_loaded_package(loaded: LoadedGaiaPackage) -> dict[str, Any]:
     from gaia.lang.compiler import compile_package
 
     return compile_package(loaded.package)
+
+
+def compile_loaded_package_artifact(loaded: LoadedGaiaPackage):
+    """Compile an already loaded Gaia package to IR plus runtime mappings."""
+    from gaia.lang.compiler import compile_package_artifact
+
+    return compile_package_artifact(loaded.package)
 
 
 def write_compiled_artifacts(pkg_path: Path, ir: dict[str, Any]) -> Path:

--- a/gaia/cli/_reviews.py
+++ b/gaia/cli/_reviews.py
@@ -14,6 +14,8 @@ from gaia.review import ClaimReview, GeneratedClaimReview, ReviewBundle, Strateg
 
 @dataclass
 class LoadedGaiaReview:
+    name: str
+    module_name: str
     module_path: Path
     bundle: ReviewBundle
 
@@ -48,13 +50,35 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def load_gaia_review(loaded: LoadedGaiaPackage) -> LoadedGaiaReview | None:
-    """Load `<package>.review` if present."""
-    review_path = loaded.source_root / loaded.import_name / "review.py"
-    if not review_path.exists():
-        return None
+def _discover_review_candidates(loaded: LoadedGaiaPackage) -> dict[str, tuple[str, Path]]:
+    package_dir = loaded.source_root / loaded.import_name
+    candidates: dict[str, tuple[str, Path]] = {}
 
-    module_name = f"{loaded.import_name}.review"
+    legacy_path = package_dir / "review.py"
+    if legacy_path.exists():
+        candidates["review"] = (f"{loaded.import_name}.review", legacy_path)
+
+    reviews_dir = package_dir / "reviews"
+    if reviews_dir.exists():
+        for path in sorted(reviews_dir.glob("*.py")):
+            if path.name == "__init__.py":
+                continue
+            review_name = path.stem
+            if review_name in candidates:
+                raise GaiaCliError(
+                    f"Error: duplicate review name {review_name!r} in package review sidecars."
+                )
+            candidates[review_name] = (f"{loaded.import_name}.reviews.{review_name}", path)
+
+    return candidates
+
+
+def _load_review_candidate(
+    *,
+    review_name: str,
+    module_name: str,
+    module_path: Path,
+) -> LoadedGaiaReview:
     try:
         module = _import_fresh(module_name)
     except ModuleNotFoundError as exc:
@@ -67,9 +91,55 @@ def load_gaia_review(loaded: LoadedGaiaPackage) -> LoadedGaiaReview | None:
     bundle = getattr(module, "REVIEW", None)
     if not isinstance(bundle, ReviewBundle):
         raise GaiaCliError(
-            "Error: review.py must export REVIEW = ReviewBundle(...)."
+            f"Error: {module_path.name} must export REVIEW = ReviewBundle(...)."
         )
-    return LoadedGaiaReview(module_path=review_path, bundle=bundle)
+    return LoadedGaiaReview(
+        name=review_name,
+        module_name=module_name,
+        module_path=module_path,
+        bundle=bundle,
+    )
+
+
+def load_gaia_review(
+    loaded: LoadedGaiaPackage,
+    *,
+    review_name: str | None = None,
+) -> LoadedGaiaReview | None:
+    """Load a package review sidecar.
+
+    Supports:
+    - legacy `<package>/review.py`
+    - multi-review `<package>/reviews/<name>.py`
+    """
+    candidates = _discover_review_candidates(loaded)
+    if not candidates:
+        return None
+
+    if review_name is None:
+        if len(candidates) == 1:
+            review_name = next(iter(candidates))
+        else:
+            available = ", ".join(sorted(candidates))
+            raise GaiaCliError(
+                "Error: multiple review sidecars found; choose one with "
+                f"`gaia infer --review <name>`. Available: {available}"
+            )
+    elif review_name not in candidates:
+        available = ", ".join(sorted(candidates))
+        raise GaiaCliError(
+            f"Error: unknown review sidecar {review_name!r}. Available: {available}"
+        )
+
+    module_name, module_path = candidates[review_name]
+    loaded_review = _load_review_candidate(
+        review_name=review_name,
+        module_name=module_name,
+        module_path=module_path,
+    )
+    if loaded_review is None:
+        return None
+    return loaded_review
 
 
 def resolve_gaia_review(loaded_review, compiled) -> ResolvedGaiaReview:

--- a/gaia/cli/_reviews.py
+++ b/gaia/cli/_reviews.py
@@ -1,0 +1,218 @@
+"""Shared review sidecar loading utilities for Gaia CLI commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from gaia.cli._packages import GaiaCliError, LoadedGaiaPackage, _import_fresh
+from gaia.ir import ParameterizationSource, PriorRecord, ResolutionPolicy, StrategyParamRecord
+from gaia.review import ClaimReview, GeneratedClaimReview, ReviewBundle, StrategyReview
+
+
+@dataclass
+class LoadedGaiaReview:
+    module_path: Path
+    bundle: ReviewBundle
+
+
+@dataclass
+class ResolvedGaiaReview:
+    source: ParameterizationSource
+    resolution_policy: ResolutionPolicy
+    objects: list[dict[str, Any]]
+    priors: list[PriorRecord]
+    strategy_params: list[StrategyParamRecord]
+
+    def to_json(self, *, ir_hash: str) -> dict[str, Any]:
+        return {
+            "ir_hash": ir_hash,
+            "source": self.source.model_dump(mode="json", exclude_none=True),
+            "resolution_policy": self.resolution_policy.model_dump(
+                mode="json",
+                exclude_none=True,
+            ),
+            "objects": self.objects,
+            "priors": [
+                record.model_dump(mode="json", exclude_none=True) for record in self.priors
+            ],
+            "strategy_params": [
+                record.model_dump(mode="json", exclude_none=True) for record in self.strategy_params
+            ],
+        }
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def load_gaia_review(loaded: LoadedGaiaPackage) -> LoadedGaiaReview | None:
+    """Load `<package>.review` if present."""
+    review_path = loaded.source_root / loaded.import_name / "review.py"
+    if not review_path.exists():
+        return None
+
+    module_name = f"{loaded.import_name}.review"
+    try:
+        module = _import_fresh(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name == module_name:
+            return None
+        raise GaiaCliError(f"Error importing review sidecar: {exc}") from exc
+    except Exception as exc:
+        raise GaiaCliError(f"Error importing review sidecar: {exc}") from exc
+
+    bundle = getattr(module, "REVIEW", None)
+    if not isinstance(bundle, ReviewBundle):
+        raise GaiaCliError(
+            "Error: review.py must export REVIEW = ReviewBundle(...)."
+        )
+    return LoadedGaiaReview(module_path=review_path, bundle=bundle)
+
+
+def resolve_gaia_review(loaded_review, compiled) -> ResolvedGaiaReview:
+    """Resolve runtime review objects to IR parameterization records."""
+    source = ParameterizationSource(
+        source_id=loaded_review.bundle.source_id,
+        model=loaded_review.bundle.model or "agent-authored",
+        policy=loaded_review.bundle.policy,
+        config=loaded_review.bundle.config,
+        created_at=_utc_now(),
+    )
+    resolution_policy = ResolutionPolicy(strategy="source", source_id=source.source_id)
+
+    priors: list[PriorRecord] = []
+    strategy_params: list[StrategyParamRecord] = []
+    objects: list[dict[str, Any]] = []
+
+    for review in loaded_review.bundle.objects:
+        if isinstance(review, ClaimReview):
+            knowledge_id = compiled.knowledge_ids_by_object.get(id(review.subject))
+            if knowledge_id is None:
+                raise GaiaCliError("Error: review_claim() references a Knowledge outside this package.")
+            if review.prior is not None:
+                priors.append(
+                    PriorRecord(
+                        knowledge_id=knowledge_id,
+                        value=review.prior,
+                        source_id=source.source_id,
+                    )
+                )
+            objects.append(
+                {
+                    "kind": "claim",
+                    "knowledge_id": knowledge_id,
+                    "label": review.subject.label,
+                    "judgment": review.judgment,
+                    "justification": review.justification,
+                    "prior": review.prior,
+                    "metadata": review.metadata or None,
+                }
+            )
+            continue
+
+        if isinstance(review, GeneratedClaimReview):
+            strategy = compiled.strategies_by_object.get(id(review.subject))
+            if strategy is None:
+                raise GaiaCliError(
+                    "Error: review_generated_claim() references a Strategy outside this package."
+                )
+            interface_roles = (strategy.metadata or {}).get("interface_roles", {})
+            if not isinstance(interface_roles, dict):
+                raise GaiaCliError(
+                    f"Error: strategy '{strategy.strategy_id}' does not expose interface roles."
+                )
+            targets = interface_roles.get(review.role)
+            if not isinstance(targets, list) or review.occurrence >= len(targets):
+                raise GaiaCliError(
+                    f"Error: strategy '{strategy.strategy_id}' has no interface role "
+                    f"{review.role!r} at occurrence {review.occurrence}."
+                )
+            knowledge_id = targets[review.occurrence]
+            if review.prior is not None:
+                priors.append(
+                    PriorRecord(
+                        knowledge_id=knowledge_id,
+                        value=review.prior,
+                        source_id=source.source_id,
+                    )
+                )
+            objects.append(
+                {
+                    "kind": "generated_claim",
+                    "strategy_id": strategy.strategy_id,
+                    "strategy_label": review.subject.label,
+                    "knowledge_id": knowledge_id,
+                    "role": review.role,
+                    "occurrence": review.occurrence,
+                    "judgment": review.judgment,
+                    "justification": review.justification,
+                    "prior": review.prior,
+                    "metadata": review.metadata or None,
+                }
+            )
+            continue
+
+        if isinstance(review, StrategyReview):
+            strategy = compiled.strategies_by_object.get(id(review.subject))
+            if strategy is None:
+                raise GaiaCliError(
+                    "Error: review_strategy() references a Strategy outside this package."
+                )
+
+            conditional_probabilities: list[float] | None = None
+            strategy_type = str(strategy.type)
+            if review.conditional_probability is not None or review.conditional_probabilities is not None:
+                if strategy_type == "noisy_and":
+                    conditional_probabilities = (
+                        list(review.conditional_probabilities)
+                        if review.conditional_probabilities is not None
+                        else [review.conditional_probability]
+                    )
+                elif strategy_type == "infer":
+                    if review.conditional_probabilities is None:
+                        raise GaiaCliError(
+                            "Error: infer strategies require "
+                            "review_strategy(..., conditional_probabilities=[...])."
+                        )
+                    conditional_probabilities = list(review.conditional_probabilities)
+                else:
+                    raise GaiaCliError(
+                        f"Error: strategy '{strategy.strategy_id}' has type '{strategy_type}' and "
+                        "does not accept conditional probabilities."
+                    )
+
+            if conditional_probabilities is not None:
+                strategy_params.append(
+                    StrategyParamRecord(
+                        strategy_id=strategy.strategy_id,
+                        conditional_probabilities=conditional_probabilities,
+                        source_id=source.source_id,
+                    )
+                )
+
+            objects.append(
+                {
+                    "kind": "strategy",
+                    "strategy_id": strategy.strategy_id,
+                    "label": review.subject.label,
+                    "type": strategy_type,
+                    "judgment": review.judgment,
+                    "justification": review.justification,
+                    "conditional_probabilities": conditional_probabilities,
+                    "metadata": review.metadata or None,
+                }
+            )
+            continue
+
+        raise GaiaCliError(f"Error: unsupported review object type {type(review)!r}.")
+
+    return ResolvedGaiaReview(
+        source=source,
+        resolution_policy=resolution_policy,
+        objects=objects,
+        priors=priors,
+        strategy_params=strategy_params,
+    )

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -19,6 +19,11 @@ def _write_json(path, payload) -> None:
 
 def infer_command(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
+    review: str | None = typer.Option(
+        None,
+        "--review",
+        help="Review sidecar name from <package>/reviews/<name>.py or 'review' for legacy review.py.",
+    ),
 ) -> None:
     """Run BP using the current IR structure plus the package review sidecar."""
     try:
@@ -55,11 +60,11 @@ def infer_command(
         raise typer.Exit(1)
 
     try:
-        loaded_review = load_gaia_review(loaded)
+        loaded_review = load_gaia_review(loaded, review_name=review)
         if loaded_review is None:
             raise GaiaCliError(
-                "Error: missing review sidecar. Create <package>/review.py with "
-                "REVIEW = ReviewBundle(...)."
+                "Error: missing review sidecar. Create <package>/review.py or "
+                "<package>/reviews/<name>.py with REVIEW = ReviewBundle(...)."
             )
         resolved_review = resolve_gaia_review(loaded_review, compiled)
     except GaiaCliError as exc:
@@ -98,9 +103,11 @@ def infer_command(
 
     gaia_dir = loaded.pkg_path / ".gaia"
     gaia_dir.mkdir(exist_ok=True)
+    review_dir = gaia_dir / "reviews" / loaded_review.name
+    review_dir.mkdir(parents=True, exist_ok=True)
 
     _write_json(
-        gaia_dir / "parameterization.json",
+        review_dir / "parameterization.json",
         resolved_review.to_json(ir_hash=compiled.graph.ir_hash),
     )
 
@@ -118,7 +125,7 @@ def infer_command(
         ],
         "diagnostics": asdict(result.diagnostics),
     }
-    _write_json(gaia_dir / "beliefs.json", beliefs_payload)
+    _write_json(review_dir / "beliefs.json", beliefs_payload)
 
     typer.echo(
         f"Inferred {len(result.beliefs)} beliefs from "
@@ -129,4 +136,5 @@ def infer_command(
         f"BP converged: {result.diagnostics.converged} "
         f"after {result.diagnostics.iterations_run} iterations"
     )
-    typer.echo(f"Output: {gaia_dir / 'beliefs.json'}")
+    typer.echo(f"Review: {loaded_review.name}")
+    typer.echo(f"Output: {review_dir / 'beliefs.json'}")

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -1,0 +1,131 @@
+"""gaia infer -- run BP from compiled IR plus review sidecar parameterization."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import typer
+
+from gaia.bp import BeliefPropagation, lower_local_graph
+from gaia.cli._packages import GaiaCliError, compile_loaded_package_artifact, load_gaia_package
+from gaia.cli._reviews import load_gaia_review, resolve_gaia_review
+from gaia.ir.validator import validate_local_graph, validate_parameterization
+
+
+def _write_json(path, payload) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def infer_command(
+    path: str = typer.Argument(".", help="Path to knowledge package directory"),
+) -> None:
+    """Run BP using the current IR structure plus the package review sidecar."""
+    try:
+        loaded = load_gaia_package(path)
+        compiled = compile_loaded_package_artifact(loaded)
+    except GaiaCliError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1)
+
+    graph_validation = validate_local_graph(compiled.graph)
+    for warning in graph_validation.warnings:
+        typer.echo(f"Warning: {warning}")
+    if graph_validation.errors:
+        for error in graph_validation.errors:
+            typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(1)
+
+    ir_hash_path = loaded.pkg_path / ".gaia" / "ir_hash"
+    ir_json_path = loaded.pkg_path / ".gaia" / "ir.json"
+    compiled_json = compiled.to_json()
+    if not ir_hash_path.exists() or not ir_json_path.exists():
+        typer.echo("Error: missing compiled artifacts; run `gaia compile` first.", err=True)
+        raise typer.Exit(1)
+    if ir_hash_path.read_text().strip() != compiled.graph.ir_hash:
+        typer.echo("Error: compiled artifacts are stale; run `gaia compile` again.", err=True)
+        raise typer.Exit(1)
+    try:
+        stored_ir = json.loads(ir_json_path.read_text())
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Error: .gaia/ir.json is not valid JSON: {exc}", err=True)
+        raise typer.Exit(1)
+    if stored_ir.get("ir_hash") != compiled.graph.ir_hash or stored_ir != compiled_json:
+        typer.echo("Error: compiled artifacts are stale; run `gaia compile` again.", err=True)
+        raise typer.Exit(1)
+
+    try:
+        loaded_review = load_gaia_review(loaded)
+        if loaded_review is None:
+            raise GaiaCliError(
+                "Error: missing review sidecar. Create <package>/review.py with "
+                "REVIEW = ReviewBundle(...)."
+            )
+        resolved_review = resolve_gaia_review(loaded_review, compiled)
+    except GaiaCliError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1)
+
+    parameterization_validation = validate_parameterization(
+        compiled.graph,
+        resolved_review.priors,
+        resolved_review.strategy_params,
+    )
+    for warning in parameterization_validation.warnings:
+        typer.echo(f"Warning: {warning}")
+    if parameterization_validation.errors:
+        for error in parameterization_validation.errors:
+            typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(1)
+
+    node_priors = {record.knowledge_id: record.value for record in resolved_review.priors}
+    strategy_params = {
+        record.strategy_id: record.conditional_probabilities
+        for record in resolved_review.strategy_params
+    }
+    factor_graph = lower_local_graph(
+        compiled.graph,
+        node_priors=node_priors,
+        strategy_conditional_params=strategy_params,
+    )
+    fg_errors = factor_graph.validate()
+    if fg_errors:
+        for error in fg_errors:
+            typer.echo(f"Error: {error}", err=True)
+        raise typer.Exit(1)
+
+    result = BeliefPropagation(damping=0.5, max_iterations=100).run(factor_graph)
+
+    gaia_dir = loaded.pkg_path / ".gaia"
+    gaia_dir.mkdir(exist_ok=True)
+
+    _write_json(
+        gaia_dir / "parameterization.json",
+        resolved_review.to_json(ir_hash=compiled.graph.ir_hash),
+    )
+
+    knowledge_by_id = {knowledge.id: knowledge for knowledge in compiled.graph.knowledges}
+    beliefs_payload = {
+        "ir_hash": compiled.graph.ir_hash,
+        "beliefs": [
+            {
+                "knowledge_id": knowledge_id,
+                "label": knowledge_by_id[knowledge_id].label,
+                "belief": belief,
+            }
+            for knowledge_id, belief in sorted(result.beliefs.items())
+        ],
+        "diagnostics": asdict(result.diagnostics),
+    }
+    _write_json(gaia_dir / "beliefs.json", beliefs_payload)
+
+    typer.echo(
+        f"Inferred {len(result.beliefs)} beliefs from "
+        f"{len(resolved_review.priors)} priors and "
+        f"{len(resolved_review.strategy_params)} strategy parameter records"
+    )
+    typer.echo(
+        f"BP converged: {result.diagnostics.converged} "
+        f"after {result.diagnostics.iterations_run} iterations"
+    )
+    typer.echo(f"Output: {gaia_dir / 'beliefs.json'}")

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -114,6 +114,7 @@ def infer_command(
                 "belief": belief,
             }
             for knowledge_id, belief in sorted(result.beliefs.items())
+            if knowledge_id in knowledge_by_id
         ],
         "diagnostics": asdict(result.diagnostics),
     }

--- a/gaia/cli/main.py
+++ b/gaia/cli/main.py
@@ -4,6 +4,7 @@ import typer
 
 from gaia.cli.commands.check import check_command
 from gaia.cli.commands.compile import compile_command
+from gaia.cli.commands.infer import infer_command
 from gaia.cli.commands.register import register_command
 
 app = typer.Typer(
@@ -20,4 +21,5 @@ def _callback() -> None:
 
 app.command(name="compile")(compile_command)
 app.command(name="check")(check_command)
+app.command(name="infer")(infer_command)
 app.command(name="register")(register_command)

--- a/gaia/lang/compiler/__init__.py
+++ b/gaia/lang/compiler/__init__.py
@@ -1,3 +1,3 @@
-from gaia.lang.compiler.compile import compile_package
+from gaia.lang.compiler.compile import CompiledPackage, compile_package, compile_package_artifact
 
-__all__ = ["compile_package"]
+__all__ = ["CompiledPackage", "compile_package", "compile_package_artifact"]

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from dataclasses import dataclass
 from typing import Any
 
 from gaia.ir import (
@@ -35,6 +36,18 @@ _COMPILE_TIME_FORMAL_STRATEGIES = frozenset(
         "extrapolation",
     }
 )
+
+
+@dataclass
+class CompiledPackage:
+    """Compiled Gaia package plus runtime-object to IR-ID mappings."""
+
+    graph: LocalCanonicalGraph
+    knowledge_ids_by_object: dict[int, str]
+    strategies_by_object: dict[int, IrStrategy]
+
+    def to_json(self) -> dict[str, Any]:
+        return self.graph.model_dump(mode="json", exclude_none=True, serialize_as_any=True)
 
 
 def _content_hash(k: Knowledge) -> str:
@@ -185,8 +198,8 @@ def _ir_steps(
     return ir_steps
 
 
-def compile_package(pkg: CollectedPackage) -> dict[str, Any]:
-    """Compile collected declarations into LocalCanonicalGraph JSON."""
+def compile_package_artifact(pkg: CollectedPackage) -> CompiledPackage:
+    """Compile collected declarations into Gaia IR plus runtime mappings."""
     # Build knowledge closure: local declarations + referenced foreign nodes.
     knowledge_nodes: list[Knowledge] = []
     seen_knowledge: set[int] = set()
@@ -321,4 +334,13 @@ def compile_package(pkg: CollectedPackage) -> dict[str, Any]:
         strategies=ir_strategies,
     )
 
-    return graph.model_dump(mode="json", exclude_none=True, serialize_as_any=True)
+    return CompiledPackage(
+        graph=graph,
+        knowledge_ids_by_object=dict(knowledge_map),
+        strategies_by_object=dict(compiled_strategies),
+    )
+
+
+def compile_package(pkg: CollectedPackage) -> dict[str, Any]:
+    """Compile collected declarations into LocalCanonicalGraph JSON."""
+    return compile_package_artifact(pkg).to_json()

--- a/gaia/review/__init__.py
+++ b/gaia/review/__init__.py
@@ -1,0 +1,25 @@
+"""Gaia review sidecar DSL.
+
+Review sidecars live next to a Gaia Lang package and provide agent-authored
+parameterization metadata without mutating the package's structural IR.
+"""
+
+from gaia.review.models import (
+    ClaimReview,
+    GeneratedClaimReview,
+    ReviewBundle,
+    StrategyReview,
+    review_claim,
+    review_generated_claim,
+    review_strategy,
+)
+
+__all__ = [
+    "ClaimReview",
+    "GeneratedClaimReview",
+    "ReviewBundle",
+    "StrategyReview",
+    "review_claim",
+    "review_generated_claim",
+    "review_strategy",
+]

--- a/gaia/review/models.py
+++ b/gaia/review/models.py
@@ -1,0 +1,137 @@
+"""Author-facing review sidecar models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from gaia.lang.runtime import Knowledge, Strategy
+
+
+@dataclass
+class ClaimReview:
+    """Review for an explicit claim Knowledge node."""
+
+    subject: Knowledge
+    prior: float | None = None
+    judgment: str | None = None
+    justification: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GeneratedClaimReview:
+    """Review for a generated strategy-interface claim.
+
+    These claims are introduced during IR formalization and therefore cannot be
+    referenced as author-facing ``Knowledge`` objects in the main package module.
+    They are instead addressed by the owning strategy plus an interface role.
+    """
+
+    subject: Strategy
+    role: str
+    prior: float | None = None
+    occurrence: int = 0
+    judgment: str | None = None
+    justification: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StrategyReview:
+    """Review for a reasoning Strategy.
+
+    Only parameterized strategies (``infer`` / ``noisy_and``) consume numeric
+    parameters during BP. Formal strategies may still carry judgments and
+    justifications for human review.
+    """
+
+    subject: Strategy
+    conditional_probability: float | None = None
+    conditional_probabilities: list[float] | None = None
+    judgment: str | None = None
+    justification: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.conditional_probability is not None and self.conditional_probabilities is not None:
+            raise ValueError(
+                "review_strategy() accepts either conditional_probability or "
+                "conditional_probabilities, not both."
+            )
+
+
+@dataclass
+class ReviewBundle:
+    """Top-level review artifact exported from ``review.py``."""
+
+    objects: list[ClaimReview | GeneratedClaimReview | StrategyReview]
+    source_id: str = "self_review"
+    model: str | None = None
+    policy: str | None = None
+    config: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.source_id:
+            raise ValueError("ReviewBundle.source_id must be non-empty.")
+
+
+def review_claim(
+    subject: Knowledge,
+    *,
+    prior: float | None = None,
+    judgment: str | None = None,
+    justification: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> ClaimReview:
+    return ClaimReview(
+        subject=subject,
+        prior=prior,
+        judgment=judgment,
+        justification=justification,
+        metadata=dict(metadata or {}),
+    )
+
+
+def review_generated_claim(
+    subject: Strategy,
+    role: str,
+    *,
+    prior: float | None = None,
+    occurrence: int = 0,
+    judgment: str | None = None,
+    justification: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> GeneratedClaimReview:
+    if occurrence < 0:
+        raise ValueError("occurrence must be >= 0")
+    return GeneratedClaimReview(
+        subject=subject,
+        role=role,
+        prior=prior,
+        occurrence=occurrence,
+        judgment=judgment,
+        justification=justification,
+        metadata=dict(metadata or {}),
+    )
+
+
+def review_strategy(
+    subject: Strategy,
+    *,
+    conditional_probability: float | None = None,
+    conditional_probabilities: list[float] | None = None,
+    judgment: str | None = None,
+    justification: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> StrategyReview:
+    return StrategyReview(
+        subject=subject,
+        conditional_probability=conditional_probability,
+        conditional_probabilities=list(conditional_probabilities)
+        if conditional_probabilities is not None
+        else None,
+        judgment=judgment,
+        justification=justification,
+        metadata=dict(metadata or {}),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["gaia.ir*", "gaia.lang*", "gaia.bp*", "gaia.cli*"]
+include = ["gaia.ir*", "gaia.lang*", "gaia.bp*", "gaia.cli*", "gaia.review*"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -20,6 +20,12 @@ def _write_base_package(pkg_dir, *, name: str, version: str = "1.0.0") -> None:
     (pkg_dir / name).mkdir()
 
 
+def _write_review(pkg_dir, package_name: str, review_name: str, body: str) -> None:
+    reviews_dir = pkg_dir / package_name / "reviews"
+    reviews_dir.mkdir(exist_ok=True)
+    (reviews_dir / f"{review_name}.py").write_text(body)
+
+
 def test_infer_writes_parameterization_and_beliefs(tmp_path):
     pkg_dir = tmp_path / "infer_demo"
     _write_base_package(pkg_dir, name="infer_demo")
@@ -31,9 +37,12 @@ def test_infer_writes_parameterization_and_beliefs(tmp_path):
         'support = noisy_and(premises=[evidence_a, evidence_b], conclusion=hypothesis)\n'
         '__all__ = ["evidence_a", "evidence_b", "hypothesis", "support"]\n'
     )
-    (pkg_dir / "infer_demo" / "review.py").write_text(
+    _write_review(
+        pkg_dir,
+        "infer_demo",
+        "self_review",
         'from gaia.review import ReviewBundle, review_claim, review_strategy\n'
-        'from . import evidence_a, evidence_b, hypothesis, support\n\n'
+        'from .. import evidence_a, evidence_b, hypothesis, support\n\n'
         'REVIEW = ReviewBundle(\n'
         '    source_id="self_review",\n'
         '    objects=[\n'
@@ -53,8 +62,10 @@ def test_infer_writes_parameterization_and_beliefs(tmp_path):
     assert "BP converged: True" in result.output
 
     gaia_dir = pkg_dir / ".gaia"
-    parameterization = json.loads((gaia_dir / "parameterization.json").read_text())
-    beliefs = json.loads((gaia_dir / "beliefs.json").read_text())
+    parameterization = json.loads(
+        (gaia_dir / "reviews" / "self_review" / "parameterization.json").read_text()
+    )
+    beliefs = json.loads((gaia_dir / "reviews" / "self_review" / "beliefs.json").read_text())
 
     assert parameterization["source"]["source_id"] == "self_review"
     assert len(parameterization["priors"]) == 3
@@ -90,9 +101,12 @@ def test_infer_fails_when_compiled_artifacts_are_stale(tmp_path):
         'main_claim = claim("Original claim.")\n'
         '__all__ = ["main_claim"]\n'
     )
-    (pkg_dir / "infer_demo" / "review.py").write_text(
+    _write_review(
+        pkg_dir,
+        "infer_demo",
+        "self_review",
         'from gaia.review import ReviewBundle, review_claim\n'
-        'from . import main_claim\n\n'
+        'from .. import main_claim\n\n'
         'REVIEW = ReviewBundle(objects=[review_claim(main_claim, prior=0.7)])\n'
     )
 
@@ -120,9 +134,12 @@ def test_infer_supports_generated_interface_claim_review(tmp_path):
         'best_explanation = abduction(observation=observation, hypothesis=hypothesis)\n'
         '__all__ = ["observation", "hypothesis", "best_explanation"]\n'
     )
-    (pkg_dir / "abduction_demo" / "review.py").write_text(
+    _write_review(
+        pkg_dir,
+        "abduction_demo",
+        "self_review",
         'from gaia.review import ReviewBundle, review_claim, review_generated_claim, review_strategy\n'
-        'from . import best_explanation, hypothesis, observation\n\n'
+        'from .. import best_explanation, hypothesis, observation\n\n'
         'REVIEW = ReviewBundle(\n'
         '    objects=[\n'
         '        review_claim(observation, prior=0.9, judgment="strong", justification="Observed directly."),\n'
@@ -139,8 +156,60 @@ def test_infer_supports_generated_interface_claim_review(tmp_path):
     result = runner.invoke(app, ["infer", str(pkg_dir)])
     assert result.exit_code == 0, result.output
 
-    parameterization = json.loads((pkg_dir / ".gaia" / "parameterization.json").read_text())
+    parameterization = json.loads(
+        (pkg_dir / ".gaia" / "reviews" / "self_review" / "parameterization.json").read_text()
+    )
     generated_reviews = [item for item in parameterization["objects"] if item["kind"] == "generated_claim"]
     assert len(generated_reviews) == 1
     assert generated_reviews[0]["role"] == "alternative_explanation"
     assert parameterization["priors"][2]["knowledge_id"].startswith("reg:abduction_demo::__alternative_explanation_")
+
+
+def test_infer_requires_review_selection_when_multiple_reviews_exist(tmp_path):
+    pkg_dir = tmp_path / "multi_review_demo"
+    _write_base_package(pkg_dir, name="multi_review_demo")
+    (pkg_dir / "multi_review_demo" / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'main_claim = claim("A claim.")\n'
+        '__all__ = ["main_claim"]\n'
+    )
+    _write_review(
+        pkg_dir,
+        "multi_review_demo",
+        "optimistic",
+        'from gaia.review import ReviewBundle, review_claim\n'
+        'from .. import main_claim\n\n'
+        'REVIEW = ReviewBundle(source_id="optimistic", objects=[review_claim(main_claim, prior=0.9)])\n',
+    )
+    _write_review(
+        pkg_dir,
+        "multi_review_demo",
+        "conservative",
+        'from gaia.review import ReviewBundle, review_claim\n'
+        'from .. import main_claim\n\n'
+        'REVIEW = ReviewBundle(source_id="conservative", objects=[review_claim(main_claim, prior=0.2)])\n',
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    ambiguous = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert ambiguous.exit_code != 0
+    assert "--review" in ambiguous.output
+    assert "optimistic" in ambiguous.output
+    assert "conservative" in ambiguous.output
+
+    optimistic = runner.invoke(app, ["infer", "--review", "optimistic", str(pkg_dir)])
+    assert optimistic.exit_code == 0, optimistic.output
+    conservative = runner.invoke(app, ["infer", "--review", "conservative", str(pkg_dir)])
+    assert conservative.exit_code == 0, conservative.output
+
+    optimistic_beliefs = json.loads(
+        (pkg_dir / ".gaia" / "reviews" / "optimistic" / "beliefs.json").read_text()
+    )
+    conservative_beliefs = json.loads(
+        (pkg_dir / ".gaia" / "reviews" / "conservative" / "beliefs.json").read_text()
+    )
+    optimistic_belief = optimistic_beliefs["beliefs"][0]["belief"]
+    conservative_belief = conservative_beliefs["beliefs"][0]["belief"]
+    assert optimistic_belief > conservative_belief

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -1,0 +1,143 @@
+"""Tests for gaia infer command."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_base_package(pkg_dir, *, name: str, version: str = "1.0.0") -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "{version}"\n\n'
+        '[tool.gaia]\nnamespace = "reg"\ntype = "knowledge-package"\n'
+    )
+    (pkg_dir / name).mkdir()
+
+
+def test_infer_writes_parameterization_and_beliefs(tmp_path):
+    pkg_dir = tmp_path / "infer_demo"
+    _write_base_package(pkg_dir, name="infer_demo")
+    (pkg_dir / "infer_demo" / "__init__.py").write_text(
+        'from gaia.lang import claim, noisy_and\n\n'
+        'evidence = claim("Observed evidence.")\n'
+        'hypothesis = claim("Main hypothesis.")\n'
+        'support = noisy_and(premises=[evidence], conclusion=hypothesis)\n'
+        '__all__ = ["evidence", "hypothesis", "support"]\n'
+    )
+    (pkg_dir / "infer_demo" / "review.py").write_text(
+        'from gaia.review import ReviewBundle, review_claim, review_strategy\n'
+        'from . import evidence, hypothesis, support\n\n'
+        'REVIEW = ReviewBundle(\n'
+        '    source_id="self_review",\n'
+        '    objects=[\n'
+        '        review_claim(evidence, prior=0.9, judgment="strong", justification="Direct observation."),\n'
+        '        review_claim(hypothesis, prior=0.4, judgment="tentative", justification="Base rate before support."),\n'
+        '        review_strategy(support, conditional_probability=0.85, judgment="good", justification="The evidence usually supports the hypothesis."),\n'
+        '    ],\n'
+        ')\n'
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "BP converged: True" in result.output
+
+    gaia_dir = pkg_dir / ".gaia"
+    parameterization = json.loads((gaia_dir / "parameterization.json").read_text())
+    beliefs = json.loads((gaia_dir / "beliefs.json").read_text())
+
+    assert parameterization["source"]["source_id"] == "self_review"
+    assert len(parameterization["priors"]) == 2
+    assert len(parameterization["strategy_params"]) == 1
+
+    belief_by_label = {item["label"]: item["belief"] for item in beliefs["beliefs"]}
+    assert belief_by_label["hypothesis"] > 0.4
+
+
+def test_infer_requires_review_sidecar(tmp_path):
+    pkg_dir = tmp_path / "infer_demo"
+    _write_base_package(pkg_dir, name="infer_demo")
+    (pkg_dir / "infer_demo" / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'main_claim = claim("A claim.")\n'
+        '__all__ = ["main_claim"]\n'
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "missing review sidecar" in result.output.lower()
+
+
+def test_infer_fails_when_compiled_artifacts_are_stale(tmp_path):
+    pkg_dir = tmp_path / "infer_demo"
+    _write_base_package(pkg_dir, name="infer_demo")
+    (pkg_dir / "infer_demo" / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'main_claim = claim("Original claim.")\n'
+        '__all__ = ["main_claim"]\n'
+    )
+    (pkg_dir / "infer_demo" / "review.py").write_text(
+        'from gaia.review import ReviewBundle, review_claim\n'
+        'from . import main_claim\n\n'
+        'REVIEW = ReviewBundle(objects=[review_claim(main_claim, prior=0.7)])\n'
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    (pkg_dir / "infer_demo" / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'main_claim = claim("Updated claim.")\n'
+        '__all__ = ["main_claim"]\n'
+    )
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "stale" in result.output.lower()
+
+
+def test_infer_supports_generated_interface_claim_review(tmp_path):
+    pkg_dir = tmp_path / "abduction_demo"
+    _write_base_package(pkg_dir, name="abduction_demo")
+    (pkg_dir / "abduction_demo" / "__init__.py").write_text(
+        'from gaia.lang import abduction, claim\n\n'
+        'observation = claim("Observation.")\n'
+        'hypothesis = claim("Hypothesis.")\n'
+        'best_explanation = abduction(observation=observation, hypothesis=hypothesis)\n'
+        '__all__ = ["observation", "hypothesis", "best_explanation"]\n'
+    )
+    (pkg_dir / "abduction_demo" / "review.py").write_text(
+        'from gaia.review import ReviewBundle, review_claim, review_generated_claim, review_strategy\n'
+        'from . import best_explanation, hypothesis, observation\n\n'
+        'REVIEW = ReviewBundle(\n'
+        '    objects=[\n'
+        '        review_claim(observation, prior=0.9, judgment="strong", justification="Observed directly."),\n'
+        '        review_claim(hypothesis, prior=0.3, judgment="possible", justification="Plausible but not dominant."),\n'
+        '        review_generated_claim(best_explanation, "alternative_explanation", prior=0.2, judgment="low", justification="There are some alternatives, but they are weaker."),\n'
+        '        review_strategy(best_explanation, judgment="formalized", justification="The abduction structure is acceptable."),\n'
+        '    ],\n'
+        ')\n'
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    parameterization = json.loads((pkg_dir / ".gaia" / "parameterization.json").read_text())
+    generated_reviews = [item for item in parameterization["objects"] if item["kind"] == "generated_claim"]
+    assert len(generated_reviews) == 1
+    assert generated_reviews[0]["role"] == "alternative_explanation"
+    assert parameterization["priors"][2]["knowledge_id"].startswith("reg:abduction_demo::__alternative_explanation_")

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -25,18 +25,20 @@ def test_infer_writes_parameterization_and_beliefs(tmp_path):
     _write_base_package(pkg_dir, name="infer_demo")
     (pkg_dir / "infer_demo" / "__init__.py").write_text(
         'from gaia.lang import claim, noisy_and\n\n'
-        'evidence = claim("Observed evidence.")\n'
+        'evidence_a = claim("Observed evidence A.")\n'
+        'evidence_b = claim("Observed evidence B.")\n'
         'hypothesis = claim("Main hypothesis.")\n'
-        'support = noisy_and(premises=[evidence], conclusion=hypothesis)\n'
-        '__all__ = ["evidence", "hypothesis", "support"]\n'
+        'support = noisy_and(premises=[evidence_a, evidence_b], conclusion=hypothesis)\n'
+        '__all__ = ["evidence_a", "evidence_b", "hypothesis", "support"]\n'
     )
     (pkg_dir / "infer_demo" / "review.py").write_text(
         'from gaia.review import ReviewBundle, review_claim, review_strategy\n'
-        'from . import evidence, hypothesis, support\n\n'
+        'from . import evidence_a, evidence_b, hypothesis, support\n\n'
         'REVIEW = ReviewBundle(\n'
         '    source_id="self_review",\n'
         '    objects=[\n'
-        '        review_claim(evidence, prior=0.9, judgment="strong", justification="Direct observation."),\n'
+        '        review_claim(evidence_a, prior=0.9, judgment="strong", justification="Direct observation."),\n'
+        '        review_claim(evidence_b, prior=0.8, judgment="supporting", justification="A second reinforcing observation."),\n'
         '        review_claim(hypothesis, prior=0.4, judgment="tentative", justification="Base rate before support."),\n'
         '        review_strategy(support, conditional_probability=0.85, judgment="good", justification="The evidence usually supports the hypothesis."),\n'
         '    ],\n'
@@ -55,10 +57,11 @@ def test_infer_writes_parameterization_and_beliefs(tmp_path):
     beliefs = json.loads((gaia_dir / "beliefs.json").read_text())
 
     assert parameterization["source"]["source_id"] == "self_review"
-    assert len(parameterization["priors"]) == 2
+    assert len(parameterization["priors"]) == 3
     assert len(parameterization["strategy_params"]) == 1
 
     belief_by_label = {item["label"]: item["belief"] for item in beliefs["beliefs"]}
+    assert all(not item["knowledge_id"].startswith("_m_") for item in beliefs["beliefs"])
     assert belief_by_label["hypothesis"] > 0.4
 
 


### PR DESCRIPTION
## Summary
- add a package-local gaia.review sidecar DSL for claim and strategy review objects
- add gaia infer to load review parameterization, validate it, and run BP from compiled IR
- cover stale artifact detection and generated interface-claim review in CLI tests

## Testing
- ruff check gaia/review gaia/cli tests/cli
- python -m pytest tests/cli/test_infer.py -q
- python -m pytest tests/ir tests/gaia/lang tests/cli -q