### PR TITLE
feat(cli): add --readme flag to gaia compile

### DIFF
--- a/docs/plans/2026-04-04-compile-readme.md
+++ b/docs/plans/2026-04-04-compile-readme.md
@@ -1,0 +1,772 @@
+# `gaia compile --readme` Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--readme` flag to `gaia compile` that generates a navigable `README.md` from compiled IR with Mermaid graph, narrative-ordered content, hyperlinked references, and optional inference results.
+
+**Architecture:** A single new module `gaia/cli/commands/_readme.py` does all the work — topological sort, Mermaid generation, Markdown rendering. The compile command gets a `--readme` flag that calls it after writing IR artifacts. No changes to IR models or BP.
+
+**Tech Stack:** Python stdlib only (no new dependencies). Mermaid diagram rendered by GitHub's built-in support.
+
+**Spec:** `docs/specs/2026-04-04-compile-readme-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `gaia/cli/commands/_readme.py` | Create | All README generation logic |
+| `gaia/cli/commands/compile.py` | Modify | Add `--readme` flag, call `generate_readme` |
+| `tests/cli/test_readme.py` | Create | Tests for README generation |
+
+---
+
+## Chunk 1: Core README generation
+
+### Task 1: Topological sort and narrative ordering
+
+**Files:**
+- Create: `gaia/cli/commands/_readme.py`
+- Test: `tests/cli/test_readme.py`
+
+- [ ] **Step 1: Write the failing test for topological sort**
+
+```python
+# tests/cli/test_readme.py
+from gaia.cli.commands._readme import topo_layers
+
+
+def test_topo_layers_linear_chain():
+    """A → B → C should produce 3 layers."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "C."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a"], "conclusion": "ns:p::b", "type": "noisy_and"},
+            {"premises": ["ns:p::b"], "conclusion": "ns:p::c", "type": "noisy_and"},
+        ],
+        "operators": [],
+    }
+    layers = topo_layers(ir)
+    # a has no incoming edges → layer 0
+    # b depends on a → layer 1
+    # c depends on b → layer 2
+    assert layers["ns:p::a"] == 0
+    assert layers["ns:p::b"] == 1
+    assert layers["ns:p::c"] == 2
+
+
+def test_topo_layers_independent_premises():
+    """Multiple independent premises should all be layer 0."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "C."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a", "ns:p::b"], "conclusion": "ns:p::c", "type": "noisy_and"},
+        ],
+        "operators": [],
+    }
+    layers = topo_layers(ir)
+    assert layers["ns:p::a"] == 0
+    assert layers["ns:p::b"] == 0
+    assert layers["ns:p::c"] == 1
+
+
+def test_topo_layers_settings_always_layer_0():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::s", "label": "s", "type": "setting", "content": "S."},
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    layers = topo_layers(ir)
+    assert layers["ns:p::s"] == 0
+    assert layers["ns:p::a"] == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/cli/test_readme.py -v`
+Expected: ImportError
+
+- [ ] **Step 3: Implement `topo_layers`**
+
+```python
+# gaia/cli/commands/_readme.py
+"""gaia compile --readme: generate README.md from compiled IR."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+
+def topo_layers(ir: dict) -> dict[str, int]:
+    """Assign each knowledge ID a topological layer (0 = no incoming edges)."""
+    all_ids = {k["id"] for k in ir["knowledges"]}
+    # Map conclusion → set of premise IDs (incoming edges)
+    incoming: dict[str, set[str]] = defaultdict(set)
+    for s in ir.get("strategies", []):
+        conclusion = s.get("conclusion")
+        if conclusion and conclusion in all_ids:
+            for p in s.get("premises", []):
+                if p in all_ids:
+                    incoming[conclusion].add(p)
+    for o in ir.get("operators", []):
+        conclusion = o.get("conclusion")
+        if conclusion and conclusion in all_ids:
+            for v in o.get("variables", []):
+                if v in all_ids:
+                    incoming[conclusion].add(v)
+
+    layers: dict[str, int] = {}
+    remaining = set(all_ids)
+
+    layer = 0
+    while remaining:
+        # Nodes whose all dependencies are already assigned
+        ready = {
+            nid for nid in remaining
+            if not (incoming.get(nid, set()) - set(layers.keys()))
+        }
+        if not ready:
+            # Cycle — assign remaining to current layer
+            ready = remaining
+        for nid in ready:
+            layers[nid] = layer
+        remaining -= ready
+        layer += 1
+
+    return layers
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/cli/test_readme.py -v`
+Expected: 3 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/cli/commands/_readme.py tests/cli/test_readme.py
+git commit -m "feat(cli): add topo_layers for README narrative ordering"
+```
+
+---
+
+### Task 2: Mermaid diagram generation
+
+**Files:**
+- Modify: `gaia/cli/commands/_readme.py`
+- Test: `tests/cli/test_readme.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_mermaid_basic():
+    """Mermaid output should contain node definitions and edges."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::obs", "label": "obs", "type": "claim", "content": "Obs."},
+            {"id": "ns:p::hyp", "label": "hyp", "type": "claim", "content": "Hyp."},
+            {"id": "ns:p::env", "label": "env", "type": "setting", "content": "Env."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::obs"], "conclusion": "ns:p::hyp", "type": "noisy_and",
+             "metadata": {"reason": "because"}},
+        ],
+        "operators": [],
+    }
+    md = render_mermaid(ir)
+    assert "graph TD" in md
+    assert "obs[" in md  # node definition
+    assert "hyp[" in md
+    assert "env[" in md
+    assert "obs -->|noisy_and| hyp" in md  # edge
+    assert ":::setting" in md  # setting class
+
+
+def test_mermaid_hides_helper_claims():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::__helper_abc", "label": "__helper_abc", "type": "claim",
+             "content": "helper"},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_mermaid(ir)
+    assert "__helper_abc" not in md
+    assert "a[" in md
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement `render_mermaid`**
+
+```python
+def render_mermaid(ir: dict, beliefs: dict[str, float] | None = None) -> str:
+    """Render a Mermaid graph TD diagram from the IR."""
+    lines = ["```mermaid", "graph TD"]
+
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+
+    # Classify nodes
+    strategy_conclusions: set[str] = set()
+    strategy_premises: set[str] = set()
+    for s in ir.get("strategies", []):
+        if s.get("conclusion"):
+            strategy_conclusions.add(s["conclusion"])
+        for p in s.get("premises", []):
+            strategy_premises.add(p)
+
+    # Render nodes
+    for k in ir["knowledges"]:
+        label = k.get("label", "")
+        if label.startswith("__"):
+            continue
+        kid = k["id"]
+        ktype = k["type"]
+
+        display = label
+        if beliefs and kid in beliefs:
+            display = f"{label} ({beliefs[kid]:.2f})"
+
+        if ktype == "setting":
+            lines.append(f'    {label}["{display}"]:::setting')
+        elif ktype == "question":
+            lines.append(f'    {label}["{display}"]:::question')
+        elif kid in strategy_conclusions:
+            lines.append(f'    {label}["{display}"]:::derived')
+        elif kid in strategy_premises:
+            lines.append(f'    {label}["{display}"]:::premise')
+        else:
+            lines.append(f'    {label}["{display}"]:::orphan')
+
+    # Render strategy edges
+    for s in ir.get("strategies", []):
+        conclusion = s.get("conclusion")
+        if not conclusion:
+            continue
+        conc_label = knowledge_by_id.get(conclusion, {}).get("label", "")
+        if conc_label.startswith("__"):
+            continue
+        stype = s.get("type", "")
+        for p in s.get("premises", []):
+            p_label = knowledge_by_id.get(p, {}).get("label", "")
+            if p_label.startswith("__"):
+                continue
+            lines.append(f"    {p_label} -->|{stype}| {conc_label}")
+
+    # Render operator edges
+    for o in ir.get("operators", []):
+        conclusion = o.get("conclusion")
+        if not conclusion:
+            continue
+        conc_label = knowledge_by_id.get(conclusion, {}).get("label", "")
+        if conc_label.startswith("__"):
+            continue
+        otype = o.get("operator", "")
+        for v in o.get("variables", []):
+            v_label = knowledge_by_id.get(v, {}).get("label", "")
+            if v_label.startswith("__"):
+                continue
+            lines.append(f"    {v_label} -.-|{otype}| {conc_label}")
+
+    # Styles
+    lines.append("")
+    lines.append("    classDef setting fill:#f0f0f0,stroke:#999")
+    lines.append("    classDef premise fill:#ddeeff,stroke:#4488bb")
+    lines.append("    classDef derived fill:#ddffdd,stroke:#44bb44")
+    lines.append("    classDef question fill:#fff3dd,stroke:#cc9944")
+    lines.append("    classDef orphan fill:#fff,stroke:#ccc,stroke-dasharray: 5 5")
+    lines.append("```")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/cli/commands/_readme.py tests/cli/test_readme.py
+git commit -m "feat(cli): add Mermaid diagram generation for README"
+```
+
+---
+
+### Task 3: Knowledge nodes section with narrative order and hyperlinks
+
+**Files:**
+- Modify: `gaia/cli/commands/_readme.py`
+- Test: `tests/cli/test_readme.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_render_knowledge_nodes_narrative_order():
+    """Premises should appear before conclusions."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "Conclusion."},
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "Premise A."},
+            {"id": "ns:p::s", "label": "s", "type": "setting", "content": "Setting."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a"], "conclusion": "ns:p::c", "type": "noisy_and",
+             "metadata": {"reason": "A supports C."}},
+        ],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    pos_s = md.index("#### s")
+    pos_a = md.index("#### a")
+    pos_c = md.index("#### c")
+    # Settings first, then premises, then conclusions
+    assert pos_s < pos_a < pos_c
+
+
+def test_render_knowledge_nodes_hyperlinks():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a"], "conclusion": "ns:p::b", "type": "noisy_and",
+             "metadata": {"reason": "A implies B."}},
+        ],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    assert "[a](#a)" in md
+
+
+def test_render_knowledge_nodes_with_beliefs():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir, beliefs={"ns:p::a": 0.85}, priors={"ns:p::a": 0.90})
+    assert "0.90" in md
+    assert "0.85" in md
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement `render_knowledge_nodes`**
+
+```python
+def _narrative_order(ir: dict) -> list[dict]:
+    """Return knowledge nodes in narrative reading order."""
+    layers = topo_layers(ir)
+    nodes = [k for k in ir["knowledges"] if not k.get("label", "").startswith("__")]
+
+    type_order = {"setting": 0, "claim": 1, "question": 2}
+
+    def sort_key(k):
+        kid = k["id"]
+        ktype = k["type"]
+        # Questions always last
+        if ktype == "question":
+            return (999, 0, k.get("label", ""))
+        # Settings always first
+        if ktype == "setting":
+            return (-1, 0, k.get("label", ""))
+        # Claims sorted by topo layer, then label
+        return (layers.get(kid, 0), type_order.get(ktype, 1), k.get("label", ""))
+
+    return sorted(nodes, key=sort_key)
+
+
+def render_knowledge_nodes(
+    ir: dict,
+    beliefs: dict[str, float] | None = None,
+    priors: dict[str, float] | None = None,
+) -> str:
+    """Render the Knowledge Nodes section in narrative order with hyperlinks."""
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    beliefs = beliefs or {}
+    priors = priors or {}
+
+    # Build conclusion → strategy map
+    strategy_for: dict[str, dict] = {}
+    for s in ir.get("strategies", []):
+        if s.get("conclusion"):
+            strategy_for[s["conclusion"]] = s
+
+    ordered = _narrative_order(ir)
+    sections: list[str] = ["## Knowledge Nodes", ""]
+    current_type = None
+
+    for k in ordered:
+        ktype = k["type"]
+        label = k.get("label", "")
+        kid = k["id"]
+        content = k.get("content", "")
+
+        # Type heading
+        if ktype != current_type:
+            current_type = ktype
+            sections.append(f"### {ktype.title()}s")
+            sections.append("")
+
+        # Node heading (anchor)
+        sections.append(f"#### {label}")
+        sections.append("")
+
+        # Content
+        sections.append(content)
+        sections.append("")
+
+        # Derivation info
+        if kid in strategy_for:
+            s = strategy_for[kid]
+            stype = s.get("type", "")
+            premise_labels = []
+            for p in s.get("premises", []):
+                p_label = knowledge_by_id.get(p, {}).get("label", p.split("::")[-1])
+                if not p_label.startswith("__"):
+                    premise_labels.append(f"[{p_label}](#{p_label})")
+            reason = (s.get("metadata") or {}).get("reason", "")
+            sections.append(f"**Derived via:** {stype}({', '.join(premise_labels)})")
+
+        # Prior / Belief
+        meta_parts = []
+        if kid in priors:
+            meta_parts.append(f"**Prior:** {priors[kid]:.2f}")
+        if kid in beliefs:
+            meta_parts.append(f"**Belief:** {beliefs[kid]:.2f}")
+        if meta_parts:
+            sections.append(" · ".join(meta_parts))
+
+        # Reason (last, can be long)
+        if kid in strategy_for:
+            reason = (strategy_for[kid].get("metadata") or {}).get("reason", "")
+            if reason:
+                sections.append(f"**Reason:** {reason}")
+
+        sections.append("")
+
+    return "\n".join(sections)
+```
+
+- [ ] **Step 4: Run tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/cli/commands/_readme.py tests/cli/test_readme.py
+git commit -m "feat(cli): add narrative-ordered knowledge nodes with hyperlinks"
+```
+
+---
+
+## Chunk 2: Integration and end-to-end
+
+### Task 4: `generate_readme` assembler and inference results
+
+**Files:**
+- Modify: `gaia/cli/commands/_readme.py`
+- Test: `tests/cli/test_readme.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_generate_readme_without_beliefs():
+    ir = {
+        "namespace": "github",
+        "package_name": "test_pkg",
+        "knowledges": [
+            {"id": "github:test_pkg::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    pkg_metadata = {"name": "test-pkg-gaia", "description": "A test package."}
+    md = generate_readme(ir, pkg_metadata)
+    assert "# test-pkg-gaia" in md
+    assert "A test package." in md
+    assert "## Knowledge Graph" in md
+    assert "## Knowledge Nodes" in md
+    assert "## Inference Results" not in md
+
+
+def test_generate_readme_with_beliefs():
+    ir = {
+        "namespace": "github",
+        "package_name": "test_pkg",
+        "knowledges": [
+            {"id": "github:test_pkg::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    pkg_metadata = {"name": "test-pkg-gaia", "description": "Test."}
+    beliefs_data = {
+        "beliefs": [{"knowledge_id": "github:test_pkg::a", "label": "a", "belief": 0.85}],
+        "diagnostics": {"converged": True, "iterations_run": 10},
+    }
+    param_data = {
+        "priors": [{"knowledge_id": "github:test_pkg::a", "value": 0.90}],
+    }
+    md = generate_readme(ir, pkg_metadata, beliefs_data=beliefs_data, param_data=param_data)
+    assert "## Inference Results" in md
+    assert "0.85" in md
+    assert "Converged" in md or "converged" in md
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement `generate_readme`**
+
+```python
+def generate_readme(
+    ir: dict,
+    pkg_metadata: dict,
+    beliefs_data: dict | None = None,
+    param_data: dict | None = None,
+) -> str:
+    """Generate full README.md content."""
+    beliefs: dict[str, float] | None = None
+    priors: dict[str, float] | None = None
+
+    if beliefs_data:
+        beliefs = {b["knowledge_id"]: b["belief"] for b in beliefs_data.get("beliefs", [])}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+
+    parts: list[str] = []
+
+    # Header
+    name = pkg_metadata.get("name", ir.get("package_name", "Package"))
+    desc = pkg_metadata.get("description", "")
+    parts.append(f"# {name}")
+    parts.append("")
+    if desc:
+        parts.append(desc)
+        parts.append("")
+
+    # Mermaid
+    parts.append("## Knowledge Graph")
+    parts.append("")
+    parts.append(render_mermaid(ir, beliefs=beliefs))
+    parts.append("")
+
+    # Knowledge nodes
+    parts.append(render_knowledge_nodes(ir, beliefs=beliefs, priors=priors))
+
+    # Inference results (optional)
+    if beliefs_data:
+        parts.append(render_inference_results(ir, beliefs_data, param_data))
+
+    return "\n".join(parts)
+
+
+def render_inference_results(
+    ir: dict,
+    beliefs_data: dict,
+    param_data: dict | None = None,
+) -> str:
+    """Render inference results section."""
+    lines = ["## Inference Results", ""]
+    diag = beliefs_data.get("diagnostics", {})
+    converged = diag.get("converged", False)
+    iterations = diag.get("iterations_run", "?")
+    lines.append(f"**BP converged:** {converged} ({iterations} iterations)")
+    lines.append("")
+
+    # Build lookup
+    priors = {}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+
+    # Classify for role column
+    strategy_conclusions = {s["conclusion"] for s in ir.get("strategies", []) if s.get("conclusion")}
+    strategy_premises = set()
+    for s in ir.get("strategies", []):
+        for p in s.get("premises", []):
+            strategy_premises.add(p)
+
+    lines.append("| Label | Type | Prior | Belief | Role |")
+    lines.append("|-------|------|-------|--------|------|")
+
+    beliefs_list = sorted(beliefs_data.get("beliefs", []), key=lambda b: b["belief"])
+    for b in beliefs_list:
+        kid = b["knowledge_id"]
+        label = b.get("label", kid.split("::")[-1])
+        if label.startswith("__"):
+            continue
+        belief = f"{b['belief']:.4f}"
+        prior = f"{priors[kid]:.2f}" if kid in priors else "—"
+        k = knowledge_by_id.get(kid, {})
+        ktype = k.get("type", "")
+        if kid in strategy_conclusions:
+            role = "derived"
+        elif kid in strategy_premises:
+            role = "independent"
+        else:
+            role = "orphaned"
+        lines.append(f"| [{label}](#{label}) | {ktype} | {prior} | {belief} | {role} |")
+
+    lines.append("")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/cli/commands/_readme.py tests/cli/test_readme.py
+git commit -m "feat(cli): add generate_readme assembler with inference results"
+```
+
+---
+
+### Task 5: Wire `--readme` flag into compile command
+
+**Files:**
+- Modify: `gaia/cli/commands/compile.py`
+- Test: `tests/cli/test_readme.py`
+
+- [ ] **Step 1: Write the failing end-to-end test**
+
+```python
+import json
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def test_compile_readme_flag_generates_readme(tmp_path):
+    """gaia compile --readme should produce README.md at package root."""
+    pkg_dir = tmp_path / "readme_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "readme-pkg-gaia"\nversion = "1.0.0"\n'
+        'description = "A test package."\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "readme_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, noisy_and\n\n"
+        'a = claim("Premise A.")\n'
+        'b = claim("Premise B.")\n'
+        'c = claim("Conclusion.", given=[a, b])\n'
+        '__all__ = ["a", "b", "c"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir), "--readme"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    readme = (pkg_dir / "README.md").read_text()
+    assert "# readme-pkg-gaia" in readme
+    assert "A test package." in readme
+    assert "```mermaid" in readme
+    assert "## Knowledge Nodes" in readme
+    # Premises before conclusion in narrative order
+    assert readme.index("#### a") < readme.index("#### c")
+    assert readme.index("#### b") < readme.index("#### c")
+    # Hyperlinks
+    assert "[a](#a)" in readme or "[b](#b)" in readme
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Wire the flag into compile command**
+
+```python
+# gaia/cli/commands/compile.py — add --readme flag
+import json
+
+def compile_command(
+    path: str = typer.Argument(".", help="Path to knowledge package directory"),
+    readme: bool = typer.Option(False, "--readme", help="Generate README.md at package root"),
+) -> None:
+    """Compile a knowledge package to .gaia/ir.json."""
+    # ... existing compile logic unchanged ...
+
+    if readme:
+        from gaia.cli.commands._readme import generate_readme
+
+        # Look for inference results
+        reviews_dir = loaded.pkg_path / ".gaia" / "reviews"
+        beliefs_data = None
+        param_data = None
+        if reviews_dir.exists():
+            # Find most recent review
+            review_dirs = sorted(reviews_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True)
+            for rd in review_dirs:
+                beliefs_path = rd / "beliefs.json"
+                param_path = rd / "parameterization.json"
+                if beliefs_path.exists():
+                    beliefs_data = json.loads(beliefs_path.read_text())
+                    if param_path.exists():
+                        param_data = json.loads(param_path.read_text())
+                    break
+
+        pkg_metadata = loaded.project_config
+        content = generate_readme(ir, pkg_metadata, beliefs_data=beliefs_data, param_data=param_data)
+        (loaded.pkg_path / "README.md").write_text(content)
+        typer.echo(f"README: {loaded.pkg_path / 'README.md'}")
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/cli/test_readme.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run full test suite + lint**
+
+Run: `pytest -x -q && ruff check gaia/cli/commands/_readme.py && ruff format --check gaia/cli/commands/_readme.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/cli/commands/compile.py gaia/cli/commands/_readme.py tests/cli/test_readme.py
+git commit -m "feat(cli): wire --readme flag into gaia compile"
+```
+
+---
+
+### Task 6: Smoke test on real package
+
+- [ ] **Step 1: Generate README for electron liquid package**
+
+```bash
+cd ~/project/SuperconductivityElectronLiquids.gaia
+uv run gaia compile --readme
+```
+
+- [ ] **Step 2: Verify README content**
+
+Check that README.md contains:
+- Package name and description
+- Mermaid diagram with correct node types and edges
+- All knowledge nodes in narrative order (settings → premises → derived → questions)
+- Hyperlinked premise references
+- Inference results table (since we ran `gaia infer` earlier)
+
+- [ ] **Step 3: Fix any rendering issues found**
+
+- [ ] **Step 4: Commit fixes if any**

--- a/docs/specs/2026-04-04-compile-readme-design.md
+++ b/docs/specs/2026-04-04-compile-readme-design.md
@@ -1,0 +1,200 @@
+# Design: `gaia compile --readme`
+
+**Status:** Target design
+**Date:** 2026-04-04
+
+## Goal
+
+`gaia compile --readme` generates a `README.md` at the package root that serves as the GitHub landing page for a Gaia knowledge package. The README presents the knowledge graph as a navigable, narrative document with a Mermaid diagram, full node content, reasoning chains, and optional inference results.
+
+## Trigger
+
+```bash
+gaia compile [path] --readme
+```
+
+Compiles the package as usual (`.gaia/ir.json`, `.gaia/ir_hash`), then generates `README.md` at the package root.
+
+## Output
+
+`{package_root}/README.md`
+
+## Data Sources
+
+| Data | Source | Required |
+|------|--------|----------|
+| Package metadata | `pyproject.toml` (`[project]`, `[tool.gaia]`) | Yes |
+| Knowledge graph | `.gaia/ir.json` (just compiled) | Yes |
+| Priors | `.gaia/reviews/*/parameterization.json` | No |
+| Beliefs | `.gaia/reviews/*/beliefs.json` | No |
+
+If multiple reviews exist, use the most recently modified one.
+
+## README Structure
+
+```
+# {Package Name}
+{description}
+
+## Knowledge Graph          ← Mermaid diagram
+## Knowledge Nodes          ← Full content, narrative order
+  ### Settings
+  ### Claims
+  ### Questions
+## Inference Results        ← Only if beliefs exist
+```
+
+## Section 1: Knowledge Graph (Mermaid)
+
+A `graph TD` Mermaid diagram showing all nodes and edges.
+
+**Nodes:**
+- Settings: grey, rectangle, label only
+- Independent premise claims: blue, label + belief (if available)
+- Derived conclusion claims: green, label + belief
+- Questions: orange, label only
+- Helper claims (`__` prefix): hidden (omit from diagram)
+
+**Edges:**
+- Strategy: solid arrow from each premise to conclusion, labeled with strategy type
+- Operator: dotted bidirectional edge, labeled with operator type (contradiction, equivalence, etc.)
+- Background: omitted from diagram (not part of the reasoning graph)
+
+**Node labels:** Use the Knowledge `label` field (snake_case). Display belief value if available: `"label (0.85)"`.
+
+## Section 2: Knowledge Nodes (Narrative Order)
+
+### Narrative Ordering Algorithm
+
+The nodes are ordered by topological sort of the reasoning DAG to create a coherent reading experience: premises appear before conclusions.
+
+```
+1. Compute topological layers:
+   - Layer 0: all nodes with no incoming strategy/operator edges (settings, independent premises, questions)
+   - Layer N: nodes whose all premise dependencies are in layers < N
+   
+2. Within layer 0, order by type: Settings first, then Claims, then Questions
+
+3. Within each layer, group by connected component:
+   - Nodes that share a common strategy/conclusion are grouped together
+   - This keeps related premises adjacent (e.g., all VDiagMC premises together)
+
+4. Questions go at the end (after all claims), regardless of layer
+```
+
+### Node Rendering
+
+Each node is an H4 section with anchor for cross-referencing.
+
+**Independent premise (no incoming strategy):**
+
+```markdown
+#### adiabatic_approx
+
+在传统金属中，Debye 频率 $\omega_D$ 远小于 Fermi 能量 $E_F$...
+
+**Prior:** 0.95 · **Belief:** 0.88
+```
+
+**Derived conclusion (has incoming strategy):**
+
+```markdown
+#### downfolded_bse
+
+消去高能模式后，完整的 BSE 可严格降标为仅依赖频率的 Fermi 面方程...
+
+**Derived via:** deduction([pair_propagator_decomposition](#pair_propagator_decomposition), [cross_term_suppressed](#cross_term_suppressed), [adiabatic_approx](#adiabatic_approx))
+**Belief:** 0.75
+**Reason:** 配对传播子的相干/非相干分解提供了降标的数学基础，交叉项被压制保证了两个通道可独立处理...
+```
+
+**Setting:**
+
+```markdown
+#### bcs_framework
+
+BCS 理论将传统超导解释为声子交换介导的电子 Cooper 配对...
+```
+
+**Rules:**
+- All premise labels in "Derived via" are hyperlinks: `[label](#label)`
+- Prior/Belief lines only appear when data exists
+- Reason only appears for derived conclusions (from strategy metadata or steps)
+- Helper claims (`__` prefix labels) are omitted entirely
+- Content is rendered in full, no truncation
+
+## Section 3: Inference Results (Optional)
+
+Only generated when `.gaia/reviews/*/beliefs.json` exists.
+
+```markdown
+## Inference Results
+
+**Review:** self_review
+**BP converged:** True (35 iterations)
+
+| Label | Prior | Belief | Role |
+|-------|-------|--------|------|
+| adiabatic_approx | 0.95 | 0.88 | independent premise |
+| downfolded_bse | — | 0.75 | derived conclusion |
+| ... | ... | ... | ... |
+```
+
+Sorted by belief ascending (most uncertain conclusions first — draws attention to where the argument is weakest).
+
+## Implementation Notes
+
+### Where the code lives
+
+New module: `gaia/cli/commands/_readme.py` (private, called from compile command).
+
+Single public function:
+
+```python
+def generate_readme(
+    ir: dict,
+    pkg_metadata: dict,       # from pyproject.toml
+    pkg_path: Path,
+    beliefs_path: Path | None,
+    parameterization_path: Path | None,
+) -> str:
+    """Generate README.md content from compiled IR and optional inference results."""
+```
+
+### Integration with compile command
+
+In `gaia/cli/commands/compile.py`, add `--readme` flag:
+
+```python
+@app.command()
+def compile(
+    path: ...
+    readme: bool = typer.Option(False, "--readme", help="Generate README.md"),
+):
+    ...  # existing compile logic
+    if readme:
+        from gaia.cli.commands._readme import generate_readme
+        content = generate_readme(ir, pkg_metadata, pkg_path, beliefs_path, param_path)
+        (pkg_path / "README.md").write_text(content)
+```
+
+### Mermaid generation
+
+Iterate over strategies and operators in the IR to build edges. Skip helper claims (labels starting with `__`). Use Mermaid `classDef` for node styling.
+
+### Topological sort
+
+Use Kahn's algorithm on the strategy premise→conclusion DAG. Nodes with no incoming edges form layer 0. Remove them, repeat for layer 1, etc. Within each layer, sort by connected component (BFS from shared conclusions).
+
+### Belief/Prior lookup
+
+- Beliefs: parse `beliefs.json`, build `{knowledge_id: belief}` map
+- Priors: parse `parameterization.json`, extract node priors from the review sidecar's `PriorRecord` entries
+- Both keyed by knowledge QID, matched against IR knowledge IDs
+
+## Not in scope
+
+- Mermaid click-to-anchor (GitHub doesn't support `click` directives)
+- Multiple review comparison
+- Custom templates / theming
+- Internationalization

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -1,0 +1,45 @@
+"""gaia compile --readme: generate README.md from compiled IR."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+def topo_layers(ir: dict) -> dict[str, int]:
+    """Assign each knowledge ID a topological layer (0 = no incoming edges)."""
+    all_ids = {k["id"] for k in ir["knowledges"]}
+    # Map conclusion → set of premise IDs (incoming edges)
+    incoming: dict[str, set[str]] = defaultdict(set)
+    for s in ir.get("strategies", []):
+        conclusion = s.get("conclusion")
+        if conclusion and conclusion in all_ids:
+            for p in s.get("premises", []):
+                if p in all_ids:
+                    incoming[conclusion].add(p)
+    for o in ir.get("operators", []):
+        conclusion = o.get("conclusion")
+        if conclusion and conclusion in all_ids:
+            for v in o.get("variables", []):
+                if v in all_ids:
+                    incoming[conclusion].add(v)
+
+    layers: dict[str, int] = {}
+    remaining = set(all_ids)
+
+    layer = 0
+    while remaining:
+        # Nodes whose all dependencies are already assigned
+        ready = {
+            nid
+            for nid in remaining
+            if not (incoming.get(nid, set()) - set(layers.keys()))
+        }
+        if not ready:
+            # Cycle — assign remaining to current layer
+            ready = remaining
+        for nid in ready:
+            layers[nid] = layer
+        remaining -= ready
+        layer += 1
+
+    return layers

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 def topo_layers(ir: dict) -> dict[str, int]:
     """Assign each knowledge ID a topological layer (0 = no incoming edges)."""
     all_ids = {k["id"] for k in ir["knowledges"]}
