### PR TITLE
feat: module narrative order + exported markers + compile --readme

### DIFF
--- a/docs/plans/2026-04-04-module-narrative.md
+++ b/docs/plans/2026-04-04-module-narrative.md
@@ -1,0 +1,568 @@
+# Module Narrative Order Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reuse Python modules as Gaia modules with declaration-order narrative. Knowledge gets `module`, `declaration_index`, `exported` fields in IR. README uses these for section grouping.
+
+**Architecture:** Runtime captures source module name and per-module declaration index during `Knowledge.__post_init__`. Compiler reads these + `__all__` to populate new IR fields. README generator uses `module_order` + `declaration_index` instead of topological sort when available.
+
+**Tech Stack:** Python stdlib only. No new dependencies.
+
+**Spec:** `docs/specs/2026-04-04-module-narrative-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `gaia/lang/runtime/nodes.py` | Modify | Add `_source_module`, `_declaration_index` to Knowledge |
+| `gaia/lang/runtime/package.py` | Modify | Track module counters and module order in CollectedPackage |
+| `gaia/ir/knowledge.py` | Modify | Add `module`, `declaration_index`, `exported` fields |
+| `gaia/ir/graphs.py` | Modify | Add `module_order` to LocalCanonicalGraph |
+| `gaia/lang/compiler/compile.py` | Modify | Populate new IR fields from runtime data + `__all__` |
+| `gaia/cli/commands/_readme.py` | Modify | Use module_order + declaration_index for narrative |
+| `tests/gaia/lang/test_module_narrative.py` | Create | Tests for runtime tracking + compilation |
+| `tests/cli/test_readme.py` | Modify | Test module-aware README generation |
+
+---
+
+## Chunk 1: Runtime tracking
+
+### Task 1: Capture source module and declaration index
+
+**Files:**
+- Modify: `gaia/lang/runtime/nodes.py`
+- Modify: `gaia/lang/runtime/package.py`
+- Create: `tests/gaia/lang/test_module_narrative.py`
+
+- [ ] **Step 1: Write failing tests for module tracking**
+
+```python
+# tests/gaia/lang/test_module_narrative.py
+"""Tests for module narrative tracking."""
+
+from gaia.lang.runtime.nodes import Knowledge, _current_package
+from gaia.lang.runtime.package import CollectedPackage
+
+
+def test_declaration_index_increments_within_module():
+    pkg = CollectedPackage("test_pkg")
+    with pkg:
+        a = Knowledge(content="A.", type="claim")
+        b = Knowledge(content="B.", type="claim")
+        c = Knowledge(content="C.", type="claim")
+    assert a._declaration_index == 0
+    assert b._declaration_index == 1
+    assert c._declaration_index == 2
+
+
+def test_module_order_tracks_first_seen():
+    pkg = CollectedPackage("test_pkg")
+    # Simulate declarations from different modules
+    a = Knowledge(content="A.", type="claim")
+    a._source_module = "s1_intro"
+    b = Knowledge(content="B.", type="claim")
+    b._source_module = "s2_model"
+    c = Knowledge(content="C.", type="claim")
+    c._source_module = "s1_intro"
+
+    pkg._register_knowledge(a)
+    pkg._register_knowledge(b)
+    pkg._register_knowledge(c)
+
+    assert pkg._module_order == ["s1_intro", "s2_model"]
+    assert a._declaration_index == 0
+    assert b._declaration_index == 0  # first in s2_model
+    assert c._declaration_index == 1  # second in s1_intro
+
+
+def test_none_module_for_init_file():
+    pkg = CollectedPackage("test_pkg")
+    a = Knowledge(content="A.", type="claim")
+    a._source_module = None
+    pkg._register_knowledge(a)
+    assert a._declaration_index == 0
+    assert pkg._module_order == []  # None module not tracked in order
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/gaia/lang/test_module_narrative.py -v`
+
+- [ ] **Step 3: Implement runtime tracking**
+
+In `gaia/lang/runtime/nodes.py`, add fields to Knowledge:
+
+```python
+@dataclass
+class Knowledge:
+    ...
+    _source_module: str | None = field(default=None, init=False, repr=False, compare=False)
+    _declaration_index: int | None = field(default=None, init=False, repr=False, compare=False)
+```
+
+In `gaia/lang/runtime/package.py`, update CollectedPackage:
+
+```python
+class CollectedPackage:
+    def __init__(self, name: str, *, namespace: str = "github", version: str = "0.1.0"):
+        ...
+        self._module_counters: dict[str | None, int] = {}
+        self._module_order: list[str] = []
+
+    def _register_knowledge(self, k: Knowledge):
+        self.knowledge.append(k)
+        module = k._source_module
+        if module not in self._module_counters:
+            if module is not None:
+                self._module_order.append(module)
+            self._module_counters[module] = 0
+        k._declaration_index = self._module_counters[module]
+        self._module_counters[module] += 1
+```
+
+Update `infer_package_from_callstack` to return both package and module name. Then in `Knowledge.__post_init__`, store the module name:
+
+```python
+# package.py
+def infer_package_and_module() -> tuple[CollectedPackage | None, str | None]:
+    """Infer package and relative module name from the call stack."""
+    module_name = _caller_module_name()
+    if not module_name:
+        return None, None
+    pyproject = _pyproject_for_module(module_name)
+    if pyproject is None:
+        return None, None
+    pkg = _load_inferred_package(pyproject)
+    if pkg is None:
+        return None, None
+    # Compute relative module name: strip package prefix
+    relative = module_name.removeprefix(f"{pkg.name}.")
+    if relative == pkg.name or relative == "__init__":
+        relative = None  # root module
+    return pkg, relative
+```
+
+```python
+# nodes.py — Knowledge.__post_init__
+def __post_init__(self):
+    pkg = _current_package.get()
+    source_module = None
+    if pkg is None:
+        from gaia.lang.runtime.package import infer_package_and_module
+        pkg, source_module = infer_package_and_module()
+    if pkg is not None:
+        self._source_module = source_module
+        self._package = pkg
+        pkg._register_knowledge(self)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/gaia/lang/test_module_narrative.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/lang/runtime/nodes.py gaia/lang/runtime/package.py tests/gaia/lang/test_module_narrative.py
+git commit -m "feat(lang): track source module and declaration index for narrative order"
+```
+
+---
+
+## Chunk 2: IR fields + compiler
+
+### Task 2: Add IR fields
+
+**Files:**
+- Modify: `gaia/ir/knowledge.py`
+- Modify: `gaia/ir/graphs.py`
+
+- [ ] **Step 1: Add fields to IR Knowledge**
+
+```python
+# gaia/ir/knowledge.py — add after provenance field:
+class Knowledge(BaseModel):
+    ...
+    module: str | None = None
+    declaration_index: int | None = None
+    exported: bool = False
+```
+
+- [ ] **Step 2: Add module_order to LocalCanonicalGraph**
+
+```python
+# gaia/ir/graphs.py
+class LocalCanonicalGraph(BaseModel):
+    ...
+    module_order: list[str] | None = None
+```
+
+Note: `module`, `declaration_index`, and `exported` should NOT participate in `ir_hash` computation (they are presentational, not semantic). Exclude them from `_canonicalize_knowledge_dump`:
+
+```python
+def _canonicalize_knowledge_dump(data: dict[str, Any]) -> dict[str, Any]:
+    canonical = dict(data)
+    canonical["parameters"] = sorted(canonical.get("parameters", []), key=_json_sort_key)
+    if canonical.get("provenance") is not None:
+        canonical["provenance"] = sorted(canonical["provenance"], key=_json_sort_key)
+    # Exclude narrative fields from content hash
+    canonical.pop("module", None)
+    canonical.pop("declaration_index", None)
+    canonical.pop("exported", None)
+    return canonical
+```
+
+Also exclude `module_order` from graph-level hash — it's not in `_canonical_json` since that only hashes knowledges/operators/strategies.
+
+- [ ] **Step 3: Run existing IR tests to verify no breakage**
+
+Run: `pytest tests/ir/ -v`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/ir/knowledge.py gaia/ir/graphs.py
+git commit -m "feat(ir): add module, declaration_index, exported fields to Knowledge"
+```
+
+---
+
+### Task 3: Populate IR fields in compiler
+
+**Files:**
+- Modify: `gaia/lang/compiler/compile.py`
+- Modify: `gaia/cli/_packages.py`
+- Create: `tests/cli/test_module_compile.py`
+
+- [ ] **Step 1: Write failing test for module fields in compiled IR**
+
+```python
+# tests/cli/test_module_compile.py
+"""Tests for module narrative fields in compiled IR."""
+
+import json
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def test_compile_single_file_no_module(tmp_path):
+    """Single-file package: module=None, declaration_index tracks order."""
+    pkg_dir = tmp_path / "single_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "single-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "single_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, setting\n\n"
+        'env = setting("Environment.")\n'
+        'a = claim("First.")\n'
+        'b = claim("Second.")\n'
+        '__all__ = ["b"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0
+
+    ir = json.loads((pkg_dir / ".gaia" / "ir.json").read_text())
+
+    by_label = {k["label"]: k for k in ir["knowledges"]}
+    assert by_label["env"]["module"] is None
+    assert by_label["env"]["declaration_index"] == 0
+    assert by_label["a"]["declaration_index"] == 1
+    assert by_label["b"]["declaration_index"] == 2
+    assert by_label["b"]["exported"] is True
+    assert by_label["a"]["exported"] is False
+    assert ir.get("module_order") is None  # single file, no modules
+
+
+def test_compile_multi_file_module_order(tmp_path):
+    """Multi-file package: module and module_order populated."""
+    pkg_dir = tmp_path / "multi_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "multi-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "multi_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "sec_a.py").write_text(
+        "from gaia.lang import claim\n\n"
+        'x = claim("X from section A.")\n'
+        'y = claim("Y from section A.")\n'
+    )
+    (pkg_src / "sec_b.py").write_text(
+        "from gaia.lang import claim\n\n"
+        'z = claim("Z from section B.")\n'
+    )
+    (pkg_src / "__init__.py").write_text(
+        "from .sec_a import *\n"
+        "from .sec_b import *\n\n"
+        '__all__ = ["z"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0
+
+    ir = json.loads((pkg_dir / ".gaia" / "ir.json").read_text())
+
+    by_label = {k["label"]: k for k in ir["knowledges"]}
+    assert by_label["x"]["module"] == "sec_a"
+    assert by_label["y"]["module"] == "sec_a"
+    assert by_label["z"]["module"] == "sec_b"
+    assert by_label["x"]["declaration_index"] == 0
+    assert by_label["y"]["declaration_index"] == 1
+    assert by_label["z"]["declaration_index"] == 0
+    assert by_label["z"]["exported"] is True
+    assert by_label["x"]["exported"] is False
+    assert ir["module_order"] == ["sec_a", "sec_b"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Update compiler to populate new fields**
+
+In `gaia/lang/compiler/compile.py`, update the knowledge IR construction:
+
+```python
+# In compile_package_artifact, where ir_knowledges is built:
+ir_knowledges = [
+    IrKnowledge(
+        id=knowledge_map[id(k)],
+        label=k.label,
+        type=k.type,
+        content=k.content,
+        parameters=[IrParameter(**p) for p in k.parameters],
+        provenance=_knowledge_provenance(k),
+        metadata=_knowledge_metadata(k),
+        module=k._source_module if hasattr(k, "_source_module") else None,
+        declaration_index=k._declaration_index if hasattr(k, "_declaration_index") else None,
+        exported=False,  # set below
+    )
+    for k in knowledge_nodes
+]
+```
+
+In `gaia/cli/_packages.py`, mark exported labels. Add a method or update `_assign_labels` to record exports:
+
+```python
+# After _assign_labels is called in load_gaia_package:
+export_names = getattr(module, "__all__", None)
+if isinstance(export_names, list):
+    pkg._exported_labels = set(export_names)
+else:
+    pkg._exported_labels = set()
+```
+
+Then in the compiler, set `exported`:
+
+```python
+exported_labels = getattr(pkg, "_exported_labels", set())
+for ir_k in ir_knowledges:
+    if ir_k.label in exported_labels:
+        ir_k.exported = True
+```
+
+Set `module_order` on the graph:
+
+```python
+module_order = pkg._module_order if pkg._module_order else None
+# ... pass to graph construction
+```
+
+The compiled package dict gets the new field:
+
+```python
+# In to_json() or wherever the IR dict is built:
+result["module_order"] = module_order
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/cli/test_module_compile.py -v`
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pytest -x -q`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/lang/compiler/compile.py gaia/cli/_packages.py tests/cli/test_module_compile.py
+git commit -m "feat(compiler): populate module, declaration_index, exported in IR"
+```
+
+---
+
+## Chunk 3: README integration
+
+### Task 4: Update README generation to use module narrative
+
+**Files:**
+- Modify: `gaia/cli/commands/_readme.py`
+- Modify: `tests/cli/test_readme.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# Add to tests/cli/test_readme.py
+
+def test_narrative_order_uses_module_order():
+    """When module_order is present, use it instead of topo sort."""
+    ir = {
+        "module_order": ["sec_a", "sec_b"],
+        "knowledges": [
+            {"id": "ns:p::z", "label": "z", "type": "claim", "content": "Z.",
+             "module": "sec_b", "declaration_index": 0, "exported": True},
+            {"id": "ns:p::x", "label": "x", "type": "claim", "content": "X.",
+             "module": "sec_a", "declaration_index": 0, "exported": False},
+            {"id": "ns:p::y", "label": "y", "type": "claim", "content": "Y.",
+             "module": "sec_a", "declaration_index": 1, "exported": False},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    pos_x = md.index("#### x")
+    pos_y = md.index("#### y")
+    pos_z = md.index("#### z")
+    # sec_a before sec_b, x before y within sec_a
+    assert pos_x < pos_y < pos_z
+    # Module headings
+    assert "### sec_a" in md
+    assert "### sec_b" in md
+
+
+def test_exported_marker_in_readme():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A.",
+             "exported": True},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B.",
+             "exported": False},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    # Exported claim gets a marker
+    assert "★" in md.split("#### a")[1].split("#### b")[0]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Update `_narrative_order` and `render_knowledge_nodes`**
+
+```python
+# _readme.py — update _narrative_order
+def _narrative_order(ir: dict) -> list[dict]:
+    """Return knowledge nodes in narrative reading order."""
+    module_order = ir.get("module_order")
+    nodes = [k for k in ir["knowledges"] if not _is_helper(k.get("label", ""))]
+
+    if module_order and any(k.get("module") for k in nodes):
+        # Module-aware ordering
+        module_rank = {m: i for i, m in enumerate(module_order)}
+
+        def sort_key(k):
+            mod = k.get("module")
+            idx = k.get("declaration_index", 0)
+            mod_rank = module_rank.get(mod, 999) if mod else -1
+            return (mod_rank, idx)
+
+        return sorted(nodes, key=sort_key)
+    else:
+        # Fallback: topo sort
+        layers = topo_layers(ir)
+
+        def sort_key(k):
+            kid = k["id"]
+            ktype = k["type"]
+            if ktype == "question":
+                return (999, 0, k.get("label", ""))
+            if ktype == "setting":
+                return (-1, 0, k.get("label", ""))
+            return (layers.get(kid, 0), 1, k.get("label", ""))
+
+        return sorted(nodes, key=sort_key)
+```
+
+Update `render_knowledge_nodes` to:
+1. Group by module (section headings: `### module_name`)
+2. Mark exported claims with ★
+
+```python
+# In render_knowledge_nodes, replace type-based grouping with module-based:
+current_module = object()  # sentinel
+for k in ordered:
+    module = k.get("module")
+    label = k.get("label", "")
+    exported = k.get("exported", False)
+
+    # Module heading (when module_order is available)
+    if module_order and module != current_module:
+        current_module = module
+        heading = module if module else "Root"
+        sections.append(f"### {heading}")
+        sections.append("")
+
+    # ... rest of node rendering, with ★ on exported
+    marker = " ★" if exported else ""
+    sections.append(f"#### {label}{marker}")
+```
+
+When no `module_order` (fallback), keep current type-based grouping (Settings/Claims/Questions).
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/cli/test_readme.py -v`
+
+- [ ] **Step 5: Run full test suite + lint**
+
+Run: `pytest -x -q && ruff check . && ruff format --check .`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/cli/commands/_readme.py tests/cli/test_readme.py
+git commit -m "feat(cli): README uses module narrative order and exported markers"
+```
+
+---
+
+### Task 5: Smoke test on electron liquid package
+
+- [ ] **Step 1: Compile with --readme**
+
+```bash
+cd ~/project/SuperconductivityElectronLiquids.gaia
+uv run gaia compile --readme
+```
+
+Verify: single-file package → fallback to topo sort (same as before), `exported` flags on `__all__` items, declaration_index in IR.
+
+- [ ] **Step 2: Verify IR has new fields**
+
+```bash
+python3 -c "
+import json
+with open('.gaia/ir.json') as f:
+    ir = json.load(f)
+for k in ir['knowledges'][:5]:
+    print(k['label'], k.get('module'), k.get('declaration_index'), k.get('exported'))
+"
+```
+
+- [ ] **Step 3: Check README for exported markers**
+
+Verify ★ appears on `__all__` entries in the README.
+
+- [ ] **Step 4: Fix any issues and commit**

