### PR TITLE
fix: pin numpy<2.4 to fix pytest-cov crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "pydantic>=2.0",
     "typer[all]>=0.12",
-    "numpy>=1.26",
+    "numpy>=1.26,<2.4",  # numpy 2.4 breaks pytest-cov (double-import C extension)
     "httpx>=0.27",
 ]
 


### PR DESCRIPTION
## Summary
- Pin `numpy>=1.26,<2.4` in pyproject.toml
- numpy 2.4 enforces strict single-import for C extensions, which crashes `pytest-cov` with `ImportError: cannot load module more than once per process`
- Affects local dev on Python 3.13; CI (Python 3.12) was unaffected but this prevents future breakage

## Test Plan
- [x] `pytest --cov` works locally after pin
- [x] 447 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)