### PR TITLE
docs: M6/M6b/M6c specs + roadmap and master plan update

### DIFF
--- a/docs/plans/2026-04-01-lkm-development-roadmap.md
+++ b/docs/plans/2026-04-01-lkm-development-roadmap.md
@@ -1,7 +1,46 @@
 # LKM 重构开发路线图
 
-**Status:** Active | **Created:** 2026-04-01  
+**Status:** Active | **Created:** 2026-04-01 | **Last updated:** 2026-04-04
 **Goal:** 基于最新 spec (M1-M8) 在 `gaia/lkm/` 下重建 LKM 模块，与上游 `gaia/bp/`、`gaia/gaia_ir/` 解耦
+
+---
+
+## 进度总览
+
+| Milestone | 名称 | 状态 | Spec | PR |
+|-----------|------|------|------|-----|
+| M1 | Data Models | ✅ Done | — | #284 |
+| M2 | Storage Layer | ✅ Done | `2026-04-01-m2-lkm-storage.md` | #284 |
+| M3 | Pipeline A (Gaia IR Lowering) | ✅ Done | — | #288 |
+| M4 | Pipeline B (XML Extraction) | ✅ Done | — | #290 |
+| M5 | Integrate (Local → Global) | ✅ Done | — | #290 |
+| — | Batch Import Pipeline | ✅ Done | `2026-04-03-import-pipeline-hardening.md` | #307 |
+| — | Neo4j Graph Store | ✅ Done | — | #297 |
+| **M6** | **Semantic Discovery** | **Next** | `2026-04-04-m6-semantic-discovery.md` | — |
+| M6b | Relation Analysis | Spec written | `2026-04-04-relation-analysis.md` | — |
+| M6c | Graph Health | Placeholder | `2026-04-04-m6c-graph-health.md` | — |
+| M7 | Global BP | Not started | — | — |
+| M8 | HTTP API | Partial (routes exist) | — | — |
+
+### 依赖关系
+
+```
+M1 → M2 → M3 ─┐
+          M4 ─┤→ M5 → M6 → M6b
+               │         ↘
+               │          M7 → M6c (conflict detection needs BP)
+               │               ↓
+               └──────────── M8
+```
+
+### 额外完成的工作（不在原 M1-M8 计划中）
+
+| 工作 | 说明 | PR |
+|------|------|-----|
+| Batch import pipeline | ByteHouse → TOS → LKM 批量导入，14,157 篇 paper 在 9.5 分钟完成 | #296, #307 |
+| Import pipeline hardening | 统一 logging、ImportStatusRecord、ByteHouse stage filter、batch upsert (merge_insert)、batch IN-clause 查询、幂等导入 | #307 |
+| Neo4j graph store | Global layer 拓扑存储（Variable → Factor → Variable） | #297 |
+| CI coverage fix | pytest --cov=gaia、codecov ignore 配置 | #307 |
 
 ---
 
@@ -265,40 +304,50 @@ python -m gaia.lkm.scripts.test_integrate_e2e
 
 ---
 
-### M6: Curation Discovery — 语义去重 & 冲突检测
+### M6: Semantic Discovery — Embedding + FAISS 聚类
 
-**代码位置：** `gaia/lkm/core/curation.py`  
-**测试位置：** `tests/gaia/lkm/core/test_curation.py`  
-**依赖：** M2 + M5（需要全局图数据）
+**Spec:** `docs/specs/2026-04-04-m6-semantic-discovery.md`  
+**代码位置：** `gaia/lkm/core/discovery.py`, `gaia/lkm/storage/bytehouse_store.py`  
+**测试位置：** `tests/gaia/lkm/core/test_discovery.py`  
+**依赖：** M2 + M5（需要 global graph 数据）
 
 **核心交付：**
-- `curation.py`:
-  - CanonicalizationDiscovery: embedding 相似度 → BindingProposal / EquivalenceProposal
-  - ConflictDetection: BP 诊断 + 结构异常
-  - StructuralAudit: 孤立节点、悬空因子、未解析引用
+- Embedding 生成：dashscope API → ByteHouse `node_embeddings` 表（增量）
+- FAISS 聚类：IndexFlatIP + Union-Find → SemanticCluster 列表
+- 只做发现，不做关系判断
 
-**验证闭环：**
-```bash
-pytest tests/gaia/lkm/core/test_curation.py -v
+**关键技术决策：**
+- Embedding 存 ByteHouse（不存 LanceDB），和上游论文数据统一管理
+- 搜索用 FAISS 内存索引（不用 ByteHouse cosineDistance）
+- 表引擎 HaUniqueMergeTree（和现有 paper_metadata 一致）
 
-# 关键测试点：
-# 1. 两个语义相似但文本不同的 claim → 发现候选
-# 2. 前提重叠高 → BindingProposal
-# 3. 前提独立 → EquivalenceProposal
-# 4. 只处理 public 变量
-# 5. StructuralAudit 检出孤立节点
-```
+---
 
-**前端检查方式：**
-- API `POST /curation/run` → 返回 CurationReport
-- 前端展示发现的候选对和审计结果
+### M6b: Relation Analysis — LLM 关系分析 + Package 生成
 
-**后端 E2E 方式：**
-```bash
-# 摄入多个包后运行 curation：
-python -m gaia.lkm.scripts.run_curation
-# 输出：发现的 binding 候选数、equivalence 候选数、矛盾数、审计警告
-```
+**Spec:** `docs/specs/2026-04-04-relation-analysis.md`  
+**代码位置：** `gaia/lkm/core/relation_analysis.py`  
+**依赖：** M6（clustering 结果）
+
+**核心交付：**
+- 对每个 cluster 做 group-level LLM 关系分析（不是 pairwise）
+- 四种关系类型 → 四种 IR 结构：
+  - Partial overlap → join node + subsumption
+  - Equivalence → common conclusion + equivalence operators
+  - Contradiction → contradiction operators + 可选 join
+  - Unrelated → 丢弃
+- 生成 Gaia Lang package 作为 relation proposal
+
+---
+
+### M6c: Graph Health — 冲突检测 + 结构审计
+
+**Spec:** `docs/specs/2026-04-04-m6c-graph-health.md`（placeholder）  
+**依赖：** M6 + M7（conflict detection 需要 BP 诊断数据）
+
+**核心交付：**
+- Conflict Detection：BP 振荡/高残差信号分析
+- Structural Audit：孤立节点、悬空因子、未解析引用、参数缺失
 
 ---
 
@@ -389,15 +438,17 @@ open http://localhost:8001/docs
 ### 开发顺序
 
 ```
-Phase 1: M1 → M2（基础，顺序执行）
+Phase 1: M1 → M2（基础，顺序执行）                    ✅ Done
          ↓
-Phase 2: M3 + M5（先跑通 Gaia IR → 全局图的端到端流程）
-         M4 可并行或延后
+Phase 2: M3 + M4 + M5 + Batch Import + Neo4j           ✅ Done
          ↓
-Phase 3: M7（全局 BP，有了数据就能推理）
-         M6 可并行或延后
+Phase 3: M6（embedding + clustering）                   ← Next
          ↓
-Phase 4: M8（API 暴露所有功能）
+Phase 4: M6b（LLM 关系分析 + package 生成）
+         M7（全局 BP）可并行
+         ↓
+Phase 5: M6c（conflict detection，依赖 M7）
+         M8（API 暴露所有功能）
 ```
 
 ### 测试策略：E2E 优先，Unit Test 按需