--- a/docs/specs/2026-04-04-module-narrative-design.md
+++ b/docs/specs/2026-04-04-module-narrative-design.md
@@ -1,0 +1,190 @@
+# Design: Python Module = Gaia Module + Narrative Order
+
+**Status:** Target design
+**Date:** 2026-04-04
+
+## Goal
+
+Reuse Python's module system as the Gaia module system. Each `.py` file in a package is a module (maps to a paper section). Knowledge declaration order within a module is the narrative order. Package-level `__init__.py` import order is the module narrative. `__all__` marks exported conclusions.
+
+## Motivation
+
+The current system compiles all knowledge into a flat, unordered IR. README generation must "guess" narrative order via topological sort. But paper formalizations have a human-authored narrative (section order), and this information is already implicit in the Python source — just not captured.
+
+## Design
+
+### Three layers of change
+
+#### 1. Runtime layer (`gaia/lang/runtime/`)
+
+**Knowledge registration** captures source module and declaration index:
+
+```python
+# nodes.py
+class Knowledge:
+    ...
+    _source_module: str | None = None     # relative module name, e.g. "s3_downfolding"
+    _declaration_index: int | None = None # position within that module (0, 1, 2, ...)
+```
+
+**CollectedPackage** tracks per-module counters and module order:
+
+```python
+# package.py
+class CollectedPackage:
+    ...
+    _module_counters: dict[str, int]     # module_name → next index
+    _module_order: list[str]             # modules in first-seen order
+
+    def _register_knowledge(self, k: Knowledge):
+        self.knowledge.append(k)
+        module = k._source_module
+        if module is not None:
+            if module not in self._module_counters:
+                self._module_order.append(module)
+                self._module_counters[module] = 0
+            k._declaration_index = self._module_counters[module]
+            self._module_counters[module] += 1
+```
+
+**Source module extraction** — `_caller_module_name()` already walks the call stack and extracts the module name. Currently the result is discarded after finding the package. Change: store it on the Knowledge as `_source_module`, converted to a relative name (strip the package prefix).
+
+```python
+# In Knowledge.__post_init__:
+module_name = _caller_module_name()  # e.g. "superconductivity_electron_liquids.s3_downfolding"
+# Strip package prefix → "s3_downfolding"
+# For __init__.py → None (root module, no separate name)
+```
+
+For single-file packages (everything in `__init__.py`), `_source_module` is `None` and the package acts as one implicit module. Declaration order within `__init__.py` is the narrative.
+
+#### 2. IR layer (`gaia/ir/`)
+
+**Knowledge** gets two new optional fields:
+
+```python
+# gaia/ir/knowledge.py
+class Knowledge(BaseModel):
+    ...
+    module: str | None = None            # source module relative name
+    declaration_index: int | None = None # order within that module
+    exported: bool = False               # True if in package __all__
+```
+
+**LocalCanonicalGraph** gets module ordering:
+
+```python
+# gaia/ir/graphs.py
+class LocalCanonicalGraph(BaseModel):
+    ...
+    module_order: list[str] | None = None  # ["s1_introduction", "s2_model", ...]
+```
+
+All new fields are optional — old IR files remain valid.
+
+#### 3. Compiler layer (`gaia/lang/compiler/compile.py`)
+
+During compilation:
+
+1. Read `_source_module` and `_declaration_index` from each runtime Knowledge → write to IR `module` and `declaration_index`
+2. Read `_module_order` from CollectedPackage → write to IR `module_order`
+3. Read the user package's `__all__` → set `exported = True` on matching Knowledge nodes
+
+**`__all__` resolution:** The compiler already loads the user's Python module. After import, read `__all__` from the module's namespace. Match labels against `__all__` entries to set `exported`.
+
+#### 4. README generation (`gaia/cli/commands/_readme.py`)
+
+Update `_narrative_order()`:
+
+```python
+def _narrative_order(ir: dict) -> list[dict]:
+    module_order = ir.get("module_order")
+    if module_order is not None:
+        # Use declared module + declaration order
+        module_rank = {m: i for i, m in enumerate(module_order)}
+        def sort_key(k):
+            mod = k.get("module")
+            idx = k.get("declaration_index", 0)
+            mod_rank = module_rank.get(mod, 999)
+            return (mod_rank, idx)
+        nodes = [k for k in ir["knowledges"] if not _is_helper(k.get("label", ""))]
+        return sorted(nodes, key=sort_key)
+    else:
+        # Fallback: topological sort (current behavior)
+        return _topo_narrative_order(ir)
+```
+
+README sections grouped by module:
+
+```markdown
+## Knowledge Nodes
+
+### Section I: Introduction
+#### bcs_framework
+...
+#### adiabatic_approx
+...
+
+### Section III: Downfolding the BSE
+#### pair_propagator_decomposition
+...
+```
+
+Module headings use the module's docstring if available, otherwise the module name.
+
+Exported conclusions get a visual marker:
+
+```markdown
+#### tc_improvement_over_phenomenological ★
+```
+
+## Example: multi-file electron liquid package
+
+```
+superconductivity_electron_liquids/
+├── __init__.py
+│     from .s1_introduction import *
+│     from .s2_model import *
+│     from .s3_downfolding import *
+│     from .s4_pseudopotential import *
+│     from .s5_eph_coupling import *
+│     from .s6_superconductors import *
+│     from .reasoning import *
+│
+├── s1_introduction.py      → bcs_framework, migdal_eliashberg, adiabatic_approx, main_question
+├── s2_model.py             → electron_phonon_action, bse_kernel_decomposition, precursory_cooper_flow
+├── s3_downfolding.py       → pair_propagator_decomposition, cross_term_suppressed, downfolded_bse, ...
+├── s4_pseudopotential.py   → ueg_vertex_challenge, homotopic_expansion, vdiagmc_method, mu_vdiagmc_values
+├── s5_eph_coupling.py      → individual_corrections_large, corrections_cancel, dfpt_reliable, ...
+├── s6_superconductors.py   → ab_initio_workflow, tc_al_predicted, tc_li_predicted, ...
+└── reasoning.py            → derive_downfolded_bse, derive_pcf, derive_mu_values, ...
+```
+
+`__init__.py`:
+```python
+from .s1_introduction import *
+from .s2_model import *
+from .s3_downfolding import *
+from .s4_pseudopotential import *
+from .s5_eph_coupling import *
+from .s6_superconductors import *
+from .reasoning import *
+
+__all__ = [
+    "ab_initio_workflow",
+    "tc_improvement_over_phenomenological",
+]
+```
+
+## Backward compatibility
+
+- Single-file packages (everything in `__init__.py`): `module = None`, `module_order = None`. README falls back to topological sort. No change in behavior.
+- `exported` defaults to `False`. Old packages without `__all__` work unchanged.
+- `declaration_index` is `None` for old IR — README fallback handles this.
+- `ir_hash` will change for recompiled packages (new fields in canonical JSON) — this is expected.
+
+## Not in scope
+
+- Module-level docstrings as section descriptions (can add later)
+- Enforcing one-module-per-section (convention, not constraint)
+- Cross-package module references

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -119,6 +119,19 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
     if isinstance(export_names, list) and all(isinstance(n, str) for n in export_names):
         pkg._exported_labels = set(export_names)
 
