### PR TITLE
docs: restore foundations/lkm/ from dp-gaia

### DIFF
--- a/docs/foundations/lkm/01-overview.md
+++ b/docs/foundations/lkm/01-overview.md
@@ -1,0 +1,184 @@
+# LKM 概述
+
+> **Status:** Target design
+
+## 定位
+
+Large Knowledge Model (LKM) 是一个建立在概率推理因子图上的计算注册中心。它接收结构化的知识内容，构建全局 FactorGraph，通过 belief propagation 计算所有命题的后验信念。
+
+LKM 的核心数据结构是 **FactorGraph**——一张由 variable nodes（命题）和 factor nodes（命题之间的概率/确定性依赖关系）组成的二部图。LKM 采用 **Local / Global 对偶 FactorGraph** 架构：Local FactorGraph 保留 ingest 后的完整内容（文本、推理步骤），Global FactorGraph 只保留图结构和参数化信息，不存文本内容。两者通过 CanonicalBinding 桥接。
+
+### 与 Gaia 生态的关系
+
+LKM 是 [Gaia 生态](https://github.com/SiliconEinstein/Gaia/tree/main/docs/foundations/ecosystem/) 的服务端组件。Gaia 生态定义了知识的创作、编译、发布和审查流程；LKM 负责接收已发布的内容，在全局尺度上做推理和维护。
+
+```
+Gaia CLI (作者端)                LKM (服务端)
+  编写 → 编译 → 本地推理           接收 → 集成 → 策展 → 全局推理
+  产出 Gaia IR                     产出 Global FactorGraph + Beliefs
+```
+
+LKM 不接触 Gaia Lang（Typst DSL），不做编译，不做本地推理。它的输入是已编译的 Gaia IR 或其他结构化格式，输出是全局信念状态。
+
+## 核心数据模型
+
+### FactorGraph
+
+FactorGraph 由两种节点组成：
+
+- **Variable Node**：对应一个命题（claim、setting、question）。分为 `public`（作者显式声明）和 `private`（lowering FormalStrategy 产生的中间节点）。
+- **Factor Node**：分为两类，严格对齐 [Gaia IR](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/gaia-ir/02-gaia-ir.md)：
+  - `strategy`（概率性）：`infer`、`noisy_and` — 携带 conditional probability
+  - `operator`（确定性）：`implication`、`equivalence`、`contradiction`、`complement`、`conjunction`、`disjunction`、`instantiation` — 无概率参数
+
+```
+Variable: "YBCO superconducts at 90K"        (public)
+    │
+Factor: strategy/infer
+    │
+Variable: "YBCO has zero resistance"          (public)
+```
+
+概率参数不存储在节点上，而是通过独立的参数化层（PriorRecord、FactorParamRecord）管理，对齐 [Gaia IR 参数化契约](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/gaia-ir/06-parameterization.md)。势函数详见 [势函数](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/bp/potentials.md)。
+
+### 为什么是 FactorGraph
+
+FactorGraph 是 belief propagation 算法的原生数据结构。LKM 当前的推理引擎是 loopy BP，因此核心数据模型直接采用 FactorGraph。
+
+这是一个有意识的耦合决策：数据模型服务于推理算法。如果未来推理引擎从 BP 演进为 MCMC 或其他方法，核心数据模型可能需要相应调整。当前设计不为这种可能性预留抽象层；需要时再重构。
+
+### 与 Gaia IR 的关系
+
+[Gaia IR](https://github.com/SiliconEinstein/Gaia/tree/main/docs/foundations/gaia-ir/) 是 Gaia 生态的中间表示层，编码推理超图的拓扑结构（Knowledge、Strategy、Operator），但不包含概率值。IR 的设计目的是解耦 M 个前端和 N 个后端。
+
+FactorGraph 是 IR 经过 **lowering**（确定性展开到 leaf strategy 和 operator 级别 + 注入参数化）后的产物。LKM 不直接在 IR 上运作——IR 是传输格式，进入 LKM 后被 lower 为 FactorGraph，之后不再保留。
+
+```
+Gaia IR (交换格式)                  FactorGraph
+  Knowledge        ──lower──→  Variable Node (public)
+  FormalStrategy   ──lower──→  Operator Factor Nodes + Variable Nodes (private)
+  Leaf Strategy    ──lower──→  Strategy Factor Node
+  Operator         ──lower──→  Operator Factor Node
+  CompositeStrategy ──lower──→  展开为 leaf strategies（不出现在 FactorGraph）
+```
+
+Lowering 是确定性的：相同的 IR + 参数化输入永远产出相同的 FactorGraph。
+
+## 数据来源与 Ingest
+
+LKM 从两个数据源接收内容，通过不同的 ingest pipeline 汇聚到同一个 global FactorGraph。
+
+### Pipeline A：社区增量内容（Gaia IR）
+
+面向社区作者通过 [Gaia 生态](https://github.com/SiliconEinstein/Gaia/tree/main/docs/foundations/ecosystem/) 发布的知识包。规模：万至十万量级。
+
+```
+作者编写 Gaia Lang
+  → gaia build (编译为 LocalCanonicalGraph)
+  → gaia publish (发布到 Registry)
+  → Registry 分配 Review Server → 审查 → rebuttal → 作者 merge review reports
+  → Registry CI 验证（编译重现 ✓、依赖可解析 ✓、review reports 合规 ✓）
+  → 包版本进入 Official Registry 索引
+  → LKM 拉取已注册包 + validated review reports
+  → lower: Gaia IR + validated review reports → local FactorGraph
+  → integrate 到 global FactorGraph
+```
+
+Registry 是 [GitHub 仓库](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/ecosystem/04-registry-operations.md)（Julia General registry 模型），通过 PR 管理包的注册和审查。LKM 不参与 Registry 治理——它只消费通过完整 registry 验证流程的包。
+
+### Pipeline B：存量论文（XML）
+
+面向已发表的科学文献批量 ingest。规模：千万至亿量级。
+
+```
+论文 XML (arXiv, PubMed, ...)
+  → rule-based extraction: 提取命题、推理关系、引用关系
+  → local FactorGraph (variable nodes + factor nodes) + 参数化记录
+  → integrate 到 global FactorGraph
+```
+
+XML 到 local FactorGraph 的转换是 **rule-based 确定性过程**，不涉及 ML。论文 XML 中的结构化信息（claims、reasoning、citations）直接映射到 variable nodes 和 factor nodes。
+
+这条路径不经过 Gaia Lang、Gaia IR、也不经过 Registry。
+
+### Source Class
+
+两个数据源的参数质量差异通过参数化层的 `ParameterizationSource.source_class` 区分：`official`（经 registry 验证的 review reports）、`heuristic`（XML 提取规则估计）、`provisional`（mock / 自动化 review）。高信任层级的参数优先，`official` 永远不被 `heuristic` 覆盖。详见 [02-storage.md](02-storage.md)。
+
+## 核心处理流程
+
+### Integrate（同步，确定性去重）
+
+Ingest 后的 local FactorGraph 集成到 global FactorGraph，通过 CanonicalBinding 记录 local → global 的身份映射。包含两类确定性去重：
+
+- **Variable 去重**：content_hash 匹配 → 复用已有 global variable，写入 CanonicalBinding（`decision=match_existing`），更新 `local_members`
+- **Factor 去重**：premises + conclusion + factor_type + subtype 匹配 → 复用已有 global factor，追加 FactorParamRecord
+
+不做语义匹配。保证完全相同的命题和推理关系从 integrate 开始就有稳定的 global ID。
+
+详见 [03-lifecycle.md](03-lifecycle.md)。
+
+### Curation（异步，语义匹配）
+
+分为 discovery 和 resolution 两阶段，对齐 [上游 ecosystem 治理模型](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/ecosystem/05-review-and-curation.md)：
+
+- **Discovery（LKM 内部）**：发现语义重复（embedding 相似度）、冲突（BP 诊断）、结构问题 → 产出提案
+- **Resolution（通过 registry）**：提案打包为 curation package → 正常 registry 流程 → integrate 生效
+
+LKM 不直接修改全局图结构。所有语义判断通过 curation package 走 registry 审查后才生效。
+
+详见 [04-curation.md](04-curation.md)。
+
+### Belief Propagation
+
+Curation 完成后，从参数化层按 resolution_policy 解析参数，在 global FactorGraph 上运行 loopy BP，结果写入 BeliefSnapshot。
+
+详见 [05-global-inference.md](05-global-inference.md)。
+
+## 读取端
+
+LKM 通过 HTTP API 暴露 global FactorGraph 的内容：
+
+- Variable nodes：命题浏览、信念查询、来源追溯
+- Factor nodes：推理关系浏览
+- 图拓扑：子图查询、DAG 可视化
+- 全文搜索：基于 variable 内容的 BM25 搜索
+- Belief 历史：BeliefSnapshot 查询
+
+端点详情见 [06-api.md](06-api.md)。
+
+## Scope 边界
+
+### LKM 做什么
+
+- 接收 local FactorGraph（从 Gaia IR lower 或从 XML 提取）
+- 集成到 global FactorGraph（含确定性去重）
+- 异步 curation（语义 canonicalization、去重、冲突检测）
+- 全局 belief propagation
+- 读取 API
+
+### LKM 不做什么
+
+- **不做编译**：Gaia Lang → Gaia IR 是 CLI 的职责
+- **不做本地推理**：`gaia infer` 是 CLI 功能，LKM 只做全局推理
+- **不做 Registry 治理**：包注册、reviewer 分配、PR 审批是 Registry 的职责
+- **不存储 Gaia IR**：IR 是传输格式，lower 后不保留
+- **不接触 Gaia Lang**：LKM 完全不了解 Typst DSL
+
+## 存储模型
+
+| 存储内容 | 说明 |
+|---------|------|
+| **Local FactorGraph** (per package/paper) | lower/extract 后的完整内容（含 content、steps），按来源归档 |
+| **Global FactorGraph** | 图结构索引（variable nodes 无 content，factor nodes 无 steps） |
+| **CanonicalBinding** | local QID → global gcn_id 的身份映射，含 decision/reason |
+| **参数化层** | PriorRecord + FactorParamRecord + ParameterizationSource |
+| **BeliefSnapshot** | BP 运行结果（含 resolution_policy、convergence info） |
+
+详见 [02-storage.md](02-storage.md)。
+
+## 未来演进
+
+- **粗粒化子图**：将子图折叠为单个 factor，在不同粒度上做 BP。需要单独设计。
+- **增量 BP**：新数据 ingest 后只更新受影响的子图，而非全图重算。
+- **推理算法演进**：当前基于 loopy BP。如果未来切换到 MCMC 等其他推理方法，核心数据模型可能需要随之调整。

--- a/docs/foundations/lkm/02-storage.md
+++ b/docs/foundations/lkm/02-storage.md
@@ -1,0 +1,246 @@
+# 存储模型
+
+> **Status:** Target design
+
+## 概述
+
+LKM 的存储围绕 **Local / Global 对偶 FactorGraph** 组织。Local FactorGraph 保留 ingest 后的完整内容（文本、推理步骤），Global FactorGraph 只保留图结构和参数化信息，不存文本内容。两者通过 CanonicalBinding 桥接。
+
+概率参数和推理结果分别存储在独立的参数化层和信念快照中。BP 内部使用的 int 索引是实现细节，不构成独立的"运行时 FactorGraph"。
+
+## Local / Global FactorGraph
+
+### 为什么分两层
+
+- BP 只需要图结构和参数，不需要文本
+- Content 的 source of truth 在 local，global 只是结构索引
+- 避免 merge 时的内容同步问题（curation binding 时只需更新指针和 local_members）
+- 与上游 Gaia IR canonicalization 设计对齐（`05-canonicalization.md §7`）
+
+### Content 访问路径
+
+`global_variable_nodes[gcn_id].representative_lcn` → `local_variable_nodes[local_id].content`，两次主键查询。
+
+### Local Variable Nodes
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | str | QID 格式：`{namespace}:{package_name}::{label}` |
+| `type` | str | `claim` / `setting` / `question` |
+| `visibility` | str | `public`（作者显式声明）/ `private`（lowering FormalStrategy 产生的中间节点） |
+| `content` | str | 命题的自然语言描述 |
+| `content_hash` | str | `SHA-256(type + content + sorted(parameters))`，不含 package_id（跨包稳定） |
+| `parameters` | list | 全称命题的参数列表（如 `[{name: "x", type: "material"}]`） |
+| `metadata` | dict | 可选元数据：文献引用 (refs)、schema 分类等 |
+
+### Global Variable Nodes
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | str | gcn_id，全局唯一 |
+| `type` | str | `claim` / `setting` / `question` |
+| `visibility` | str | `public` / `private` |
+| `content_hash` | str | SHA-256，仅用于 dedup 索引 |
+| `parameters` | list | 全称命题的参数列表 |
+| `metadata` | dict | 可选元数据 |
+| `representative_lcn` | dict | 代表性 local node：`{package_id, local_id}` |
+| `local_members` | list | 所有映射到此 global node 的 local node：`[{package_id, local_id}, ...]` |
+
+Global variable node **不存 content**——content 通过 `representative_lcn` 指向 local 层获取。
+
+**Visibility 规则（对齐 [Gaia IR helper claims](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/gaia-ir/04-helper-claims.md)）：**
+
+- `public`：可有独立 PriorRecord，参与 canonicalization，暴露给查询
+- `private`：禁止独立 PriorRecord，不参与 canonicalization，不暴露给普通查询。Prior policy 遵循上游 Gaia IR 定义
+
+### Local Factor Nodes
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | str | local factor 唯一标识 |
+| `factor_type` | str | `strategy` / `operator` |
+| `subtype` | str | 见下表 |
+| `premises` | list[str] | Premise variable QIDs |
+| `conclusion` | str | Conclusion variable QID |
+| `steps` | list[dict] | 推理步骤：`[{reasoning: ...}]` |
+| `source_package` | str | 来源包标识 |
+
+### Global Factor Nodes
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | str | global factor 唯一标识 |
+| `factor_type` | str | `strategy` / `operator` |
+| `subtype` | str | 见下表 |
+| `premises` | list[str] | Premise variable gcn_ids |
+| `conclusion` | str | Conclusion variable gcn_id |
+| `source_package` | str | 最初创建此 factor 的来源标识 |
+
+Global factor node **不存 steps**——steps 通过 local factor 获取。
+
+**factor_type + subtype 严格对齐 [Gaia IR](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/gaia-ir/02-gaia-ir.md)：**
+
+| factor_type | subtype | 势函数 | 需要 FactorParamRecord |
+|-------------|---------|--------|----------------------|
+| `strategy` | `infer` | 概率性，premises false → silent | 是 |
+| `strategy` | `noisy_and` | 概率性，premises false → leak ε | 是 |
+| `operator` | `implication` | 确定性 | 否 |
+| `operator` | `equivalence` | 确定性 | 否 |
+| `operator` | `contradiction` | 确定性 | 否 |
+| `operator` | `complement` | 确定性 | 否 |
+| `operator` | `conjunction` | 确定性 | 否 |
+| `operator` | `disjunction` | 确定性 | 否 |
+| `operator` | `instantiation` | 确定性 | 否 |
+
+势函数详见 [势函数](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/bp/potentials.md)。
+
+CompositeStrategy 不出现在 FactorGraph 中——lowering 时已展开为 leaf strategies。FormalStrategy 不出现——lowering 时展开为 operators + 中间 variables。
+
+**Factor 精确匹配**：当两个 factor 具有相同的 premises + conclusion + factor_type + subtype 时，视为同一 factor（合并，各自保留 FactorParamRecord）。factor_type 或 subtype 不同则为独立 factor。
+
+## CanonicalBinding
+
+CanonicalBinding 记录 local node 到 global node 的身份映射（many local → one global）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `local_id` | str | QID |
+| `global_id` | str | gcn_id |
+| `package_id` | str | 来源包标识 |
+| `version` | str | 包版本 |
+| `decision` | str | `match_existing` / `create_new` / `equivalent_candidate` |
+| `reason` | str | 决策原因（如 `content_hash exact match`、`cosine similarity 0.95`） |
+
+多个 local node 绑定同一 global node 时，`global_variable_nodes[gcn_id].local_members` 增长，`representative_lcn` 指向其中一个代表。
+
+按 `local_id` 和 `global_id` 双向索引。
+
+## 参数化层
+
+概率参数独立于 FactorGraph 结构存储，对齐 [Gaia IR 参数化契约](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/gaia-ir/06-parameterization.md)。
+
+### PriorRecord
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `variable_id` | str | 关联的 global variable node gcn_id |
+| `value` | float | 先验概率 |
+| `source_id` | str | 参数来源标识 |
+| `created_at` | datetime | 创建时间 |
+
+一个 variable 可有多条 PriorRecord（来自不同 reviewer/模型）。仅 `visibility: "public"` 的 variable 可有 PriorRecord。
+
+### FactorParamRecord
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `factor_id` | str | 关联的 global factor node ID |
+| `conditional_probabilities` | list[float] | 条件概率（数量取决于 subtype） |
+| `source_id` | str | 参数来源标识 |
+| `created_at` | datetime | 创建时间 |
+
+一个 factor 可有多条 FactorParamRecord（来自不同包对同一推理关系的评估）。仅 `factor_type: "strategy"` 的 factor 需要 FactorParamRecord。
+
+### ParameterizationSource
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `source_id` | str | 唯一标识 |
+| `source_class` | str | 信任层级：`official` / `heuristic` / `provisional` |
+| `model` | str | 产生参数的模型/方法（如 reviewer ID、LLM model name） |
+| `policy` | str | 参数赋值策略 |
+| `created_at` | datetime | 创建时间 |
+
+**Source class 层级**（对齐 [上游 ecosystem 的参数治理](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/ecosystem/04-registry-operations.md)）：
+
+| source_class | 来源 | 信任优先级 |
+|---|---|---|
+| `official` | 通过 registry 验证的 validated review reports | 最高 |
+| `heuristic` | XML 提取规则估计 | 中 |
+| `provisional` | mock / 自动化 review | 最低 |
+
+Resolution policy 按 source_class 分层：同一 variable/factor 有多条参数记录时，高信任层级的记录优先。同层内按 `latest` 或 `source:<id>` 选择。`official` 参数永远不被 `heuristic` 覆盖，不可逆。
+
+## 推理输出层
+
+### BeliefSnapshot
+
+每次 BP 运行后保存一份快照：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `snapshot_id` | str | 快照标识 |
+| `timestamp` | datetime | 运行时间 |
+| `graph_hash` | str | 运行时的图结构哈希 |
+| `resolution_policy` | str | 本次运行使用的参数选择策略 |
+| `prior_cutoff` | datetime | 本次运行使用的参数截止时间 |
+| `beliefs` | dict[str, float] | gcn_id → belief 值 |
+| `converged` | bool | BP 是否收敛 |
+| `iterations` | int | 迭代次数 |
+| `max_residual` | float | 最终最大残差 |
+
+`resolution_policy` + `prior_cutoff` + `graph_hash` 三者共同保证 BP 结果可复现。
+
+## 不存储的内容
+
+| 不存 | 原因 |
+|------|------|
+| Gaia IR（LocalCanonicalGraph） | 传输格式，lower 后不保留 |
+| Gaia Lang 源码 | CLI 职责，LKM 不接触 |
+| GlobalInferenceState（单例） | 参数在参数化层，belief 在快照层 |
+
+## 存储后端
+
+| 后端 | 用途 | 是否必需 |
+|------|------|---------|
+| **LanceDB** | Local/Global FactorGraph + CanonicalBinding + 参数化层 + 快照持久化，BM25 全文搜索 | 是 |
+| **Graph DB (Neo4j / Kuzu)** | 图拓扑遍历查询（仅 global 层 gcn_id 节点 + global factor 关系） | 可选 |
+| **Vector Index** | Embedding 相似度搜索（curation 用） | 可选 |
+
+Content store（LanceDB）始终是数据源。Graph store 和 vector store 是可选的加速层——缺少时系统优雅降级。Graph store 可从 content store 重建。
+
+### LanceDB 表
+
+| 表名 | 层 | 内容 |
+|------|----|----|
+| `local_variable_nodes` | local | LocalVariableNode，含 content |
+| `local_factor_nodes` | local | LocalFactorNode，含 steps |
+| `global_variable_nodes` | global | GlobalVariableNode，无 content |
+| `global_factor_nodes` | global | GlobalFactorNode，无 steps |
+| `canonical_bindings` | 桥接 | QID → gcn_id 映射 + decision |
+| `prior_records` | 参数化 | PriorRecord（按 gcn_id 索引） |
+| `factor_param_records` | 参数化 | FactorParamRecord（按 global factor_id 索引） |
+| `param_sources` | 参数化 | ParameterizationSource |
+| `belief_snapshots` | 推理输出 | BeliefSnapshot |
+| `node_embeddings` | curation | local variable node embedding 向量 |
+
+### 后端选择
+
+通过 `StorageConfig` 配置：
+
+- **LanceDB**：本地路径或远程 S3/TOS URI
+- **Graph 后端**：`"kuzu"`（嵌入式，开发默认）、`"neo4j"`（生产）或 `"none"`
+- **Vector store**：与 content store 共用 LanceDB 连接，独立表
+
+### 实现要点
+
+- PyArrow schema：复杂结构（list、dict）序列化为 JSON 字符串列
+- `run_in_executor()` 包装所有 LanceDB 同步调用（LanceDB 是同步库）
+- 批量写入：`table.add(rows)` 一次写多行，不在循环里逐条写
+- `content_hash` 列建索引，用于 integrate 时 O(1) dedup 查找
+- `canonical_bindings` 按 `local_id` 和 `global_id` 双向索引
+- Neo4j/Kuzu `write_factors()` 用 `UNWIND` 批量写，不能逐条
+
+## 写入协议
+
+包 ingest 时的写入遵循先写后可见的协议：
+
+1. 写入 local FactorGraph（状态 `preparing`，对读取不可见）
+2. 写入 CanonicalBinding
+3. 写入 global FactorGraph：新 variable nodes + factor nodes（含 integrate 时的确定性去重）
+4. 写入参数化层：PriorRecord + FactorParamRecord
+5. 写入 graph store：拓扑关系（如已配置）
+6. 写入 vector store：embeddings（如已配置）
+7. 标记状态为 `merged`（对读取可见）
+
+失败时数据保持 `preparing` 状态——对读取不可见，可安全重试。

--- a/docs/foundations/lkm/03-lifecycle.md
+++ b/docs/foundations/lkm/03-lifecycle.md
@@ -1,0 +1,142 @@
+# Write Side 生命周期
+
+> **Status:** Target design
+
+## 概述
+
+Write side 描述数据如何进入 LKM 并最终反映在全局信念状态中。完整流程：
+
+```
+数据源 → Ingest (lower/extract) → Integrate (确定性去重) → Curation (语义去重) → Global BP
+```
+
+Ingest + integrate 是同步的、per-package 操作。Curation + BP 是异步的、全局操作。
+
+## Ingest
+
+Ingest 将外部数据转换为 local FactorGraph。两条 pipeline 针对不同数据源，产出相同的结构。
+
+### Pipeline A：Gaia IR（社区内容）
+
+```
+已注册包 (Gaia IR + validated review reports)
+  → lower: 展开 Strategy/Operator 到 leaf level，生成 private variable nodes
+  → 注入参数化: PriorRecord + FactorParamRecord (from validated review reports, source_class: official)
+  → local FactorGraph + 参数化记录
+```
+
+LKM 只消费通过 [Registry 完整验证流程](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/ecosystem/04-registry-operations.md) 的包——包括 reviewer 身份验证、assignment 匹配、report 数量达标、参数范围合法。
+
+Lowering 是确定性的。详见 [Lowering 契约](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/gaia-ir/07-lowering.md)。
+
+Lowering 过程中：
+- 每个 Knowledge (claim/setting/question) → `visibility: "public"` 的 variable node
+- FormalStrategy 展开产生的中间节点 → `visibility: "private"` 的 variable node
+- Leaf Strategy (infer/noisy_and) → `factor_type: "strategy"` 的 factor node
+- Operator (equivalence/contradiction/...) → `factor_type: "operator"` 的 factor node
+- CompositeStrategy 展开为 leaf strategies，不出现在 FactorGraph 中
+
+Validated review reports 提供 PriorRecord（`source_class: official`）和 FactorParamRecord（`source_class: official`）。
+
+### Pipeline B：XML（存量论文）
+
+```
+论文 XML (arXiv, PubMed, ...)
+  → rule-based extraction: 提取命题、推理关系、引用
+  → 估计参数化: PriorRecord + FactorParamRecord
+  → local FactorGraph + 参数化记录
+```
+
+Rule-based 确定性提取，不涉及 ML。参数由提取规则根据元数据（期刊等级、引用数等）估计。
+
+### Source Class
+
+两个数据源的参数质量差异通过参数化层的 `ParameterizationSource.source_class` 区分：
+
+| 来源 | `source_class` | 说明 |
+|------|---------------|------|
+| 社区内容（经 Review） | `official` | 参数由 reviewer 赋值，经 registry 验证 |
+| 存量论文（XML 提取） | `heuristic` | 参数由规则根据元数据估计 |
+
+## Integrate
+
+将 local FactorGraph 集成到 global FactorGraph。同步操作，per-package。**包含确定性去重。**
+
+### Variable 去重（content_hash）
+
+对每个 local variable node（仅 `visibility: "public"`）：
+
+1. 计算 `content_hash`
+2. 在 `global_variable_nodes` 中查找相同 `content_hash` 的 variable（走索引，O(1)）
+3. **匹配** → 写入 CanonicalBinding（`decision=match_existing`），更新 global node 的 `local_members`
+4. **无匹配** → 新建 GlobalVariableNode，写入 CanonicalBinding（`decision=create_new`）
+
+这是 O(1) 哈希查找，确定性的，不涉及语义匹配。保证完全相同的命题从 integrate 开始就有稳定的 gcn_id。
+
+`visibility: "private"` 的 variable 直接分配新 gcn_id，不走 hash 查找（它们是特定 FormalStrategy 的内部节点，不跨包去重）。
+
+### Factor 去重（精确匹配）
+
+对每个 local factor node：
+
+1. 用 CanonicalBinding 将 premises/conclusion 的 local QIDs 映射为 gcn_ids
+2. 在 `global_factor_nodes` 中查找相同 `premises + conclusion + factor_type + subtype` 的 factor
+3. **匹配** → 复用已有 global factor，追加新的 FactorParamRecord（不同来源对同一推理关系的参数评估）
+4. **无匹配** → 新建 GlobalFactorNode
+
+`factor_type` 或 `subtype` 不同则视为独立 factor（不同类型的推理关系，不是重复）。
+
+### 跨包引用解析（QID）
+
+Gaia IR 中的 Knowledge 使用 QID（Qualified Node ID）作为 local identity：
+
+```
+{namespace}:{package_name}::{label}
+```
+
+其中 `namespace` 为 `reg`（注册表包）或 `paper`（提取的论文）。`package_name` 在各自 namespace 内保证全局唯一（`reg` 由 registry 强制，`paper` 由数据库 metadata ID 保证）。跨包引用在 IR 中直接使用目标 Knowledge 的 QID，不需要 `ext:` 特殊前缀——`package_name` 本身已经是 disambiguator。
+
+Integrate 时的解析流程：
+
+1. Factor 的 premises/conclusion 中出现非本包的 QID → 跨包引用
+2. 查 CanonicalBinding 或 `global_variable_nodes` 找到该 QID 对应的 gcn_id
+3. **命中** → 替换为 gcn_id
+4. **未命中**（目标包尚未 ingest）→ 该 factor 被丢弃，记录在 `unresolved_cross_refs` 中，供后续 curation 阶段处理
+
+### 写入存储
+
+按 [写入协议](02-storage.md) 写入：local FactorGraph + CanonicalBinding + global FactorGraph + 参数化记录。
+
+## Curation
+
+异步批量的图维护操作。处理 integrate 无法发现的语义级冗余和冲突。
+
+详见 [04-curation.md](04-curation.md)。
+
+## Global BP
+
+Curation 完成后，在 global FactorGraph 上运行 loopy BP。从 PriorRecord / FactorParamRecord 按 resolution_policy 解析出具体参数值，运行推理，结果写入 BeliefSnapshot。
+
+详见 [05-global-inference.md](05-global-inference.md)。
+
+## 流程时序
+
+```
+t0  Package A arrives → ingest → integrate (content_hash dedup + factor dedup)
+t1  Package B arrives → ingest → integrate (same)
+t2  Package C arrives → ingest → integrate (same)
+t3  Curation runs (async)          — 语义匹配发现近义 variables，合并或创建 equivalence
+t4  Global BP runs                 — beliefs updated
+t5  Package D arrives → ingest → integrate
+t6  Curation runs (incremental)
+t7  Global BP runs
+...
+```
+
+Curation 和 BP 的触发策略是可配置的：每次 integrate 后触发、按时间间隔批量触发、或手动触发。
+
+## 当前实现
+
+当前 write side 通过批处理脚本实现（`scripts/pipeline/run_full_pipeline.py`），7 个阶段作为子进程顺序执行。这是临时方案，用于初始数据填充和开发验证。
+
+目标状态：ingest + integrate 由 HTTP 端点触发（`POST /packages/ingest`），curation 作为后台定时任务运行，BP 在 curation 完成后异步触发。

--- a/docs/foundations/lkm/04-curation.md
+++ b/docs/foundations/lkm/04-curation.md
@@ -1,0 +1,96 @@
+# Curation
+
+> **Status:** Target design
+
+## 概述
+
+Curation 是对 global FactorGraph 的异步维护流程。它在 integrate 之后运行，处理 integrate 阶段无法通过确定性匹配发现的语义级冗余和冲突。
+
+Integrate 已处理：content_hash 完全相同的 variable 去重、premises+conclusion+type 完全相同的 factor 去重。Curation 处理剩余的模糊匹配。
+
+### Discovery vs Resolution
+
+Curation 分为两个阶段，对齐 [上游 ecosystem 治理模型](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/ecosystem/05-review-and-curation.md)：
+
+1. **Discovery（LKM 内部）**：发现语义重复、冲突、结构问题 → 产出结构化的发现报告和提案
+2. **Resolution（通过 registry）**：将提案打包为 curation package → 走正常 registry 流程（assignment → review → registration）→ 注册通过后 integrate 到 global FactorGraph
+
+LKM **不直接修改全局图结构**（合并 variable、创建 equivalence/contradiction factor 等）。所有结构变更通过 curation package 走 registry 审查后才生效。这保证了：
+- 所有结构变更可审计、可追溯
+- 语义判断可被 review 和 rebuttal
+- 没有 single point of authority
+
+**例外**：integrate 阶段的 content_hash 精确去重是确定性操作，不需要走 curation package。
+
+## Discovery 阶段
+
+LKM 执行以下发现任务，产出提案报告：
+
+### Canonicalization（语义规范化）
+
+发现 global FactorGraph 中**文本不同但语义等价**的 `visibility: "public"` variable nodes。
+
+匹配策略（content_hash 已在 integrate 阶段处理）：
+
+1. **Embedding 相似度**：余弦相似度超过阈值（默认 0.90）→ 判定为语义等价候选
+2. **TF-IDF 回退**：无 embedding 模型时使用 scikit-learn TF-IDF
+
+匹配前置过滤：
+- 仅 `visibility: "public"` 的 variable 参与
+- 仅相同 `type` 的 variable 才有资格匹配
+- 含 `parameters` 的全称 claim 额外比较参数结构（count + types，忽略 name）
+
+发现语义等价后，需要判断背后的 factor nodes 是否提供了独立证据：
+
+- **共享 premises → Binding 提案**：建议合并为一个 variable，合并关联的 factor
+- **不同 premises → Equivalence 提案**：建议创建 equivalence factor 连接两者（独立验证增强可信度）
+
+### Conflict Detection（冲突检测）
+
+发现 global FactorGraph 中的矛盾：
+
+- **直接矛盾**：两个 variable 被不同来源分别支持和反对（BP 诊断中表现为振荡或高残差）
+- **结构矛盾**：图拓扑异常（不一致的 instantiation 关系等）
+
+产出 **Contradiction 提案**：建议创建 contradiction factor 连接相关 variables。
+
+### Structural Audit（结构审计）
+
+检查 global FactorGraph 的健康状况：
+
+- 孤立 variable nodes（无任何 factor 连接）
+- 悬空 factor 引用（premise/conclusion 指向不存在的 variable）
+- 未解析的跨包引用（integrate 时 pending 的 `unresolved_cross_refs`）
+
+产出审计报告：errors、warnings、info。
+
+### Discovery 产出
+
+所有发现汇总为结构化报告：
+
+- Binding 提案列表（含匹配证据：相似度分数、premise 重叠分析）
+- Equivalence 提案列表
+- Contradiction 提案列表
+- 审计报告
+
+报告发布到 LKM repo 的 Issues（对齐 [上游 ecosystem 的 relation reports 机制](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/ecosystem/04-registry-operations.md)）。
+
+## Resolution 阶段
+
+基于 discovery 产出，创建 curation package：
+
+1. 将已确认的提案（binding、equivalence、contradiction）编码为 curation package
+2. Curation package 提交到 registry，走正常的 assignment → review → registration 流程
+3. 注册通过后，LKM 通过正常的 ingest → integrate 路径消费 curation package
+4. Curation package 中的结构变更（merge、创建 factor 等）在 integrate 时生效
+
+Curation package 的具体格式待定义（需和上游 ecosystem 对齐）。
+
+## 触发策略
+
+Discovery 阶段可按以下方式触发：
+- **批量**：累积 N 个包后或间隔 T 时间后批量运行
+- **手动**：通过 API 或 CLI 触发
+- **增量**（目标状态）：只处理自上次 discovery 以来新增的 variable/factor nodes
+
+当前实现为全量批处理。增量 discovery 是未来优化方向。

--- a/docs/foundations/lkm/05-global-inference.md
+++ b/docs/foundations/lkm/05-global-inference.md
@@ -1,0 +1,56 @@
+# 全局推理
+
+> **Status:** Target design
+
+## 概述
+
+全局推理在 global FactorGraph 上运行 loopy belief propagation (BP)，计算所有 variable nodes 的后验信念。它在 curation 完成后触发，是 write side 的最后一步。
+
+## 与本地推理的关系
+
+本地推理（`gaia infer`）和全局推理使用完全相同的 BP 算法和势函数。区别仅在于作用域和参数来源：
+
+| 方面 | 本地 BP | 全局 BP |
+|------|---------|---------|
+| **图** | Local FactorGraph（单包） | Global FactorGraph（所有包 + 论文） |
+| **参数** | ReviewOutput 产生的 PriorRecord / FactorParamRecord | 全局参数化层中的所有 PriorRecord / FactorParamRecord |
+| **参数解析** | 直接使用（单来源） | 按 resolution_policy 从多来源中选择 |
+| **触发** | `gaia infer` CLI 命令 | Curation 完成后 |
+| **输出** | 本地信念预览 | BeliefSnapshot（持久化） |
+
+算法、消息调度、势函数、Cromwell's rule 完全一致。详见 [推理](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/bp/inference.md)、[势函数](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/bp/potentials.md)、[局部与全局](https://github.com/SiliconEinstein/Gaia/blob/main/docs/foundations/bp/local-vs-global.md)。
+
+## 执行流程
+
+1. **加载 FactorGraph**：从存储读取所有 variable nodes 和 factor nodes
+2. **解析参数**：按 `resolution_policy` + `prior_cutoff` 从 PriorRecord / FactorParamRecord 中选择具体的 prior 和 conditional probability 值
+3. **构建 BP 运行时**：将 FactorGraph + 解析后的参数传入 BP 引擎（内部转换为 int 索引是实现细节）
+4. **运行 BP**：damping=0.5, max_iterations=50, threshold=1e-6
+5. **保存 BeliefSnapshot**：包含 beliefs、resolution_policy、prior_cutoff、graph_hash、convergence_info
+
+### Resolution Policy
+
+当一个 variable/factor 有多条 PriorRecord / FactorParamRecord 时，resolution_policy 决定使用哪个值：
+
+- `latest`：使用 `created_at` 最新的记录
+- `source:<id>`：使用指定来源的记录
+
+Resolution policy 和 prior_cutoff 记录在 BeliefSnapshot 中，保证 BP 结果可复现：给定相同的 graph_hash + resolution_policy + prior_cutoff，产出相同的 beliefs。
+
+## 何时运行
+
+全局 BP 在以下情况后触发：
+
+1. **Curation 完成** — 图中的重复和冲突已处理
+2. **手动触发** — 通过 API 或 CLI
+
+**不**在每次 integrate 后立即运行。原因：
+- Integrate 后的确定性去重已消除精确重复，但语义重复仍存在
+- 等 curation 处理完语义重复再跑，避免 double counting
+- 批量 ingest 场景下（灌入大量论文），逐包跑 BP 无意义
+
+## 未来演进
+
+- **增量 BP**：只在受新 integrate/curation 影响的子图上重新运行，而非全图
+- **粗粒化 BP**：将子图折叠为单个 factor，在不同粒度上运行 BP。需要单独设计
+- **算法演进**：如果从 BP 切换到 MCMC 等其他推理方法，全局推理的实现需要重新设计

--- a/docs/foundations/lkm/06-api.md
+++ b/docs/foundations/lkm/06-api.md
@@ -1,0 +1,83 @@
+# API
+
+> **Status:** Target design
+
+本文档描述 LKM 的目标 HTTP API 设计。基于 Local / Global 对偶 FactorGraph 架构，使用 variable / factor 术语。
+
+## 服务器
+
+FastAPI 应用。依赖注入通过 `StorageManager` 单例管理，在启动时初始化。
+
+## 端点
+
+### Ingest
+
+| Method | Path | 描述 |
+|---|---|---|
+| `POST` | `/packages/ingest` | 触发 Pipeline A（接收 Gaia IR package），执行 lower → integrate 全流程 |
+
+请求体：Gaia IR package（`LocalCanonicalGraph` + validated review reports）。
+
+响应：`{ package_id, status, variable_count, factor_count }`。
+
+摄取端点按 [写入协议](02-storage.md) 执行：local FactorGraph → CanonicalBinding → global FactorGraph → 参数化层 → graph store → vector store。
+
+### Variables
+
+| Method | Path | 描述 |
+|---|---|---|
+| `GET` | `/variables` | 列出 variable nodes（分页 + BM25 搜索） |
+| `GET` | `/variables/{id}` | 查询单个 variable node |
+
+`GET /variables/{id}` 返回 global variable node 信息。content 通过 `representative_lcn` join `local_variable_nodes` 获取。
+
+查询参数：
+- `q`：BM25 全文搜索（匹配 local variable 的 content）
+- `type`：按 type 过滤（`claim` / `setting` / `question`）
+- `visibility`：按 visibility 过滤（默认仅 `public`）
+- `limit` / `offset`：分页
+
+### Factors
+
+| Method | Path | 描述 |
+|---|---|---|
+| `GET` | `/factors/{id}` | 查询单个 factor node |
+
+返回 global factor node 信息。steps 通过 local factor lookup 获取。
+
+### Graph
+
+| Method | Path | 描述 |
+|---|---|---|
+| `GET` | `/graph/subgraph` | N 跳子图查询 |
+
+查询参数：
+- `node_id`：起始 gcn_id
+- `hops`：跳数（默认 1）
+- `direction`：`upstream` / `downstream` / `both`
+
+返回子图内的 variable nodes + factor nodes + edges。
+
+### Beliefs
+
+| Method | Path | 描述 |
+|---|---|---|
+| `GET` | `/beliefs/snapshots` | BeliefSnapshot 列表 |
+| `GET` | `/beliefs/snapshots/{snapshot_id}` | 单个 BeliefSnapshot |
+| `GET` | `/beliefs/variables/{id}` | 某个 variable 的 belief 历史 |
+
+### Admin
+
+| Method | Path | 描述 |
+|---|---|---|
+| `POST` | `/curation/run` | 手动触发 curation discovery |
+| `POST` | `/bp/run` | 手动触发 global BP |
+
+## 认证
+
+未实现认证。仅供内部/开发使用。
+
+## 错误处理
+
+- `404` -- 资源未找到（variable、factor、snapshot）。
+- `503` -- 存储未初始化（启动失败或缺少配置）。

--- a/docs/foundations/lkm/07-agent-credit.md
+++ b/docs/foundations/lkm/07-agent-credit.md
@@ -1,0 +1,78 @@
+# Agent Credit
+
+> **Status:** Target design — 不在第一期实现范围内（M1–M8），后续阶段实现
+>
+> Agent credit 需要引入新的 factor_type（`authored`、`rejected`），将在核心 FactorGraph 基础设施（M1–M8）完成后作为独立模块开发。
+
+## 核心思想
+
+Agent credit 是 BP 在作者维度上的自然延伸。Agent 的可信度是知识图谱中的一个 **claim**，其信念值由 BP 根据证据（agent 发布的知识）计算得出。无需代币，无需区块链——credit 就是 belief。
+
+## Agent Credit 作为 Knowledge Claim
+
+每个 agent 在图中都有一个对应的 knowledge 节点：
+
+```
+name: agent_<id>_reliability
+type: claim
+content: "Agent <id> is a reliable knowledge producer"
+prior: 0.5  (neutral starting point)
+belief: <computed by BP> = the agent's credit score
+```
+
+这是一个一等公民的 knowledge 单元。其 belief 值就是 agent 的 credit。
+
+## Authored Factor
+
+Agent 发布的每个 knowledge 单元都会创建一个 `authored` factor，将 agent 的可靠性 claim 与该 knowledge 连接：
+
+```
+agent_reliability <-- factor: authored --> K1 (belief: 0.90)
+agent_reliability <-- factor: authored --> K2 (belief: 0.75)
+agent_reliability <-- factor: authored --> K3 (belief: 0.30)
+```
+
+- 高 belief(K) = agent 可靠性的正面证据
+- 低 belief(K) = agent 可靠性的负面证据
+
+作者关系本身是确定的（事实）。不确定的是"此 agent 是否可靠"这一 claim——BP 从累积的证据中解决这个问题。
+
+## 拒绝作为负面证据
+
+被拒绝的提交提供直接的负面证据。当一个包未通过同行评审时，会添加一个 `rejected` factor。每次提交都是一次声誉赌注：
+
+- 优质工作被批准：credit 上升
+- 劣质工作被拒绝：credit 直接下降
+- 反复提交垃圾：credit 崩溃，agent 被限流
+
+Agent 的声誉本身就是赌注——无需单独的质押机制。
+
+## Credit 衰减
+
+Agent credit 通过 BP 自然衰减。如果 agent 发布的知识后来被反面证据驳斥，knowledge 的 belief 值下降，这通过 `authored` factor 传播，降低 agent 的 credit。无需显式的时间衰减——过时或被驳斥的知识会自动降低 credit。
+
+## 基于 Credit 的限流
+
+提交频率由 credit 控制：
+
+| Credit 范围 | 提交限制 | 理由 |
+|---|---|---|
+| 0.7+ | 无限制 | 已证明的良好记录 |
+| 0.4 -- 0.7 | 每周 N 次 | 标准贡献者 |
+| < 0.4 | 每月 N 次 | 低可靠性，保护评审资源 |
+
+这在不需要外部质押的情况下防止了低质量内容泛滥。
+
+## 多 Agent Credit 分配
+
+当多个 agent 共同创作一个包时，每个 agent 都会获得一个 `authored` factor，将其可靠性 claim 与该包的 knowledge 单元连接。Credit 通过相同的 BP 机制分配——每个共同作者的 credit 基于共同工作的 belief 值更新。共同创作权重的具体参数化是一个开放的设计问题。
+
+## Credit 反馈回路
+
+Credit 轻微影响新 knowledge 的先验值：`initial_prior = 0.5 + 0.1 * credit(agent)`。影响有界（最大 +0.1），因此质量始终优先于声誉。无论 credit 如何，同行评审始终是必须的。BP 决定最终 belief，而非 credit。
+
+该回路收敛的原因：（1）credit 对先验的影响有界，（2）同行评审是独立的门控，（3）loopy BP 处理循环图，（4）最终 belief 取决于证据结构。
+
+## 来源
+
+- [https://github.com/SiliconEinstein/Gaia/blob/main/docs/archive/foundations-v2/agent-credit.md](https://github.com/SiliconEinstein/Gaia/blob/main/docs/archive/foundations-v2/agent-credit.md)


### PR DESCRIPTION
## Summary
- Restore 7 LKM foundation docs removed in #270 during dp-gaia migration
- Files: overview, storage, lifecycle, curation, global-inference, api, agent-credit
- Completes the `docs/foundations/` layer per CLAUDE.md architecture

## Test Plan
- [x] Docs only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)