--- a/docs/plans/2026-04-03-import-pipeline-hardening.md
+++ b/docs/plans/2026-04-03-import-pipeline-hardening.md
@@ -1,0 +1,786 @@
+# Import Pipeline Hardening: Logging + ImportStatus + Stage Filter
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the batch import pipeline production-ready: unified logging across all LKM modules, `import_status` table tracking, ByteHouse stage filtering, and completion timestamps.
+
+**Architecture:** Add a `gaia/lkm/logging.py` central config; add `logger = logging.getLogger(__name__)` to every core/storage/pipeline module; add `import_status` schema + model + read/write to storage layer; modify `search_papers()` to JOIN `task_status` for stage filtering; batch-write import_status at the end of `batch_integrate()`.
+
+**Tech Stack:** Python logging (stdlib), LanceDB, ByteHouse (clickhouse-connect)
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `gaia/lkm/logging.py` | Central logging config (console + file handler) |
+| Create | `gaia/lkm/models/import_status.py` | `ImportStatusRecord` Pydantic model |
+| Modify | `gaia/lkm/models/__init__.py` | Re-export `ImportStatusRecord` |
+| Modify | `gaia/lkm/storage/_schemas.py` | Add `IMPORT_STATUS` PyArrow schema to `TABLE_SCHEMAS` |
+| Modify | `gaia/lkm/storage/_serialization.py` | Add `import_status_to_row` / `row_to_import_status` |
+| Modify | `gaia/lkm/storage/lance_store.py` | Add `write_import_status_batch()`, `get_import_status()` |
+| Modify | `gaia/lkm/storage/manager.py` | Expose `write_import_status_batch()`, add logging |
+| Modify | `gaia/lkm/core/extract.py` | Add `logger` with DEBUG-level extraction stats |
+| Modify | `gaia/lkm/core/integrate.py` | Add `logger` with INFO-level dedup/create stats |
+| Modify | `gaia/lkm/storage/source_lance.py` | Add `logger`; modify `search_papers()` to JOIN `task_status` |
+| Modify | `gaia/lkm/pipelines/import_lance.py` | Use `configure_logging()`; batch-write `import_status`; progress log |
+| Modify | `gaia/lkm/api/app.py` | Call `configure_logging()` at startup |
+| Create | `tests/gaia/lkm/test_logging.py` | Test `configure_logging()` |
+| Create | `tests/gaia/lkm/models/test_import_status.py` | Test `ImportStatusRecord` model |
+| Modify | `tests/gaia/lkm/storage/test_lance_store.py` | Test `write_import_status_batch()` |
+| Modify | `tests/gaia/lkm/pipelines/test_import_lance.py` | Test stage filter + import_status write |
+
+---
+
+## Task 1: Unified Logging Config
+
+**Files:**
+- Create: `gaia/lkm/logging.py`
+- Create: `tests/gaia/lkm/test_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/gaia/lkm/test_logging.py
+import logging
+from pathlib import Path
+
+
+def test_configure_logging_console_only():
+    from gaia.lkm.logging import configure_logging
+
+    configure_logging(level="DEBUG")
+    logger = logging.getLogger("gaia.lkm.test")
+    assert logger.getEffectiveLevel() <= logging.DEBUG
+
+
+def test_configure_logging_with_file(tmp_path: Path):
+    from gaia.lkm.logging import configure_logging
+
+    log_file = tmp_path / "test.log"
+    configure_logging(level="INFO", log_file=log_file)
+    logger = logging.getLogger("gaia.lkm.test_file")
+    logger.info("hello")
+    assert log_file.exists()
+    assert "hello" in log_file.read_text()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/gaia/lkm/test_logging.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'gaia.lkm.logging'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# gaia/lkm/logging.py
+"""Unified logging configuration for LKM."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+
+def configure_logging(
+    level: str = "INFO",
+    log_file: Path | None = None,
+) -> None:
+    """Configure logging for all gaia.lkm.* loggers.
+
+    Call once at process startup (CLI entry point or API lifespan).
+    Console handler is always added; file handler is added if log_file is set.
+    """
+    root_logger = logging.getLogger("gaia.lkm")
+    root_logger.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    # Clear existing handlers to allow reconfiguration
+    root_logger.handlers.clear()
+
+    formatter = logging.Formatter(_FORMAT)
+
+    console = logging.StreamHandler()
+    console.setFormatter(formatter)
+    root_logger.addHandler(console)
+
+    if log_file is not None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        fh = logging.FileHandler(log_file)
+        fh.setFormatter(formatter)
+        root_logger.addHandler(fh)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/gaia/lkm/test_logging.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/lkm/logging.py tests/gaia/lkm/test_logging.py
+git commit -m "feat(lkm): add unified logging configuration"
+```
+
+---
+
+## Task 2: ImportStatusRecord Model + Schema + Serialization
+
+**Files:**
+- Create: `gaia/lkm/models/import_status.py`
+- Modify: `gaia/lkm/models/__init__.py`
+- Modify: `gaia/lkm/storage/_schemas.py`
+- Modify: `gaia/lkm/storage/_serialization.py`
+- Create: `tests/gaia/lkm/models/test_import_status.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/gaia/lkm/models/test_import_status.py
+from datetime import datetime, timezone
+
+
+def test_import_status_record_defaults():
+    from gaia.lkm.models import ImportStatusRecord
+
+    r = ImportStatusRecord(
+        package_id="paper:12345",
+        status="ingested",
+        variable_count=10,
+        factor_count=3,
+        prior_count=8,
+        factor_param_count=2,
+    )
+    assert r.package_id == "paper:12345"
+    assert r.status == "ingested"
+    assert r.variable_count == 10
+    assert isinstance(r.started_at, datetime)
+    assert isinstance(r.completed_at, datetime)
+
+
+def test_import_status_roundtrip():
+    from gaia.lkm.models import ImportStatusRecord
+    from gaia.lkm.storage._serialization import import_status_to_row, row_to_import_status
+
+    r = ImportStatusRecord(
+        package_id="paper:99",
+        status="ingested",
+        variable_count=5,
+        factor_count=2,
+        prior_count=4,
+        factor_param_count=1,
+    )
+    row = import_status_to_row(r)
+    assert isinstance(row["started_at"], str)
+    back = row_to_import_status(row)
+    assert back.package_id == r.package_id
+    assert back.variable_count == r.variable_count
+    assert back.prior_count == r.prior_count
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/gaia/lkm/models/test_import_status.py -v`
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 3: Write ImportStatusRecord model**
+
+```python
+# gaia/lkm/models/import_status.py
+"""Import status tracking model."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ImportStatusRecord(BaseModel):
+    """Tracks the import status of a single package (paper) into LKM."""
+
+    package_id: str
+    status: str  # "ingested" | "failed:<reason>"
+    variable_count: int = 0
+    factor_count: int = 0
+    prior_count: int = 0
+    factor_param_count: int = 0
+    started_at: datetime = Field(default_factory=_utcnow)
+    completed_at: datetime = Field(default_factory=_utcnow)
+    error: str = ""
+```
+
+- [ ] **Step 4: Add re-export in `gaia/lkm/models/__init__.py`**
+
+Add to imports:
+
+```python
+from gaia.lkm.models.import_status import ImportStatusRecord
+```
+
+Add `"ImportStatusRecord"` to `__all__`.
+
+- [ ] **Step 5: Add PyArrow schema in `_schemas.py`**
+
+Add after `PARAM_SOURCES`:
+
+```python
+IMPORT_STATUS = pa.schema(
+    [
+        pa.field("package_id", pa.string()),
+        pa.field("status", pa.string()),
+        pa.field("variable_count", pa.int32()),
+        pa.field("factor_count", pa.int32()),
+        pa.field("prior_count", pa.int32()),
+        pa.field("factor_param_count", pa.int32()),
+        pa.field("started_at", pa.string()),
+        pa.field("completed_at", pa.string()),
+        pa.field("error", pa.string()),
+    ]
+)
+```
+
+Add `"import_status": IMPORT_STATUS` to `TABLE_SCHEMAS`.
+
+- [ ] **Step 6: Add serialization functions in `_serialization.py`**
+
+```python
+from gaia.lkm.models.import_status import ImportStatusRecord
+
+def import_status_to_row(r: ImportStatusRecord) -> dict:
+    return {
+        "package_id": r.package_id,
+        "status": r.status,
+        "variable_count": r.variable_count,
+        "factor_count": r.factor_count,
+        "prior_count": r.prior_count,
+        "factor_param_count": r.factor_param_count,
+        "started_at": r.started_at.isoformat(),
+        "completed_at": r.completed_at.isoformat(),
+        "error": r.error,
+    }
+
+
+def row_to_import_status(row: dict) -> ImportStatusRecord:
+    return ImportStatusRecord(
+        package_id=row["package_id"],
+        status=row["status"],
+        variable_count=row["variable_count"],
+        factor_count=row["factor_count"],
+        prior_count=row["prior_count"],
+        factor_param_count=row["factor_param_count"],
+        started_at=datetime.fromisoformat(row["started_at"]),
+        completed_at=datetime.fromisoformat(row["completed_at"]),
+        error=row.get("error", ""),
+    )
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pytest tests/gaia/lkm/models/test_import_status.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add gaia/lkm/models/import_status.py gaia/lkm/models/__init__.py \
+    gaia/lkm/storage/_schemas.py gaia/lkm/storage/_serialization.py \
+    tests/gaia/lkm/models/test_import_status.py
+git commit -m "feat(lkm): add ImportStatusRecord model, schema, and serialization"
+```
+
+---
+
+## Task 3: Storage Layer — import_status Read/Write
+
+**Files:**
+- Modify: `gaia/lkm/storage/lance_store.py`
+- Modify: `gaia/lkm/storage/manager.py`
+- Modify: `tests/gaia/lkm/storage/test_lance_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/gaia/lkm/storage/test_lance_store.py`:
+
+```python
+async def test_write_and_read_import_status(storage: StorageManager):
+    """Batch write import_status records and read them back."""
+    from gaia.lkm.models import ImportStatusRecord
+
+    records = [
+        ImportStatusRecord(
+            package_id="paper:aaa",
+            status="ingested",
+            variable_count=10,
+            factor_count=3,
+            prior_count=8,
+            factor_param_count=2,
+        ),
+        ImportStatusRecord(
+            package_id="paper:bbb",
+            status="failed:download",
+            variable_count=0,
+            factor_count=0,
+            prior_count=0,
+            factor_param_count=0,
+            error="TOS timeout",
+        ),
+    ]
+    await storage.write_import_status_batch(records)
+
+    result = await storage.get_import_status("paper:aaa")
+    assert result is not None
+    assert result.status == "ingested"
+    assert result.variable_count == 10
+
+    result2 = await storage.get_import_status("paper:bbb")
+    assert result2 is not None
+    assert result2.status == "failed:download"
+
+    missing = await storage.get_import_status("paper:zzz")
+    assert missing is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/gaia/lkm/storage/test_lance_store.py::test_write_and_read_import_status -v`
+Expected: FAIL — `AttributeError: 'StorageManager' has no attribute 'write_import_status_batch'`
+
+- [ ] **Step 3: Add methods to `LanceContentStore`**
+
+In `gaia/lkm/storage/lance_store.py`, add imports:
+
+```python
+from gaia.lkm.models.import_status import ImportStatusRecord
+from gaia.lkm.storage._serialization import import_status_to_row, row_to_import_status
+```
+
+Add methods to `LanceContentStore`:
+
+```python
+async def write_import_status_batch(self, records: list[ImportStatusRecord]) -> None:
+    """Batch write import status records."""
+    if not records:
+        return
+    table = self._db.open_table("import_status")
+    rows = [import_status_to_row(r) for r in records]
+    await self._run(table.add, rows)
+
+async def get_import_status(self, package_id: str) -> ImportStatusRecord | None:
+    table = self._db.open_table("import_status")
+    escaped = _q(package_id)
+    results = await self._run(
+        lambda: table.search().where(f"package_id = '{escaped}'").limit(1).to_list()
+    )
+    return row_to_import_status(results[0]) if results else None
+```
+
+- [ ] **Step 4: Expose via `StorageManager`**
+
+In `gaia/lkm/storage/manager.py`, add import and methods:
+
+```python
+from gaia.lkm.models.import_status import ImportStatusRecord
+
+async def write_import_status_batch(self, records: list[ImportStatusRecord]) -> None:
+    await self.content.write_import_status_batch(records)
+
+async def get_import_status(self, package_id: str) -> ImportStatusRecord | None:
+    return await self.content.get_import_status(package_id)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/gaia/lkm/storage/test_lance_store.py::test_write_and_read_import_status -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/lkm/storage/lance_store.py gaia/lkm/storage/manager.py \
+    tests/gaia/lkm/storage/test_lance_store.py
+git commit -m "feat(lkm): add import_status batch write and read to storage layer"
+```
+
+---
+
+## Task 4: ByteHouse Stage Filtering
+
+**Files:**
+- Modify: `gaia/lkm/storage/source_lance.py`
+- Modify: `tests/gaia/lkm/pipelines/test_import_lance.py`
+
+- [ ] **Step 1: Modify `search_papers()` to JOIN `task_status`**
+
+In `gaia/lkm/storage/source_lance.py`, replace `search_papers()`:
+
+```python
+def search_papers(
+    client: Any,
+    *,
+    keywords: str | None = None,
+    areas: str | None = None,
+    require_stages: tuple[str, ...] = (
+        "is_extract_conclusion",
+        "is_extract_reasoning",
+        "is_review",
+    ),
+    limit: int = 1000,
+) -> list[dict]:
+    """Search papers in ByteHouse, filtered by extraction stage completion.
+
+    Joins paper_metadata with task_status to ensure only papers with
+    all required stages completed are returned.
+
+    Args:
+        client: clickhouse-connect client.
+        keywords: Token search on en_title.
+        areas: Filter by areas partition.
+        require_stages: Stage columns that must be true in task_status.
+        limit: Max results.
+    """
+    where_parts = []
+    if keywords:
+        safe_kw = keywords.replace("'", "\\'")
+        where_parts.append(f"hasTokens(m.en_title, '{safe_kw}')")
+    if areas:
+        safe_areas = areas.replace("'", "\\'")
+        where_parts.append(f"m.areas = '{safe_areas}'")
+    for stage in require_stages:
+        where_parts.append(f"t.{stage} = true")
+
+    where_clause = " AND ".join(where_parts) if where_parts else "1=1"
+
+    sql = (
+        f"SELECT m.id, m.doi, m.en_title, m.areas\n"
+        f"FROM paper_data.paper_metadata m\n"
+        f"JOIN paper_data.task_status t ON toString(m.id) = t.pdf_id\n"
+        f"WHERE {where_clause}\n"
+        f"ORDER BY m.id DESC\n"
+        f"LIMIT {limit}\n"
+        f"SETTINGS enable_inverted_index_push_down = 1, "
+        f"enable_optimizer = 0, optimize_lazy_materialization = 1"
+    )
+
+    result = client.query(sql)
+    rows = result.result_rows
+    columns = result.column_names
+    return [dict(zip(columns, row)) for row in rows]
+```
+
+- [ ] **Step 2: Update existing test to match new signature**
+
+Check `tests/gaia/lkm/pipelines/test_import_lance.py` — if it mocks `search_papers`, update the mock to accept the new `require_stages` kwarg. The default value means existing callers don't break.
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `pytest tests/gaia/lkm/pipelines/test_import_lance.py -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lkm/storage/source_lance.py tests/gaia/lkm/pipelines/test_import_lance.py
+git commit -m "feat(lkm): filter ByteHouse papers by stage completion via task_status JOIN"
+```
+
+---
+
+## Task 5: Add Logging to Core + Storage Modules
+
+**Files:**
+- Modify: `gaia/lkm/core/extract.py`
+- Modify: `gaia/lkm/core/integrate.py`
+- Modify: `gaia/lkm/storage/manager.py`
+- Modify: `gaia/lkm/storage/source_lance.py`
+
+No new tests needed — logging doesn't change behavior. Verify existing tests still pass.
+
+- [ ] **Step 1: Add logger to `core/extract.py`**
+
+At top of file (after imports):
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+At end of `extract()` function, before `return result`:
+
+```python
+logger.debug(
+    "Extracted paper %s: %d variables, %d factors, %d priors, %d factor_params",
+    metadata_id,
+    len(result.local_variables),
+    len(result.local_factors),
+    len(result.prior_records),
+    len(result.factor_param_records),
+)
+```
+
+- [ ] **Step 2: Add logger to `core/integrate.py`**
+
+At top of file (after imports):
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+At end of `integrate()`, before `return result`:
+
+```python
+logger.info(
+    "Integrated %s: %d new globals, %d matched, %d new factors, %d unresolved",
+    package_id,
+    len(result.new_global_variables),
+    len(result.updated_global_variables),
+    len(result.new_global_factors),
+    len(result.unresolved_cross_refs),
+)
+```
+
+At end of `batch_integrate()`, before `return stats`:
+
+```python
+logger.info(
+    "Batch integrated %d packages: %d new global vars, %d new global factors, "
+    "%d dedup within batch, %d dedup with existing, %d unresolved",
+    stats.packages,
+    stats.new_global_variables,
+    stats.new_global_factors,
+    stats.dedup_within_batch,
+    stats.dedup_with_existing,
+    len(stats.unresolved_cross_refs),
+)
+```
+
+- [ ] **Step 3: Add logger to `storage/manager.py`**
+
+At top (after imports):
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+Add timing log to `ingest_local_graph`:
+
+```python
+async def ingest_local_graph(self, ...) -> None:
+    logger.info(
+        "Ingesting local graph %s@%s: %d variables, %d factors",
+        package_id, version, len(variable_nodes), len(factor_nodes),
+    )
+    ...  # existing code
+```
+
+Add timing log to `integrate_global_graph`:
+
+```python
+async def integrate_global_graph(self, ...) -> None:
+    logger.info(
+        "Integrating global graph: %d variables, %d factors, %d bindings",
+        len(variable_nodes), len(factor_nodes), len(bindings),
+    )
+    ...  # existing code
+```
+
+- [ ] **Step 4: Add logger to `storage/source_lance.py`**
+
+At top (after imports):
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+In `download_paper_xmls`, log per-paper failures at WARNING and batch summary at INFO:
+
+```python
+# After the download loop, before return:
+downloaded_count = sum(1 for v in results.values() if v is not None)
+failed_count = sum(1 for v in results.values() if v is None)
+logger.info("Downloaded XMLs: %d succeeded, %d failed (of %d)", downloaded_count, failed_count, len(paper_ids))
+```
+
+In `_download_one`, existing failures are silent — add at the per-paper level:
+
+```python
+# Where results[pid] = None:
+except Exception:
+    logger.warning("Download failed for paper %s", pid, exc_info=True)
+    results[pid] = None
+```
+
+- [ ] **Step 5: Run all LKM tests**
+
+Run: `pytest tests/gaia/lkm/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/lkm/core/extract.py gaia/lkm/core/integrate.py \
+    gaia/lkm/storage/manager.py gaia/lkm/storage/source_lance.py
+git commit -m "feat(lkm): add structured logging to core, storage, and source modules"
+```
+
+---
+
+## Task 6: Wire Everything into `import_lance.py`
+
+**Files:**
+- Modify: `gaia/lkm/pipelines/import_lance.py`
+- Modify: `tests/gaia/lkm/pipelines/test_import_lance.py`
+
+- [ ] **Step 1: Update `import_lance.py`**
+
+Replace `logging.basicConfig(...)` in `main()` with:
+
+```python
+from gaia.lkm.logging import configure_logging
+
+configure_logging(level="INFO", log_file=args.output_dir / "import.log")
+```
+
+After `batch_integrate` succeeds (the `if extraction_results:` block), batch-write import_status:
+
+```python
+from datetime import datetime, timezone
+from gaia.lkm.models import ImportStatusRecord
+
+# After batch_result is computed, before checkpointing:
+status_records = []
+for pid, ext_result in zip(extracted_ids, extraction_results):
+    status_records.append(
+        ImportStatusRecord(
+            package_id=ext_result.package_id,
+            status="ingested",
+            variable_count=len(ext_result.local_variables),
+            factor_count=len(ext_result.local_factors),
+            prior_count=len(ext_result.prior_records),
+            factor_param_count=len(ext_result.factor_param_records),
+            started_at=batch_started_at,  # capture datetime before the loop
+            completed_at=datetime.now(timezone.utc),
+        )
+    )
+await storage.write_import_status_batch(status_records)
+logger.info("Wrote %d import_status records", len(status_records))
+```
+
+Also record `batch_started_at = datetime.now(timezone.utc)` at the top of `run_batch_import()`.
+
+Add a progress log every 100 papers during extraction:
+
+```python
+for i, pid in enumerate(pending):
+    if i > 0 and i % 100 == 0:
+        logger.info("Extraction progress: %d/%d papers", i, len(pending))
+    ...
+```
+
+Also write failed statuses to import_status:
+
+```python
+# Where a paper fails download or extraction:
+failed_statuses.append(
+    ImportStatusRecord(
+        package_id=f"paper:{pid}",
+        status=f"failed:{reason}",
+        error=str(e) if e else "",
+        started_at=batch_started_at,
+        completed_at=datetime.now(timezone.utc),
+    )
+)
+```
+
+Then batch-write failed statuses after the main loop:
+
+```python
+if failed_statuses:
+    await storage.write_import_status_batch(failed_statuses)
+```
+
+- [ ] **Step 2: Update test**
+
+In `tests/gaia/lkm/pipelines/test_import_lance.py`, verify that after a mock run, `import_status` table has the expected records. This depends on the existing test structure — adapt the existing mocked test to assert `storage.get_import_status(...)` returns a record.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/gaia/lkm/pipelines/test_import_lance.py -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lkm/pipelines/import_lance.py tests/gaia/lkm/pipelines/test_import_lance.py
+git commit -m "feat(lkm): wire logging + import_status into batch import pipeline"
+```
+
+---
+
+## Task 7: Wire Logging into API
+
+**Files:**
+- Modify: `gaia/lkm/api/app.py`
+
+- [ ] **Step 1: Add `configure_logging()` call in lifespan**
+
+```python
+from gaia.lkm.logging import configure_logging
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    configure_logging()
+    ...  # existing code
+```
+
+- [ ] **Step 2: Run existing API tests if any, else run full suite**
+
+Run: `pytest tests/gaia/lkm/ -v`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gaia/lkm/api/app.py
+git commit -m "feat(lkm): wire unified logging into API startup"
+```
+
+---
+
+## Task 8: Final Verification + Lint
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+pytest tests/gaia/lkm/ -v
+```
+
+- [ ] **Step 2: Run ruff lint + format**
+
+```bash
+ruff check gaia/lkm/ tests/gaia/lkm/
+ruff format --check gaia/lkm/ tests/gaia/lkm/
+```
+
+- [ ] **Step 3: Fix any lint/format errors**
+
+- [ ] **Step 4: Final commit if needed, then push and create PR**
+
+```bash
+git push -u origin feat/lkm-import-pipeline-hardening
+gh pr create --title "feat(lkm): import pipeline hardening — logging, import_status, stage filter" --body "..."
+```

--- a/docs/specs/2026-03-31-lkm-master-plan.md
+++ b/docs/specs/2026-03-31-lkm-master-plan.md
@@ -123,26 +123,33 @@ global_factor_nodes:
 ## 四、模块拆分与执行顺序
 
 ```