+    # Extract module docstrings as titles
+    module_titles: dict[str, str] = {}
+    for mod_name in pkg._module_order:
+        full_name = f"{import_name}.{mod_name}"
+        sub = sys.modules.get(full_name)
+        if sub is not None:
+            doc = getattr(sub, "__doc__", None)
+            if isinstance(doc, str) and doc.strip():
+                # Use first line of docstring as title
+                module_titles[mod_name] = doc.strip().split("\n")[0].strip()
+    if module_titles:
+        pkg._module_titles = module_titles
+
     pkg.name = import_name
     pkg.version = version
     if "namespace" in gaia_config:

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -55,17 +55,11 @@ def _import_fresh(import_name: str) -> ModuleType:
 def _assign_labels(module: ModuleType, pkg: CollectedPackage) -> None:
     local_knowledge_ids = {id(k) for k in pkg.knowledge}
     local_strategy_ids = {id(s) for s in pkg.strategies}
-    export_names = getattr(module, "__all__", None)
-    if isinstance(export_names, list) and all(isinstance(name, str) for name in export_names):
-        names = export_names
-    else:
-        names = [name for name in dir(module) if not name.startswith("_")]
-    for attr in names:
+    all_names = [name for name in dir(module) if not name.startswith("_")]
+    for attr in all_names:
         obj = getattr(module, attr, None)
         if isinstance(obj, Knowledge) and id(obj) in local_knowledge_ids and obj.label is None:
             obj.label = attr
-    for attr in [name for name in dir(module) if not name.startswith("_")]:
-        obj = getattr(module, attr, None)
         if isinstance(obj, Strategy) and id(obj) in local_strategy_ids and obj.label is None:
             obj.label = attr
 
@@ -119,6 +113,11 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
         )
 
     _assign_labels(module, pkg)
+
+    # Record exported labels from __all__ for the compiler
+    export_names = getattr(module, "__all__", None)
+    if isinstance(export_names, list) and all(isinstance(n, str) for n in export_names):
+        pkg._exported_labels = set(export_names)
 
     pkg.name = import_name
     pkg.version = version

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -113,8 +113,22 @@ def render_mermaid(ir: dict, beliefs: dict[str, float] | None = None) -> str:
 
 def _narrative_order(ir: dict) -> list[dict]:
     """Return knowledge nodes in narrative reading order."""
-    layers = topo_layers(ir)
     nodes = [k for k in ir["knowledges"] if not _is_helper(k.get("label", ""))]
+    module_order = ir.get("module_order")
+
+    if module_order and any(k.get("module") for k in nodes):
+        module_rank = {m: i for i, m in enumerate(module_order)}
+
+        def sort_key(k):
+            mod = k.get("module")
+            idx = k.get("declaration_index", 0)
+            mod_rank = module_rank.get(mod, 999) if mod else -1
+            return (mod_rank, idx)
+
+        return sorted(nodes, key=sort_key)
+
+    # Fallback: topo sort (single-file or legacy packages)
+    layers = topo_layers(ir)
 
     def sort_key(k):
         kid = k["id"]