-    # Map conclusion → set of premise IDs (incoming edges)
     incoming: dict[str, set[str]] = defaultdict(set)
     for s in ir.get("strategies", []):
         conclusion = s.get("conclusion")
@@ -25,21 +24,256 @@ def topo_layers(ir: dict) -> dict[str, int]:
 
     layers: dict[str, int] = {}
     remaining = set(all_ids)
-
     layer = 0
     while remaining:
-        # Nodes whose all dependencies are already assigned
-        ready = {
-            nid
-            for nid in remaining
-            if not (incoming.get(nid, set()) - set(layers.keys()))
-        }
+        ready = {nid for nid in remaining if not (incoming.get(nid, set()) - set(layers.keys()))}
         if not ready:
-            # Cycle — assign remaining to current layer
             ready = remaining
         for nid in ready:
             layers[nid] = layer
         remaining -= ready
         layer += 1
-
     return layers
+
+
+def _is_helper(label: str) -> bool:
+    return label.startswith("__")
+
+
+def render_mermaid(ir: dict, beliefs: dict[str, float] | None = None) -> str:
+    """Render a Mermaid graph TD diagram from the IR."""
+    lines = ["```mermaid", "graph TD"]
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+
+    strategy_conclusions: set[str] = set()
+    strategy_premises: set[str] = set()
+    for s in ir.get("strategies", []):
+        if s.get("conclusion"):
+            strategy_conclusions.add(s["conclusion"])
+        for p in s.get("premises", []):
+            strategy_premises.add(p)
+
+    for k in ir["knowledges"]:
+        label = k.get("label", "")
+        if _is_helper(label):
+            continue
+        kid = k["id"]
+        ktype = k["type"]
+        display = f"{label} ({beliefs[kid]:.2f})" if beliefs and kid in beliefs else label
+        # Escape quotes in display for Mermaid
+        display = display.replace('"', "#quot;")
+        if ktype == "setting":
+            lines.append(f'    {label}["{display}"]:::setting')
+        elif ktype == "question":
+            lines.append(f'    {label}["{display}"]:::question')
+        elif kid in strategy_conclusions:
+            lines.append(f'    {label}["{display}"]:::derived')
+        elif kid in strategy_premises:
+            lines.append(f'    {label}["{display}"]:::premise')
+        else:
+            lines.append(f'    {label}["{display}"]:::orphan')
+
+    for s in ir.get("strategies", []):
+        conclusion = s.get("conclusion")
+        if not conclusion:
+            continue
+        conc_label = knowledge_by_id.get(conclusion, {}).get("label", "")
+        if _is_helper(conc_label):
+            continue
+        stype = s.get("type", "")
+        for p in s.get("premises", []):
+            p_label = knowledge_by_id.get(p, {}).get("label", "")
+            if _is_helper(p_label):
+                continue
+            lines.append(f"    {p_label} -->|{stype}| {conc_label}")
+
+    for o in ir.get("operators", []):
+        conclusion = o.get("conclusion")
+        if not conclusion:
+            continue
+        conc_label = knowledge_by_id.get(conclusion, {}).get("label", "")
+        if _is_helper(conc_label):
+            continue
+        otype = o.get("operator", "")
+        for v in o.get("variables", []):
+            v_label = knowledge_by_id.get(v, {}).get("label", "")
+            if _is_helper(v_label):
+                continue
+            lines.append(f"    {v_label} -.-|{otype}| {conc_label}")
+
+    lines.append("")
+    lines.append("    classDef setting fill:#f0f0f0,stroke:#999")
+    lines.append("    classDef premise fill:#ddeeff,stroke:#4488bb")
+    lines.append("    classDef derived fill:#ddffdd,stroke:#44bb44")
+    lines.append("    classDef question fill:#fff3dd,stroke:#cc9944")
+    lines.append("    classDef orphan fill:#fff,stroke:#ccc,stroke-dasharray: 5 5")
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _narrative_order(ir: dict) -> list[dict]:
+    """Return knowledge nodes in narrative reading order."""
+    layers = topo_layers(ir)
+    nodes = [k for k in ir["knowledges"] if not _is_helper(k.get("label", ""))]
+
+    def sort_key(k):
+        kid = k["id"]
+        ktype = k["type"]
+        if ktype == "question":
+            return (999, 0, k.get("label", ""))
+        if ktype == "setting":
+            return (-1, 0, k.get("label", ""))
+        return (layers.get(kid, 0), 1, k.get("label", ""))
+
+    return sorted(nodes, key=sort_key)
+
+
+def render_knowledge_nodes(
+    ir: dict,
+    beliefs: dict[str, float] | None = None,
+    priors: dict[str, float] | None = None,
+) -> str:
+    """Render the Knowledge Nodes section in narrative order with hyperlinks."""
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    beliefs = beliefs or {}
+    priors = priors or {}
+
+    strategy_for: dict[str, dict] = {}
+    for s in ir.get("strategies", []):
+        if s.get("conclusion"):
+            strategy_for[s["conclusion"]] = s
+
+    ordered = _narrative_order(ir)
+    sections: list[str] = ["## Knowledge Nodes", ""]
+    current_type = None
+
+    for k in ordered:
+        ktype = k["type"]
+        label = k.get("label", "")
+        kid = k["id"]
+        content = k.get("content", "")
+
+        if ktype != current_type:
+            current_type = ktype
+            sections.append(f"### {ktype.title()}s")
+            sections.append("")
+
+        sections.append(f"#### {label}")
+        sections.append("")
+        sections.append(content)
+        sections.append("")
+
+        if kid in strategy_for:
+            s = strategy_for[kid]
+            stype = s.get("type", "")
+            premise_labels = []
+            for p in s.get("premises", []):
+                p_label = knowledge_by_id.get(p, {}).get("label", p.split("::")[-1])
+                if not _is_helper(p_label):
+                    premise_labels.append(f"[{p_label}](#{p_label})")
+            sections.append(f"**Derived via:** {stype}({', '.join(premise_labels)})")
+
+        meta_parts = []
+        if kid in priors:
+            meta_parts.append(f"**Prior:** {priors[kid]:.2f}")
+        if kid in beliefs:
+            meta_parts.append(f"**Belief:** {beliefs[kid]:.2f}")
+        if meta_parts:
+            sections.append(" · ".join(meta_parts))
+
+        if kid in strategy_for:
+            reason = (strategy_for[kid].get("metadata") or {}).get("reason", "")
+            if reason:
+                sections.append(f"**Reason:** {reason}")
+
+        sections.append("")
+
+    return "\n".join(sections)
+
+
+def render_inference_results(
+    ir: dict,
+    beliefs_data: dict,
+    param_data: dict | None = None,
+) -> str:
+    """Render inference results summary table."""
+    lines = ["## Inference Results", ""]
+    diag = beliefs_data.get("diagnostics", {})
+    converged = diag.get("converged", False)
+    iterations = diag.get("iterations_run", "?")
+    lines.append(f"**BP converged:** {converged} ({iterations} iterations)")
+    lines.append("")
+
+    priors: dict[str, float] = {}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    strategy_conclusions = {
+        s["conclusion"] for s in ir.get("strategies", []) if s.get("conclusion")
+    }
+    strategy_premises: set[str] = set()
+    for s in ir.get("strategies", []):
+        for p in s.get("premises", []):
+            strategy_premises.add(p)
+
+    lines.append("| Label | Type | Prior | Belief | Role |")
+    lines.append("|-------|------|-------|--------|------|")
+
+    for b in sorted(beliefs_data.get("beliefs", []), key=lambda x: x["belief"]):
+        kid = b["knowledge_id"]
+        label = b.get("label", kid.split("::")[-1])
+        if _is_helper(label):
+            continue
+        belief = f"{b['belief']:.4f}"
+        prior = f"{priors[kid]:.2f}" if kid in priors else "\u2014"
+        k = knowledge_by_id.get(kid, {})
+        ktype = k.get("type", "")
+        if kid in strategy_conclusions:
+            role = "derived"
+        elif kid in strategy_premises:
+            role = "independent"
+        else:
+            role = "orphaned"
+        lines.append(f"| [{label}](#{label}) | {ktype} | {prior} | {belief} | {role} |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def generate_readme(
+    ir: dict,
+    pkg_metadata: dict,
+    beliefs_data: dict | None = None,
+    param_data: dict | None = None,
+) -> str:
+    """Generate full README.md content from compiled IR and optional inference results."""
+    beliefs: dict[str, float] | None = None
+    priors: dict[str, float] | None = None
+
+    if beliefs_data:
+        beliefs = {b["knowledge_id"]: b["belief"] for b in beliefs_data.get("beliefs", [])}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+
+    parts: list[str] = []
+
+    name = pkg_metadata.get("name", ir.get("package_name", "Package"))
+    desc = pkg_metadata.get("description", "")
+    parts.append(f"# {name}")
+    parts.append("")
+    if desc:
+        parts.append(desc)
+        parts.append("")
+
+    parts.append("## Knowledge Graph")
+    parts.append("")
+    parts.append(render_mermaid(ir, beliefs=beliefs))
+    parts.append("")
+
+    parts.append(render_knowledge_nodes(ir, beliefs=beliefs, priors=priors))
+
+    if beliefs_data:
+        parts.append(render_inference_results(ir, beliefs_data, param_data))
+
+    return "\n".join(parts)