-Phase 1（基础）
+Phase 1（基础）                                          ✅ Done
   [M1] LKM 数据模型（Pydantic models）
-  [M2] Storage layer（LanceDB + Neo4j/Kuzu + StorageManager）
+  [M2] Storage layer（LanceDB + Neo4j + StorageManager）
     └── 依赖 M1
 
-Phase 2（Ingest，M1+M2 完成后可并行）
+Phase 2（Ingest）                                         ✅ Done
   [M3] Pipeline A：Gaia IR lowering
     └── 依赖 M1
   [M4] Pipeline B：XML extraction
     └── 依赖 M1
   [M5] Integrate（dedup + CanonicalBinding + 写入）
-    └── 依赖 M1 + M2 + M3（M4 可后接）
+    └── 依赖 M1 + M2 + M3/M4
+  [—] Batch import pipeline + Neo4j graph store
 
-Phase 3（推理）
-  [M6] Curation Discovery（异步）
+Phase 3（语义发现）                                       ← Next
+  [M6] Semantic Discovery（embedding + FAISS clustering）
     └── 依赖 M2 + M5
+  [M6b] Relation Analysis（LLM group 分析 + package 生成）
+    └── 依赖 M6
+
+Phase 4（推理）
   [M7] Global BP
     └── 依赖 M2 + M5