@@ -144,21 +158,33 @@ def render_knowledge_nodes(
             strategy_for[s["conclusion"]] = s
 
     ordered = _narrative_order(ir)
+    module_order = ir.get("module_order")
+    has_modules = module_order and any(k.get("module") for k in ordered)
     sections: list[str] = ["## Knowledge Nodes", ""]
-    current_type = None
+    current_group = None
 
     for k in ordered:
         ktype = k["type"]
         label = k.get("label", "")
         kid = k["id"]
         content = k.get("content", "")
+        exported = k.get("exported", False)
 
-        if ktype != current_type:
-            current_type = ktype
-            sections.append(f"### {ktype.title()}s")
-            sections.append("")
+        if has_modules:
+            group = k.get("module") or "Root"
+            if group != current_group:
+                current_group = group
+                sections.append(f"### {group}")
+                sections.append("")
+        else:
+            group = ktype
+            if group != current_group:
+                current_group = group
+                sections.append(f"### {ktype.title()}s")
+                sections.append("")
 
-        sections.append(f"#### {label}")
+        marker = " \u2605" if exported else ""
+        sections.append(f"#### {label}{marker}")
         sections.append("")
         sections.append(content)
         sections.append("")

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -281,42 +281,33 @@ def _render_introduction(
     beliefs: dict[str, float],
     priors: dict[str, float],
 ) -> list[str]:
-    """Render the Introduction section.
+    """Render an Introduction section from exported conclusions.
 
-    If a 'motivation' module exists, show its content.
-    Otherwise, show exported conclusions.
+    Only used when there is NO motivation module (since the motivation module
+    itself serves as the introduction). When no motivation module exists,
+    show exported conclusions as a summary.
     """
+    # If a motivation module exists, it IS the introduction — skip this section
+    module_order = ir.get("module_order") or []
+    if "motivation" in module_order:
+        return []
+
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
     strategy_for: dict[str, dict] = {}
     for s in ir.get("strategies", []):
         if s.get("conclusion"):
             strategy_for[s["conclusion"]] = s
 
-    lines = ["## Introduction", ""]
-
-    # Check for motivation module
-    motivation_nodes = [
-        k
-        for k in ir["knowledges"]
-        if k.get("module") == "motivation" and not _is_helper(k.get("label", ""))
-    ]
-    if motivation_nodes:
-        motivation_nodes.sort(key=lambda k: k.get("declaration_index", 0))
-        for k in motivation_nodes:
-            lines.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
-        return lines
-
-    # Fallback: show exported conclusions
     exported = [
         k for k in ir["knowledges"] if k.get("exported") and not _is_helper(k.get("label", ""))
     ]
-    if exported:
-        for k in exported:
-            lines.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
-        return lines
+    if not exported:
+        return []
 
-    # No motivation module and no exports: skip intro
-    return []
+    lines = ["## Introduction", ""]
+    for k in exported:
+        lines.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+    return lines
 
 
 def render_knowledge_nodes(

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -40,75 +40,159 @@ def _is_helper(label: str) -> bool:
     return label.startswith("__")
 
 
-def render_mermaid(ir: dict, beliefs: dict[str, float] | None = None) -> str:
-    """Render a Mermaid graph TD diagram from the IR."""
-    lines = ["```mermaid", "graph TD"]
-    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+# ── Mermaid rendering ──
 
-    strategy_conclusions: set[str] = set()
-    strategy_premises: set[str] = set()
+
+_MERMAID_STYLES = """\
+    classDef setting fill:#f0f0f0,stroke:#999
+    classDef premise fill:#ddeeff,stroke:#4488bb
+    classDef derived fill:#ddffdd,stroke:#44bb44
+    classDef question fill:#fff3dd,stroke:#cc9944
+    classDef orphan fill:#fff,stroke:#ccc,stroke-dasharray: 5 5
+    classDef external fill:#fff,stroke:#aaa,stroke-dasharray: 3 3"""
+
+
+def _classify_nodes(ir: dict) -> tuple[set[str], set[str]]:
+    """Return (strategy_conclusions, strategy_premises) ID sets."""
+    conclusions: set[str] = set()
+    premises: set[str] = set()
     for s in ir.get("strategies", []):
         if s.get("conclusion"):
-            strategy_conclusions.add(s["conclusion"])
+            conclusions.add(s["conclusion"])
         for p in s.get("premises", []):
-            strategy_premises.add(p)
+            premises.add(p)
+    return conclusions, premises
 
+
+def _mermaid_node_line(
+    label: str,
+    kid: str,
+    ktype: str,
+    strategy_conclusions: set[str],
+    strategy_premises: set[str],
+    beliefs: dict[str, float] | None,
+    *,
+    css_class_override: str | None = None,
+) -> str:
+    display = f"{label} ({beliefs[kid]:.2f})" if beliefs and kid in beliefs else label
+    display = display.replace('"', "#quot;")
+    if css_class_override:
+        css = css_class_override
+    elif ktype == "setting":
+        css = "setting"
+    elif ktype == "question":
+        css = "question"
+    elif kid in strategy_conclusions:
+        css = "derived"
+    elif kid in strategy_premises:
+        css = "premise"
+    else:
+        css = "orphan"
+    return f'    {label}["{display}"]:::{css}'
+
+
+def render_mermaid(
+    ir: dict,
+    beliefs: dict[str, float] | None = None,
+    *,
+    node_ids: set[str] | None = None,
+) -> str:
+    """Render a Mermaid graph TD diagram.
+
+    If node_ids is given, only show those nodes + edges between them.
+    External premises (not in node_ids but connected) shown as dashed.
+    """
+    lines = ["```mermaid", "graph TD"]
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    strategy_conclusions, strategy_premises = _classify_nodes(ir)
+
+    # Determine which nodes to render
+    if node_ids is not None:
+        # Collect external premises that feed into this module's conclusions
+        external_ids: set[str] = set()
+        for s in ir.get("strategies", []):
+            conc = s.get("conclusion")
+            if conc and conc in node_ids:
+                for p in s.get("premises", []):
+                    if p not in node_ids:
+                        p_label = knowledge_by_id.get(p, {}).get("label", "")
+                        if not _is_helper(p_label):
+                            external_ids.add(p)
+        for o in ir.get("operators", []):
+            conc = o.get("conclusion")
+            if conc and conc in node_ids:
+                for v in o.get("variables", []):
+                    if v not in node_ids:
+                        v_label = knowledge_by_id.get(v, {}).get("label", "")
+                        if not _is_helper(v_label):
+                            external_ids.add(v)
+        all_visible = node_ids | external_ids
+    else:
+        external_ids = set()
+        all_visible = set(knowledge_by_id.keys())
+
+    # Render nodes
     for k in ir["knowledges"]:
+        kid = k["id"]
+        if kid not in all_visible:
+            continue
         label = k.get("label", "")
         if _is_helper(label):
             continue
-        kid = k["id"]
-        ktype = k["type"]
-        display = f"{label} ({beliefs[kid]:.2f})" if beliefs and kid in beliefs else label
-        # Escape quotes in display for Mermaid
-        display = display.replace('"', "#quot;")
-        if ktype == "setting":
-            lines.append(f'    {label}["{display}"]:::setting')
-        elif ktype == "question":
-            lines.append(f'    {label}["{display}"]:::question')
-        elif kid in strategy_conclusions:
-            lines.append(f'    {label}["{display}"]:::derived')
-        elif kid in strategy_premises:
-            lines.append(f'    {label}["{display}"]:::premise')
-        else:
-            lines.append(f'    {label}["{display}"]:::orphan')
+        css_override = "external" if kid in external_ids else None
+        lines.append(
+            _mermaid_node_line(
+                label,
+                kid,
+                k["type"],
+                strategy_conclusions,
+                strategy_premises,
+                beliefs,
+                css_class_override=css_override,
+            )
+        )
 
+    # Render strategy edges (only if both ends visible)
     for s in ir.get("strategies", []):
         conclusion = s.get("conclusion")
-        if not conclusion:
+        if not conclusion or conclusion not in all_visible:
             continue
         conc_label = knowledge_by_id.get(conclusion, {}).get("label", "")
         if _is_helper(conc_label):
             continue
         stype = s.get("type", "")
         for p in s.get("premises", []):
+            if p not in all_visible:
+                continue
             p_label = knowledge_by_id.get(p, {}).get("label", "")
             if _is_helper(p_label):
                 continue
             lines.append(f"    {p_label} -->|{stype}| {conc_label}")
 
+    # Render operator edges
     for o in ir.get("operators", []):
         conclusion = o.get("conclusion")
-        if not conclusion:
+        if not conclusion or conclusion not in all_visible:
             continue
         conc_label = knowledge_by_id.get(conclusion, {}).get("label", "")
         if _is_helper(conc_label):
             continue
         otype = o.get("operator", "")
         for v in o.get("variables", []):
+            if v not in all_visible:
+                continue
             v_label = knowledge_by_id.get(v, {}).get("label", "")
             if _is_helper(v_label):
                 continue
             lines.append(f"    {v_label} -.-|{otype}| {conc_label}")
 
     lines.append("")
-    lines.append("    classDef setting fill:#f0f0f0,stroke:#999")
-    lines.append("    classDef premise fill:#ddeeff,stroke:#4488bb")
-    lines.append("    classDef derived fill:#ddffdd,stroke:#44bb44")
-    lines.append("    classDef question fill:#fff3dd,stroke:#cc9944")
-    lines.append("    classDef orphan fill:#fff,stroke:#ccc,stroke-dasharray: 5 5")
+    lines.append(_MERMAID_STYLES)
     lines.append("```")
     return "\n".join(lines)
+
+
+# ── Narrative ordering ──
 
 
 def _narrative_order(ir: dict) -> list[dict]:
@@ -142,12 +226,105 @@ def _narrative_order(ir: dict) -> list[dict]:
     return sorted(nodes, key=sort_key)
 
 
+# ── Knowledge node rendering ──
+
+
+def _render_node(
+    k: dict,
+    strategy_for: dict[str, dict],
+    knowledge_by_id: dict[str, dict],
+    beliefs: dict[str, float],
+    priors: dict[str, float],
+) -> list[str]:
+    """Render a single knowledge node as markdown lines."""
+    label = k.get("label", "")
+    kid = k["id"]
+    content = k.get("content", "")
+    exported = k.get("exported", False)
+    lines: list[str] = []
+
+    marker = " \u2605" if exported else ""
+    lines.append(f"#### {label}{marker}")
+    lines.append("")
+    lines.append(content)
+    lines.append("")
+
+    if kid in strategy_for:
+        s = strategy_for[kid]
+        stype = s.get("type", "")
+        premise_labels = []
+        for p in s.get("premises", []):
+            p_label = knowledge_by_id.get(p, {}).get("label", p.split("::")[-1])
+            if not _is_helper(p_label):
+                premise_labels.append(f"[{p_label}](#{p_label})")
+        lines.append(f"**Derived via:** {stype}({', '.join(premise_labels)})")
+
+    meta_parts = []
+    if kid in priors:
+        meta_parts.append(f"**Prior:** {priors[kid]:.2f}")
+    if kid in beliefs:
+        meta_parts.append(f"**Belief:** {beliefs[kid]:.2f}")
+    if meta_parts:
+        lines.append(" \u00b7 ".join(meta_parts))
+
+    if kid in strategy_for:
+        reason = (strategy_for[kid].get("metadata") or {}).get("reason", "")
+        if reason:
+            lines.append(f"**Reason:** {reason}")
+
+    lines.append("")
+    return lines
+
+
+def _render_introduction(
+    ir: dict,
+    beliefs: dict[str, float],
+    priors: dict[str, float],
+) -> list[str]:
+    """Render the Introduction section.
+
+    If a 'motivation' module exists, show its content.
+    Otherwise, show exported conclusions.
+    """
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    strategy_for: dict[str, dict] = {}
+    for s in ir.get("strategies", []):
+        if s.get("conclusion"):
+            strategy_for[s["conclusion"]] = s
+
+    lines = ["## Introduction", ""]
+
+    # Check for motivation module
+    motivation_nodes = [
+        k
+        for k in ir["knowledges"]
+        if k.get("module") == "motivation" and not _is_helper(k.get("label", ""))
+    ]
+    if motivation_nodes:
+        motivation_nodes.sort(key=lambda k: k.get("declaration_index", 0))
+        for k in motivation_nodes:
+            lines.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+        return lines
+
+    # Fallback: show exported conclusions
+    exported = [
+        k for k in ir["knowledges"] if k.get("exported") and not _is_helper(k.get("label", ""))
+    ]
+    if exported:
+        for k in exported:
+            lines.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+        return lines
+
+    # No motivation module and no exports: skip intro
+    return []
+
+
 def render_knowledge_nodes(
     ir: dict,
     beliefs: dict[str, float] | None = None,
     priors: dict[str, float] | None = None,
 ) -> str:
-    """Render the Knowledge Nodes section in narrative order with hyperlinks."""
+    """Render knowledge nodes grouped by module with per-module Mermaid diagrams."""
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
     beliefs = beliefs or {}
     priors = priors or {}
@@ -160,61 +337,63 @@ def render_knowledge_nodes(
     ordered = _narrative_order(ir)
     module_order = ir.get("module_order")
     has_modules = module_order and any(k.get("module") for k in ordered)
-    sections: list[str] = ["## Knowledge Nodes", ""]
-    current_group = None
+    sections: list[str] = []
 
-    for k in ordered:
-        ktype = k["type"]
-        label = k.get("label", "")
-        kid = k["id"]
-        content = k.get("content", "")
-        exported = k.get("exported", False)
+    if has_modules:
+        # Group nodes by module
+        module_nodes: dict[str, list[dict]] = defaultdict(list)
+        for k in ordered:
+            mod = k.get("module") or "Root"
+            module_nodes[mod].append(k)
 
-        if has_modules:
-            group = k.get("module") or "Root"
-            if group != current_group:
-                current_group = group
-                sections.append(f"### {group}")
-                sections.append("")
-        else:
-            group = ktype
-            if group != current_group:
-                current_group = group
+        # Render each module as a section with its own Mermaid diagram
+        for mod in module_order or []:
+            nodes = module_nodes.get(mod, [])
+            if not nodes:
+                continue
+
+            sections.append(f"## {mod}")
+            sections.append("")
+
+            # Per-module Mermaid: nodes in this module + external premises
+            mod_ids = {k["id"] for k in nodes}
+            mermaid = render_mermaid(ir, beliefs=beliefs, node_ids=mod_ids)
+            sections.append(mermaid)
+            sections.append("")
+
+            # Render each node
+            for k in nodes:
+                sections.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+
+        # Root nodes (no module)
+        root_nodes = module_nodes.get("Root", [])
+        if root_nodes:
+            sections.append("## Root")
+            sections.append("")
+            for k in root_nodes:
+                sections.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+    else:
+        # Single-file/legacy: one global diagram + type-based grouping
+        sections.append("## Knowledge Graph")
+        sections.append("")
+        sections.append(render_mermaid(ir, beliefs=beliefs))
+        sections.append("")
+
+        sections.append("## Knowledge Nodes")
+        sections.append("")
+        current_type = None
+        for k in ordered:
+            ktype = k["type"]
+            if ktype != current_type:
+                current_type = ktype
                 sections.append(f"### {ktype.title()}s")
                 sections.append("")
-
-        marker = " \u2605" if exported else ""
-        sections.append(f"#### {label}{marker}")
-        sections.append("")
-        sections.append(content)
-        sections.append("")
-
-        if kid in strategy_for:
-            s = strategy_for[kid]
-            stype = s.get("type", "")
-            premise_labels = []
-            for p in s.get("premises", []):
-                p_label = knowledge_by_id.get(p, {}).get("label", p.split("::")[-1])
-                if not _is_helper(p_label):
-                    premise_labels.append(f"[{p_label}](#{p_label})")
-            sections.append(f"**Derived via:** {stype}({', '.join(premise_labels)})")
-
-        meta_parts = []
-        if kid in priors:
-            meta_parts.append(f"**Prior:** {priors[kid]:.2f}")
-        if kid in beliefs:
-            meta_parts.append(f"**Belief:** {beliefs[kid]:.2f}")
-        if meta_parts:
-            sections.append(" · ".join(meta_parts))
-
-        if kid in strategy_for:
-            reason = (strategy_for[kid].get("metadata") or {}).get("reason", "")
-            if reason:
-                sections.append(f"**Reason:** {reason}")
-
-        sections.append("")
+            sections.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
 
     return "\n".join(sections)
+
+
+# ── Inference results ──
 
 
 def render_inference_results(
@@ -235,13 +414,7 @@ def render_inference_results(
         priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
 
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
-    strategy_conclusions = {
-        s["conclusion"] for s in ir.get("strategies", []) if s.get("conclusion")
-    }
-    strategy_premises: set[str] = set()
-    for s in ir.get("strategies", []):
-        for p in s.get("premises", []):
-            strategy_premises.add(p)
+    strategy_conclusions, strategy_premises = _classify_nodes(ir)
 
     lines.append("| Label | Type | Prior | Belief | Role |")
     lines.append("|-------|------|-------|--------|------|")
@@ -265,6 +438,9 @@ def render_inference_results(
 
     lines.append("")
     return "\n".join(lines)
+
+
+# ── Top-level assembler ──
 
 
 def generate_readme(
@@ -292,13 +468,16 @@ def generate_readme(
         parts.append(desc)
         parts.append("")
 
-    parts.append("## Knowledge Graph")
-    parts.append("")
-    parts.append(render_mermaid(ir, beliefs=beliefs))
-    parts.append("")
+    # Introduction: motivation module or exported conclusions
+    intro = _render_introduction(ir, beliefs or {}, priors or {})
+    if intro:
+        parts.extend(intro)
+        parts.append("")
 
+    # Module sections (each with focused Mermaid) or single-file fallback
     parts.append(render_knowledge_nodes(ir, beliefs=beliefs, priors=priors))
 
+    # Inference results
     if beliefs_data:
         parts.append(render_inference_results(ir, beliefs_data, param_data))
 

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -72,9 +72,11 @@ def _mermaid_node_line(
     strategy_premises: set[str],
     beliefs: dict[str, float] | None,
     *,
+    title: str | None = None,
     css_class_override: str | None = None,
 ) -> str:
-    display = f"{label} ({beliefs[kid]:.2f})" if beliefs and kid in beliefs else label
+    display_name = title or label
+    display = f"{display_name} ({beliefs[kid]:.2f})" if beliefs and kid in beliefs else display_name
     display = display.replace('"', "#quot;")
     if css_class_override:
         css = css_class_override
@@ -148,6 +150,7 @@ def render_mermaid(
                 strategy_conclusions,
                 strategy_premises,
                 beliefs,
+                title=k.get("title"),
                 css_class_override=css_override,
             )
         )
@@ -243,34 +246,53 @@ def _render_node(
     exported = k.get("exported", False)
     lines: list[str] = []
 
+    title = k.get("title") or label
     marker = " \u2605" if exported else ""
-    lines.append(f"#### {label}{marker}")
-    lines.append("")
-    lines.append(content)
+    ktype = k.get("type", "claim")
+
+    # Heading: title (with label as anchor for linking)
+    lines.append(f"#### {title}{marker}")
     lines.append("")
 
+    # Type + label badge line
+    type_emoji = {"setting": "\U0001f4cb", "claim": "\U0001f4cc", "question": "\u2753"}.get(
+        ktype, ""
+    )
+    badge_parts = [f"{type_emoji} `{label}`"]
+    if kid in priors:
+        badge_parts.append(f"Prior: {priors[kid]:.2f}")
+    if kid in beliefs:
+        badge_parts.append(f"Belief: **{beliefs[kid]:.2f}**")
+    lines.append(" \u00a0\u00a0|\u00a0\u00a0 ".join(badge_parts))
+    lines.append("")
+
+    # Content in blockquote
+    if content:
+        for content_line in content.split("\n"):
+            lines.append(f"> {content_line}")
+        lines.append("")
+
+    # Derivation
     if kid in strategy_for:
         s = strategy_for[kid]
         stype = s.get("type", "")
-        premise_labels = []
+        premise_links = []
         for p in s.get("premises", []):
-            p_label = knowledge_by_id.get(p, {}).get("label", p.split("::")[-1])
+            pk = knowledge_by_id.get(p, {})
+            p_label = pk.get("label", p.split("::")[-1])
+            p_title = pk.get("title") or p_label
             if not _is_helper(p_label):
-                premise_labels.append(f"[{p_label}](#{p_label})")
-        lines.append(f"**Derived via:** {stype}({', '.join(premise_labels)})")
-
-    meta_parts = []
-    if kid in priors:
-        meta_parts.append(f"**Prior:** {priors[kid]:.2f}")
-    if kid in beliefs:
-        meta_parts.append(f"**Belief:** {beliefs[kid]:.2f}")
-    if meta_parts:
-        lines.append(" \u00b7 ".join(meta_parts))
-
-    if kid in strategy_for:
-        reason = (strategy_for[kid].get("metadata") or {}).get("reason", "")
+                premise_links.append(f"[{p_title}](#{p_label})")
+        lines.append(f"\U0001f517 **{stype}**({', '.join(premise_links)})")
+        lines.append("")
+        reason = (s.get("metadata") or {}).get("reason", "")
         if reason:
-            lines.append(f"**Reason:** {reason}")
+            lines.append("<details><summary>Reasoning</summary>")
+            lines.append("")
+            lines.append(reason)
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
 
     lines.append("")
     return lines
@@ -338,12 +360,14 @@ def render_knowledge_nodes(
             module_nodes[mod].append(k)
 
         # Render each module as a section with its own Mermaid diagram
+        module_titles = ir.get("module_titles") or {}
         for mod in module_order or []:
             nodes = module_nodes.get(mod, [])
             if not nodes:
                 continue
 
-            sections.append(f"## {mod}")
+            heading = module_titles.get(mod, mod)
+            sections.append(f"## {heading}")
             sections.append("")
 
             # Per-module Mermaid: nodes in this module + external premises

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -40,6 +40,26 @@ def _is_helper(label: str) -> bool:
     return label.startswith("__")
 
 
+def _anchor_id(label: str) -> str:
+    return label
+
+
+def _module_key(k: dict) -> str:
+    module = k.get("module")
+    return module if module else "Root"
+
+
+def _module_segments(nodes: list[dict]) -> list[tuple[str, list[dict]]]:
+    segments: list[tuple[str, list[dict]]] = []
+    for node in nodes:
+        module_key = _module_key(node)
+        if segments and segments[-1][0] == module_key:
+            segments[-1][1].append(node)
+            continue
+        segments.append((module_key, [node]))
+    return segments
+
+
 # ── Mermaid rendering ──
 
 
@@ -238,6 +258,8 @@ def _render_node(
     knowledge_by_id: dict[str, dict],
     beliefs: dict[str, float],
     priors: dict[str, float],
+    *,
+    emit_anchor: bool = True,
 ) -> list[str]:
     """Render a single knowledge node as markdown lines."""
     label = k.get("label", "")
@@ -250,7 +272,11 @@ def _render_node(
     marker = " \u2605" if exported else ""
     ktype = k.get("type", "claim")
 
-    # Heading: title (with label as anchor for linking)
+    # Keep a stable label-based anchor even when the visible heading uses title.
+    if emit_anchor and label:
+        lines.append(f'<a id="{_anchor_id(label)}"></a>')
+        lines.append("")
+
     lines.append(f"#### {title}{marker}")
     lines.append("")
 
@@ -282,7 +308,7 @@ def _render_node(
             p_label = pk.get("label", p.split("::")[-1])
             p_title = pk.get("title") or p_label
             if not _is_helper(p_label):
-                premise_links.append(f"[{p_title}](#{p_label})")
+                premise_links.append(f"[{p_title}](#{_anchor_id(p_label)})")
         lines.append(f"\U0001f517 **{stype}**({', '.join(premise_links)})")
         lines.append("")
         reason = (s.get("metadata") or {}).get("reason", "")
@@ -303,11 +329,11 @@ def _render_introduction(
     beliefs: dict[str, float],
     priors: dict[str, float],
 ) -> list[str]:
-    """Render an Introduction section from exported conclusions.
+    """Render an Introduction section from exported knowledge.
 
     Only used when there is NO motivation module (since the motivation module
     itself serves as the introduction). When no motivation module exists,
-    show exported conclusions as a summary.
+    show exported knowledge as a summary.
     """
     # If a motivation module exists, it IS the introduction — skip this section
     module_order = ir.get("module_order") or []
@@ -328,7 +354,16 @@ def _render_introduction(
 
     lines = ["## Introduction", ""]
     for k in exported:
-        lines.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+        lines.extend(
+            _render_node(
+                k,
+                strategy_for,
+                knowledge_by_id,
+                beliefs,
+                priors,
+                emit_anchor=False,
+            )
+        )
     return lines
 
 
@@ -347,48 +382,40 @@ def render_knowledge_nodes(
         if s.get("conclusion"):
             strategy_for[s["conclusion"]] = s
 
-    ordered = _narrative_order(ir)
     module_order = ir.get("module_order")
-    has_modules = module_order and any(k.get("module") for k in ordered)
+    has_modules = module_order and any(k.get("module") for k in knowledge_by_id.values())
     sections: list[str] = []
 
     if has_modules:
-        # Group nodes by module
-        module_nodes: dict[str, list[dict]] = defaultdict(list)
-        for k in ordered:
-            mod = k.get("module") or "Root"
-            module_nodes[mod].append(k)
-
-        # Render each module as a section with its own Mermaid diagram
+        ordered_nodes = [k for k in ir["knowledges"] if not _is_helper(k.get("label", ""))]
+        segments = _module_segments(ordered_nodes)
         module_titles = ir.get("module_titles") or {}
-        for mod in module_order or []:
-            nodes = module_nodes.get(mod, [])
-            if not nodes:
-                continue
+        segment_counts: dict[str, int] = defaultdict(int)
 
-            heading = module_titles.get(mod, mod)
+        for mod, nodes in segments:
+            count = segment_counts[mod]
+            if mod == "Root":
+                heading = "Root"
+            else:
+                heading = module_titles.get(mod, mod)
+            if count:
+                heading = f"{heading} (continued)"
+            segment_counts[mod] += 1
+
             sections.append(f"## {heading}")
             sections.append("")
 
-            # Per-module Mermaid: nodes in this module + external premises
-            mod_ids = {k["id"] for k in nodes}
-            mermaid = render_mermaid(ir, beliefs=beliefs, node_ids=mod_ids)
-            sections.append(mermaid)
-            sections.append("")
+            if mod != "Root":
+                mod_ids = {k["id"] for k in nodes}
+                mermaid = render_mermaid(ir, beliefs=beliefs, node_ids=mod_ids)
+                sections.append(mermaid)
+                sections.append("")
 
-            # Render each node
             for k in nodes:
-                sections.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
-
-        # Root nodes (no module)
-        root_nodes = module_nodes.get("Root", [])
-        if root_nodes:
-            sections.append("## Root")
-            sections.append("")
-            for k in root_nodes:
                 sections.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
     else:
         # Single-file/legacy: one global diagram + type-based grouping
+        ordered = _narrative_order(ir)
         sections.append("## Knowledge Graph")
         sections.append("")
         sections.append(render_mermaid(ir, beliefs=beliefs))
@@ -449,7 +476,7 @@ def render_inference_results(
             role = "independent"
         else:
             role = "orphaned"
-        lines.append(f"| [{label}](#{label}) | {ktype} | {prior} | {belief} | {role} |")
+        lines.append(f"| [{label}](#{_anchor_id(label)}) | {ktype} | {prior} | {belief} | {role} |")
 
     lines.append("")
     return "\n".join(lines)
@@ -483,7 +510,7 @@ def generate_readme(
         parts.append(desc)
         parts.append("")
 
-    # Introduction: motivation module or exported conclusions
+    # Introduction: motivation module or exported knowledge
     intro = _render_introduction(ir, beliefs or {}, priors or {})
     if intro:
         parts.extend(intro)

--- a/gaia/ir/graphs.py
+++ b/gaia/ir/graphs.py
@@ -25,6 +25,10 @@ def _canonicalize_knowledge_dump(data: dict[str, Any]) -> dict[str, Any]:
     canonical["parameters"] = sorted(canonical.get("parameters", []), key=_json_sort_key)
     if canonical.get("provenance") is not None:
         canonical["provenance"] = sorted(canonical["provenance"], key=_json_sort_key)
+    # Exclude narrative/presentational fields from content hash
+    canonical.pop("module", None)
+    canonical.pop("declaration_index", None)
+    canonical.pop("exported", None)
     return canonical
 
 
@@ -94,6 +98,7 @@ class LocalCanonicalGraph(BaseModel):
     knowledges: list[Knowledge]
     operators: list[Operator] = []
     strategies: list[CompositeStrategy | FormalStrategy | Strategy] = []
+    module_order: list[str] | None = None
 
     @model_validator(mode="after")
     def _compute_hash(self) -> LocalCanonicalGraph:

--- a/gaia/ir/graphs.py
+++ b/gaia/ir/graphs.py
@@ -26,6 +26,7 @@ def _canonicalize_knowledge_dump(data: dict[str, Any]) -> dict[str, Any]:
     if canonical.get("provenance") is not None:
         canonical["provenance"] = sorted(canonical["provenance"], key=_json_sort_key)
     # Exclude narrative/presentational fields from content hash
+    canonical.pop("title", None)
     canonical.pop("module", None)
     canonical.pop("declaration_index", None)
     canonical.pop("exported", None)
@@ -99,6 +100,7 @@ class LocalCanonicalGraph(BaseModel):
     operators: list[Operator] = []
     strategies: list[CompositeStrategy | FormalStrategy | Strategy] = []
     module_order: list[str] | None = None
+    module_titles: dict[str, str] | None = None
 
     @model_validator(mode="after")
     def _compute_hash(self) -> LocalCanonicalGraph:

--- a/gaia/ir/knowledge.py
+++ b/gaia/ir/knowledge.py
@@ -79,6 +79,11 @@ class Knowledge(BaseModel):
     # provenance
     provenance: list[PackageRef] | None = None
 
+    # narrative (presentational, excluded from content hash)
+    module: str | None = None
+    declaration_index: int | None = None
+    exported: bool = False
+
     @model_validator(mode="after")
     def _compute_derived_fields(self) -> Knowledge:
         # Knowledge is valid if it has id OR label (or both).

--- a/gaia/ir/knowledge.py
+++ b/gaia/ir/knowledge.py
@@ -70,6 +70,7 @@ class Knowledge(BaseModel):
 
     id: str | None = None
     label: str | None = None
+    title: str | None = None
     type: KnowledgeType
     content: str | None = None
     content_hash: str | None = None

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -251,6 +251,7 @@ def compile_package_artifact(pkg: CollectedPackage) -> CompiledPackage:
         )
         knowledge_map[id(k)] = knowledge_id
 
+    exported_labels = getattr(pkg, "_exported_labels", set())
     ir_knowledges = [
         IrKnowledge(
             id=knowledge_map[id(k)],
@@ -260,6 +261,9 @@ def compile_package_artifact(pkg: CollectedPackage) -> CompiledPackage:
             parameters=[IrParameter(**p) for p in k.parameters],
             provenance=_knowledge_provenance(k),
             metadata=_knowledge_metadata(k),
+            module=getattr(k, "_source_module", None),
+            declaration_index=getattr(k, "_declaration_index", None),
+            exported=k.label in exported_labels if k.label else False,
         )
         for k in knowledge_nodes
     ]
@@ -329,12 +333,14 @@ def compile_package_artifact(pkg: CollectedPackage) -> CompiledPackage:
         ir_strategies.append(compile_strategy(s))
         emitted_strategies.add(strategy_key)
 
+    module_order = pkg._module_order if pkg._module_order else None
     graph = LocalCanonicalGraph(
         namespace=pkg.namespace,
         package_name=pkg.name,
         knowledges=[*ir_knowledges, *generated_knowledges],
         operators=ir_operators,
         strategies=ir_strategies,
+        module_order=module_order,
     )
 
     return CompiledPackage(

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -256,6 +256,7 @@ def compile_package_artifact(pkg: CollectedPackage) -> CompiledPackage:
         IrKnowledge(
             id=knowledge_map[id(k)],
             label=k.label,
+            title=getattr(k, "title", None),
             type=k.type,
             content=k.content,
             parameters=[IrParameter(**p) for p in k.parameters],
@@ -334,6 +335,7 @@ def compile_package_artifact(pkg: CollectedPackage) -> CompiledPackage:
         emitted_strategies.add(strategy_key)
 
     module_order = pkg._module_order if pkg._module_order else None
+    module_titles = getattr(pkg, "_module_titles", None) or None
     graph = LocalCanonicalGraph(
         namespace=pkg.namespace,
         package_name=pkg.name,
@@ -341,6 +343,7 @@ def compile_package_artifact(pkg: CollectedPackage) -> CompiledPackage:
         operators=ir_operators,
         strategies=ir_strategies,
         module_order=module_order,
+        module_titles=module_titles if module_titles else None,
     )
 
     return CompiledPackage(

--- a/gaia/lang/dsl/knowledge.py
+++ b/gaia/lang/dsl/knowledge.py
@@ -3,23 +3,25 @@
 from gaia.lang.runtime import Knowledge, Strategy
 
 
-def setting(content: str, **metadata) -> Knowledge:
+def setting(content: str, *, title: str | None = None, **metadata) -> Knowledge:
     """Declare a background assumption. No probability, no BP participation."""
     provenance = metadata.pop("provenance", None)
     return Knowledge(
         content=content.strip(),
         type="setting",
+        title=title,
         provenance=provenance or [],
         metadata=metadata,
     )
 
 
-def question(content: str, **metadata) -> Knowledge:
+def question(content: str, *, title: str | None = None, **metadata) -> Knowledge:
     """Declare a research question. No probability, no BP participation."""
     provenance = metadata.pop("provenance", None)
     return Knowledge(
         content=content.strip(),
         type="question",
+        title=title,
         provenance=provenance or [],
         metadata=metadata,
     )
@@ -28,6 +30,7 @@ def question(content: str, **metadata) -> Knowledge:
 def claim(
     content: str,
     *,
+    title: str | None = None,
     given: list[Knowledge] | None = None,
     background: list[Knowledge] | None = None,
     parameters: list[dict] | None = None,
@@ -38,6 +41,7 @@ def claim(
     k = Knowledge(
         content=content.strip(),
         type="claim",
+        title=title,
         background=background or [],
         parameters=parameters or [],
         provenance=provenance or [],

--- a/gaia/lang/runtime/nodes.py
+++ b/gaia/lang/runtime/nodes.py
@@ -25,14 +25,18 @@ class Knowledge:
     label: str | None = None
     strategy: Strategy | None = None
     _package: CollectedPackage | None = field(default=None, init=False, repr=False, compare=False)
+    _source_module: str | None = field(default=None, init=False, repr=False, compare=False)
+    _declaration_index: int | None = field(default=None, init=False, repr=False, compare=False)
 
     def __post_init__(self):
         pkg = _current_package.get()
+        source_module = None
         if pkg is None:
-            from gaia.lang.runtime.package import infer_package_from_callstack
+            from gaia.lang.runtime.package import infer_package_and_module
 
-            pkg = infer_package_from_callstack()
+            pkg, source_module = infer_package_and_module()
         if pkg is not None:
+            self._source_module = source_module
             self._package = pkg
             pkg._register_knowledge(self)
 

--- a/gaia/lang/runtime/nodes.py
+++ b/gaia/lang/runtime/nodes.py
@@ -18,6 +18,7 @@ class Knowledge:
 
     content: str
     type: str  # "claim" | "setting" | "question"
+    title: str | None = None
     background: list[Knowledge] = field(default_factory=list)
     parameters: list[dict] = field(default_factory=list)
     provenance: list[dict[str, str]] = field(default_factory=list)

--- a/gaia/lang/runtime/package.py
+++ b/gaia/lang/runtime/package.py
@@ -25,6 +25,9 @@ class CollectedPackage:
         self.strategies: list[Strategy] = []
         self.operators: list[Operator] = []
         self._token = None
+        self._module_counters: dict[str | None, int] = {}
+        self._module_order: list[str] = []
+        self._exported_labels: set[str] = set()
 
     def __enter__(self):
         self._token = _current_package.set(self)
@@ -36,6 +39,13 @@ class CollectedPackage:
 
     def _register_knowledge(self, k: Knowledge):
         self.knowledge.append(k)
+        module = k._source_module
+        if module not in self._module_counters:
+            if module is not None:
+                self._module_order.append(module)
+            self._module_counters[module] = 0
+        k._declaration_index = self._module_counters[module]
+        self._module_counters[module] += 1
 
     def _register_strategy(self, s: Strategy):
         self.strategies.append(s)
@@ -129,15 +139,31 @@ def _caller_module_name() -> str | None:
 
 
 def infer_package_from_callstack() -> CollectedPackage | None:
+    pkg, _ = infer_package_and_module()
+    return pkg
+
+
+def infer_package_and_module() -> tuple[CollectedPackage | None, str | None]:
+    """Infer package and relative module name from the call stack."""
     module_name = _caller_module_name()
     if not module_name:
-        return None
+        return None, None
 
     pyproject = _pyproject_for_module(module_name)
     if pyproject is None:
-        return None
+        return None, None
 
-    return _load_inferred_package(pyproject)
+    pkg = _load_inferred_package(pyproject)
+    if pkg is None:
+        return None, None
+
+    # Compute relative module name: strip package prefix
+    # e.g. "my_package.s3_downfolding" → "s3_downfolding"
+    # "my_package" or "my_package.__init__" → None (root module)
+    if module_name == pkg.name or module_name.endswith(".__init__"):
+        return pkg, None
+    relative = module_name.removeprefix(f"{pkg.name}.")
+    return pkg, relative
 
 
 def get_inferred_package(pyproject: Path) -> CollectedPackage | None:

--- a/tests/cli/test_module_compile.py
+++ b/tests/cli/test_module_compile.py
@@ -1,0 +1,81 @@
+"""Tests for module narrative fields in compiled IR."""
+
+import json
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def test_compile_single_file_declaration_index(tmp_path):
+    """Single-file package: module=None, declaration_index tracks order."""
+    pkg_dir = tmp_path / "single_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "single-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "single_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, setting\n\n"
+        'env = setting("Environment.")\n'
+        'a = claim("First.")\n'
+        'b = claim("Second.")\n'
+        '__all__ = ["b"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    ir = json.loads((pkg_dir / ".gaia" / "ir.json").read_text())
+    by_label = {k["label"]: k for k in ir["knowledges"] if "label" in k}
+
+    assert by_label["env"].get("module") is None  # None excluded from JSON
+    assert by_label["env"]["declaration_index"] == 0
+    assert by_label["a"]["declaration_index"] == 1
+    assert by_label["b"]["declaration_index"] == 2
+    assert by_label["b"]["exported"] is True
+    assert by_label["a"].get("exported", False) is False
+    assert ir.get("module_order") is None
+
+
+def test_compile_multi_file_module_order(tmp_path):
+    """Multi-file package: module and module_order populated."""
+    pkg_dir = tmp_path / "multi_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "multi-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "multi_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "sec_a.py").write_text(
+        "from gaia.lang import claim\n\n"
+        'x = claim("X from section A.")\n'
+        'y = claim("Y from section A.")\n'
+    )
+    (pkg_src / "sec_b.py").write_text(
+        'from gaia.lang import claim\n\nz = claim("Z from section B.")\n'
+    )
+    (pkg_src / "__init__.py").write_text(
+        'from .sec_a import *\nfrom .sec_b import *\n\n__all__ = ["z"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    ir = json.loads((pkg_dir / ".gaia" / "ir.json").read_text())
+    by_label = {k["label"]: k for k in ir["knowledges"] if "label" in k}
+
+    assert by_label["x"]["module"] == "sec_a"
+    assert by_label["y"]["module"] == "sec_a"
+    assert by_label["z"]["module"] == "sec_b"
+    assert by_label["x"]["declaration_index"] == 0
+    assert by_label["y"]["declaration_index"] == 1
+    assert by_label["z"]["declaration_index"] == 0
+    assert by_label["z"]["exported"] is True
+    assert by_label["x"]["exported"] is False
+    assert ir["module_order"] == ["sec_a", "sec_b"]

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -468,3 +468,97 @@ def test_motivation_module_suppresses_introduction():
     assert "## Introduction" not in md
     assert "## motivation" in md
     assert "## results" in md
+
+
+# ── coverage: operator edges, inference results, single-file fallback ──
+
+
+def test_mermaid_operator_edges():
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "C."},
+        ],
+        "strategies": [],
+        "operators": [
+            {
+                "operator": "contradiction",
+                "variables": ["ns:p::a", "ns:p::b"],
+                "conclusion": "ns:p::c",
+            },
+        ],
+    }
+    md = render_mermaid(ir)
+    assert "a -.-|contradiction| c" in md
+
+
+def test_generate_readme_with_inference_results():
+    from gaia.cli.commands._readme import generate_readme
+
+    ir = {
+        "namespace": "github",
+        "package_name": "test_pkg",
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a"], "conclusion": "ns:p::b", "type": "noisy_and"},
+        ],
+        "operators": [],
+    }
+    beliefs_data = {
+        "beliefs": [
+            {"knowledge_id": "ns:p::a", "label": "a", "belief": 0.90},
+            {"knowledge_id": "ns:p::b", "label": "b", "belief": 0.70},
+        ],
+        "diagnostics": {"converged": True, "iterations_run": 5},
+    }
+    param_data = {
+        "priors": [{"knowledge_id": "ns:p::a", "value": 0.95}],
+    }
+    md = generate_readme(
+        ir, {"name": "test-gaia"}, beliefs_data=beliefs_data, param_data=param_data
+    )
+    assert "## Inference Results" in md
+    assert "| a |" in md or "| [a]" in md
+    assert "0.90" in md
+    assert "independent" in md
+    assert "derived" in md
+
+
+def test_single_file_fallback_has_global_graph():
+    """Single-file package (no module_order) renders one global Mermaid graph."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::s", "label": "s", "type": "setting", "content": "S."},
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    assert "## Knowledge Graph" in md
+    assert "```mermaid" in md
+    assert "### Settings" in md
+    assert "### Claims" in md
+
+
+def test_mermaid_with_node_ids_filter():
+    """render_mermaid with node_ids only shows specified nodes + external premises."""
+    ir = {
+        "knowledges": [
+            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
+            {"id": "ns:p::c", "label": "c", "type": "claim", "content": "C."},
+        ],
+        "strategies": [
+            {"premises": ["ns:p::a"], "conclusion": "ns:p::b", "type": "noisy_and"},
+        ],
+        "operators": [],
+    }
+    md = render_mermaid(ir, node_ids={"ns:p::b"})
+    assert "b[" in md
+    assert "a[" in md  # external premise pulled in
+    assert "c[" not in md  # not in node_ids, not connected

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -380,3 +380,39 @@ def test_introduction_with_exported():
     # Internal claim should NOT be in introduction
     intro = md.split("## Introduction")[1].split("##")[0]
     assert "An internal claim." not in intro
+
+
+def test_motivation_module_suppresses_introduction():
+    """When motivation module exists, no separate Introduction section."""
+    from gaia.cli.commands._readme import generate_readme
+
+    ir = {
+        "namespace": "github",
+        "package_name": "test_pkg",
+        "module_order": ["motivation", "results"],
+        "knowledges": [
+            {
+                "id": "ns:p::bg",
+                "label": "bg",
+                "type": "setting",
+                "content": "Background.",
+                "module": "motivation",
+                "declaration_index": 0,
+            },
+            {
+                "id": "ns:p::result",
+                "label": "result",
+                "type": "claim",
+                "content": "Result.",
+                "module": "results",
+                "declaration_index": 0,
+                "exported": True,
+            },
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = generate_readme(ir, {"name": "test-gaia", "description": "Test."})
+    assert "## Introduction" not in md
+    assert "## motivation" in md
+    assert "## results" in md

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -265,19 +265,11 @@ def test_compile_readme_flag_generates_readme(tmp_path):
 # ── module narrative ──
 
 
-def test_narrative_order_uses_module_order():
+def test_module_sections_with_per_module_mermaid():
+    """Multi-module: each module gets its own section with Mermaid diagram."""
     ir = {
         "module_order": ["sec_a", "sec_b"],
         "knowledges": [
-            {
-                "id": "ns:p::z",
-                "label": "z",
-                "type": "claim",
-                "content": "Z.",
-                "module": "sec_b",
-                "declaration_index": 0,
-                "exported": True,
-            },
             {
                 "id": "ns:p::x",
                 "label": "x",
@@ -296,20 +288,36 @@ def test_narrative_order_uses_module_order():
                 "declaration_index": 1,
                 "exported": False,
             },
+            {
+                "id": "ns:p::z",
+                "label": "z",
+                "type": "claim",
+                "content": "Z.",
+                "module": "sec_b",
+                "declaration_index": 0,
+                "exported": True,
+            },
         ],
-        "strategies": [],
+        "strategies": [
+            {"premises": ["ns:p::x"], "conclusion": "ns:p::z", "type": "noisy_and"},
+        ],
         "operators": [],
     }
     md = render_knowledge_nodes(ir)
-    pos_x = md.index("#### x")
-    pos_y = md.index("#### y")
-    pos_z = md.index("#### z")
-    assert pos_x < pos_y < pos_z
-    assert "### sec_a" in md
-    assert "### sec_b" in md
+    # Module section headings
+    assert "## sec_a" in md
+    assert "## sec_b" in md
+    # Order: sec_a nodes before sec_b
+    assert md.index("#### x") < md.index("#### z")
+    assert md.index("#### y") < md.index("#### z")
+    # Per-module Mermaid diagrams
+    assert md.count("```mermaid") == 2
+    # sec_b's diagram should show x as external premise
+    sec_b_section = md.split("## sec_b")[1]
+    assert "x" in sec_b_section.split("```")[1]  # x appears in sec_b's mermaid
 
 
-def test_exported_marker_in_readme():
+def test_exported_marker():
     ir = {
         "module_order": ["mod"],
         "knowledges": [
@@ -338,3 +346,37 @@ def test_exported_marker_in_readme():
     md = render_knowledge_nodes(ir)
     assert "\u2605" in md.split("#### a")[1].split("#### b")[0]
     assert "\u2605" not in md.split("#### b")[1]
+
+
+def test_introduction_with_exported():
+    """Introduction shows exported conclusions when no motivation module."""
+    from gaia.cli.commands._readme import generate_readme
+
+    ir = {
+        "namespace": "github",
+        "package_name": "test_pkg",
+        "knowledges": [
+            {
+                "id": "ns:p::main_result",
+                "label": "main_result",
+                "type": "claim",
+                "content": "The main conclusion.",
+                "exported": True,
+            },
+            {
+                "id": "ns:p::internal",
+                "label": "internal",
+                "type": "claim",
+                "content": "An internal claim.",
+                "exported": False,
+            },
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = generate_readme(ir, {"name": "test-gaia", "description": "Test."})
+    assert "## Introduction" in md
+    assert "The main conclusion." in md
+    # Internal claim should NOT be in introduction
+    intro = md.split("## Introduction")[1].split("##")[0]
+    assert "An internal claim." not in intro

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -260,3 +260,81 @@ def test_compile_readme_flag_generates_readme(tmp_path):
     assert readme.index("#### a") < readme.index("#### c")
     assert readme.index("#### b") < readme.index("#### c")
     assert "[a](#a)" in readme or "[b](#b)" in readme
+
+
+# ── module narrative ──
+
+
+def test_narrative_order_uses_module_order():
+    ir = {
+        "module_order": ["sec_a", "sec_b"],
+        "knowledges": [
+            {
+                "id": "ns:p::z",
+                "label": "z",
+                "type": "claim",
+                "content": "Z.",
+                "module": "sec_b",
+                "declaration_index": 0,
+                "exported": True,
+            },
+            {
+                "id": "ns:p::x",
+                "label": "x",
+                "type": "claim",
+                "content": "X.",
+                "module": "sec_a",
+                "declaration_index": 0,
+                "exported": False,
+            },
+            {
+                "id": "ns:p::y",
+                "label": "y",
+                "type": "claim",
+                "content": "Y.",
+                "module": "sec_a",
+                "declaration_index": 1,
+                "exported": False,
+            },
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    pos_x = md.index("#### x")
+    pos_y = md.index("#### y")
+    pos_z = md.index("#### z")
+    assert pos_x < pos_y < pos_z
+    assert "### sec_a" in md
+    assert "### sec_b" in md
+
+
+def test_exported_marker_in_readme():
+    ir = {
+        "module_order": ["mod"],
+        "knowledges": [
+            {
+                "id": "ns:p::a",
+                "label": "a",
+                "type": "claim",
+                "content": "A.",
+                "module": "mod",
+                "declaration_index": 0,
+                "exported": True,
+            },
+            {
+                "id": "ns:p::b",
+                "label": "b",
+                "type": "claim",
+                "content": "B.",
+                "module": "mod",
+                "declaration_index": 1,
+                "exported": False,
+            },
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    assert "\u2605" in md.split("#### a")[1].split("#### b")[0]
+    assert "\u2605" not in md.split("#### b")[1]

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -152,7 +152,13 @@ def test_render_knowledge_nodes_narrative_order():
 def test_render_knowledge_nodes_hyperlinks():
     ir = {
         "knowledges": [
-            {"id": "ns:p::a", "label": "a", "type": "claim", "content": "A."},
+            {
+                "id": "ns:p::a",
+                "label": "a",
+                "title": "Alpha Title",
+                "type": "claim",
+                "content": "A.",
+            },
             {"id": "ns:p::b", "label": "b", "type": "claim", "content": "B."},
         ],
         "strategies": [
@@ -166,7 +172,8 @@ def test_render_knowledge_nodes_hyperlinks():
         "operators": [],
     }
     md = render_knowledge_nodes(ir)
-    assert "[a](#a)" in md
+    assert '<a id="a"></a>' in md
+    assert "[Alpha Title](#a)" in md
 
 
 def test_render_knowledge_nodes_with_beliefs():
@@ -317,6 +324,43 @@ def test_module_sections_with_per_module_mermaid():
     assert "x" in sec_b_section.split("```")[1]  # x appears in sec_b's mermaid
 
 
+def test_module_sections_preserve_root_segments():
+    ir = {
+        "module_order": ["sec_a"],
+        "knowledges": [
+            {
+                "id": "ns:p::intro",
+                "label": "intro",
+                "type": "setting",
+                "content": "Intro.",
+                "module": None,
+                "declaration_index": 0,
+            },
+            {
+                "id": "ns:p::x",
+                "label": "x",
+                "type": "claim",
+                "content": "X.",
+                "module": "sec_a",
+                "declaration_index": 0,
+            },
+            {
+                "id": "ns:p::outro",
+                "label": "outro",
+                "type": "claim",
+                "content": "Outro.",
+                "module": None,
+                "declaration_index": 1,
+            },
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    md = render_knowledge_nodes(ir)
+    assert md.index("## Root") < md.index("## sec_a") < md.index("## Root (continued)")
+    assert md.index("#### intro") < md.index("#### x") < md.index("#### outro")
+
+
 def test_exported_marker():
     ir = {
         "module_order": ["mod"],
@@ -348,8 +392,8 @@ def test_exported_marker():
     assert "\u2605" not in md.split("#### b")[1]
 
 
-def test_introduction_with_exported():
-    """Introduction shows exported conclusions when no motivation module."""
+def test_introduction_with_exported_knowledge():
+    """Introduction shows exported knowledge when no motivation module."""
     from gaia.cli.commands._readme import generate_readme
 
     ir = {
@@ -361,6 +405,13 @@ def test_introduction_with_exported():
                 "label": "main_result",
                 "type": "claim",
                 "content": "The main conclusion.",
+                "exported": True,
+            },
+            {
+                "id": "ns:p::context",
+                "label": "context",
+                "type": "setting",
+                "content": "Shared context.",
                 "exported": True,
             },
             {
@@ -377,6 +428,7 @@ def test_introduction_with_exported():
     md = generate_readme(ir, {"name": "test-gaia", "description": "Test."})
     assert "## Introduction" in md
     assert "The main conclusion." in md
+    assert "Shared context." in md
     # Internal claim should NOT be in introduction
     intro = md.split("## Introduction")[1].split("##")[0]
     assert "An internal claim." not in intro

--- a/tests/gaia/lang/test_compiler.py
+++ b/tests/gaia/lang/test_compiler.py
@@ -1,0 +1,278 @@
+"""Unit tests for gaia.lang.compiler.compile internals."""
+
+import pytest
+
+from gaia.lang import Step, claim, noisy_and, setting, composite, abduction, contradiction
+from gaia.lang.compiler.compile import (
+    compile_package_artifact,
+    _compile_reason,
+    _knowledge_id,
+    _normalize_label,
+    _anonymous_label,
+    _content_hash,
+)
+from gaia.lang.runtime.package import CollectedPackage
+
+
+# ── _content_hash / _anonymous_label / _normalize_label ──
+
+
+def test_content_hash_deterministic():
+    a = claim("Test content.")
+    b = claim("Test content.")
+    assert _content_hash(a) == _content_hash(b)
+
+
+def test_content_hash_differs_by_type():
+    a = claim("Same text.")
+    b = setting("Same text.")
+    assert _content_hash(a) != _content_hash(b)
+
+
+def test_anonymous_label_format():
+    k = claim("Some claim.")
+    label = _anonymous_label(k)
+    assert label.startswith("_anon_")
+    assert len(label) == len("_anon_") + 8
+
+
+def test_normalize_label_basic():
+    assert _normalize_label("Hello World") == "hello_world"
+
+
+def test_normalize_label_empty():
+    assert _normalize_label("") == "_anon"
+
+
+def test_normalize_label_starts_with_digit():
+    assert _normalize_label("3d_model") == "_3d_model"
+
+
+# ── _knowledge_id ──
+
+
+def test_knowledge_id_local_with_label():
+    pkg = CollectedPackage("test_pkg", namespace="github")
+    k = claim("A.")
+    k.label = "my_claim"
+    pkg.knowledge.append(k)
+    kid, counter = _knowledge_id(k, pkg, local_anon_counter=0)
+    assert kid == "github:test_pkg::my_claim"
+    assert counter == 0  # label was set, no counter increment
+
+
+def test_knowledge_id_local_anonymous():
+    pkg = CollectedPackage("test_pkg", namespace="github")
+    k = claim("A.")
+    k.label = None
+    pkg.knowledge.append(k)
+    kid, counter = _knowledge_id(k, pkg, local_anon_counter=5)
+    assert kid == "github:test_pkg::_anon_005"
+    assert counter == 6
+
+
+def test_knowledge_id_foreign_with_metadata_qid():
+    pkg = CollectedPackage("test_pkg", namespace="github")
+    k = claim("Foreign claim.")
+    k.metadata["qid"] = "external:other_pkg::foreign_claim"
+    # NOT in pkg.knowledge → foreign
+    kid, counter = _knowledge_id(k, pkg, local_anon_counter=0)
+    assert kid == "external:other_pkg::foreign_claim"
+
+
+def test_knowledge_id_foreign_with_package():
+    pkg = CollectedPackage("test_pkg", namespace="github")
+    foreign_pkg = CollectedPackage("other_pkg", namespace="github")
+    k = claim("Foreign claim.")
+    k.label = "fc"
+    k._package = foreign_pkg
+    kid, counter = _knowledge_id(k, pkg, local_anon_counter=0)
+    assert kid == "github:other_pkg::fc"
+
+
+def test_knowledge_id_foreign_fallback():
+    pkg = CollectedPackage("test_pkg", namespace="github")
+    k = claim("Orphan claim.")
+    k.label = "orphan"
+    k._package = None
+    kid, counter = _knowledge_id(k, pkg, local_anon_counter=0)
+    assert kid == "external:anonymous::orphan"
+
+
+# ── _compile_reason ──
+
+
+def test_compile_reason_string():
+    result = _compile_reason("simple reason", {})
+    assert result is None  # string goes to metadata, not steps
+
+
+def test_compile_reason_empty_list():
+    result = _compile_reason([], {})
+    assert result is None
+
+
+def test_compile_reason_string_list():
+    result = _compile_reason(["step 1", "step 2"], {})
+    assert len(result) == 2
+    assert result[0].reasoning == "step 1"
+
+
+def test_compile_reason_step_objects():
+    a = claim("A.")
+    km = {id(a): "ns:p::a"}
+    result = _compile_reason([Step(reason="uses A", premises=[a])], km)
+    assert len(result) == 1
+    assert result[0].reasoning == "uses A"
+    assert result[0].premises == ["ns:p::a"]
+
+
+def test_compile_reason_invalid_type():
+    with pytest.raises(ValueError, match="Unsupported reason entry type"):
+        _compile_reason([123], {})
+
+
+# ── compile_package_artifact ──
+
+
+def test_compile_basic_package():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        a = claim("Claim A.")
+        a.label = "a"
+        b = claim("Claim B.", given=[a])
+        b.label = "b"
+    result = compile_package_artifact(pkg)
+    assert result.graph.namespace == "github"
+    assert result.graph.package_name == "test_pkg"
+    knowledge_ids = {k.label: k.id for k in result.graph.knowledges}
+    assert "github:test_pkg::a" in knowledge_ids.values()
+    assert "github:test_pkg::b" in knowledge_ids.values()
+    assert len(result.graph.strategies) == 1
+
+
+def test_compile_with_background():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        ctx = setting("Context.")
+        ctx.label = "ctx"
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        noisy_and(premises=[a], conclusion=b, background=[ctx])
+    result = compile_package_artifact(pkg)
+    strat = result.graph.strategies[0]
+    assert strat.background is not None
+    assert "github:test_pkg::ctx" in strat.background
+
+
+def test_compile_with_reason_steps():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        noisy_and(
+            premises=[a],
+            conclusion=b,
+            reason=[Step(reason="A supports B", premises=[a])],
+        )
+    result = compile_package_artifact(pkg)
+    strat = result.graph.strategies[0]
+    assert strat.steps is not None
+    assert strat.steps[0].reasoning == "A supports B"
+    assert strat.steps[0].premises == ["github:test_pkg::a"]
+
+
+def test_compile_composite_strategy():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        a = claim("A.")
+        a.label = "a"
+        mid = claim("Mid.")
+        mid.label = "mid"
+        c = claim("C.")
+        c.label = "c"
+        s1 = noisy_and(premises=[a], conclusion=mid)
+        s2 = noisy_and(premises=[mid], conclusion=c)
+        composite(premises=[a], conclusion=c, sub_strategies=[s1, s2])
+    result = compile_package_artifact(pkg)
+    # Should have 3 strategies: s1, s2, and composite
+    assert len(result.graph.strategies) == 3
+
+
+def test_compile_abduction_creates_formal_strategy():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        obs = claim("Observation.")
+        obs.label = "obs"
+        hyp = claim("Hypothesis.")
+        hyp.label = "hyp"
+        abduction(observation=obs, hypothesis=hyp, reason="best explanation")
+    result = compile_package_artifact(pkg)
+    # abduction is a compile-time formal strategy
+    assert len(result.graph.strategies) == 1
+    strat = result.graph.strategies[0]
+    assert strat.type == "abduction"
+
+
+def test_compile_operator():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        c = contradiction(a, b, reason="they conflict")
+        c.label = "a_vs_b"
+    result = compile_package_artifact(pkg)
+    assert len(result.graph.operators) == 1
+    op = result.graph.operators[0]
+    assert op.operator == "contradiction"
+
+
+def test_compile_exported_labels():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    pkg._exported_labels = {"b"}
+    with pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+    result = compile_package_artifact(pkg)
+    by_label = {k.label: k for k in result.graph.knowledges}
+    assert by_label["a"].exported is False
+    assert by_label["b"].exported is True
+
+
+def test_compile_title_preserved():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        a = claim("A.", title="Claim Alpha")
+        a.label = "a"
+    result = compile_package_artifact(pkg)
+    ir_a = next(k for k in result.graph.knowledges if k.label == "a")
+    assert ir_a.title == "Claim Alpha"
+
+
+def test_compile_module_order():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    pkg._module_order = ["sec_a", "sec_b"]
+    with pkg:
+        a = claim("A.")
+        a.label = "a"
+    result = compile_package_artifact(pkg)
+    assert result.graph.module_order == ["sec_a", "sec_b"]
+
+
+def test_compile_module_titles():
+    pkg = CollectedPackage("test_pkg", namespace="github", version="1.0.0")
+    pkg._module_order = ["intro"]
+    pkg._module_titles = {"intro": "Introduction"}
+    with pkg:
+        a = claim("A.")
+        a.label = "a"
+    result = compile_package_artifact(pkg)
+    assert result.graph.module_titles == {"intro": "Introduction"}

--- a/tests/gaia/lang/test_module_narrative.py
+++ b/tests/gaia/lang/test_module_narrative.py
@@ -1,0 +1,43 @@
+"""Tests for module narrative tracking."""
+
+from gaia.lang.runtime.nodes import Knowledge
+from gaia.lang.runtime.package import CollectedPackage
+
+
+def test_declaration_index_increments_within_module():
+    pkg = CollectedPackage("test_pkg")
+    with pkg:
+        a = Knowledge(content="A.", type="claim")
+        b = Knowledge(content="B.", type="claim")
+        c = Knowledge(content="C.", type="claim")
+    assert a._declaration_index == 0
+    assert b._declaration_index == 1
+    assert c._declaration_index == 2
+
+
+def test_module_order_tracks_first_seen():
+    pkg = CollectedPackage("test_pkg")
+    a = Knowledge(content="A.", type="claim")
+    a._source_module = "s1_intro"
+    b = Knowledge(content="B.", type="claim")
+    b._source_module = "s2_model"
+    c = Knowledge(content="C.", type="claim")
+    c._source_module = "s1_intro"
+
+    pkg._register_knowledge(a)
+    pkg._register_knowledge(b)
+    pkg._register_knowledge(c)
+
+    assert pkg._module_order == ["s1_intro", "s2_model"]
+    assert a._declaration_index == 0
+    assert b._declaration_index == 0  # first in s2_model
+    assert c._declaration_index == 1  # second in s1_intro
+
+
+def test_none_module_for_root():
+    pkg = CollectedPackage("test_pkg")
+    a = Knowledge(content="A.", type="claim")
+    a._source_module = None
+    pkg._register_knowledge(a)
+    assert a._declaration_index == 0
+    assert pkg._module_order == []  # None module not tracked in order


### PR DESCRIPTION
## Summary
Python module = Gaia module. Declaration order = narrative. `__all__` = exported conclusions.

### Changes
- **Runtime**: `Knowledge` captures `_source_module` and `_declaration_index` during `__post_init__`
- **IR**: `Knowledge` gets `module`, `declaration_index`, `exported` fields; `LocalCanonicalGraph` gets `module_order`
- **Compiler**: populates new IR fields from runtime data + `__all__`
- **CLI**: `gaia compile --readme` generates README.md with Mermaid graph, module-grouped narrative, hyperlinks, exported markers (★), optional BP results
- **Label assignment fix**: `_assign_labels` now scans all module attributes (not just `__all__`) so multi-file packages get labels on all Knowledge objects

### IR field semantics
- `module`: relative Python module name (e.g. `"s3_downfolding"`), `null` for root `__init__.py`
- `declaration_index`: position within the module (0, 1, 2, ...)
- `exported`: `true` if the Knowledge's label is in `__all__`
- `module_order`: ordered list of module names as they were first imported
- All narrative fields excluded from `ir_hash` (presentational, not semantic)

### Backward compatibility
All new fields are optional with sensible defaults. Old IR files remain valid. Single-file packages work unchanged (fallback to topological sort for README).

## Test plan
- [x] 19 new tests pass (runtime tracking, compilation, README generation, CLI integration)
- [x] 412 existing tests pass (1 pre-existing failure from unmerged PR #315)
- [x] Ruff lint + format clean

**Spec:** `docs/specs/2026-04-04-module-narrative-design.md`
**Plan:** `docs/plans/2026-04-04-module-narrative.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)