### PR TITLE
feat(readme): render strategies and operators as Mermaid intermediate nodes

### DIFF
--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -123,7 +123,7 @@ def _mermaid_node_line(
 ) -> str:
     display_name = title or label
     display = f"{display_name} ({beliefs[kid]:.2f})" if beliefs and kid in beliefs else display_name
-    display = display.replace('"', "#quot;")
+    display = display.replace('"', "#quot;").replace("*", "#ast;")
     if css_class_override:
         css = css_class_override
     else:
@@ -453,7 +453,7 @@ def _render_overview_graph(
         kid = k["id"]
         title = k.get("title") or label
         display = f"{title} ({beliefs[kid]:.2f})" if beliefs and kid in beliefs else title
-        display = display.replace('"', "#quot;")
+        display = display.replace('"', "#quot;").replace("*", "#ast;")
         role = node_role(kid, k["type"], c)
         css = _ROLE_TO_CSS.get(role, "orphan")
         lines.append(f'    {label}["{display}"]:::{css}')

--- a/gaia/cli/commands/_readme.py
+++ b/gaia/cli/commands/_readme.py
@@ -65,15 +65,15 @@ def _module_segments(nodes: list[dict]) -> list[tuple[str, list[dict]]]:
 # ── Mermaid rendering ──
 
 _MERMAID_STYLES = """\
-    classDef setting fill:#f0f0f0,stroke:#999
-    classDef premise fill:#ddeeff,stroke:#4488bb
-    classDef derived fill:#ddffdd,stroke:#44bb44
-    classDef question fill:#fff3dd,stroke:#cc9944
-    classDef background fill:#f5f5f5,stroke:#bbb,stroke-dasharray: 5 5
-    classDef orphan fill:#fff,stroke:#ccc,stroke-dasharray: 5 5
-    classDef external fill:#fff,stroke:#aaa,stroke-dasharray: 3 3
-    classDef weak fill:#fff9c4,stroke:#f9a825,stroke-dasharray: 5 5
-    classDef contra fill:#ffebee,stroke:#c62828"""
+    classDef setting fill:#f0f0f0,stroke:#999,color:#333
+    classDef premise fill:#ddeeff,stroke:#4488bb,color:#333
+    classDef derived fill:#ddffdd,stroke:#44bb44,color:#333
+    classDef question fill:#fff3dd,stroke:#cc9944,color:#333
+    classDef background fill:#f5f5f5,stroke:#bbb,stroke-dasharray: 5 5,color:#333
+    classDef orphan fill:#fff,stroke:#ccc,stroke-dasharray: 5 5,color:#333
+    classDef external fill:#fff,stroke:#aaa,stroke-dasharray: 3 3,color:#333
+    classDef weak fill:#fff9c4,stroke:#f9a825,stroke-dasharray: 5 5,color:#333
+    classDef contra fill:#ffebee,stroke:#c62828,color:#333"""
 
 # Map node_role() output to Mermaid CSS class names
 _ROLE_TO_CSS = {

--- a/tests/cli/test_readme.py
+++ b/tests/cli/test_readme.py
@@ -300,8 +300,6 @@ def test_overview_graph_shows_transitive_deps():
     assert "a --> b" in md
     # mid is not exported, so it should NOT appear
     assert "mid" not in md
-    # c is exported but independent — no edges to/from c, so not in the graph
-    # (overview only shows nodes that have edges)
 
 
 def test_overview_graph_stops_at_nearest_exported():
@@ -336,8 +334,7 @@ def test_overview_graph_empty_when_no_deps():
         "strategies": [],
         "operators": [],
     }
-    lines = _render_overview_graph(ir)
-    assert lines == []
+    assert _render_overview_graph(ir) == []
 
 
 def test_overview_graph_empty_when_single_export():
@@ -349,8 +346,7 @@ def test_overview_graph_empty_when_single_export():
         "strategies": [],
         "operators": [],
     }
-    lines = _render_overview_graph(ir)
-    assert lines == []
+    assert _render_overview_graph(ir) == []
 
 
 # ── module narrative ──
@@ -395,17 +391,14 @@ def test_module_sections_with_per_module_mermaid():
         "operators": [],
     }
     md = render_knowledge_nodes(ir)
-    # Module section headings
     assert "## sec_a" in md
     assert "## sec_b" in md
-    # Order: sec_a nodes before sec_b
     assert md.index("#### x") < md.index("#### z")
     assert md.index("#### y") < md.index("#### z")
     # First module (sec_a) skips Mermaid; sec_b gets one
     assert md.count("```mermaid") == 1
-    # sec_b's diagram should show x as external premise
     sec_b_section = md.split("## sec_b")[1]
-    assert "x" in sec_b_section.split("```")[1]  # x appears in sec_b's mermaid
+    assert "x" in sec_b_section.split("```")[1]
 
 
 def test_module_sections_preserve_root_segments():


### PR DESCRIPTION
## Summary

- Strategies render as stadium-shaped intermediate nodes (`strat_N(["type"])`) instead of edge labels
- Operators render as hexagon nodes with symbols (⊗ ≡ ⊕ ∨ ∧ →) instead of dashed edge labels
- Deterministic strategies (deduction, elimination, etc.) get default styling; probabilistic ones (noisy_and, infer, abduction, etc.) get `:::weak` (yellow dashed)
- Contradiction operators get `:::contra` (red); equivalence/complement use undirected `---` edges
- Background claims connect to strategy nodes with dashed `-.->` edges
- Operators now pull in cross-module variables for visibility in per-module diagrams

Follows the visual language from `docs/foundations/theory/05-formalization-methodology.md`.

Closes #329

## Test plan

- [x] 26 existing + new tests pass (`tests/cli/test_readme.py`)
- [x] Full test suite: 586 passed
- [x] Lint clean
- [ ] Visual check with electron liquid package README

🤖 Generated with [Claude Code](https://claude.com/claude-code)