+  [M6c] Graph Health（conflict detection + structural audit）
+    └── 依赖 M6 + M7
 
-Phase 4（对外）
+Phase 5（对外）
   [M8] HTTP API
     └── 依赖 M2 + M5（M6/M7 可选）
 ```
@@ -317,34 +324,44 @@ Phase 4（对外）
 
 ---
 
-### M6 — Curation Discovery
+### M6 — Semantic Discovery（Embedding + Clustering）
 
-**设计文档**：`docs/foundations/lkm/04-curation.md`
+**Spec**：`docs/specs/2026-04-04-m6-semantic-discovery.md`
 
-**职责**：异步批量发现语义重复、冲突、结构问题，产出结构化提案报告。**不直接修改 global graph**。
+**职责**：对 global variable nodes 生成 embedding，通过 FAISS 向量相似度聚类，输出语义相似的 variable 组。**只做发现，不做关系判断。**
 
-**三个发现任务**：
+**关键技术决策**：
+- Embedding 存 ByteHouse `node_embeddings` 表（不存 LanceDB）
+- 搜索用 FAISS 内存索引（IndexFlatIP + Union-Find）
+- Embedding API：`https://openapi.dp.tech/openapi/v1/test/vectorize`（dashscope，512 维）
 
-1. **Canonicalization（语义去重）**：
-   - Embedding 余弦相似度 > 0.90 → 等价候选
-   - 同 type + 参数结构匹配（对齐 `05-canonicalization.md §4`）
-   - 共享 premises → Binding 提案；独立 premises → Equivalence 提案
+---
 