--- a/gaia/cli/commands/compile.py
+++ b/gaia/cli/commands/compile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import typer
 
 from gaia.cli._packages import GaiaCliError, compile_loaded_package, load_gaia_package
@@ -12,6 +14,7 @@ from gaia.ir.validator import validate_local_graph
 
 def compile_command(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
+    readme: bool = typer.Option(False, "--readme", help="Generate README.md at package root"),
 ) -> None:
     """Compile a knowledge package to .gaia/ir.json."""
     try:
@@ -38,3 +41,31 @@ def compile_command(
     )
     typer.echo(f"IR hash: {ir['ir_hash'][:16]}...")
     typer.echo(f"Output: {gaia_dir / 'ir.json'}")
+
+    if readme:
+        from gaia.cli.commands._readme import generate_readme
+
+        beliefs_data = None
+        param_data = None
+        reviews_dir = loaded.pkg_path / ".gaia" / "reviews"
+        if reviews_dir.exists():
+            review_dirs = sorted(
+                (d for d in reviews_dir.iterdir() if d.is_dir()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            for rd in review_dirs:
+                beliefs_path = rd / "beliefs.json"
+                if beliefs_path.exists():
+                    beliefs_data = json.loads(beliefs_path.read_text())
+                    param_path = rd / "parameterization.json"
+                    if param_path.exists():
+                        param_data = json.loads(param_path.read_text())
+                    break
+
+        content = generate_readme(
+            ir, loaded.project_config, beliefs_data=beliefs_data, param_data=param_data
+        )
+        readme_path = loaded.pkg_path / "README.md"
+        readme_path.write_text(content)
+        typer.echo(f"README: {readme_path}")

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -1,0 +1,56 @@
+"""Tests for gaia compile --readme."""
+
+from gaia.cli.commands._readme import topo_layers
+
+
+def test_topo_layers_linear_chain():
+    """A → B → C should produce 3 layers."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "C."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a"], "conclusion": "ns:p::b", "type": "noisy_and"},
+            {"premises": ["ns:p::b"], "conclusion": "ns:p::c", "type": "noisy_and"},
+        ],
+        "operators": [],
+    }
+    layers = topo_layers(ir)
+    assert layers["ns:p::a"] == 0
+    assert layers["ns:p::b"] == 1
+    assert layers["ns:p::c"] == 2
+
+
+def test_topo_layers_independent_premises():
+    """Multiple independent premises should all be layer 0."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "C."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a", "ns:p::b"], "conclusion": "ns:p::c", "type": "noisy_and"},
+        ],
+        "operators": [],
+    }
+    layers = topo_layers(ir)
+    assert layers["ns:p::a"] == 0
+    assert layers["ns:p::b"] == 0
+    assert layers["ns:p::c"] == 1
+
+
+def test_topo_layers_settings_always_layer_0():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::s", "label": "s", "type": "setting", "content": "S."},
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    layers = topo_layers(ir)
+    assert layers["ns:p::s"] == 0
+    assert layers["ns:p::a"] == 0

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -1,10 +1,22 @@
 """Tests for gaia compile --readme."""
 
