### PR TITLE
feat(lkm): chunked import pipeline with local-first strategy

### DIFF
--- a/gaia/lkm/logging.py
+++ b/gaia/lkm/logging.py
@@ -31,6 +31,8 @@ def configure_logging(
 
     if log_file is not None:
         log_file.parent.mkdir(parents=True, exist_ok=True)
+        # Unbuffered writes so `tail -f` shows progress in real time
         fh = logging.FileHandler(log_file)
         fh.setFormatter(formatter)
+        fh.stream.reconfigure(line_buffering=True)
         root_logger.addHandler(fh)

--- a/gaia/lkm/pipelines/import_lance.py
+++ b/gaia/lkm/pipelines/import_lance.py
@@ -1,11 +1,27 @@
-"""Batch import: Lance query → TOS download → extract → integrate.
+"""Batch import: ByteHouse query → TOS download → extract → integrate.
+
+Processes papers in chunked batches to stay memory-bounded at any scale.
 
 Usage:
-    python -m gaia.lkm.pipelines.import_lance \
-        --categories cond-mat.stat-mech \
-        --lkm-db-uri s3://bucket/lkm \
-        --output-dir ./output/stat-mech \
+    # Fast local import (空表 → add() 快路径, ~100s/1000篇)
+    python -m gaia.lkm.pipelines.import_lance import \
+        --lkm-db-uri ./data/lancedb/lkm-bulk \
+        --max-papers 300000
+
+    # Upload local LanceDB to S3 after import
+    python -m gaia.lkm.pipelines.import_lance upload \
+        --local-path ./data/lancedb/lkm-bulk \
+        --s3-uri s3://datainfra-test/gaia_server_test
+
+    # Direct S3 import (slower, for incremental updates)
+    python -m gaia.lkm.pipelines.import_lance import \
+        --lkm-db-uri s3://datainfra-test/gaia_server_test \
         --max-papers 100
+
+    # Dry run
+    python -m gaia.lkm.pipelines.import_lance import \
+        --lkm-db-uri ./data/lancedb/lkm-bulk \
+        --dry-run
 """
 
 from __future__ import annotations
@@ -14,10 +30,11 @@ import argparse
 import asyncio
 import json
 import logging
+import signal
+import time
 from dataclasses import dataclass, field
-from pathlib import Path
-
 from datetime import datetime, timezone
+from pathlib import Path
 
 from gaia.lkm.core.extract import ExtractionResult, extract
 from gaia.lkm.models import ImportStatusRecord
@@ -39,7 +56,11 @@ logger = logging.getLogger(__name__)
 
 
 class Checkpoint:
-    """JSON-backed per-paper status tracker with atomic writes."""
+    """JSON-backed per-paper status tracker with atomic writes.
+
+    For large imports (>100K papers) the JSON file grows but remains manageable
+    (~50MB for 1M entries). Writes are batched via flush() to avoid per-paper I/O.
+    """
 
     def __init__(self, path: Path) -> None:
         self._path = path
@@ -47,18 +68,30 @@ class Checkpoint:
             self._data: dict[str, str] = json.loads(path.read_text())
         else:
             self._data = {}
+        self._dirty = False
 
     def status(self, paper_id: str) -> str | None:
         return self._data.get(paper_id)
 
     def update(self, paper_id: str, status: str) -> None:
         self._data[paper_id] = status
+        self._dirty = True
+
+    def flush(self) -> None:
+        """Write checkpoint to disk if dirty."""
+        if not self._dirty:
+            return
         tmp = self._path.with_suffix(".tmp")
         tmp.write_text(json.dumps(self._data, indent=2))
         tmp.rename(self._path)
+        self._dirty = False
 
     def pending(self, paper_ids: list[str]) -> list[str]:
         return [p for p in paper_ids if self._data.get(p) != "ingested"]
+
+    @property
+    def ingested_count(self) -> int:
+        return sum(1 for v in self._data.values() if v == "ingested")
 
 
 # ── Stats ──
@@ -73,85 +106,52 @@ class ImportStats:
     errors: dict[str, str] = field(default_factory=dict)
 
 
-# ── Orchestrator ──
+def _fmt_duration(seconds: float) -> str:
+    """Format seconds as human-readable duration."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    if seconds < 3600:
+        return f"{seconds / 60:.1f}m"
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    return f"{h}h{m}m"
 
 
-async def run_batch_import(
-    lkm_db_uri: str,
-    output_dir: Path,
-    *,
-    keywords: str | None = None,
-    areas: str | None = None,
-    bytehouse_config: ByteHouseConfig | None = None,
-    tos_config: TOSConfig | None = None,
-    concurrency: int = 10,
-    max_papers: int | None = None,
-    dry_run: bool = False,
-) -> ImportStats:
-    """Batch import papers from ByteHouse/TOS into LKM.
+# ── Graceful shutdown ──
 
-    1. Search ByteHouse paper_data.paper_metadata
-    2. Filter via checkpoint → skip already ingested
-    3. Batch download XMLs from TOS (in-memory)
-    4. Init shared StorageManager (target LKM)
-    5. For each paper (semaphore limited):
-       merge XMLs → run_extract() → checkpoint
-    6. Return summary stats
-    """
-    batch_started_at = datetime.now(timezone.utc)
-    failed_statuses: list[ImportStatusRecord] = []
-    stats = ImportStats()
+_shutdown_requested = False
 
-    # 1. Search ByteHouse
-    if bytehouse_config is None:
-        bytehouse_config = ByteHouseConfig.from_env()
-    bh_client = connect_bytehouse(bytehouse_config)
-    papers = search_papers(bh_client, keywords=keywords, areas=areas, limit=max_papers or 1000)
-    logger.info(
-        "ByteHouse returned %d papers (keywords=%s, areas=%s)", len(papers), keywords, areas
-    )
 
-    paper_ids = [str(p["id"]) for p in papers]
-    stats.total = len(paper_ids)
+def _request_shutdown(signum: int, frame: object) -> None:
+    """Signal handler: finish current chunk, then exit."""
+    global _shutdown_requested  # noqa: PLW0603
+    _shutdown_requested = True
+    logger.info("Shutdown requested (signal %d). Will exit after current chunk.", signum)
 
-    if dry_run:
-        for p in papers[:10]:
-            print(f"  {p['id']}: {p.get('en_title', '')[:80]}")
-        print(f"\nTotal: {len(papers)} papers (dry run, no import)")
-        return stats
 
-    # 2. Filter via checkpoint
-    output_dir.mkdir(parents=True, exist_ok=True)
-    checkpoint = Checkpoint(output_dir / "checkpoint.json")
-    pending = checkpoint.pending(paper_ids)
-    stats.skipped = len(paper_ids) - len(pending)
-    if stats.skipped:
-        logger.info("Skipping %d already-ingested papers", stats.skipped)
+# ── Chunk processor ──
 
-    if not pending:
-        logger.info("All papers already ingested")
-        return stats
 
-    # 3. Batch download XMLs from TOS
-    if tos_config is None:
-        tos_config = TOSConfig.from_env()
-    logger.info("Downloading XMLs for %d papers...", len(pending))
-    downloaded = await download_paper_xmls(tos_config, pending)
+async def _process_chunk(
+    chunk_ids: list[str],
+    tos_config: TOSConfig,
+    storage: StorageManager,
+    checkpoint: Checkpoint,
+    stats: ImportStats,
+    batch_started_at: datetime,
+) -> None:
+    """Download → extract → integrate one chunk of papers."""
+    # Download XMLs for this chunk
+    downloaded = await download_paper_xmls(tos_config, chunk_ids)
 
-    # 4. Init target StorageManager (picks up TOS_* creds from env)
-    config = StorageConfig(lancedb_uri=lkm_db_uri)
-    storage = StorageManager(config)
-    await storage.initialize()
-
-    # 5. Extract all papers (pure computation, safe to parallelize)
+    # Extract
     extraction_results: list[ExtractionResult] = []
     extracted_ids: list[str] = []
-    for i, pid in enumerate(pending):
-        if i > 0 and i % 100 == 0:
-            logger.info("Extraction progress: %d/%d papers", i, len(pending))
+    failed_statuses: list[ImportStatusRecord] = []
+
+    for pid in chunk_ids:
         xmls = downloaded.get(pid)
         if xmls is None:
-            logger.warning("No XMLs downloaded for %s, skipping", pid)
             checkpoint.update(pid, "failed:download")
             failed_statuses.append(
                 ImportStatusRecord(
@@ -184,18 +184,19 @@ async def run_batch_import(
             stats.errors[pid] = str(e)
             stats.failed += 1
 
-    # 6. Batch integrate (dedup within batch + against existing globals)
+    # Batch integrate
     if extraction_results:
-        logger.info("Integrating %d papers (batch dedup)...", len(extraction_results))
         batch_result = await run_extract_batch(extraction_results, storage)
         logger.info(
-            "Batch integrate: %d new globals, %d new factors, "
-            "%d dedup within batch, %d dedup with existing",
+            "Chunk integrate: %d papers → %d new globals, %d new factors, "
+            "%d dedup batch, %d dedup existing",
+            len(extraction_results),
             batch_result.new_global_variables,
             batch_result.new_global_factors,
             batch_result.dedup_within_batch,
             batch_result.dedup_with_existing,
         )
+
         status_records = [
             ImportStatusRecord(
                 package_id=ext_result.package_id,
@@ -210,19 +211,140 @@ async def run_batch_import(
             for ext_result in extraction_results
         ]
         await storage.write_import_status_batch(status_records)
-        logger.info("Wrote %d import_status records", len(status_records))
-        stats.succeeded = len(extracted_ids)
+        stats.succeeded += len(extracted_ids)
         for pid in extracted_ids:
             checkpoint.update(pid, "ingested")
 
     if failed_statuses:
         await storage.write_import_status_batch(failed_statuses)
-        logger.info("Wrote %d failed import_status records", len(failed_statuses))
+
+    # Flush checkpoint after each chunk
+    checkpoint.flush()
+
+
+# ── Orchestrator ──
+
+
+async def run_batch_import(
+    lkm_db_uri: str,
+    output_dir: Path,
+    *,
+    keywords: str | None = None,
+    areas: str | None = None,
+    bytehouse_config: ByteHouseConfig | None = None,
+    tos_config: TOSConfig | None = None,
+    max_papers: int | None = None,
+    chunk_size: int = 1000,
+    dry_run: bool = False,
+) -> ImportStats:
+    """Batch import papers from ByteHouse/TOS into LKM.
+
+    Processes papers in chunks of `chunk_size` to stay memory-bounded.
+    Each chunk: download XMLs → extract → batch integrate → checkpoint.
+    Resumable via checkpoint file.
+    """
+    wall_start = time.monotonic()
+    batch_started_at = datetime.now(timezone.utc)
+    stats = ImportStats()
+
+    # 1. Search ByteHouse
+    if bytehouse_config is None:
+        bytehouse_config = ByteHouseConfig.from_env()
+    bh_client = connect_bytehouse(bytehouse_config)
+    limit = max_papers or 500_000
+    papers = search_papers(bh_client, keywords=keywords, areas=areas, limit=limit)
+    logger.info(
+        "ByteHouse returned %d papers (keywords=%s, areas=%s)", len(papers), keywords, areas
+    )
+
+    paper_ids = [str(p["id"]) for p in papers]
+    stats.total = len(paper_ids)
+
+    if dry_run:
+        for p in papers[:20]:
+            print(f"  {p['id']}: {p.get('en_title', '')[:80]}")
+        if len(papers) > 20:
+            print(f"  ... and {len(papers) - 20} more")
+        print(f"\nTotal: {len(papers)} papers (dry run, no import)")
+        return stats
+
+    # 2. Filter via checkpoint
+    output_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint = Checkpoint(output_dir / "checkpoint.json")
+    pending = checkpoint.pending(paper_ids)
+    stats.skipped = len(paper_ids) - len(pending)
+    if stats.skipped:
+        logger.info("Skipping %d already-ingested papers", stats.skipped)
+
+    if not pending:
+        logger.info("All papers already ingested")
+        return stats
+
+    logger.info("Will process %d pending papers in chunks of %d", len(pending), chunk_size)
+
+    # 3. Init resources
+    if tos_config is None:
+        tos_config = TOSConfig.from_env()
+    config = StorageConfig(lancedb_uri=lkm_db_uri)
+    storage = StorageManager(config)
+    await storage.initialize()
+
+    # 4. Install signal handlers for graceful shutdown
+    global _shutdown_requested  # noqa: PLW0603
+    _shutdown_requested = False
+    prev_sigint = signal.signal(signal.SIGINT, _request_shutdown)
+    prev_sigterm = signal.signal(signal.SIGTERM, _request_shutdown)
+
+    # 5. Process in chunks
+    n_chunks = (len(pending) + chunk_size - 1) // chunk_size
+    for i in range(0, len(pending), chunk_size):
+        if _shutdown_requested:
+            logger.info("Shutdown requested — stopping before chunk %d", i // chunk_size + 1)
+            break
+
+        chunk = pending[i : i + chunk_size]
+        chunk_num = i // chunk_size + 1
+        chunk_start = time.monotonic()
+
+        logger.info(
+            "── Chunk %d/%d: %d papers (total progress: %d/%d) ──",
+            chunk_num,
+            n_chunks,
+            len(chunk),
+            stats.succeeded + stats.failed + stats.skipped,
+            stats.total,
+        )
+
+        await _process_chunk(chunk, tos_config, storage, checkpoint, stats, batch_started_at)
+
+        chunk_elapsed = time.monotonic() - chunk_start
+        total_elapsed = time.monotonic() - wall_start
+        papers_done = stats.succeeded + stats.failed
+        if papers_done > 0:
+            rate = papers_done / total_elapsed
+            remaining = len(pending) - (i + len(chunk))
+            eta = remaining / rate if rate > 0 else 0
+            logger.info(
+                "Chunk %d done in %s | Rate: %.1f papers/s | "
+                "ETA for remaining %d: %s | Elapsed: %s",
+                chunk_num,
+                _fmt_duration(chunk_elapsed),
+                rate,
+                remaining,
+                _fmt_duration(eta),
+                _fmt_duration(total_elapsed),
+            )
+
+    # 6. Restore signal handlers
+    signal.signal(signal.SIGINT, prev_sigint)
+    signal.signal(signal.SIGTERM, prev_sigterm)
 
     # 7. Summary
     await storage.close()
+    total_elapsed = time.monotonic() - wall_start
     logger.info(
-        "Done: %d succeeded, %d failed, %d skipped (of %d total)",
+        "Done in %s: %d succeeded, %d failed, %d skipped (of %d total)",
+        _fmt_duration(total_elapsed),
         stats.succeeded,
         stats.failed,
         stats.skipped,
@@ -231,57 +353,142 @@ async def run_batch_import(
     return stats
 
 
+# ── Upload local → S3 ──
+
+
+def upload_local_to_s3(local_path: str, s3_uri: str) -> None:
+    """Upload a local LanceDB directory to S3 by copying all lance table data.
+
+    Opens both databases and copies each table from local to remote via
+    LanceDB's add() (pure append, fast for bulk upload).
+    """
+    import lancedb as _lancedb
+
+    from gaia.lkm.storage.config import StorageConfig
+
+    config = StorageConfig(lancedb_uri=s3_uri)
+    opts = config.storage_options
+
+    local_db = _lancedb.connect(local_path)
+    remote_db = _lancedb.connect(s3_uri, storage_options=opts) if opts else _lancedb.connect(s3_uri)
+
+    local_tables = local_db.list_tables().tables
+    remote_tables = set(remote_db.list_tables().tables)
+
+    for table_name in local_tables:
+        local_table = local_db.open_table(table_name)
+        row_count = local_table.count_rows()
+        if row_count == 0:
+            logger.info("Skipping empty table: %s", table_name)
+            continue
+
+        data = local_table.to_arrow()
+        logger.info("Uploading %s: %d rows (%.1f MB)...", table_name, row_count, data.nbytes / 1e6)
+
+        if table_name in remote_tables:
+            remote_table = remote_db.open_table(table_name)
+            existing = remote_table.count_rows()
+            if existing > 0:
+                logger.warning(
+                    "Remote table %s already has %d rows. "
+                    "Use merge_insert for incremental sync — skipping to avoid duplicates.",
+                    table_name,
+                    existing,
+                )
+                continue
+            remote_table.add(data)
+        else:
+            remote_db.create_table(table_name, data)
+
+        logger.info("Uploaded %s ✓", table_name)
+
+    logger.info("Upload complete: %d tables", len(local_tables))
+
+
 # ── CLI ──
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Batch import papers from Lance/TOS into LKM")
-    parser.add_argument(
+    parser = argparse.ArgumentParser(description="Batch import papers from ByteHouse/TOS into LKM")
+    sub = parser.add_subparsers(dest="command")
+
+    # ── import (default) ──
+    p_import = sub.add_parser("import", help="Import papers into LanceDB")
+    p_import.add_argument(
         "--keywords",
         default=None,
         help="Token search on en_title (e.g. 'nuclear fusion')",
     )
-    parser.add_argument(
+    p_import.add_argument(
         "--areas",
         default=None,
         help="Filter by areas partition (e.g. 'Physics')",
     )
-    parser.add_argument(
+    p_import.add_argument(
         "--lkm-db-uri",
         required=True,
-        help="Target LKM LanceDB URI (local path or s3://...)",
+        help="Target LanceDB URI (local path for fast import, or s3://...)",
     )
-    parser.add_argument(
+    p_import.add_argument(
         "--output-dir",
         type=Path,
         default=Path("./output/import"),
-        help="Output directory for checkpoint (default: ./output/import)",
+        help="Output directory for checkpoint and logs (default: ./output/import)",
     )
-    parser.add_argument(
-        "--concurrency",
+    p_import.add_argument(
+        "--chunk-size",
         type=int,
-        default=10,
-        help="Max concurrent extract+integrate tasks (default: 10)",
+        default=1000,
+        help="Papers per chunk (download+extract+integrate) (default: 1000)",
     )
-    parser.add_argument(
+    p_import.add_argument(
         "--max-papers",
         type=int,
         default=None,
         help="Limit number of papers to import",
     )
-    parser.add_argument(
+    p_import.add_argument(
         "--dry-run",
         action="store_true",
         help="Query and print matching papers without importing",
     )
+
+    # ── upload ──
+    p_upload = sub.add_parser("upload", help="Upload local LanceDB to S3")
+    p_upload.add_argument(
+        "--local-path",
+        required=True,
+        help="Local LanceDB path (e.g. ./data/lancedb/lkm-bulk)",
+    )
+    p_upload.add_argument(
+        "--s3-uri",
+        required=True,
+        help="Target S3 URI (e.g. s3://datainfra-test/gaia_server_test)",
+    )
+
     args = parser.parse_args()
 
     from dotenv import load_dotenv
 
     load_dotenv()
 
+    # Default to 'import' when no subcommand given but --lkm-db-uri is passed
+    if args.command is None:
+        # Re-parse as import for backward compatibility
+        args = p_import.parse_args()
+        args.command = "import"
+
+    if args.command == "upload":
+        logging.basicConfig(
+            level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+        )
+        upload_local_to_s3(args.local_path, args.s3_uri)
+        return
+
+    # command == "import"
     from gaia.lkm.logging import configure_logging
 
+    args.output_dir.mkdir(parents=True, exist_ok=True)
     configure_logging(level="INFO", log_file=args.output_dir / "import.log")
 
     stats = asyncio.run(
@@ -290,16 +497,16 @@ def main() -> None:
             output_dir=args.output_dir,
             keywords=args.keywords,
             areas=args.areas,
-            concurrency=args.concurrency,
+            chunk_size=args.chunk_size,
             max_papers=args.max_papers,
             dry_run=args.dry_run,
         )
     )
 
-    print(f"\nImport complete: {stats.succeeded}/{stats.total} succeeded")
+    print(f"\nImport complete: {stats.succeeded}/{stats.total} succeeded, {stats.failed} failed")
     if stats.errors:
         print(f"Errors ({len(stats.errors)}):")
-        for pid, err in list(stats.errors.items())[:10]:
+        for pid, err in list(stats.errors.items())[:20]:
             print(f"  {pid}: {err}")
 
 

--- a/gaia/lkm/pipelines/import_lance.py
+++ b/gaia/lkm/pipelines/import_lance.py
@@ -4,7 +4,7 @@ Processes papers in chunked batches to stay memory-bounded at any scale.
 
 Usage:
     # Fast local import (空表 → add() 快路径, ~100s/1000篇)
-    python -m gaia.lkm.pipelines.import_lance import \
+    python -m gaia.lkm.pipelines.import_lance \
         --lkm-db-uri ./data/lancedb/lkm-bulk \
         --max-papers 300000
 
@@ -14,12 +14,12 @@ Usage:
         --s3-uri s3://datainfra-test/gaia_server_test
 
     # Direct S3 import (slower, for incremental updates)
-    python -m gaia.lkm.pipelines.import_lance import \
+    python -m gaia.lkm.pipelines.import_lance \
         --lkm-db-uri s3://datainfra-test/gaia_server_test \
         --max-papers 100
 
     # Dry run
-    python -m gaia.lkm.pipelines.import_lance import \
+    python -m gaia.lkm.pipelines.import_lance \
         --lkm-db-uri ./data/lancedb/lkm-bulk \
         --dry-run
 """
@@ -356,13 +356,17 @@ async def run_batch_import(
 # ── Upload local → S3 ──
 
 
-def upload_local_to_s3(local_path: str, s3_uri: str) -> None:
-    """Upload a local LanceDB directory to S3 by copying all lance table data.
+_UPLOAD_BATCH_SIZE = 50_000  # rows per upload batch to avoid OOM
 
-    Opens both databases and copies each table from local to remote via
-    LanceDB's add() (pure append, fast for bulk upload).
+
+def upload_local_to_s3(local_path: str, s3_uri: str) -> None:
+    """Upload a local LanceDB directory to S3 by streaming table data in batches.
+
+    Reads each table in batches of _UPLOAD_BATCH_SIZE rows to stay memory-bounded,
+    even for tables with millions of rows.
     """
     import lancedb as _lancedb
+    import pyarrow as pa
 
     from gaia.lkm.storage.config import StorageConfig
 
@@ -382,9 +386,6 @@ def upload_local_to_s3(local_path: str, s3_uri: str) -> None:
             logger.info("Skipping empty table: %s", table_name)
             continue
 
-        data = local_table.to_arrow()
-        logger.info("Uploading %s: %d rows (%.1f MB)...", table_name, row_count, data.nbytes / 1e6)
-
         if table_name in remote_tables:
             remote_table = remote_db.open_table(table_name)
             existing = remote_table.count_rows()
@@ -396,11 +397,22 @@ def upload_local_to_s3(local_path: str, s3_uri: str) -> None:
                     existing,
                 )
                 continue
-            remote_table.add(data)
-        else:
-            remote_db.create_table(table_name, data)
 
-        logger.info("Uploaded %s ✓", table_name)
+        logger.info(
+            "Uploading %s: %d rows in batches of %d...", table_name, row_count, _UPLOAD_BATCH_SIZE
+        )
+        uploaded = 0
+        for batch in local_table.to_lance().to_batches(batch_size=_UPLOAD_BATCH_SIZE):
+            batch_table = pa.Table.from_batches([batch], schema=batch.schema)
+            if table_name not in remote_tables:
+                remote_db.create_table(table_name, batch_table)
+                remote_tables.add(table_name)
+            else:
+                remote_db.open_table(table_name).add(batch_table)
+            uploaded += batch_table.num_rows
+            logger.info("  %s: %d/%d rows uploaded", table_name, uploaded, row_count)
+
+        logger.info("Uploaded %s ✓ (%d rows)", table_name, uploaded)
 
     logger.info("Upload complete: %d tables", len(local_tables))
 
@@ -412,48 +424,47 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Batch import papers from ByteHouse/TOS into LKM")
     sub = parser.add_subparsers(dest="command")
 
-    # ── import (default) ──
-    p_import = sub.add_parser("import", help="Import papers into LanceDB")
-    p_import.add_argument(
+    # ── import: args on main parser so bare invocation works ──
+    parser.add_argument(
         "--keywords",
         default=None,
         help="Token search on en_title (e.g. 'nuclear fusion')",
     )
-    p_import.add_argument(
+    parser.add_argument(
         "--areas",
         default=None,
         help="Filter by areas partition (e.g. 'Physics')",
     )
-    p_import.add_argument(
+    parser.add_argument(
         "--lkm-db-uri",
-        required=True,
+        default=None,
         help="Target LanceDB URI (local path for fast import, or s3://...)",
     )
-    p_import.add_argument(
+    parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path("./output/import"),
         help="Output directory for checkpoint and logs (default: ./output/import)",
     )
-    p_import.add_argument(
+    parser.add_argument(
         "--chunk-size",
         type=int,
         default=1000,
         help="Papers per chunk (download+extract+integrate) (default: 1000)",
     )
-    p_import.add_argument(
+    parser.add_argument(
         "--max-papers",
         type=int,
         default=None,
         help="Limit number of papers to import",
     )
-    p_import.add_argument(
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Query and print matching papers without importing",
     )
 
-    # ── upload ──
+    # ── upload subcommand ──
     p_upload = sub.add_parser("upload", help="Upload local LanceDB to S3")
     p_upload.add_argument(
         "--local-path",
@@ -472,12 +483,6 @@ def main() -> None:
 
     load_dotenv()
 
-    # Default to 'import' when no subcommand given but --lkm-db-uri is passed
-    if args.command is None:
-        # Re-parse as import for backward compatibility
-        args = p_import.parse_args()
-        args.command = "import"
-
     if args.command == "upload":
         logging.basicConfig(
             level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
@@ -485,7 +490,10 @@ def main() -> None:
         upload_local_to_s3(args.local_path, args.s3_uri)
         return
 
-    # command == "import"
+    # command is None or "import" → run import
+    if not args.lkm_db_uri:
+        parser.error("--lkm-db-uri is required for import")
+
     from gaia.lkm.logging import configure_logging
 
     args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/gaia/lkm/pipelines/import_lance.py
+++ b/gaia/lkm/pipelines/import_lance.py
@@ -366,7 +366,6 @@ def upload_local_to_s3(local_path: str, s3_uri: str) -> None:
     even for tables with millions of rows.
     """
     import lancedb as _lancedb
-    import pyarrow as pa
 
     from gaia.lkm.storage.config import StorageConfig
 
@@ -402,14 +401,18 @@ def upload_local_to_s3(local_path: str, s3_uri: str) -> None:
             "Uploading %s: %d rows in batches of %d...", table_name, row_count, _UPLOAD_BATCH_SIZE
         )
         uploaded = 0
-        for batch in local_table.to_lance().to_batches(batch_size=_UPLOAD_BATCH_SIZE):
-            batch_table = pa.Table.from_batches([batch], schema=batch.schema)
+        offset = 0
+        while offset < row_count:
+            batch_table = local_table.search().offset(offset).limit(_UPLOAD_BATCH_SIZE).to_arrow()
+            if batch_table.num_rows == 0:
+                break
             if table_name not in remote_tables:
                 remote_db.create_table(table_name, batch_table)
                 remote_tables.add(table_name)
             else:
                 remote_db.open_table(table_name).add(batch_table)
             uploaded += batch_table.num_rows
+            offset += _UPLOAD_BATCH_SIZE
             logger.info("  %s: %d/%d rows uploaded", table_name, uploaded, row_count)
 
         logger.info("Uploaded %s ✓ (%d rows)", table_name, uploaded)

--- a/gaia/lkm/pipelines/import_lance.py
+++ b/gaia/lkm/pipelines/import_lance.py
@@ -49,7 +49,7 @@ from gaia.lkm.storage.source_lance import (
     search_papers,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("gaia.lkm.pipelines.import_lance")
 
 
 # ── Checkpoint ──

--- a/tests/gaia/lkm/pipelines/test_import_lance.py
+++ b/tests/gaia/lkm/pipelines/test_import_lance.py
@@ -18,6 +18,7 @@ class TestCheckpoint:
         path = tmp_path / "cp.json"
         cp1 = Checkpoint(path)
         cp1.update("paper1", "ingested")
+        cp1.flush()
 
         cp2 = Checkpoint(path)
         assert cp2.status("paper1") == "ingested"
@@ -29,6 +30,11 @@ class TestCheckpoint:
 
         pending = cp.pending(["p1", "p2", "p3"])
         assert pending == ["p2", "p3"]
+
+    def test_flush_noop_when_clean(self, tmp_path):
+        cp = Checkpoint(tmp_path / "cp.json")
+        cp.flush()  # should not crash on empty, non-dirty state
+        assert not (tmp_path / "cp.json").exists()
 
 
 class TestMergeXmls:


### PR DESCRIPTION
## Summary

- Refactor `import_lance.py` for large-scale paper ingestion (287K+ papers)
- **Chunked processing**: download → extract → integrate per chunk (default 1000 papers), bounded memory
- **Local-first strategy**: write to local LanceDB (`add()` fast path) instead of S3 `merge_insert` — **6x faster** (100s vs 10min per 1000 papers)
- **Upload subcommand**: `python -m gaia.lkm.pipelines.import_lance upload --local-path ... --s3-uri ...`
- **Graceful shutdown**: SIGINT/SIGTERM finishes current chunk, flushes checkpoint, exits cleanly
- **Real-time logging**: line-buffered file handler for `tail -f` monitoring
- **ETA tracking**: per-chunk rate and remaining time estimates

## Benchmark

| | S3 direct | Local + upload |
|---|---|---|
| 1000 papers | 10 min | **100s** |
| 287K full | ~45h | **~8h** |
| Bottleneck | S3 merge_insert | TOS download |

## Usage

```bash
# Step 1: Fast local import
python -m gaia.lkm.pipelines.import_lance import \
    --lkm-db-uri ./data/lancedb/lkm-bulk --max-papers 300000

# Step 2: Upload to S3
python -m gaia.lkm.pipelines.import_lance upload \
    --local-path ./data/lancedb/lkm-bulk \
    --s3-uri s3://datainfra-test/gaia_server_test
```

## Test plan

- [x] 134 LKM tests pass (including updated checkpoint tests)
- [x] Benchmarked 1000 papers local import: 100s, 0 failures
- [x] Benchmarked 1000 papers S3 import: ~10min, 0 failures
- [ ] Full 287K import run (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)