-2. **Conflict Detection**：
-   - BP 诊断：振荡 / 高残差 → 矛盾候选 → Contradiction 提案
-   - 拓扑异常（不一致的 instantiation 关系等）
+### M6b — Relation Analysis（LLM 关系分析 + Package 生成）
 
-3. **Structural Audit**：
-   - 孤立 variable nodes、悬空 factor 引用、unresolved_cross_refs
+**Spec**：`docs/specs/2026-04-04-relation-analysis.md`
+
+**职责**：对 M6 输出的每个 cluster 做 group-level LLM 关系分析（不是 pairwise），根据关系类型生成 Gaia Lang package 作为 relation proposal。
+
+**四种 group 关系类型**：
+- **Partial Overlap** → 新建 join node，每个结论 subsume join
+- **Equivalence** → 新建 common conclusion，equivalence operators
+- **Contradiction** → contradiction operators + 可选 join
+- **Unrelated** → 丢弃
 
 **上游参考**：
-- `Gaia/docs/foundations/ecosystem/05-review-and-curation.md`：curation package 流程、LKM 与 registry 的分工
-- `Gaia/docs/foundations/gaia-ir/05-canonicalization.md §2`：Binding vs Equivalence 判断逻辑
+- `propositional_logic_analysis/clustering/prompts/join_symmetric.md`：prompt 写法参考
+- `Gaia/docs/foundations/gaia-ir/05-canonicalization.md §2`：Binding vs Equivalence 语义
 
-**旧代码参考**：
-- `propositional_logic_analysis/clustering/src/clustering.py`：贪心余弦相似度聚类、ANN（LSH）实现，可参考 embedding 搜索加速思路
-- `propositional_logic_analysis/clustering/src/faiss_clusterer.py`：FAISS 封装参考
-- LanceDB vector search（`table.search(query_vector).limit(k)`）作为简单实现起点
+---
+
+### M6c — Graph Health（Conflict Detection + Structural Audit）
+
+**Spec**：`docs/specs/2026-04-04-m6c-graph-health.md`（placeholder）
+
+**职责**：图健康检查。依赖 M7（conflict detection 需要 BP 诊断数据）。
+- Conflict Detection：BP 振荡/高残差信号
+- Structural Audit：孤立节点、悬空因子、未解析引用
 
 ---
 
@@ -400,16 +417,19 @@ Phase 4（对外）
 
 ## 六、各模块对应 Spec 文件
 
-| 模块 | Spec 文件（待创建） |
-|------|-------------------|
-| M1 数据模型 | `2026-03-31-m1-data-models.md` |
-| M2 Storage layer | `2026-03-31-m2-storage.md` |
-| M3 Pipeline A (Lowering) | `2026-03-31-m3-pipeline-a.md` |
-| M4 Pipeline B (XML) | `2026-03-31-m4-pipeline-b.md` |
-| M5 Integrate | `2026-03-31-m5-integrate.md` |
-| M6 Curation Discovery | `2026-03-31-m6-curation.md` |
-| M7 Global BP | `2026-03-31-m7-global-bp.md` |
-| M8 HTTP API | `2026-03-31-m8-api.md` |
+| 模块 | Spec 文件 | 状态 |
+|------|----------|------|
+| M1 数据模型 | （内嵌于 master plan） | ✅ Done |
+| M2 Storage layer | `2026-04-01-m2-lkm-storage.md` | ✅ Done |
+| M3 Pipeline A (Lowering) | （内嵌于 master plan） | ✅ Done |
+| M4 Pipeline B (XML) | （内嵌于 master plan） | ✅ Done |
+| M5 Integrate | （内嵌于 master plan） | ✅ Done |
+| — Batch Import Hardening | `2026-04-03-import-pipeline-hardening.md` | ✅ Done |
+| M6 Semantic Discovery | `2026-04-04-m6-semantic-discovery.md` | **Next** |
+| M6b Relation Analysis | `2026-04-04-relation-analysis.md` | Spec written |
+| M6c Graph Health | `2026-04-04-m6c-graph-health.md` | Placeholder |
+| M7 Global BP | 待创建 | Not started |
+| M8 HTTP API | 待创建 | Partial |
 
 ---
 