-from gaia.cli.commands._readme import topo_layers
+from typer.testing import CliRunner
+
+from gaia.cli.commands._readme import (
+    generate_readme,
+    render_knowledge_nodes,
+    render_mermaid,
+    topo_layers,
+)
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+# ── topo_layers ──
 
 
 def test_topo_layers_linear_chain():
-    """A → B → C should produce 3 layers."""
     ir = {
         "knowledges": [
             {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
@@ -24,7 +36,6 @@ def test_topo_layers_linear_chain():
 
 
 def test_topo_layers_independent_premises():
-    """Multiple independent premises should all be layer 0."""
     ir = {
         "knowledges": [
             {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
@@ -54,3 +65,198 @@ def test_topo_layers_settings_always_layer_0():
     layers = topo_layers(ir)
     assert layers["ns:p::s"] == 0
     assert layers["ns:p::a"] == 0
+
+
+# ── render_mermaid ──
+
+
+def test_mermaid_basic():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::obs", "label": "obs", "type": "claim", "content": "Obs."},
+            {"id": "ns:p::hyp", "label": "hyp", "type": "claim", "content": "Hyp."},
+            {"id": "ns:p::env", "label": "env", "type": "setting", "content": "Env."},
+        ],
+        "strategies": [
+            {
+                "premises": ["ns:p::obs"],
+                "conclusion": "ns:p::hyp",
+                "type": "noisy_and",
+                "metadata": {"reason": "because"},
+            },
+        ],
+        "operators": [],
+    }
+    md = render_mermaid(ir)
+    assert "graph TD" in md
+    assert "obs[" in md
+    assert "hyp[" in md
+    assert "env[" in md
+    assert "obs -->|noisy_and| hyp" in md
+    assert ":::setting" in md
+
+
+def test_mermaid_hides_helper_claims():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::__helper_abc", "label": "__helper_abc", "type": "claim", "content": "h"},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_mermaid(ir)
+    assert "__helper_abc" not in md
+    assert "a[" in md
+
+
+def test_mermaid_with_beliefs():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_mermaid(ir, beliefs={"ns:p::a": 0.85})
+    assert "0.85" in md
+
+
+# ── render_knowledge_nodes ──
+
+
+def test_render_knowledge_nodes_narrative_order():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "Conclusion."},
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "Premise A."},
+            {"id": "ns:p::s", "label": "s", "type": "setting", "content": "Setting."},
+        ],
+        "strategies": [
+            {
+                "premises": ["ns:p::a"],
+                "conclusion": "ns:p::c",
+                "type": "noisy_and",
+                "metadata": {"reason": "A supports C."},
+            },
+        ],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    pos_s = md.index("#### s")
+    pos_a = md.index("#### a")
+    pos_c = md.index("#### c")
+    assert pos_s < pos_a < pos_c
+
+
+def test_render_knowledge_nodes_hyperlinks():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+        ],
+        "strategies": [
+            {
+                "premises": ["ns:p::a"],
+                "conclusion": "ns:p::b",
+                "type": "noisy_and",
+                "metadata": {"reason": "A implies B."},
+            },
+        ],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    assert "[a](#a)" in md
+
+
+def test_render_knowledge_nodes_with_beliefs():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir, beliefs={"ns:p::a": 0.85}, priors={"ns:p::a": 0.90})
+    assert "0.90" in md
+    assert "0.85" in md
+
+
+# ── generate_readme ──
+
+
+def test_generate_readme_without_beliefs():
+    ir = {
+        "namespace": "github",
+        "package_name": "test_pkg",
+        "knowledges": [
+            {"id": "github:test_pkg::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    pkg_metadata = {"name": "test-pkg-gaia", "description": "A test package."}
+    md = generate_readme(ir, pkg_metadata)
+    assert "# test-pkg-gaia" in md
+    assert "A test package." in md
+    assert "## Knowledge Graph" in md
+    assert "## Knowledge Nodes" in md
+    assert "## Inference Results" not in md
+
+
+def test_generate_readme_with_beliefs():
+    ir = {
+        "namespace": "github",
+        "package_name": "test_pkg",
+        "knowledges": [
+            {"id": "github:test_pkg::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    pkg_metadata = {"name": "test-pkg-gaia", "description": "Test."}
+    beliefs_data = {
+        "beliefs": [{"knowledge_id": "github:test_pkg::a", "label": "a", "belief": 0.85}],
+        "diagnostics": {"converged": True, "iterations_run": 10},
+    }
+    param_data = {
+        "priors": [{"knowledge_id": "github:test_pkg::a", "value": 0.90}],
+    }
+    md = generate_readme(ir, pkg_metadata, beliefs_data=beliefs_data, param_data=param_data)
+    assert "## Inference Results" in md
+    assert "0.85" in md
+    assert "converged" in md.lower()
+
+
+# ── CLI integration ──
+
+
+def test_compile_readme_flag_generates_readme(tmp_path):
+    pkg_dir = tmp_path / "readme_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "readme-pkg-gaia"\nversion = "1.0.0"\n'
+        'description = "A test package."\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "readme_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, noisy_and\n\n"
+        'a = claim("Premise A.")\n'
+        'b = claim("Premise B.")\n'
+        'c = claim("Conclusion.", given=[a, b])\n'
+        '__all__ = ["a", "b", "c"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir), "--readme"])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    readme = (pkg_dir / "README.md").read_text()
+    assert "# readme-pkg-gaia" in readme
+    assert "A test package." in readme
+    assert "```mermaid" in readme
+    assert "## Knowledge Nodes" in readme
+    assert readme.index("#### a") < readme.index("#### c")
+    assert readme.index("#### b") < readme.index("#### c")
+    assert "[a](#a)" in readme or "[b](#b)" in readme


### PR DESCRIPTION
## Summary
- New `gaia compile --readme` flag generates `README.md` at package root
- Mermaid knowledge graph diagram with color-coded node types (setting/premise/derived/question/orphan) and belief values
- Knowledge nodes rendered in **narrative order** (topological sort of reasoning DAG) with hyperlinked premise references
- Optional inference results table when `gaia infer` has been run (reads `.gaia/reviews/*/beliefs.json`)

## Implementation
- New module `gaia/cli/commands/_readme.py` with pure functions: `topo_layers`, `render_mermaid`, `render_knowledge_nodes`, `render_inference_results`, `generate_readme`
- `--readme` flag added to existing `compile_command` in `compile.py`
- 12 unit + integration tests

## Example output
Tested on the SuperconductivityElectronLiquids.gaia package — generates a full README with 42 knowledge nodes, Mermaid graph, and BP belief table.

## Test plan
- [x] 12 new tests pass (`tests/cli/test_readme.py`)
- [x] Existing tests unaffected
- [x] Ruff lint + format clean
- [x] Smoke tested on real package

**Spec:** `docs/specs/2026-04-04-compile-readme-design.md`
**Plan:** `docs/plans/2026-04-04-compile-readme.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)