### PR TITLE
fix: read full import_status for checkpoint seeding

### DIFF
--- a/gaia/lkm/pipelines/import_lance.py
+++ b/gaia/lkm/pipelines/import_lance.py
@@ -258,6 +258,7 @@ async def run_batch_import(
     max_papers: int | None = None,
     chunk_size: int = 1000,
     min_disk_gb: int = 0,
+    seed_from: str | None = None,
     dry_run: bool = False,
 ) -> ImportStats:
     """Batch import papers from ByteHouse/TOS into LKM.
@@ -291,17 +292,20 @@ async def run_batch_import(
         print(f"\nTotal: {len(papers)} papers (dry run, no import)")
         return stats
 
-    # 2. Filter via checkpoint (seed from import_status if empty)
+    # 2. Filter via checkpoint (seed from remote import_status if empty)
     output_dir.mkdir(parents=True, exist_ok=True)
     checkpoint = Checkpoint(output_dir / "checkpoint.json")
-    if checkpoint.ingested_count == 0:
-        config = StorageConfig(lancedb_uri=lkm_db_uri)
-        storage_for_seed = StorageManager(config)
+    if checkpoint.ingested_count == 0 and seed_from:
+        logger.info("Checkpoint empty — seeding from %s ...", seed_from)
+        seed_config = StorageConfig(lancedb_uri=seed_from)
+        storage_for_seed = StorageManager(seed_config)
         await storage_for_seed.initialize()
         seeded = await _seed_checkpoint_from_import_status(storage_for_seed, checkpoint)
         await storage_for_seed.close()
         if seeded:
             logger.info("Seeded checkpoint from import_status: %d papers already ingested", seeded)
+        else:
+            logger.info("No existing import_status found in %s", seed_from)
     pending = checkpoint.pending(paper_ids)
     stats.skipped = len(paper_ids) - len(pending)
     if stats.skipped:
@@ -516,6 +520,11 @@ def main() -> None:
         help="Stop importing when free disk drops below this (GB, default: 10, 0=disable)",
     )
     parser.add_argument(
+        "--seed-from",
+        default=None,
+        help="LanceDB URI to seed checkpoint from (e.g. s3://datainfra-test/gaia_server_test)",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Query and print matching papers without importing",
@@ -570,6 +579,7 @@ def main() -> None:
             chunk_size=args.chunk_size,
             max_papers=args.max_papers,
             min_disk_gb=args.min_disk_gb,
+            seed_from=args.seed_from,
             dry_run=args.dry_run,
         )
     )

--- a/gaia/lkm/storage/lance_store.py
+++ b/gaia/lkm/storage/lance_store.py
@@ -629,16 +629,12 @@ class LanceContentStore:
     async def list_ingested_package_ids(self) -> list[str]:
         """Return all package_ids with status='ingested' from import_status."""
         table = self._db.open_table("import_status")
-        results = await self._run(
-            lambda: (
-                table.search()
-                .where("status = 'ingested'")
-                .select(["package_id"])
-                .limit(_MAX_SCAN)
-                .to_list()
-            )
-        )
-        return [r["package_id"] for r in results]
+
+        def _read() -> list[str]:
+            df = table.to_pandas(columns=["package_id", "status"])
+            return df.loc[df["status"] == "ingested", "package_id"].tolist()
+
+        return await self._run(_read)
 
     # ── Table counts ──
 

--- a/scripts/bulk-import-loop.sh
+++ b/scripts/bulk-import-loop.sh
@@ -53,6 +53,7 @@ while true; do
         --output-dir "$OUTPUT_DIR" \
         --max-papers "$MAX_PAPERS" \
         --chunk-size "$CHUNK_SIZE" \
+        --seed-from "$S3_URI" \
         || true  # don't exit on Ctrl+C or error
 
     new_ingested=$(checkpoint_count)


### PR DESCRIPTION
## Summary

- `search().where().limit()` on remote S3 LanceDB returns incomplete results (2K instead of 46K) depending on index/fragment state
- Switch to `to_pandas()` for reliable full-table read when seeding checkpoint
- import_status table is small (~50K rows max), so full read is fine

## Test plan

- [x] 8 pipeline tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)