--- a/docs/specs/2026-04-04-m6-semantic-discovery.md
+++ b/docs/specs/2026-04-04-m6-semantic-discovery.md
@@ -1,0 +1,258 @@
+# M6 — Semantic Discovery Spec
+
+> **Status:** Draft
+> **Date:** 2026-04-04
+> **Supersedes:** `2026-03-31-m6-curation.md`（scope 缩减，只保留 embedding + clustering）
+
+## 概述
+
+M6 专注于**语义聚类发现**：对 global FactorGraph 中所有 public variable nodes 生成 embedding，通过 FAISS 向量相似度搜索找到语义相似的 variable 组（cluster），输出结构化的聚类结果。
+
+**M6 只做发现，不做判断。** 聚类结果交给下游 spec（Relation Analysis）来用 LLM 分析 cluster 内 variable 之间的具体关系（subsumption / equivalence / contradiction / unrelated），并生成 Gaia Lang package 提交 proposal。
+
+**不在 M6 scope 内的：**
+- Binding / Equivalence / Contradiction 的具体判断 → 后续 Relation Analysis spec
+- ConflictDetection（BP 诊断信号）→ 后续 spec
+- StructuralAudit（孤立节点、悬空因子）→ 后续 spec
+- Curation 包的生成和提交 → 后续 spec
+
+M6 依赖 M2（存储层）+ M5（integrate 完成后的 global graph）。
+
+## 上游参考
+
+- `propositional_logic_analysis/clustering/`：FAISS 聚类 + embedding 参考实现
+- `propositional_logic_analysis/clustering/prompts/join_symmetric.md`：关系分类 prompt（下游 spec 参考）
+
+---
+
+## 数据流
+
+```
+┌──────────────┐     gcn_ids needing    ┌──────────────┐
+│   LanceDB    │     embedding          │  Embedding   │
+│              │ ─────────────────────► │    API       │
+│ global vars  │                        │  (dashscope) │
+│ local vars   │     content text       │              │
+│ (content)    │ ─────────────────────► │              │
+└──────────────┘                        └──────┬───────┘
+                                               │ vectors
+                                               ▼
+                                        ┌──────────────┐
+                                        │  ByteHouse   │
+                                        │              │
+                                        │ node_        │
+                                        │  embeddings  │
+                                        └──────┬───────┘
+                                               │ load all
+                                               │ embeddings
+                                               ▼
+                                        ┌──────────────┐
+                                        │    FAISS     │
+                                        │  clustering  │
+                                        │              │
+                                        │ IndexFlatIP  │
+                                        │ + UnionFind  │
+                                        └──────┬───────┘
+                                               │
+                                               ▼
+                                        ┌──────────────┐
+                                        │   Clusters   │
+                                        │              │
+                                        │ [{gcn_ids},  │
+                                        │  {gcn_ids},  │
+                                        │  ...]        │
+                                        └──────────────┘
+```
+
+---
+
+## 三个系统的职责
+
+| 系统 | 存什么 | M6 中的查询 |
+|------|--------|------------|
+| **LanceDB** | LKM 结构化数据 | 获取 public global variable 列表 + content（通过 representative_lcn 回查 local） |
+| **ByteHouse** | `node_embeddings` 表 | 存取 embedding 向量 |
+| **FAISS** | 内存索引（不持久化） | ANN search + Union-Find 聚类 |
+
+---
+
+## Step 1: Embedding 生成与存储
+
+**触发时机：** integrate 完成后，对新增的 global variable nodes 生成 embedding。
+
+**流程：**
+
+1. 从 LanceDB 获取所有 `visibility="public"` 的 global variable gcn_ids
+2. 从 ByteHouse 查已有 embedding 的 gcn_ids，取差集得到 pending
+3. 对 pending gcn_ids，从 LanceDB 回查 content（通过 `representative_lcn` → `local_variable_nodes.content`）
+4. 调用 embedding API 生成 512 维向量
+5. 批量写入 ByteHouse `node_embeddings` 表
+
+**Embedding API：**
+- URL: `https://openapi.dp.tech/openapi/v1/test/vectorize`
+- Auth: `accessKey` header（env: `ACCESS_KEY`）
+- Request: `{"text": "...", "provider": "dashscope"}`
+- Response: `{"data": {"vector": [float * 512]}}`
+- 维度: 512
+
+**并发控制（参考 propositional_logic_analysis）：**
+- `asyncio.gather()` + `Semaphore(N)`
+- 专用 writer 线程做 ByteHouse 批量写入，避免阻塞 embedding 计算
+- 失败重试（3 次 + exponential backoff）
+
+**ByteHouse 表结构：**
+
+```sql
+CREATE TABLE paper_data.node_embeddings (
+    gcn_id        String,
+    content       String,
+    node_type     String,      -- "claim" | "question" | "setting" | "action"
+    embedding     Array(Float32),
+    source_id     String,      -- embedding model identifier
+    created_at    DateTime DEFAULT now()
+) ENGINE = HaUniqueMergeTree(...)
+ORDER BY gcn_id
+UNIQUE KEY gcn_id
+SETTINGS index_granularity = 128
+```
+
+---
+
+## Step 2: FAISS 聚类
+
+**参考实现：** `propositional_logic_analysis/clustering/src/faiss_clusterer.py`
+
+**算法：**
+
+1. 从 ByteHouse 批量加载 embedding（按 `node_type` 分组，只处理同类型）
+2. 构建 FAISS `IndexFlatIP`（内积 = 归一化向量上的 cosine similarity）
+3. 对每个 variable 做 k-NN search（`k` 默认 100）
+4. Union-Find 合并：similarity > `threshold` 的 pair 合并到同一组
+5. 提取连通分量 = 语义聚类
+
+**过滤约束（参考 propositional_logic_analysis）：**
+- **仅同类型比较**：claim 只和 claim 聚，question 只和 question 聚
+- **`exclude_same_factor`**：同一个 factor 的 premise 和 conclusion 不互聚（需从 Neo4j 查拓扑）
+- **`max_cluster_size`**：单个 cluster 上限（默认 20），防止 mega-cluster
+- **排除已知 binding**：已有 CanonicalBinding 的 pair 跳过（已经在 integrate 阶段处理过）
+
+**Union-Find 选择理由（vs k-means / DBSCAN）：**
+- 不需要预设聚类数
+- 自然处理传递性（A 近 B、B 近 C → ABC 同组）
+- 和 propositional_logic_analysis 的方法一致
+
+---
+
+## 输出
+
+```python
+@dataclass
+class SemanticCluster:
+    cluster_id: str                   # 自动生成
+    node_type: str                    # "claim" | "question" | ...
+    gcn_ids: list[str]                # cluster 内的 global variable ids
+    centroid_gcn_id: str              # 离质心最近的 variable（cluster 代表）
+    avg_similarity: float             # cluster 内平均 pairwise 相似度
+    min_similarity: float             # cluster 内最小 pairwise 相似度
+
+@dataclass
+class ClusteringResult:
+    clusters: list[SemanticCluster]
+    stats: ClusteringStats
+    timestamp: datetime
+
+@dataclass
+class ClusteringStats:
+    total_variables_scanned: int      # 参与聚类的 variable 总数
+    total_embeddings_computed: int    # 本次新计算的 embedding 数
+    total_clusters: int
+    cluster_size_distribution: dict[int, int]  # size → count
+    elapsed_seconds: float
+```
+
+---
+
+## 实现文件结构
+
+```
+gaia/lkm/core/
+    discovery.py             # run_semantic_discovery() 主函数
+    _embedding.py            # embedding 生成 + ByteHouse 读写
+    _clustering.py           # FAISS 聚类 + Union-Find
+
+gaia/lkm/models/
+    discovery.py             # SemanticCluster, ClusteringResult, ClusteringStats
+
+gaia/lkm/storage/
+    bytehouse_store.py       # ByteHouseEmbeddingStore: CRUD + 批量加载
+```
+
+---
+
+## 配置参数
+
+```python
+@dataclass
+class DiscoveryConfig:
+    # Embedding
+    embedding_api_url: str = "https://openapi.dp.tech/openapi/v1/test/vectorize"
+    embedding_provider: str = "dashscope"
+    embedding_dim: int = 512
+    embedding_concurrency: int = 24  # semaphore limit for async API calls
+
+    # Clustering
+    similarity_threshold: float = 0.85
+    faiss_k: int = 100              # k-NN search top-k
+    max_cluster_size: int = 20
+    exclude_same_factor: bool = True
+
+    # FAISS index type
+    faiss_index_type: str = "flat"  # "flat" (exact) or "ivf" (approximate)
+```
+
+---
+
+## 关键约束
+
+1. **M6 只做聚类发现，不做关系判断** — 不判断 binding/equivalence/contradiction
+2. **仅 public variable 参与**：private variable 不参与
+3. **相同 type 才聚类**：claim 只和 claim 聚
+4. **Embedding 存 ByteHouse**：不存 LanceDB
+5. **增量计算**：只对新增 variable 生成 embedding，不重算已有的
+6. **FAISS 在内存中运行**：不持久化索引，每次运行重建
+
+---
+
+## 测试要求
+
+### 单元测试
+
+- `test_embedding_api_call`：content → embedding 向量，维度 512
+- `test_incremental_embedding`：只对新增 variable 计算 embedding
+- `test_clustering_similar_pairs`：相似 variable pair 在同一 cluster
+- `test_clustering_dissimilar_separate`：不相似的 variable 在不同 cluster
+- `test_type_filter`：不同 type 不聚类
+- `test_private_excluded`：private variable 不参与
+- `test_max_cluster_size`：单个 cluster 不超过上限
+- `test_exclude_same_factor`：同 factor 的节点不互聚
+
+### 集成测试
+
+- `test_full_discovery_pipeline`：从 fixture 数据跑完整发现流程
+- `test_idempotent_discovery`：跑两次结果一致（同样的 embedding + 同样的阈值）
+
+---
+
+## 下游消费者（后续 Relation Analysis spec）
+
+M6 输出的 `ClusteringResult` 交给下游处理：
+
+1. 对每个 cluster，加载各 variable 的 content
+2. 用 LLM 做 pairwise 关系分类（参考 `join_symmetric.md` 的四种关系）：
+   - **Subsumption**（蕴含）：A entails B → 建立层级
+   - **Partial Overlap**（部分重叠）→ 创建 join/abstract node
+   - **Contradiction**（矛盾）→ 标记冲突
+   - **Unrelated**（无关）→ 跳过（clustering 误匹配）
+3. 生成 Gaia Lang package，以 relation proposal 的形式提交到 registry
+
+这部分不在 M6 scope 内，将在独立 spec 中定义。

