### PR TITLE
feat(cli): add gaia init and gaia add commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,16 @@ cd Gaia && uv sync
 ## CLI Workflow
 
 ```
-gaia compile   →   gaia check   →   gaia infer   →   gaia register
-  (DSL → IR)      (validate)      (BP preview)      (registry PR)
+gaia init → gaia compile → gaia check → gaia add → gaia infer → gaia register
+(scaffold)   (DSL → IR)    (validate)  (add deps)  (BP preview)  (registry PR)
 ```
 
 | Command | Purpose |
 |---------|---------|
+| `gaia init <name>` | Scaffold a new Gaia knowledge package |
 | `gaia compile [path]` | Compile Python DSL to Gaia IR (`.gaia/ir.json`) |
 | `gaia check [path]` | Validate package structure and IR consistency |
+| `gaia add <package>` | Install a registered Gaia package from the [official registry](https://github.com/SiliconEinstein/gaia-registry) |
 | `gaia infer [path]` | Run belief propagation with a review sidecar |
 | `gaia register [path]` | Submit package to the [Gaia Official Registry](https://github.com/SiliconEinstein/gaia-registry) |
 
@@ -58,29 +60,15 @@ gaia compile   →   gaia check   →   gaia infer   →   gaia register
 **1. Initialize**
 
 ```bash
-uv init --lib galileo-falling-bodies-gaia
+gaia init galileo-falling-bodies-gaia
 cd galileo-falling-bodies-gaia
-uv add gaia-lang
-mv src/galileo_falling_bodies_gaia src/galileo_falling_bodies
 ```
 
-**2. Configure `pyproject.toml`**
+This scaffolds a complete package with `pyproject.toml` (including `[tool.gaia]`
+config and a generated UUID), the correct `src/` directory layout, and a DSL
+template. Package name must end with `-gaia`.
 
-```toml
-[project]
-name = "galileo-falling-bodies-gaia"
-version = "1.0.0"
-
-[tool.gaia]
-type = "knowledge-package"
-uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-```
-
-- Package name must end with `-gaia`
-- `type` must be `"knowledge-package"`
-- `uuid` is required for registry submission
-
-**3. Write DSL declarations** in `src/galileo_falling_bodies/__init__.py`
+**2. Write DSL declarations** in `src/galileo_falling_bodies/__init__.py`
 
 ```python
 from gaia.lang import claim, setting, contradiction
@@ -100,18 +88,34 @@ __all__ = ["aristotle", "heavy_faster", "composite_slower",
            "composite_faster", "paradox", "vacuum_law"]
 ```
 
-**4. Compile and validate**
+**3. Compile and validate**
 
 ```bash
 gaia compile .
 gaia check .
 ```
 
-**5. Publish**
+**4. Publish**
 
 ```bash
 git tag v1.0.0 && git push origin main --tags
 gaia register . --registry-dir ../gaia-registry --create-pr
+```
+
+## Install a Package
+
+Add a registered Gaia knowledge package as a dependency:
+
+```bash
+gaia add galileo-falling-bodies-gaia
+```
+
+This queries the [Gaia Official Registry](https://github.com/SiliconEinstein/gaia-registry)
+for the package metadata, resolves the latest version, and calls `uv add` with
+a pinned git URL. Use `--version` to pin a specific version:
+
+```bash
+gaia add galileo-falling-bodies-gaia --version 1.0.0
 ```
 
 ## DSL Surface
@@ -155,7 +159,7 @@ gaia/
 ├── lang/       DSL runtime, declarations, and compiler
 ├── ir/         Gaia IR schema, validation, formalization
 ├── bp/         Belief propagation engine (4 backends)
-├── cli/        CLI commands (compile, check, infer, register)
+├── cli/        CLI commands (init, compile, check, add, infer, register)
 └── review/     Review sidecar model
 ```
 

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -8,22 +8,43 @@ since: v5-phase-1
 
 ## Overview
 
-The Gaia CLI is a knowledge package authoring toolkit. It provides a four-command
-pipeline that takes a Python DSL package from source code to registry registration:
+The Gaia CLI is a knowledge package authoring toolkit. It provides a six-command
+pipeline that takes a Python DSL package from scaffolding to registry registration:
 
 ```
-author source --> gaia compile --> gaia check --> gaia infer --> git tag --> gaia register
-                  (DSL -> IR)     (validate)     (BP preview)              (registry PR)
+gaia init --> gaia compile --> gaia check --> gaia add --> gaia infer --> git tag --> gaia register
+(scaffold)    (DSL -> IR)     (validate)   (add deps)   (BP preview)              (registry PR)
 ```
 
 Entry point: installed as the `gaia` CLI command via `pyproject.toml`
 `[project.scripts]`, backed by a Typer app at `gaia.cli.main:app`.
 
-`gaia init` is planned but not yet implemented. Currently authors scaffold
-packages with `uv init` and manual `[tool.gaia]` configuration.
-
 
 ## Commands
+
+### `gaia init <NAME>`
+
+Scaffold a new Gaia knowledge package.
+
+```
+gaia init <NAME>
+```
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `NAME`   | (required) | Package name (must end with `-gaia`) |
+
+**What it does:**
+
+1. Runs `uv init --lib` under the hood to create the package directory.
+2. Adds `[tool.gaia]` configuration to `pyproject.toml` (with `type = "knowledge-package"` and a generated `uuid`).
+3. Renames the `src/` subdirectory to match the Gaia import name convention (strips the `-gaia` suffix, replaces hyphens with underscores).
+4. Writes a DSL template into the package module's `__init__.py`.
+
+The resulting directory is a complete Gaia knowledge package ready for `gaia compile`.
+
+**Key output:** a new directory `<NAME>/` containing `pyproject.toml`, `src/<import_name>/__init__.py` with DSL template code.
+
 
 ### `gaia compile [PATH]`
 
@@ -81,6 +102,33 @@ printed but do not fail the check.
 **Key output:** none (validation only, prints pass/fail summary).
 
 Reference: [Compilation](compilation.md) for validation details.
+
+
+### `gaia add <PACKAGE> [OPTIONS]`
+
+Install a registered Gaia knowledge package from the official registry.
+
+```
+gaia add <PACKAGE> [--version VERSION] [--registry REPO]
+```
+
+| Argument / Option | Default | Description |
+|-------------------|---------|-------------|
+| `PACKAGE`         | (required) | Package name (e.g., `galileo-falling-bodies-gaia`) |
+| `--version VERSION` | latest | Specific version to install |
+| `--registry REPO` | `SiliconEinstein/gaia-registry` | Custom registry repo slug |
+
+**What it does:**
+
+1. Queries registry metadata via the GitHub API to resolve the package and version.
+2. Resolves the version to a specific git tag and SHA.
+3. Calls `uv add` with a pinned git URL pointing to the resolved tag.
+
+The package is added as a standard Python dependency in `pyproject.toml` and
+installed into the project environment.
+
+**Key output:** updated `pyproject.toml` `[project].dependencies` and
+`uv.lock` with the pinned Gaia package dependency.
 
 
 ### `gaia infer [PATH] [--review NAME]`
@@ -177,9 +225,10 @@ Reference: [Registration](registration.md) for details.
 
 | Stage    | Command          | Key Artifacts |
 |----------|------------------|---------------|
-| Create   | `uv init` + manual config | `pyproject.toml` with `[tool.gaia]`, `src/<import_name>/__init__.py` |
+| Init     | `gaia init`      | `pyproject.toml` with `[tool.gaia]`, `src/<import_name>/__init__.py` with DSL template |
 | Compile  | `gaia compile`   | `.gaia/ir.json`, `.gaia/ir_hash` |
 | Check    | `gaia check`     | (validation only) |
+| Add      | `gaia add`       | Updated `pyproject.toml` dependencies, `uv.lock` |
 | Infer    | `gaia infer`     | `.gaia/reviews/<name>/parameterization.json`, `.gaia/reviews/<name>/beliefs.json` |
 | Register | `gaia register`  | `packages/<name>/Package.toml`, `Versions.toml`, `Deps.toml` (in registry repo) |
 
@@ -203,32 +252,32 @@ replace hyphens with underscores (e.g., `galileo-falling-bodies-gaia` becomes
 ## Quick Start
 
 ```bash
-# 1. Scaffold a package (gaia init not yet available)
-uv init galileo-falling-bodies-gaia
+# 1. Scaffold a package
+gaia init galileo-falling-bodies-gaia
 cd galileo-falling-bodies-gaia
-# Add [tool.gaia] to pyproject.toml:
-#   [tool.gaia]
-#   type = "knowledge-package"
-#   uuid = "<generate-a-uuid>"
-# Add gaia-lang as a dependency, write DSL code in src/galileo_falling_bodies/
 
-# 2. Compile DSL to IR
+# 2. Write DSL declarations in src/galileo_falling_bodies/__init__.py
+
+# 3. Compile DSL to IR
 gaia compile .
 
-# 3. Validate package
+# 4. Validate package
 gaia check .
 
-# 4. Preview beliefs (optional)
+# 5. Add dependencies from the registry (optional)
+gaia add some-prerequisite-gaia
+
+# 6. Preview beliefs (optional)
 gaia infer . --review self_review
 
-# 5. Tag and push
+# 7. Tag and push
 git add -A && git commit -m "initial package"
 git tag v0.1.0
 git push origin main --tags
 
-# 6. Dry-run registration (prints JSON plan)
+# 8. Dry-run registration (prints JSON plan)
 gaia register .
 
-# 7. Write to registry and open PR
+# 9. Write to registry and open PR
 gaia register . --registry-dir ../gaia-registry --create-pr
 ```

--- a/docs/plans/2026-04-03-gaia-init-add-registry-ci.md
+++ b/docs/plans/2026-04-03-gaia-init-add-registry-ci.md
@@ -1,0 +1,663 @@
+# gaia init, gaia add, Registry CI Update — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `gaia init` (scaffold package) and `gaia add` (install from registry) CLI commands, and update the official registry CI to use PyPI-installed gaia-lang with namespace validation.
+
+**Architecture:** Two new Typer commands following existing patterns in `gaia/cli/commands/`. `gaia init` shells out to `uv init --lib` then patches files. `gaia add` fetches registry TOML via GitHub API (httpx), parses with tomllib, then shells out to `uv add`. Registry CI update is a YAML edit in a separate repo.
+
+**Tech Stack:** Python 3.12, Typer, httpx (for GitHub API), tomllib, subprocess (for uv), pytest + CliRunner
+
+**Spec:** `docs/specs/2026-04-03-gaia-init-add-registry-ci-design.md`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|----------------|
+| `gaia/cli/commands/init.py` | **New.** `gaia init <name>` — scaffold a Gaia package |
+| `gaia/cli/commands/add.py` | **New.** `gaia add <package>` — install from registry |
+| `gaia/cli/_registry.py` | **New.** Shared registry API client (fetch Package.toml, Versions.toml) |
+| `gaia/cli/main.py` | **Modify.** Register `init` and `add` commands |
+| `tests/cli/test_init.py` | **New.** Tests for init command |
+| `tests/cli/test_add.py` | **New.** Tests for add command |
+
+Registry CI is in a separate repo (`SiliconEinstein/gaia-registry`) — Task 5 provides the exact YAML.
+
+---
+
+## Chunk 1: gaia init + gaia add
+
+### Task 1: `gaia init` command
+
+**Files:**
+- Create: `gaia/cli/commands/init.py`
+- Modify: `gaia/cli/main.py`
+- Test: `tests/cli/test_init.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/cli/test_init.py`:
+
+```python
+"""Tests for gaia init command."""
+
+import subprocess
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def test_init_rejects_name_without_gaia_suffix():
+    """Name must end with -gaia."""
+    result = runner.invoke(app, ["init", "my-package"])
+    assert result.exit_code != 0
+    assert "-gaia" in result.output
+
+
+def test_init_creates_package(tmp_path, monkeypatch):
+    """gaia init creates pyproject.toml with [tool.gaia] and correct src layout."""
+    pkg_name = "test-pkg-gaia"
+    pkg_dir = tmp_path / pkg_name
+    monkeypatch.chdir(tmp_path)
+
+    # Mock uv init to just create the directory with minimal structure
+    def mock_uv_init(args, **kwargs):
+        pkg_dir.mkdir(exist_ok=True)
+        (pkg_dir / "pyproject.toml").write_text(
+            f'[project]\nname = "{pkg_name}"\nversion = "0.1.0"\n'
+            f'requires-python = ">=3.12"\n\n'
+            f'[build-system]\nrequires = ["hatchling"]\n'
+            f'build-backend = "hatchling.build"\n'
+        )
+        src = pkg_dir / "src" / "test_pkg_gaia"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("")
+        return subprocess.CompletedProcess(args, 0)
+
+    # Mock uv add to be a no-op
+    def mock_run(args, **kwargs):
+        if args[0] == "uv" and args[1] == "init":
+            return mock_uv_init(args, **kwargs)
+        return subprocess.CompletedProcess(args, 0)
+
+    with patch("gaia.cli.commands.init._run_uv", side_effect=mock_run):
+        result = runner.invoke(app, ["init", pkg_name])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    # pyproject.toml has [tool.gaia]
+    import tomllib
+    toml = tomllib.loads((pkg_dir / "pyproject.toml").read_text())
+    assert toml["tool"]["gaia"]["type"] == "knowledge-package"
+    assert "uuid" in toml["tool"]["gaia"]
+
+    # src dir renamed: test_pkg (not test_pkg_gaia)
+    assert (pkg_dir / "src" / "test_pkg").exists()
+    assert not (pkg_dir / "src" / "test_pkg_gaia").exists()
+
+    # __init__.py has DSL example
+    init_py = (pkg_dir / "src" / "test_pkg" / "__init__.py").read_text()
+    assert "from gaia.lang import" in init_py
+    assert "__all__" in init_py
+
+    # .gitignore has .gaia/
+    gitignore = (pkg_dir / ".gitignore").read_text()
+    assert ".gaia/" in gitignore
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/cli/test_init.py -v`
+Expected: FAIL (init command not registered)
+
+- [ ] **Step 3: Implement `gaia/cli/commands/init.py`**
+
+```python
+"""gaia init -- scaffold a new Gaia knowledge package."""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+import typer
+
+from gaia.cli._packages import GaiaCliError
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_INIT_TEMPLATE = '''\
+from gaia.lang import claim, setting
+
+context = setting("Background context for this package.")
+hypothesis = claim("A scientific hypothesis.")
+evidence = claim("Supporting evidence.", given=[hypothesis])
+
+__all__ = ["context", "hypothesis", "evidence"]
+'''
+
+
+def _run_uv(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    """Run a uv command. Separated for testability."""
+    return subprocess.run(args, text=True, capture_output=True, **kwargs)
+
+
+def _patch_pyproject(pyproject_path: Path) -> None:
+    """Add [tool.gaia] section to pyproject.toml."""
+    text = pyproject_path.read_text()
+    gaia_section = (
+        "\n[tool.gaia]\n"
+        'type = "knowledge-package"\n'
+        f'uuid = "{uuid.uuid4()}"\n'
+    )
+    text += gaia_section
+    pyproject_path.write_text(text)
+
+
+def init_command(
+    name: str = typer.Argument(help="Package name (must end with -gaia)"),
+) -> None:
+    """Scaffold a new Gaia knowledge package."""
+    if not name.endswith("-gaia"):
+        typer.echo("Error: package name must end with '-gaia'.", err=True)
+        typer.echo(f"  Suggestion: {name}-gaia", err=True)
+        raise typer.Exit(1)
+
+    # Derive import name: strip -gaia suffix, replace hyphens with underscores
+    import_name = name.removesuffix("-gaia").replace("-", "_")
+    uv_import_name = name.replace("-", "_")  # what uv generates
+
+    # 1. Run uv init --lib
+    result = _run_uv(["uv", "init", "--lib", name])
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        typer.echo(f"Error: uv init failed: {stderr}", err=True)
+        raise typer.Exit(1)
+
+    pkg_dir = Path(name)
+
+    # 2. Patch pyproject.toml
+    _patch_pyproject(pkg_dir / "pyproject.toml")
+
+    # 3. Rename src directory (strip -gaia suffix from import name)
+    src_old = pkg_dir / "src" / uv_import_name
+    src_new = pkg_dir / "src" / import_name
+    if src_old.exists() and src_old != src_new:
+        src_old.rename(src_new)
+
+    # 4. Write DSL template
+    (src_new / "__init__.py").write_text(_INIT_TEMPLATE)
+
+    # 5. Append .gaia/ to .gitignore
+    gitignore = pkg_dir / ".gitignore"
+    if gitignore.exists():
+        text = gitignore.read_text()
+        if ".gaia/" not in text:
+            gitignore.write_text(text.rstrip() + "\n\n# Gaia build artifacts\n.gaia/\n")
+    else:
+        gitignore.write_text("# Gaia build artifacts\n.gaia/\n")
+
+    # 6. Add gaia-lang dependency
+    result = _run_uv(["uv", "add", "gaia-lang"], cwd=pkg_dir)
+    if result.returncode != 0:
+        typer.echo(f"Warning: 'uv add gaia-lang' failed: {result.stderr.strip()}", err=True)
+        typer.echo("  Run it manually: cd {name} && uv add gaia-lang", err=True)
+
+    typer.echo(f"Created {name}/")
+    typer.echo(f"  src/{import_name}/__init__.py — edit your knowledge declarations here")
+    typer.echo(f"  pyproject.toml — package metadata with [tool.gaia]")
+    typer.echo(f"\nNext: cd {name} && gaia compile .")
+```
+
+- [ ] **Step 4: Register command in `gaia/cli/main.py`**
+
+Add import and registration:
+
+```python
+from gaia.cli.commands.init import init_command
+app.command(name="init")(init_command)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/cli/test_init.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/cli/commands/init.py gaia/cli/main.py tests/cli/test_init.py
+git commit -m "feat(cli): add gaia init command"
+```
+
+---
+
+### Task 2: Registry API client
+
+**Files:**
+- Create: `gaia/cli/_registry.py`
+
+- [ ] **Step 1: Implement `_registry.py`**
+
+```python
+"""Shared registry metadata client — fetches package info from GitHub API."""
+
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass
+
+import httpx
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from gaia.cli._packages import GaiaCliError
+
+DEFAULT_REGISTRY = "SiliconEinstein/gaia-registry"
+
+
+@dataclass
+class RegistryVersion:
+    """Resolved version metadata from the registry."""
+
+    version: str
+    repo: str
+    git_tag: str
+    git_sha: str
+    ir_hash: str
+
+
+def _github_headers() -> dict[str, str]:
+    """Build headers, using GITHUB_TOKEN if available for rate limits."""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_file(registry: str, path: str) -> str:
+    """Fetch a file from the registry repo via GitHub API."""
+    url = f"https://api.github.com/repos/{registry}/contents/{path}"
+    resp = httpx.get(url, headers=_github_headers(), timeout=15)
+    if resp.status_code == 404:
+        raise GaiaCliError(f"Not found in registry: {path}")
+    resp.raise_for_status()
+    content = resp.json().get("content", "")
+    return base64.b64decode(content).decode()
+
+
+def resolve_package(
+    package: str,
+    *,
+    version: str | None = None,
+    registry: str = DEFAULT_REGISTRY,
+) -> RegistryVersion:
+    """Resolve a package name + optional version to repo URL and git SHA."""
+    # Normalize: strip -gaia suffix for registry lookup
+    name = package.removesuffix("-gaia") if package.endswith("-gaia") else package
+
+    pkg_toml = tomllib.loads(_fetch_file(registry, f"packages/{name}/Package.toml"))
+    ver_toml = tomllib.loads(_fetch_file(registry, f"packages/{name}/Versions.toml"))
+
+    versions = ver_toml.get("versions", {})
+    if not versions:
+        raise GaiaCliError(f"No versions found for package '{name}'.")
+
+    if version is None:
+        # Latest: last key in ordered dict
+        version = list(versions)[-1]
+
+    if version not in versions:
+        available = ", ".join(versions)
+        raise GaiaCliError(
+            f"Version '{version}' not found for '{name}'. Available: {available}"
+        )
+
+    entry = versions[version]
+    return RegistryVersion(
+        version=version,
+        repo=pkg_toml["repo"],
+        git_tag=entry["git_tag"],
+        git_sha=entry["git_sha"],
+        ir_hash=entry["ir_hash"],
+    )
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add gaia/cli/_registry.py
+git commit -m "feat(cli): add registry API client"
+```
+
+---
+
+### Task 3: `gaia add` command
+
+**Files:**
+- Create: `gaia/cli/commands/add.py`
+- Modify: `gaia/cli/main.py`
+- Test: `tests/cli/test_add.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/cli/test_add.py`:
+
+```python
+"""Tests for gaia add command."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from gaia.cli._registry import RegistryVersion
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+MOCK_VERSION = RegistryVersion(
+    version="4.0.5",
+    repo="https://github.com/kunyuan/GalileoFallingBodies.gaia",
+    git_tag="v4.0.5",
+    git_sha="dac84fc722bf81398a7e77c830a60b2b068de18a",
+    ir_hash="sha256:abc123",
+)
+
+
+@patch("gaia.cli.commands.add.resolve_package", return_value=MOCK_VERSION)
+@patch("gaia.cli.commands.add._run_uv")
+def test_add_installs_with_git_url(mock_uv, mock_resolve):
+    """gaia add resolves registry metadata and calls uv add with git URL."""
+    mock_uv.return_value = MagicMock(returncode=0)
+
+    result = runner.invoke(app, ["add", "galileo-falling-bodies-gaia"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    mock_resolve.assert_called_once_with(
+        "galileo-falling-bodies-gaia", version=None, registry="SiliconEinstein/gaia-registry"
+    )
+
+    # Check uv add was called with correct git URL
+    uv_args = mock_uv.call_args[0][0]
+    assert uv_args[0] == "uv"
+    assert uv_args[1] == "add"
+    assert "git+https://github.com/kunyuan/GalileoFallingBodies.gaia@dac84fc7" in uv_args[2]
+
+
+@patch("gaia.cli.commands.add.resolve_package", return_value=MOCK_VERSION)
+@patch("gaia.cli.commands.add._run_uv")
+def test_add_with_version(mock_uv, mock_resolve):
+    """gaia add --version passes version to resolver."""
+    mock_uv.return_value = MagicMock(returncode=0)
+
+    result = runner.invoke(app, ["add", "galileo-falling-bodies-gaia", "--version", "4.0.5"])
+    assert result.exit_code == 0
+
+    mock_resolve.assert_called_once_with(
+        "galileo-falling-bodies-gaia", version="4.0.5", registry="SiliconEinstein/gaia-registry"
+    )
+
+
+@patch("gaia.cli.commands.add.resolve_package")
+def test_add_not_found(mock_resolve):
+    """gaia add shows error for unknown package."""
+    from gaia.cli._packages import GaiaCliError
+    mock_resolve.side_effect = GaiaCliError("Not found in registry: packages/no-such/Package.toml")
+
+    result = runner.invoke(app, ["add", "no-such-gaia"])
+    assert result.exit_code != 0
+    assert "Not found" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/cli/test_add.py -v`
+Expected: FAIL (add command not registered)
+
+- [ ] **Step 3: Implement `gaia/cli/commands/add.py`**
+
+```python
+"""gaia add -- install a Gaia knowledge package from the official registry."""
+
+from __future__ import annotations
+
+import subprocess
+
+import typer
+
+from gaia.cli._packages import GaiaCliError
+from gaia.cli._registry import DEFAULT_REGISTRY, resolve_package
+
+
+def _run_uv(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    """Run a uv command. Separated for testability."""
+    return subprocess.run(args, text=True, capture_output=True, **kwargs)
+
+
+def add_command(
+    package: str = typer.Argument(help="Package name (e.g., galileo-falling-bodies-gaia)"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Specific version"),
+    registry: str = typer.Option(DEFAULT_REGISTRY, "--registry", help="Registry GitHub repo"),
+) -> None:
+    """Install a registered Gaia knowledge package."""
+    try:
+        resolved = resolve_package(package, version=version, registry=registry)
+    except GaiaCliError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1)
+
+    dep_spec = f"{package} @ git+{resolved.repo}@{resolved.git_sha}"
+    typer.echo(f"Resolved {package} v{resolved.version} → {resolved.git_sha[:8]}")
+
+    result = _run_uv(["uv", "add", dep_spec])
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        typer.echo(f"Error: uv add failed: {stderr}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo(f"Added {package} v{resolved.version}")
+```
+
+- [ ] **Step 4: Register command in `gaia/cli/main.py`**
+
+Add import and registration:
+
+```python
+from gaia.cli.commands.add import add_command
+app.command(name="add")(add_command)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/cli/test_add.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Run all CLI tests**
+
+Run: `pytest tests/cli/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Lint and format**
+
+```bash
+ruff check gaia/cli/ tests/cli/
+ruff format gaia/cli/ tests/cli/
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add gaia/cli/commands/add.py gaia/cli/main.py tests/cli/test_add.py
+git commit -m "feat(cli): add gaia add command — install from registry"
+```
+
+---
+
+### Task 4: Add httpx dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add httpx to dependencies**
+
+`gaia add` uses httpx for GitHub API calls. Add it to the `[project].dependencies` list in `pyproject.toml`:
+
+```toml
+dependencies = [
+    "pydantic>=2.0",
+    "typer[all]>=0.12",
+    "numpy>=1.26",
+    "httpx>=0.27",
+]
+```
+
+- [ ] **Step 2: Run `uv sync`**
+
+```bash
+uv sync
+```
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+pytest tests/ir tests/cli tests/test_lowering.py tests/test_science_examples.py -v
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "build: add httpx dependency for registry API"
+```
+
+---
+
+## Chunk 2: Registry CI Update
+
+### Task 5: Update `register.yml` in gaia-registry repo
+
+This task operates on the **gaia-registry** repo, not the Gaia main repo.
+
+**Files:**
+- Modify: `gaia-registry/.github/workflows/register.yml`
+
+- [ ] **Step 1: Clone gaia-registry locally**
+
+```bash
+git clone https://github.com/SiliconEinstein/gaia-registry.git /tmp/gaia-registry
+cd /tmp/gaia-registry
+git checkout -b feat/pypi-gaia-lang-and-namespace
+```
+
+- [ ] **Step 2: Update `register.yml`**
+
+Replace the `GAIA_REPO` / `GAIA_REF` env block and the "Clone Gaia CLI source" step with a simpler PyPI install. Add namespace validation step.
+
+The updated sandbox-validate job steps should be:
+
+1. checkout
+2. Install uv + Python (unchanged)
+3. Parse registration payload (unchanged)
+4. **Install Gaia CLI from PyPI** (replaces clone):
+   ```yaml
+   - name: Install Gaia CLI
+     run: uv pip install --system gaia-lang
+   ```
+5. Clone and validate source release — simplified:
+   - Remove the `GAIA_APP` and `/tmp/gaia/.venv/bin/python -c` pattern
+   - Call `gaia compile .` and `gaia check .` directly
+6. **New step: Validate namespace**:
+   ```yaml
+   - name: Validate namespace
+     run: |
+       python3 -c "
+       import json, sys
+       graph = json.load(open('.gaia/ir.json'))
+       ns = graph.get('namespace', '')
+       if ns != 'github':
+           print(f'Error: namespace must be \"github\", got \"{ns}\"', file=sys.stderr)
+           sys.exit(1)
+       print(f'Namespace OK: {ns}')
+       "
+     working-directory: pkg
+   ```
+
+Also remove the top-level `env:` block that defines `GAIA_REPO` and `GAIA_REF`.
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+cd /tmp/gaia-registry
+git add .github/workflows/register.yml
+git commit -m "feat(ci): use PyPI gaia-lang + namespace validation
+
+- Replace GAIA_REPO/GAIA_REF clone with 'uv pip install gaia-lang'
+- Add namespace == 'github' validation in sandbox job
+- Simplify gaia compile/check invocation (direct CLI, no python -c wrapper)"
+git push origin feat/pypi-gaia-lang-and-namespace
+```
+
+- [ ] **Step 4: Create PR**
+
+```bash
+gh pr create \
+  --repo SiliconEinstein/gaia-registry \
+  --title "feat(ci): use PyPI gaia-lang + namespace validation" \
+  --body "$(cat <<'EOF'
+## Summary
+- Replace clone + GAIA_REF with `uv pip install gaia-lang` from PyPI
+- Add namespace validation (must be `github` for this registry)
+- Simplify CLI invocation in sandbox job
+
+## Test plan
+- [ ] Trigger a test registration PR to verify the updated CI works
+EOF
+)"
+```
+
+---
+
+### Task 6: Update docs and bump version
+
+**Files:**
+- Modify: `docs/foundations/cli/workflow.md` (add `gaia init` and `gaia add` descriptions)
+- Modify: `README.md` (update install and workflow sections)
+
+- [ ] **Step 1: Update `workflow.md`**
+
+Add `gaia init` and `gaia add` sections to the Commands list, following the existing pattern for compile/check/infer/register.
+
+- [ ] **Step 2: Update `README.md`**
+
+Update the "Create a Knowledge Package" section to use `gaia init` instead of manual `uv init`.
+Add a "Install a Package" section showing `gaia add`.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+ruff check . && ruff format --check .
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/foundations/cli/workflow.md README.md
+git commit -m "docs: add gaia init and gaia add to workflow docs and README"
+```

--- a/docs/specs/2026-04-03-gaia-init-add-registry-ci-design.md
+++ b/docs/specs/2026-04-03-gaia-init-add-registry-ci-design.md
@@ -1,0 +1,158 @@
+# gaia init, gaia add, and Registry CI Update — Design
+
+**Status:** Target design
+**Date:** 2026-04-03
+
+## Summary
+
+Add two new CLI commands (`gaia init`, `gaia add`) and update the official registry CI
+to use PyPI-installed `gaia-lang` and validate namespace.
+
+## 1. `gaia init <name>`
+
+Scaffold a new Gaia knowledge package using `uv init --lib` as the base.
+
+**Usage:**
+
+```bash
+gaia init galileo-falling-bodies-gaia
+```
+
+**Steps:**
+
+1. Validate `name` ends with `-gaia`, abort otherwise
+2. Run `uv init --lib <name>` to generate standard Python package structure
+3. Modify `pyproject.toml`:
+   - Add `[tool.gaia]` section with `type = "knowledge-package"` and auto-generated `uuid`
+4. Rename `src/<name_with_underscores>/` → `src/<import_name>/` (strip `-gaia` suffix)
+5. Overwrite `src/<import_name>/__init__.py` with a DSL example:
+   ```python
+   from gaia.lang import claim, setting
+
+   context = setting("Background context for this package.")
+   hypothesis = claim("A scientific hypothesis.")
+   evidence = claim("Supporting evidence.", given=[hypothesis])
+
+   __all__ = ["context", "hypothesis", "evidence"]
+   ```
+6. Append `.gaia/` to `.gitignore`
+7. Run `uv add gaia-lang` to add the dependency
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `name` | Yes | Package name, must end with `-gaia` |
+
+**Error cases:**
+
+- Name doesn't end with `-gaia` → error with suggestion
+- `uv` not installed → error with install instructions
+- Directory already exists → let `uv init` handle the error
+
+## 2. `gaia add <package>`
+
+Install a registered Gaia knowledge package by querying the official registry metadata
+via GitHub API, then delegating to `uv add` with a pinned git URL.
+
+**Usage:**
+
+```bash
+gaia add galileo-falling-bodies-gaia
+gaia add galileo-falling-bodies-gaia --version 4.0.5
+```
+
+**Steps:**
+
+1. Strip `-gaia` suffix to get registry package name (e.g., `galileo-falling-bodies`)
+2. Fetch `packages/<name>/Package.toml` from GitHub API (`SiliconEinstein/gaia-registry`)
+3. Fetch `packages/<name>/Versions.toml` from GitHub API
+4. Parse TOML, select version:
+   - Default: latest (last entry in `[versions]`)
+   - `--version X.Y.Z`: specific version
+5. Extract `repo` (from Package.toml), `git_sha` (from Versions.toml)
+6. Run `uv add "<name>-gaia @ git+<repo>@<git_sha>"`
+
+**Arguments / Options:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `package` | Yes | Package name (with or without `-gaia` suffix) |
+| `--version` | No | Specific version, default latest |
+| `--registry` | No | Registry GitHub repo, default `SiliconEinstein/gaia-registry` |
+
+**Error cases:**
+
+- Package not found in registry → clear error with available packages hint
+- Version not found → error listing available versions
+- GitHub API failure / rate limit → error with suggestion to set `GITHUB_TOKEN`
+- `uv` not installed → error
+
+**GitHub API access:**
+
+- Uses `GITHUB_TOKEN` env var if set (for rate limits), otherwise anonymous
+- Fetches file content via `GET /repos/{owner}/{repo}/contents/{path}`
+- Decodes base64 content, parses TOML with `tomllib`
+
+## 3. Registry CI Update
+
+**File:** `gaia-registry/.github/workflows/register.yml`
+
+**Changes:**
+
+### 3a. Replace GAIA_REPO/GAIA_REF with PyPI install
+
+Before:
+```yaml
+env:
+  GAIA_REPO: https://github.com/SiliconEinstein/Gaia.git
+  GAIA_REF: e9fcb1ae...
+
+- name: Clone Gaia CLI source
+  run: |
+    git clone "$GAIA_REPO" /tmp/gaia
+    cd /tmp/gaia && git checkout "$GAIA_REF" && uv sync
+```
+
+After:
+```yaml
+- name: Install Gaia CLI
+  run: uv pip install gaia-lang
+```
+
+And simplify the validation step to call `gaia` directly instead of going through
+`/tmp/gaia/.venv/bin/python -c "..."`.
+
+### 3b. Add namespace validation
+
+After `gaia compile` and `gaia check`, add:
+
+```yaml
+- name: Validate namespace
+  run: |
+    python3 -c "
+    import json
+    graph = json.load(open('.gaia/ir.json'))
+    ns = graph.get('namespace', '')
+    assert ns == 'github', f'Namespace must be \"github\" for this registry, got \"{ns}\"'
+    print(f'Namespace OK: {ns}')
+    "
+```
+
+## File Changes
+
+| Repo | File | Action |
+|------|------|--------|
+| Gaia | `gaia/cli/main.py` | Register `init` and `add` commands |
+| Gaia | `gaia/cli/commands/init.py` | New — scaffold command |
+| Gaia | `gaia/cli/commands/add.py` | New — registry install command |
+| Gaia | `tests/cli/test_init.py` | New — init tests |
+| Gaia | `tests/cli/test_add.py` | New — add tests |
+| gaia-registry | `.github/workflows/register.yml` | Modify — PyPI install + namespace check |
+
+## Non-Goals
+
+- Local registry cache (`~/.gaia/registry/`) — future optimization
+- `gaia remove` / `gaia update` — not needed yet
+- Configurable registry URL in `pyproject.toml` — hardcoded for now
+- Publishing author packages to PyPI from registry CI — separate future work

--- a/gaia/cli/_registry.py
+++ b/gaia/cli/_registry.py
@@ -1,0 +1,81 @@
+"""Shared registry metadata client — fetches package info from GitHub API."""
+
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass
+
+import httpx
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from gaia.cli._packages import GaiaCliError
+
+DEFAULT_REGISTRY = "SiliconEinstein/gaia-registry"
+
+
+@dataclass
+class RegistryVersion:
+    """Resolved version metadata from the registry."""
+
+    version: str
+    repo: str
+    git_tag: str
+    git_sha: str
+    ir_hash: str
+
+
+def _github_headers() -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_file(registry: str, path: str) -> str:
+    url = f"https://api.github.com/repos/{registry}/contents/{path}"
+    resp = httpx.get(url, headers=_github_headers(), timeout=15)
+    if resp.status_code == 404:
+        raise GaiaCliError(f"Not found in registry: {path}")
+    resp.raise_for_status()
+    content = resp.json().get("content", "")
+    return base64.b64decode(content).decode()
+
+
+def resolve_package(
+    package: str,
+    *,
+    version: str | None = None,
+    registry: str = DEFAULT_REGISTRY,
+) -> RegistryVersion:
+    """Resolve a package name (and optional version) to registry metadata."""
+    # Strip -gaia suffix for registry lookup
+    name = package.removesuffix("-gaia") if package.endswith("-gaia") else package
+
+    pkg_toml = tomllib.loads(_fetch_file(registry, f"packages/{name}/Package.toml"))
+    ver_toml = tomllib.loads(_fetch_file(registry, f"packages/{name}/Versions.toml"))
+
+    versions = ver_toml.get("versions", {})
+    if not versions:
+        raise GaiaCliError(f"No versions found for package '{name}'.")
+
+    if version is None:
+        version = list(versions)[-1]
+
+    if version not in versions:
+        available = ", ".join(versions)
+        raise GaiaCliError(f"Version '{version}' not found for '{name}'. Available: {available}")
+
+    entry = versions[version]
+    return RegistryVersion(
+        version=version,
+        repo=pkg_toml["repo"],
+        git_tag=entry["git_tag"],
+        git_sha=entry["git_sha"],
+        ir_hash=entry["ir_hash"],
+    )

--- a/gaia/cli/commands/add.py
+++ b/gaia/cli/commands/add.py
@@ -1,0 +1,38 @@
+"""gaia add -- install a Gaia knowledge package from the official registry."""
+
+from __future__ import annotations
+
+import subprocess
+
+import typer
+
+from gaia.cli._packages import GaiaCliError
+from gaia.cli._registry import DEFAULT_REGISTRY, resolve_package
+
+
+def _run_uv(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, text=True, capture_output=True, **kwargs)
+
+
+def add_command(
+    package: str = typer.Argument(help="Package name (e.g., galileo-falling-bodies-gaia)"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Specific version"),
+    registry: str = typer.Option(DEFAULT_REGISTRY, "--registry", help="Registry GitHub repo"),
+) -> None:
+    """Install a registered Gaia knowledge package."""
+    try:
+        resolved = resolve_package(package, version=version, registry=registry)
+    except GaiaCliError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1)
+
+    dep_spec = f"{package} @ git+{resolved.repo}@{resolved.git_sha}"
+    typer.echo(f"Resolved {package} v{resolved.version} → {resolved.git_sha[:8]}")
+
+    result = _run_uv(["uv", "add", dep_spec])
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        typer.echo(f"Error: uv add failed: {stderr}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo(f"Added {package} v{resolved.version}")

--- a/gaia/cli/commands/init.py
+++ b/gaia/cli/commands/init.py
@@ -1,0 +1,103 @@
+"""gaia init -- scaffold a new Gaia knowledge package."""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+import typer
+
+from gaia.cli._packages import GaiaCliError
+
+_DSL_TEMPLATE = """\
+from gaia.lang import claim, setting
+
+context = setting("Background context for this package.")
+hypothesis = claim("A scientific hypothesis.")
+evidence = claim("Supporting evidence.", given=[hypothesis])
+
+__all__ = ["context", "hypothesis", "evidence"]
+"""
+
+
+def _run_uv(
+    args: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(args, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "command failed"
+        raise GaiaCliError(f"Error running {' '.join(args)}: {stderr}")
+    return result
+
+
+def init_command(
+    name: str = typer.Argument(help="Package name (must end with '-gaia')."),
+) -> None:
+    """Create a new Gaia knowledge package."""
+    # --- validate name suffix ---------------------------------------------------
+    if not name.endswith("-gaia"):
+        suggested = f"{name}-gaia"
+        typer.echo(
+            f"Error: package name must end with '-gaia'. Did you mean '{suggested}'?",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    cwd = Path.cwd()
+    pkg_dir = cwd / name
+
+    # --- scaffold with uv init --lib -------------------------------------------
+    try:
+        _run_uv(["uv", "init", "--lib", name], cwd=cwd)
+    except GaiaCliError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1)
+
+    # --- patch pyproject.toml with [tool.gaia] section -------------------------
+    pyproject_path = pkg_dir / "pyproject.toml"
+    gaia_uuid = str(uuid.uuid4())
+    gaia_section = f'\n[tool.gaia]\ntype = "knowledge-package"\nuuid = "{gaia_uuid}"\n'
+    with open(pyproject_path, "a") as f:
+        f.write(gaia_section)
+
+    # --- rename src/<uv_default_name>/ → src/<import_name>/ --------------------
+    import_name = name.removesuffix("-gaia").replace("-", "_")
+    uv_default_name = name.replace("-", "_")
+    src_dir = pkg_dir / "src"
+    uv_pkg_dir = src_dir / uv_default_name
+    target_pkg_dir = src_dir / import_name
+
+    if uv_pkg_dir.exists() and uv_pkg_dir != target_pkg_dir:
+        uv_pkg_dir.rename(target_pkg_dir)
+    elif not uv_pkg_dir.exists() and not target_pkg_dir.exists():
+        # Fallback: create the target directory if uv didn't create expected layout
+        target_pkg_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- write DSL template into __init__.py -----------------------------------
+    init_py = target_pkg_dir / "__init__.py"
+    init_py.write_text(_DSL_TEMPLATE)
+
+    # --- append .gaia/ to .gitignore -------------------------------------------
+    gitignore_path = pkg_dir / ".gitignore"
+    if gitignore_path.exists():
+        existing = gitignore_path.read_text()
+        if ".gaia/" not in existing:
+            with open(gitignore_path, "a") as f:
+                f.write("\n.gaia/\n")
+    else:
+        gitignore_path.write_text(".gaia/\n")
+
+    # --- add gaia-lang dependency (warn on failure) ----------------------------
+    try:
+        _run_uv(["uv", "add", "gaia-lang"], cwd=pkg_dir)
+    except GaiaCliError:
+        typer.echo(
+            "Warning: could not add gaia-lang dependency. Run 'uv add gaia-lang' manually.",
+            err=True,
+        )
+
+    typer.echo(f"Created Gaia knowledge package: {name}")

--- a/gaia/cli/main.py
+++ b/gaia/cli/main.py
@@ -2,6 +2,7 @@
 
 import typer
 
+from gaia.cli.commands.add import add_command
 from gaia.cli.commands.check import check_command
 from gaia.cli.commands.compile import compile_command
 from gaia.cli.commands.infer import infer_command
@@ -20,6 +21,7 @@ def _callback() -> None:
     """Gaia — knowledge package authoring toolkit."""
 
 
+app.command(name="add")(add_command)
 app.command(name="compile")(compile_command)
 app.command(name="check")(check_command)
 app.command(name="infer")(infer_command)

--- a/gaia/cli/main.py
+++ b/gaia/cli/main.py
@@ -5,6 +5,7 @@ import typer
 from gaia.cli.commands.check import check_command
 from gaia.cli.commands.compile import compile_command
 from gaia.cli.commands.infer import infer_command
+from gaia.cli.commands.init import init_command
 from gaia.cli.commands.register import register_command
 
 app = typer.Typer(
@@ -22,4 +23,5 @@ def _callback() -> None:
 app.command(name="compile")(compile_command)
 app.command(name="check")(check_command)
 app.command(name="infer")(infer_command)
+app.command(name="init")(init_command)
 app.command(name="register")(register_command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pydantic>=2.0",
     "typer[all]>=0.12",
     "numpy>=1.26",
+    "httpx>=0.27",
 ]
 
 [project.urls]

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -1,0 +1,53 @@
+"""Tests for gaia add command."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from gaia.cli._registry import RegistryVersion
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+MOCK_VERSION = RegistryVersion(
+    version="4.0.5",
+    repo="https://github.com/kunyuan/GalileoFallingBodies.gaia",
+    git_tag="v4.0.5",
+    git_sha="dac84fc722bf81398a7e77c830a60b2b068de18a",
+    ir_hash="sha256:abc123",
+)
+
+
+@patch("gaia.cli.commands.add.resolve_package", return_value=MOCK_VERSION)
+@patch("gaia.cli.commands.add._run_uv")
+def test_add_installs_with_git_url(mock_uv, mock_resolve):
+    mock_uv.return_value = MagicMock(returncode=0)
+    result = runner.invoke(app, ["add", "galileo-falling-bodies-gaia"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    mock_resolve.assert_called_once()
+    uv_args = mock_uv.call_args[0][0]
+    assert "git+" in uv_args[2]
+    assert "dac84fc7" in uv_args[2]
+
+
+@patch("gaia.cli.commands.add.resolve_package", return_value=MOCK_VERSION)
+@patch("gaia.cli.commands.add._run_uv")
+def test_add_with_version(mock_uv, mock_resolve):
+    mock_uv.return_value = MagicMock(returncode=0)
+    result = runner.invoke(app, ["add", "galileo-falling-bodies-gaia", "--version", "4.0.5"])
+    assert result.exit_code == 0
+    mock_resolve.assert_called_once_with(
+        "galileo-falling-bodies-gaia",
+        version="4.0.5",
+        registry="SiliconEinstein/gaia-registry",
+    )
+
+
+@patch("gaia.cli.commands.add.resolve_package")
+def test_add_not_found(mock_resolve):
+    from gaia.cli._packages import GaiaCliError
+
+    mock_resolve.side_effect = GaiaCliError("Not found in registry: packages/no-such/Package.toml")
+    result = runner.invoke(app, ["add", "no-such-gaia"])
+    assert result.exit_code != 0
+    assert "Not found" in result.output

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,0 +1,156 @@
+"""Tests for gaia init command."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+runner = CliRunner()
+
+
+def _fake_uv_init(args, *, cwd, text, capture_output):
+    """Simulate `uv init --lib <name>`: create the directory tree that uv would create."""
+    # args: ["uv", "init", "--lib", "<name>"]
+    name = args[3]
+    uv_import_name = name.replace("-", "_")
+    pkg_dir = Path(cwd) / name
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "0.1.0"\n'
+        f'description = "Add your description here"\n'
+    )
+    src_dir = pkg_dir / "src" / uv_import_name
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").write_text(
+        f'def hello() -> str:\n    return "Hello from {uv_import_name}!"\n'
+    )
+    (pkg_dir / ".gitignore").write_text("# uv default gitignore\n")
+    return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+def _fake_uv_add_ok(args, *, cwd, text, capture_output):
+    """Simulate a successful `uv add gaia-lang`."""
+    return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+def _fake_uv_add_fail(args, *, cwd, text, capture_output):
+    """Simulate a failing `uv add gaia-lang`."""
+    return subprocess.CompletedProcess(args, 1, stdout="", stderr="package not found")
+
+
+def _fake_subprocess_run(args, *, cwd, text, capture_output):
+    """Dispatch to the correct fake based on the command."""
+    if args[:3] == ["uv", "init", "--lib"]:
+        return _fake_uv_init(args, cwd=cwd, text=text, capture_output=capture_output)
+    if args[:2] == ["uv", "add"]:
+        return _fake_uv_add_ok(args, cwd=cwd, text=text, capture_output=capture_output)
+    return subprocess.CompletedProcess(args, 1, stdout="", stderr="unexpected command")
+
+
+def _fake_subprocess_run_uv_add_fails(args, *, cwd, text, capture_output):
+    """Dispatch where uv add fails."""
+    if args[:3] == ["uv", "init", "--lib"]:
+        return _fake_uv_init(args, cwd=cwd, text=text, capture_output=capture_output)
+    if args[:2] == ["uv", "add"]:
+        return _fake_uv_add_fail(args, cwd=cwd, text=text, capture_output=capture_output)
+    return subprocess.CompletedProcess(args, 1, stdout="", stderr="unexpected command")
+
+
+def test_init_rejects_name_without_gaia_suffix():
+    """Package name must end with '-gaia'."""
+    result = runner.invoke(app, ["init", "my-package"])
+    assert result.exit_code != 0
+    assert "must end with '-gaia'" in result.output
+    assert "my-package-gaia" in result.output
+
+
+def test_init_creates_package(tmp_path, monkeypatch):
+    """Successful init scaffolds the expected files."""
+    monkeypatch.chdir(tmp_path)
+    with patch("gaia.cli.commands.init.subprocess.run", side_effect=_fake_subprocess_run):
+        result = runner.invoke(app, ["init", "my-research-gaia"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Created Gaia knowledge package" in result.output
+
+    pkg_dir = tmp_path / "my-research-gaia"
+    assert pkg_dir.exists()
+
+    # pyproject.toml has [tool.gaia] section
+    pyproject = pkg_dir / "pyproject.toml"
+    config = tomllib.loads(pyproject.read_text())
+    assert config["tool"]["gaia"]["type"] == "knowledge-package"
+    assert "uuid" in config["tool"]["gaia"]
+    # uuid should be a valid UUID string
+    import uuid
+
+    uuid.UUID(config["tool"]["gaia"]["uuid"])
+
+    # src directory was renamed: my_research_gaia → my_research
+    import_dir = pkg_dir / "src" / "my_research"
+    assert import_dir.exists()
+    uv_default_dir = pkg_dir / "src" / "my_research_gaia"
+    assert not uv_default_dir.exists()
+
+    # __init__.py has DSL template
+    init_py = import_dir / "__init__.py"
+    content = init_py.read_text()
+    assert "from gaia.lang import claim, setting" in content
+    assert "context = setting(" in content
+    assert "hypothesis = claim(" in content
+    assert "evidence = claim(" in content
+    assert '__all__ = ["context", "hypothesis", "evidence"]' in content
+
+    # .gitignore includes .gaia/
+    gitignore = pkg_dir / ".gitignore"
+    assert ".gaia/" in gitignore.read_text()
+
+
+def test_init_simple_name(tmp_path, monkeypatch):
+    """A simple name like 'foo-gaia' removes the -gaia suffix for the import name."""
+    monkeypatch.chdir(tmp_path)
+    with patch("gaia.cli.commands.init.subprocess.run", side_effect=_fake_subprocess_run):
+        result = runner.invoke(app, ["init", "foo-gaia"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    pkg_dir = tmp_path / "foo-gaia"
+    # src/foo_gaia → src/foo
+    assert (pkg_dir / "src" / "foo").exists()
+    assert not (pkg_dir / "src" / "foo_gaia").exists()
+
+
+def test_init_uv_add_failure_warns_but_succeeds(tmp_path, monkeypatch):
+    """If 'uv add gaia-lang' fails, the command warns but exits 0."""
+    monkeypatch.chdir(tmp_path)
+    with patch(
+        "gaia.cli.commands.init.subprocess.run",
+        side_effect=_fake_subprocess_run_uv_add_fails,
+    ):
+        result = runner.invoke(app, ["init", "warn-gaia"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Warning" in result.output or "could not add gaia-lang" in result.output
+    # Package was still created
+    assert (tmp_path / "warn-gaia" / "pyproject.toml").exists()
+
+
+def test_init_gitignore_not_duplicated(tmp_path, monkeypatch):
+    """If .gaia/ is already in .gitignore, don't add it again."""
+    monkeypatch.chdir(tmp_path)
+    with patch("gaia.cli.commands.init.subprocess.run", side_effect=_fake_subprocess_run):
+        result = runner.invoke(app, ["init", "dedup-gaia"])
+
+    assert result.exit_code == 0
+    gitignore = (tmp_path / "dedup-gaia" / ".gitignore").read_text()
+    assert gitignore.count(".gaia/") == 1

--- a/uv.lock
+++ b/uv.lock
@@ -579,10 +579,24 @@ wheels = [
 ]
 
 [[package]]
-name = "gaia"
+name = "gaia-lang"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+server = [
     { name = "clickhouse-connect" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -591,58 +605,44 @@ dependencies = [
     { name = "litellm" },
     { name = "lxml" },
     { name = "neo4j" },
-    { name = "numpy" },
     { name = "pandas" },
     { name = "pyarrow" },
-    { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "tos" },
-    { name = "typer" },
     { name = "typst" },
     { name = "uvicorn" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "httpx" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "python-dotenv" },
-    { name = "ruff" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "clickhouse-connect", specifier = ">=0.7" },
-    { name = "fastapi", specifier = ">=0.110" },
+    { name = "clickhouse-connect", marker = "extra == 'server'", specifier = ">=0.7" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
-    { name = "kuzu", specifier = ">=0.4" },
-    { name = "lancedb", specifier = ">=0.6" },
-    { name = "litellm", specifier = ">=1.40" },
-    { name = "lxml", specifier = ">=5.0" },
-    { name = "neo4j", specifier = ">=5.0" },
+    { name = "httpx", marker = "extra == 'server'", specifier = ">=0.27" },
+    { name = "kuzu", marker = "extra == 'server'", specifier = ">=0.4" },
+    { name = "lancedb", marker = "extra == 'server'", specifier = ">=0.6" },
+    { name = "litellm", marker = "extra == 'server'", specifier = ">=1.40" },
+    { name = "lxml", marker = "extra == 'server'", specifier = ">=5.0" },
+    { name = "neo4j", marker = "extra == 'server'", specifier = ">=5.0" },
     { name = "numpy", specifier = ">=1.26" },
-    { name = "pandas", specifier = ">=2.0" },
-    { name = "pyarrow", specifier = ">=15.0" },
+    { name = "pandas", marker = "extra == 'server'", specifier = ">=2.0" },
+    { name = "pyarrow", marker = "extra == 'server'", specifier = ">=15.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
-    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'server'", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
-    { name = "scikit-learn", specifier = ">=1.8.0" },
-    { name = "tos", specifier = ">=2.7" },
+    { name = "scikit-learn", marker = "extra == 'server'", specifier = ">=1.8.0" },
+    { name = "tos", marker = "extra == 'server'", specifier = ">=2.7" },
     { name = "typer", extras = ["all"], specifier = ">=0.12" },
-    { name = "typst", specifier = ">=0.12" },
-    { name = "uvicorn", specifier = ">=0.29" },
+    { name = "typst", marker = "extra == 'server'", specifier = ">=0.12" },
+    { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.29" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "server"]
 
 [[package]]
 name = "h11"


### PR DESCRIPTION
## Summary
- **`gaia init <name>`** — scaffold a new Gaia knowledge package (wraps `uv init --lib` + adds `[tool.gaia]` config, renames src dir, writes DSL template)
- **`gaia add <package>`** — install a registered package from the official registry (queries GitHub API for metadata, resolves version, calls `uv add` with pinned git URL)
- **`gaia/cli/_registry.py`** — shared registry API client
- **httpx** added as dependency for GitHub API calls
- Updated workflow docs and README with new commands

## Related
- Registry CI update: SiliconEinstein/gaia-registry#15

## Test plan
- [x] 5 tests for `gaia init` (name validation, package creation, rename, template, gitignore)
- [x] 3 tests for `gaia add` (git URL install, version passthrough, not-found error)
- [x] 258 total tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)