--- a/docs/specs/2026-04-04-m6c-graph-health.md
+++ b/docs/specs/2026-04-04-m6c-graph-health.md
@@ -1,0 +1,73 @@
+# M6c — Graph Health: Conflict Detection + Structural Audit
+
+> **Status:** Placeholder
+> **Date:** 2026-04-04
+> **依赖:** M6 (Semantic Discovery) + M7 (Global BP, for conflict detection)
+
+## 概述
+
+M6c 负责 global FactorGraph 的健康检查，包含两个独立的子任务：
+
+1. **Conflict Detection** — 从 BP 推理结果中发现矛盾信号
+2. **Structural Audit** — 检查图的结构完整性
+
+从原 `2026-03-31-m6-curation.md` 拆出，M6 只保留 embedding + clustering，M6b 做关系分析，M6c 做图健康检查。
+
+---
+
+## 1. Conflict Detection
+
+**依赖：** M7 Global BP（需要 BP 运行后的诊断数据）
+
+**BP 诊断信号：**
+- 振荡（`direction_changes` 高）→ variable 从图的不同部分接收矛盾证据
+- 高残差（`max_residual` 大）→ BP 未收敛，可能存在结构冲突
+- 语义矛盾：M6b 已经标记的 contradiction + BP 信念值一高一低的 pair
+
+**输出：**
+```python
+@dataclass
+class ConflictReport:
+    oscillating_variables: list[dict]    # gcn_id + direction_changes
+    high_residual_variables: list[dict]  # gcn_id + residual value
+    semantic_conflicts: list[dict]       # 高相似 + prior 差异大
+```
+
+## 2. Structural Audit
+
+**无额外依赖，可随时运行。**
+
+**检查项：**
+- **孤立 variable**：无任何 factor 连接的 gcn_id（Neo4j 查询）
+- **悬空 factor**：premise 或 conclusion 指向不存在 variable 的 gfac_id
+- **未解析跨包引用**：integrate 时 pending 的 cross-ref
+- **参数缺失**：有 factor 但无对应 FactorParamRecord
+- **Prior 缺失**：public variable 无 PriorRecord
+
+**输出：**
+```python
+@dataclass
+class AuditReport:
+    orphan_variables: list[str]
+    dangling_factors: list[str]
+    unresolved_cross_refs: list[dict]
+    missing_params: list[str]
+    missing_priors: list[str]
+    summary: dict[str, int]
+```
+
+---
+
+## 实现文件结构
+
+```
+gaia/lkm/core/
+    conflict_detection.py     # BP 诊断信号分析
+    structural_audit.py       # 图结构完整性检查
+```
+
+---
+
+## 备注
+
+详细实现 spec 将在 M7 (Global BP) 完成后补充。Structural Audit 可以提前实现（不依赖 BP），Conflict Detection 必须等 M7。

--- a/docs/specs/2026-04-04-relation-analysis.md
+++ b/docs/specs/2026-04-04-relation-analysis.md
@@ -1,0 +1,331 @@
+# M6b — Relation Analysis: 从语义聚类到关系提案包
+
+> **Status:** Draft
+> **Date:** 2026-04-04
+> **依赖:** M6 Semantic Discovery（clustering 结果）
+
+## 概述
+
+接收 M6 输出的语义��类结果（`SemanticCluster` 列表），对每个 cluster 进行 **group-level 关系分析**，判断组内所有结论之间的关系类型，并生成对应的 Gaia Lang package 作为 relation proposal 提交。
+
+**核心原则：** 分析以 group 为单位，不是 pairwise。一个 cluster 整体被分类为一种关系类型，然后根据类型生成对应的 IR 结构。
+
+## 上游参考
+
+- `propositional_logic_analysis/clustering/prompts/join_symmetric.md`：LLM prompt 的写法参考（关系定义、join 构造规则、entailment 自检）
+- `docs/foundations/gaia-ir/05-canonicalization.md`：canonicalization 进入公共记录的方式
+- M6 Semantic Discovery spec：clustering 输出格式
+
+---
+
+## 四种 Group 关系类型
+
+对每个语义 cluster，LLM 将其整体��类为以下之一：
+
+### 1. Partial Overlap（部分重叠）
+
+**含义：** 组内结论讨论相关主题，有共同内容，但各自有独立主张。
+
+**IR 结构：**
+```
+Conclusion_A ──subsumption──►  Join Node (抽象共同内容)
+Conclusion_B ──subsumption──►  Join Node
+Conclusion_C ──subsumption──►  Join Node
+```
+
+- 新建一个 **join node**（claim），内容是组内所有结论共同 entail 的最具体命题
+- 每个结论到 join node 建立 subsumption（strategy: deduction，premise → conclusion）
+- join node 必须满足 join_symmetric.md 的质量要求：
+  - 自包含（不依赖原始结论就能理解）
+  - intersection 而非 union（每个结论独立 entail join）
+  - 有实质科学内容（不能是空洞泛化）
+  - 不使用 meta-language（"is studied"、"focuses on" 等）
+
+**关键检验：one-child test** — 对 join 中的每个断言，问："如果只看这一个结论，它能独立支持这个断言吗？" 如果不能，就是 union error，需要删掉。
+
+### 2. Equivalence（等价）
+
+**含义：** 组内结论在说同一件事（不同表述、不同粒度、不同符号，但语义等价）。
+
+**IR 结构：**
+```
+Conclusion_A ──equivalence──► Common Conclusion Node
+Conclusion_B ──equivalence──► Common Conclusion Node
+Conclusion_C ──equivalence──► Common Conclusion Node
+```
+
+- 新建一个**公共 conclusion node**（claim），是组内结论的统一表述
+- 每个原始结论和公共 conclusion 之间建立 equivalence operator
+- 公共 conclusion 的内容应选择组内最清晰、最完整的表述，或由 LLM 综合
+
+### 3. Contradiction（矛盾）
+
+**含义：** 组内结论对同一系统在同一条件下做出不兼容的断言。
+
+**IR 结构：**
+```
+Conclusion_A ──contradiction──► Conclusion_B
+Conclusion_A ──contradiction──► Conclusion_C
+Conclusion_B ──contradiction──► Conclusion_C
+
+（可选，如果有共同内容）
+Conclusion_A ──subsumption──► Join Node
+Conclusion_B ──subsumption──► Join Node
+Conclusion_C ──subsumption──► Join Node
+```
+
+- 矛盾结论之间建立 contradiction operator
+- **可选加 join node**：如果矛盾组有共同前提或共同主题（例如"理论预测 X" 和 "实验否定 X" 共享 "X 被预测/��论"），则创建 join node 捕获共同内容
+- join node 是否需要，由 LLM 判断
+
+### 4. Unrelated（无关）
+
+**含义：** 聚类误匹配，组内结论无实质逻辑关联。
+
+**IR 结构：** 无。丢弃该 cluster，不生成任何 package。
+
+---
+
+## 流程
+
+```
+M6 Clustering Result
+  │
+  │  for each SemanticCluster:
+  ▼
+┌──────────────────────────┐
+│  1. Load content          │  从 LanceDB 加载 cluster 内每个 gcn_id 的 content
+│                          │  （通过 representative_lcn → local_variable_nodes）
+├──────────────────────────┤
+│  2. LLM Group Analysis   │  将整组结论发给 LLM，判断 group 关系类型
+│                          │  + 生成 join/common conclusion（如需要）
+│                          │  Prompt 参考 join_symmetric.md
+├──────────────────────────┤
+│  3. Parse LLM Output     │  ��析 XML 输出 → GroupAnalysisResult
+│                          │
+├──────────────────────────┤
+│  4. Generate Gaia Lang   │  根据关系类型生成对应的 IR 结构
+│     Package              │  （knowledge nodes + operators/strategies）
+│                          │
+├──────────────────────────┤
+│  5. Validate & Submit    │  验证生成的 package 合法
+│                          │  （IR validation + compile check）
+└──────────────────────────┘
+```
+
+---
+
+## LLM Prompt 设计
+
+### 输入
+
+```xml
+<cluster id="cluster_xxx" node_type="claim" size="4">
+  <proposition id="gcn_001">
+    <content>Single-layer FeSe/STO exhibits a superconducting transition at Tc ≈ 109 K...</content>
+  </proposition>
+  <proposition id="gcn_002">
+    <content>Interface-enhanced superconductivity in FeSe thin films on STO substrates...</content>
+  </proposition>
+  <proposition id="gcn_003">
+    <content>The superconducting gap of FeSe/STO is nodeless with Δ ≈ 20 meV...</content>
+  </proposition>
+  <proposition id="gcn_004">
+    <content>FeSe/STO does not exhibit bulk superconductivity above 10 K...</content>
+  </proposition>
+</cluster>
+```
+
+### LLM 任务
+
+> 你是一个严谨的科学逻辑学家。给定一组科学命题（通过 embedding 相似度聚类），判断它们之间的 **group-level 关系**。
+>
+> **四种可能的关系（互斥）：**
+>
+> 1. **Partial Overlap** — 共同主题但各有独立主张 → 构造 join node
+> 2. **Equivalence** — 在说同一件事 → 构造 common conclusion
+> 3. **Contradiction** — 对同一系统做不兼容断言 → 标记矛盾，可选 join
+> 4. **Unrelated** — 无实质关联 → 丢弃
+>
+> **重要：这是 group-level 判断，不是 pairwise。** 一个 group 整体归为一种类型。如果 group 内同时有 equivalent 和 contradictory 的 pair，以 contradiction 为主（contradiction 优先）。
+
+### 输出格式
+
+```xml
+<group_analysis cluster_id="cluster_xxx" relation="partial_overlap">
+  <!-- relation: "partial_overlap" | "equivalence" | "contradiction" | "unrelated" -->
+
+  <!-- For partial_overlap: join node -->
+  <join>
+    <title>Short title of the join proposition</title>
+    <content>Self-contained proposition capturing shared content...</content>
+    <notations>
+      - Symbol: definition
+    </notations>
+    <keywords>
+      - keyword1
+      - keyword2
+    </keywords>
+    <entailment_check>
+      <child id="gcn_001" entails="true">Reason why this child entails the join</child>
+      <child id="gcn_002" entails="true">Reason...</child>
+    </entailment_check>
+  </join>
+
+  <!-- For equivalence: common conclusion -->
+  <common_conclusion>
+    <title>Unified statement</title>
+    <content>The canonical form of what all propositions are saying...</content>
+  </common_conclusion>
+
+  <!-- For contradiction: pairs + optional join -->
+  <contradictions>
+    <pair a="gcn_001" b="gcn_004">
+      <reason>gcn_001 claims Tc ≈ 109K, gcn_004 claims no bulk Tc above 10K...</reason>
+    </pair>
+  </contradictions>
+  <join><!-- optional, same format as partial_overlap join --></join>
+
+  <reasoning>Overall reasoning for the group classification...</reasoning>
+</group_analysis>
+```
+
+---
+
+## IR 生成规则
+
+### Partial Overlap → Package
+
+```python
+# 1. 创建 join claim
+join_claim = Claim(
+    content=llm_output.join.content,
+    label="join_{cluster_id}",
+)
+
+# 2. ��个原始结论 → join 的 subsumption
+for gcn_id in cluster.gcn_ids:
+    Strategy(
+        type="deduction",
+        conclusion=join_claim,
+        given=[ExternalRef(gcn_id)],  # 引用已有 global variable
+    )
+```
+
+### Equivalence → Package
+
+```python
+# 1. 创建 common conclusion
+common = Claim(
+    content=llm_output.common_conclusion.content,
+    label="common_{cluster_id}",
+)
+
+# 2. 每个原始结论和 common 之间建立 equivalence
+for gcn_id in cluster.gcn_ids:
+    Operator(
+        type="equivalence",
+        operands=[ExternalRef(gcn_id), common],
+    )
+```
+
+### Contradiction → Package
+
+```python
+# 1. 矛盾 pair 之间建立 contradiction
+for pair in llm_output.contradictions:
+    Operator(
+        type="contradiction",
+        operands=[ExternalRef(pair.a), ExternalRef(pair.b)],
+    )
+
+# 2. 可选 join（如果有共同内容）
+if llm_output.join:
+    join_claim = Claim(content=llm_output.join.content, ...)
+    for gcn_id in cluster.gcn_ids:
+        Strategy(type="deduction", conclusion=join_claim, given=[ExternalRef(gcn_id)])
+```
+
+---
+
+## 配置
+
+```python
+@dataclass
+class RelationAnalysisConfig:
+    # LLM
+    llm_model: str = "openai/chenkun/gpt-5-mini"
+    llm_concurrency: int = 8
+    llm_max_retries: int = 3
+
+    # 过滤
+    min_cluster_size: int = 2       # 单个 variable 的 cluster 跳过
+    max_cluster_size: int = 20      # 太大的 cluster 先拆分再分析
+
+    # 输出
+    output_dir: str = "./output/relation-packages"
+```
+
+---
+
+## 质量保障
+
+### LLM 输出校验
+
+1. **XML 解析检查**：输出必须是 well-formed XML
+2. **relation 类型合法**：必须是四种之一
+3. **join 质量检查**（for partial_overlap / contradiction with join）：
+   - entailment_check 中所有 child 必须 entails="true"
+   - content 不为空，长度 > 50 chars
+   - 不含 meta-language（"is studied"、"focuses on" 等）
+4. **equivalence 检查**：common_conclusion content 不为空
+5. **contradiction 检查**：至少一对 contradiction pair
+
+### 失败处理
+
+- LLM 输出解析失败 → 重试（最多 3 次）
+- 重试仍失败 → 标记为 `analysis_failed`，跳过
+- join 质量不达标 → 降级为 unrelated（宁可丢弃也不产出低质量 proposal）
+
+---
+
+## ���现文件结构
+
+```
+gaia/lkm/core/
+    relation_analysis.py      # run_relation_analysis() 主函数
+    _llm_analyzer.py          # LLM 调用 + prompt 构造 + output 解析
+    _package_generator.py     # 从 GroupAnalysisResult 生成 Gaia Lang package
+
+gaia/lkm/models/
+    relation.py               # GroupAnalysisResult, JoinNode, ContradictionPair, etc.
+```
+
+---
+
+## 关键约束
+
+1. **Group-level 分析，不是 pairwise** — 一个 cluster 整体归为一种关系
+2. **Contradiction 优先** — 如果组内同时有 equivalent 和 contradictory 的元素，以 contradiction 为主
+3. **Join node 必须是 intersection 不是 union** — 每个 child 独立 entail join
+4. **生成的 package 是 proposal** — 提交到 registry，走正常 review 流程，不直接修改 global graph
+5. **LLM 调用走 litellm + AI gateway** — 用 `openai/` 前缀模型名
+6. **Unrelated 不产出** — 宁可丢弃也不产出无关 proposal
+
+---
+
+## 测试要求
+
+### 单元测试
+
+- `test_partial_overlap_generates_join`：partial overlap group → 生成 join node + subsumption
+- `test_equivalence_generates_common`：equivalence group → 生成 common conclusion + equivalence operators
+- `test_contradiction_generates_operators`：contradiction group → 生成 contradiction operators
+- `test_unrelated_produces_nothing`：unrelated group → 无输出
+- `test_join_quality_one_child_test`：join 不通过 one-child test → 降级为 unrelated
+- `test_xml_parsing`：各种 LLM 输出格式的解析
+
+### 集成测试
+
+- `test_end_to_end_from_clusters`：从 fixture clustering 结果 → LLM 分析 → package 生成
+- `test_generated_package_validates`：生成的 Gaia Lang package 通过 IR validation


### PR DESCRIPTION
## Summary

- **M6 Semantic Discovery spec** — embedding (dashscope API → ByteHouse) + FAISS clustering (IndexFlatIP + Union-Find)
- **M6b Relation Analysis spec** — LLM group-level analysis (partial overlap / equivalence / contradiction / unrelated) + Gaia Lang package generation
- **M6c Graph Health spec** — placeholder for conflict detection + structural audit (depends on M7)
- **Import pipeline hardening plan** — the plan doc from the completed #307
- **Roadmap update** — progress table with PR links, dependency graph, M6 split into M6/M6b/M6c
- **Master plan update** — M6 section rewritten, spec mapping table with statuses, phase diagram updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)