### PR TITLE
feat: coarse IR + MI + narrative outline + metadata fix

### DIFF
--- a/gaia/cli/commands/_github.py
+++ b/gaia/cli/commands/_github.py
@@ -1,0 +1,434 @@
+"""Orchestrate GitHub output generation for a compiled Gaia package.
+
+Combines wiki pages, graph.json, manifest.json, assets, section placeholders,
+a React SPA template, and a README skeleton into a single ``.github-output/`` directory.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from gaia.cli.commands._graph_json import generate_graph_json
+from gaia.cli.commands._manifest import generate_manifest
+from gaia.ir.coarsen import coarsen_ir
+from gaia.cli.commands._wiki import generate_all_wiki
+
+
+def _copy_react_template(docs_dir: Path) -> None:
+    """Copy the React SPA template from ``gaia.cli.templates.pages`` to *docs_dir*.
+
+    The template provides the scaffold (``package.json``, ``src/``, ``index.html``,
+    etc.) on top of which data files (``public/data/``, ``public/assets/``) are
+    overlaid by the caller.
+
+    ``node_modules``, ``dist``, ``package-lock.json``, and Python bytecode are
+    excluded from the copy so the output stays lightweight and reproducible.
+    """
+    import gaia.cli.templates.pages as pages_pkg
+
+    template_path = Path(pages_pkg.__file__).parent
+
+    if docs_dir.exists():
+        shutil.rmtree(docs_dir)
+
+    shutil.copytree(
+        template_path,
+        docs_dir,
+        ignore=shutil.ignore_patterns(
+            "node_modules", "dist", "package-lock.json", "__pycache__", "*.pyc"
+        ),
+    )
+
+
+def _write_meta_json(
+    data_dir: Path,
+    ir: dict,
+    pkg_metadata: dict,
+) -> None:
+    """Write ``meta.json`` with package identity and description."""
+    meta = {
+        "package_name": ir.get("package_name", ""),
+        "namespace": ir.get("namespace", ""),
+        "name": pkg_metadata.get("name", ir.get("package_name", "")),
+        "description": pkg_metadata.get("description", ""),
+    }
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def generate_github_output(
+    ir: dict,
+    pkg_path: Path,
+    *,
+    beliefs_data: dict | None = None,
+    param_data: dict | None = None,
+    exported_ids: set[str] | None = None,
+    pkg_metadata: dict | None = None,
+) -> Path:
+    """Generate the full ``.github-output/`` tree and return its path.
+
+    Steps:
+    0. Copy React SPA template to ``docs/``
+    1. Create remaining directory structure
+    2. Write wiki pages
+    3. Write ``docs/public/data/graph.json``
+    4. Copy ``beliefs.json`` if beliefs_data is available
+    5. Write ``docs/public/data/meta.json``
+    6. Copy artifacts to ``docs/public/assets/``
+    7. Create section placeholder files (one per module)
+    8. Write ``manifest.json``
+    9. Generate README.md skeleton
+    10. Return the output directory path
+    """
+    exported = exported_ids or set()
+    metadata = pkg_metadata or {}
+
+    output_dir = pkg_path / ".github-output"
+    docs_dir = output_dir / "docs"
+    wiki_dir = output_dir / "wiki"
+    data_dir = docs_dir / "public" / "data"
+    assets_dir = docs_dir / "public" / "assets"
+    sections_dir = data_dir / "sections"
+
+    # ── 0. Copy React template if available ──
+    try:
+        _copy_react_template(docs_dir)
+    except Exception:
+        pass  # Template not installed — skip, data-only mode
+
+    # Create remaining directory structure (template may already provide some)
+    for d in (wiki_dir, data_dir, assets_dir, sections_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # ── 1. Wiki pages ──
+    wiki_pages = generate_all_wiki(ir, beliefs_data=beliefs_data, param_data=param_data)
+    for filename, content in wiki_pages.items():
+        (wiki_dir / filename).write_text(content, encoding="utf-8")
+
+    # ── 2. graph.json ──
+    graph_json = generate_graph_json(
+        ir,
+        beliefs_data=beliefs_data,
+        param_data=param_data,
+        exported_ids=exported,
+    )
+    (data_dir / "graph.json").write_text(graph_json, encoding="utf-8")
+
+    # ── 3. beliefs.json (if available) ──
+    if beliefs_data is not None:
+        (data_dir / "beliefs.json").write_text(
+            json.dumps(beliefs_data, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    # ── 4. meta.json ──
+    _write_meta_json(data_dir, ir, metadata)
+
+    # ── 5. Copy artifacts to assets (recursive) ──
+    artifacts_dir = pkg_path / "artifacts"
+    asset_names: list[str] = []
+    if artifacts_dir.is_dir():
+        for item in sorted(artifacts_dir.rglob("*")):
+            if item.is_file():
+                rel = item.relative_to(artifacts_dir)
+                dest = assets_dir / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(item, dest)
+                asset_names.append(str(rel))
+
+    # ── 6. Section placeholders (one per unique module) ──
+    modules: set[str] = set()
+    for k in ir.get("knowledges", []):
+        mod = k.get("module")
+        if mod:
+            modules.add(mod)
+    for mod in sorted(modules):
+        placeholder = sections_dir / f"{mod}.md"
+        if not placeholder.exists():
+            placeholder.write_text(
+                f"# {mod}\n\n<!-- Section placeholder for module: {mod} -->\n",
+                encoding="utf-8",
+            )
+
+    # ── 7. manifest.json ──
+    manifest_json = generate_manifest(
+        ir,
+        exported,
+        list(wiki_pages.keys()),
+        assets=asset_names,
+    )
+    (output_dir / "manifest.json").write_text(manifest_json, encoding="utf-8")
+
+    # ── 8. Narrative outline (for agent consumption) ──
+    # Split into two phases: outline (always fast) and MI (may be slow)
+    try:
+        from gaia.ir.linearize import linearize_narrative, render_narrative_outline
+
+        coarse_for_outline = coarsen_ir(ir, exported)
+        node_priors = {kid: 0.5 for k in ir["knowledges"] for kid in [k["id"]]}
+        if param_data:
+            for p in param_data.get("priors", []):
+                node_priors[p["knowledge_id"]] = p["value"]
+
+        # Phase 1: compute MI for small strategies (fast)
+        mi_map: dict[int, float] = {}
+        try:
+            from gaia.ir.coarsen import compute_coarse_cpts, mutual_information
+
+            sp: dict[str, list[float]] = {}
+            if param_data:
+                for s in param_data.get("strategy_params", []):
+                    sid = s.get("strategy_id", "")
+                    if s.get("conditional_probabilities"):
+                        sp[sid] = s["conditional_probabilities"]
+                    elif s.get("conditional_probability") is not None:
+                        sp[sid] = [s["conditional_probability"]]
+            computable = {
+                i for i, s in enumerate(coarse_for_outline["strategies"])
+                if len(s["premises"]) <= 8
+            }
+            cpts = compute_coarse_cpts(
+                ir, coarse_for_outline, node_priors=node_priors, strategy_params=sp,
+                strategy_indices=computable,
+            )
+            for i in cpts:
+                pp = [node_priors.get(p, 0.5) for p in coarse_for_outline["strategies"][i]["premises"]]
+                mi_map[i] = mutual_information(cpts[i], pp)
+        except Exception:
+            pass  # MI computation failed — outline still works without it
+
+        # Phase 2: generate outline (always works, with or without MI)
+        b = {x["knowledge_id"]: x["belief"] for x in beliefs_data.get("beliefs", [])} if beliefs_data else {}
+        sections = linearize_narrative(coarse_for_outline, beliefs=b, priors=node_priors, mi_per_strategy=mi_map)
+        outline = render_narrative_outline(sections)
+        (output_dir / "narrative-outline.md").write_text(outline, encoding="utf-8")
+    except Exception:
+        pass  # Outline generation failed entirely
+
+    # ── 9. README.md skeleton ──
+    readme = _generate_readme_skeleton(
+        ir,
+        beliefs_data=beliefs_data,
+        param_data=param_data,
+        exported_ids=exported,
+        pkg_metadata=metadata,
+    )
+    (output_dir / "README.md").write_text(readme, encoding="utf-8")
+
+    return output_dir
+
+
+def _render_coarse_mermaid(
+    ir: dict,
+    beliefs: dict[str, float],
+    priors: dict[str, float],
+    exported_ids: set[str],
+    param_data: dict | None = None,
+) -> str:
+    """Render a coarse-grained Mermaid graph: leaf premises → exported conclusions."""
+    coarse = coarsen_ir(ir, exported_ids)
+    kid_to_k = {k["id"]: k for k in coarse["knowledges"]}
+
+    lines = [
+        "```mermaid",
+        "---",
+        "config:",
+        "  flowchart:",
+        "    rankSpacing: 80",
+        "    nodeSpacing: 30",
+        "---",
+        "graph TB",
+    ]
+
+    for k in coarse["knowledges"]:
+        kid = k["id"]
+        label = k.get("title") or k.get("label", "?")
+        safe = k.get("label", "x").replace("-", "_")
+        b = beliefs.get(kid)
+        p = priors.get(kid)
+        is_exp = kid in exported_ids
+
+        prior_val = p if p is not None else 0.5
+        if is_exp:
+            ann = f"{prior_val:.2f} → {b:.2f}" if b is not None else ""
+            display = f"★ {label}\\n({ann})" if ann else f"★ {label}"
+            css = ":::exported"
+        else:
+            ann = f"{prior_val:.2f} → {b:.2f}" if b is not None else f"{prior_val:.2f}"
+            display = f"{label}\\n({ann})"
+            css = ":::premise"
+
+        display = display.replace('"', "#quot;").replace("*", "#ast;")
+        lines.append(f'    {safe}["{display}"]{css}')
+
+    # Strategy intermediate nodes (stadium shape) with CPT annotation
+    _DETERMINISTIC = {"deduction", "reductio", "elimination", "mathematical_induction", "case_analysis"}
+
+    # Compute coarse CPTs + mutual information if beliefs are available
+    coarse_cpts: dict[int, list[float]] = {}
+    if beliefs:
+        try:
+            from gaia.ir.coarsen import compute_coarse_cpts
+            node_priors_for_cpt = {kid: priors.get(kid, 0.5) for kid in beliefs}
+            strat_params: dict[str, list[float]] = {}
+            if param_data:
+                for sp in param_data.get("strategy_params", []):
+                    sid = sp.get("strategy_id", "")
+                    if sp.get("conditional_probabilities"):
+                        strat_params[sid] = sp["conditional_probabilities"]
+                    elif sp.get("conditional_probability") is not None:
+                        strat_params[sid] = [sp["conditional_probability"]]
+            computable_strats = {
+                i for i, s in enumerate(coarse["strategies"])
+                if len(s["premises"]) <= 8
+            }
+            coarse_cpts = compute_coarse_cpts(
+                ir, coarse,
+                node_priors=node_priors_for_cpt,
+                strategy_params=strat_params,
+                strategy_indices=computable_strats,
+            )
+        except Exception:
+            pass
+
+    total_mi = 0.0
+    for i, s in enumerate(coarse["strategies"]):
+        stype = s.get("type", "infer")
+        sid = f"strat_{i}"
+        conc = kid_to_k.get(s["conclusion"], {}).get("label", "?").replace("-", "_")
+        css = "" if stype in _DETERMINISTIC else ":::weak"
+
+        # Mutual information annotation
+        cpt = coarse_cpts.get(i)
+        if cpt and len(cpt) >= 2:
+            from gaia.ir.coarsen import mutual_information
+            premise_priors_list = [priors.get(p, 0.5) for p in s["premises"]]
+            mi = mutual_information(cpt, premise_priors_list)
+            total_mi += mi
+            ann = f"{stype}\\n{mi:.2f} bits"
+        else:
+            ann = stype
+
+        lines.append(f'    {sid}(["{ann}"]){css}')
+        for p in s["premises"]:
+            prem = kid_to_k.get(p, {}).get("label", "?").replace("-", "_")
+            lines.append(f"    {prem} --> {sid}")
+        lines.append(f"    {sid} --> {conc}")
+
+    # Operator nodes (hexagon shape)
+    _OP_SYMBOLS = {
+        "contradiction": "\u2297", "equivalence": "\u2261",
+        "complement": "\u2295", "disjunction": "\u2228",
+    }
+    _UNDIRECTED = {"equivalence", "contradiction", "complement"}
+    for i, o in enumerate(coarse.get("operators", [])):
+        otype = o.get("operator", "")
+        symbol = _OP_SYMBOLS.get(otype, otype)
+        oid = f"oper_{i}"
+        css = ":::contra" if otype == "contradiction" else ""
+        lines.append(f'    {oid}{{{{"{symbol}"}}}}{css}')
+        edge = " --- " if otype in _UNDIRECTED else " --> "
+        for v in o.get("variables", []):
+            v_label = kid_to_k.get(v, {}).get("label", "?").replace("-", "_")
+            lines.append(f"    {v_label}{edge}{oid}")
+        conc = o.get("conclusion")
+        if conc:
+            c_label = kid_to_k.get(conc, {}).get("label", "?").replace("-", "_")
+            lines.append(f"    {oid}{edge}{c_label}")
+
+    lines.append("")
+    lines.append("    classDef premise fill:#ddeeff,stroke:#4488bb,color:#333")
+    lines.append("    classDef exported fill:#d4edda,stroke:#28a745,stroke-width:2px,color:#333")
+    lines.append("    classDef weak fill:#fff9c4,stroke:#f9a825,stroke-dasharray: 5 5,color:#333")
+    lines.append("    classDef contra fill:#ffebee,stroke:#c62828,color:#333")
+    lines.append("```")
+    return "\n".join(lines), total_mi
+
+
+def _generate_readme_skeleton(
+    ir: dict,
+    *,
+    beliefs_data: dict | None = None,
+    param_data: dict | None = None,
+    exported_ids: set[str] | None = None,
+    pkg_metadata: dict | None = None,
+) -> str:
+    """Build a README.md with Mermaid overview, conclusion table, and placeholders."""
+    exported = exported_ids or set()
+    metadata = pkg_metadata or {}
+    pkg_name = metadata.get("name", ir.get("package_name", "Package"))
+    description = metadata.get("description", "")
+
+    lines: list[str] = []
+
+    # Title and description
+    lines.append(f"# {pkg_name}")
+    lines.append("")
+    if description:
+        lines.append(description)
+        lines.append("")
+
+    # Badges placeholder
+    lines.append("<!-- badges:start -->")
+    lines.append("<!-- badges:end -->")
+    lines.append("")
+
+    # Simplified Mermaid graph (only when beliefs are available)
+    beliefs: dict[str, float] = {}
+    priors: dict[str, float] = {}
+    if beliefs_data:
+        beliefs = {b["knowledge_id"]: b["belief"] for b in beliefs_data.get("beliefs", [])}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+
+    if beliefs:
+        lines.append("## Overview")
+        lines.append("")
+        mermaid, total_mi = _render_coarse_mermaid(
+            ir, beliefs, priors, exported, param_data=param_data,
+        )
+        if total_mi > 0:
+            lines.append("> [!TIP]")
+            lines.append(
+                f"> **Reasoning graph information gain: `{total_mi:.1f} bits`**"
+            )
+            lines.append(">")
+            lines.append(
+                "> Total mutual information between leaf premises and "
+                "exported conclusions — measures how much the reasoning "
+                "structure reduces uncertainty about the results."
+            )
+            lines.append("")
+        lines.append(mermaid)
+        lines.append("")
+
+    # Exported conclusions table
+    knowledge_by_id = {k["id"]: k for k in ir.get("knowledges", [])}
+    exported_nodes = [knowledge_by_id[eid] for eid in sorted(exported) if eid in knowledge_by_id]
+    if exported_nodes:
+        lines.append("## Conclusions")
+        lines.append("")
+        lines.append("| Label | Content | Prior | Belief |")
+        lines.append("|-------|---------|-------|--------|")
+        for k in exported_nodes:
+            label = k.get("label", "")
+            content = k.get("content", "")
+            if len(content) > 80:
+                content = content[:77] + "..."
+            kid = k["id"]
+            prior = f"{priors.get(kid, 0.5):.2f}"
+            belief = f"{beliefs[kid]:.2f}" if kid in beliefs else "\u2014"
+            lines.append(f"| {label} | {content} | {prior} | {belief} |")
+        lines.append("")
+
+    # Placeholder markers
+    lines.append("<!-- content:start -->")
+    lines.append("<!-- content:end -->")
+    lines.append("")
+
+    return "\n".join(lines)

--- a/gaia/cli/commands/_graph_json.py
+++ b/gaia/cli/commands/_graph_json.py
@@ -1,0 +1,72 @@
+"""Generate graph.json for interactive visualization."""
+
+from __future__ import annotations
+
+import json
+
+
+def generate_graph_json(
+    ir: dict,
+    beliefs_data: dict | None = None,
+    param_data: dict | None = None,
+    exported_ids: set[str] | None = None,
+) -> str:
+    """Generate JSON with nodes and edges for Cytoscape.js visualization."""
+    beliefs: dict[str, float] = {}
+    if beliefs_data:
+        beliefs = {b["knowledge_id"]: b["belief"] for b in beliefs_data.get("beliefs", [])}
+    priors: dict[str, float] = {}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+    exported = exported_ids or set()
+
+    nodes = []
+    for k in ir["knowledges"]:
+        kid = k["id"]
+        label = k.get("label", "")
+        if label.startswith("__"):
+            continue
+        nodes.append(
+            {
+                "id": kid,
+                "label": label,
+                "title": k.get("title"),
+                "type": k["type"],
+                "module": k.get("module"),
+                "content": k.get("content", ""),
+                "prior": priors.get(kid),
+                "belief": beliefs.get(kid),
+                "exported": kid in exported,
+                "metadata": k.get("metadata", {}),
+            }
+        )
+
+    edges = []
+    for s in ir.get("strategies", []):
+        conc = s.get("conclusion")
+        if not conc:
+            continue
+        for p in s.get("premises", []):
+            edges.append(
+                {
+                    "source": p,
+                    "target": conc,
+                    "type": "strategy",
+                    "strategy_type": s.get("type", ""),
+                    "reason": s.get("reason", ""),
+                }
+            )
+    for o in ir.get("operators", []):
+        conc = o.get("conclusion")
+        for v in o.get("variables", []):
+            edges.append(
+                {
+                    "source": v,
+                    "target": conc or v,
+                    "type": "operator",
+                    "operator_type": o.get("operator", ""),
+                    "reason": o.get("reason", ""),
+                }
+            )
+
+    return json.dumps({"nodes": nodes, "edges": edges}, indent=2, ensure_ascii=False)

--- a/gaia/cli/commands/_manifest.py
+++ b/gaia/cli/commands/_manifest.py
@@ -1,0 +1,69 @@
+"""Generate manifest.json summarizing all GitHub output artifacts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+
+def generate_manifest(
+    ir: dict,
+    exported_ids: set[str],
+    wiki_pages: list[str],
+    *,
+    assets: list[str] | None = None,
+    sections: list[str] | None = None,
+) -> str:
+    """Return a JSON string describing the generated GitHub output.
+
+    Fields:
+    - package_name: from IR
+    - generated_at: ISO-8601 UTC timestamp
+    - wiki_pages: list of wiki page filenames
+    - pages_sections: one ``<module>.md`` per unique module (or explicit override)
+    - assets: list of asset filenames
+    - exported_conclusions: list of exported knowledge labels
+    - total_claims: count of claim-type knowledge nodes (excluding helpers)
+    - total_beliefs: count of non-helper knowledge nodes
+    - readme_placeholders: list of placeholder markers for future expansion
+    """
+    # Derive sections from unique modules unless explicitly provided
+    if sections is not None:
+        pages_sections = list(sections)
+    else:
+        seen: set[str] = set()
+        pages_sections: list[str] = []
+        for k in ir.get("knowledges", []):
+            mod = k.get("module")
+            if mod and mod not in seen:
+                seen.add(mod)
+                pages_sections.append(f"{mod}.md")
+
+    # Build exported conclusions list (labels)
+    knowledge_by_id = {k["id"]: k for k in ir.get("knowledges", [])}
+    exported_conclusions: list[str] = []
+    for eid in sorted(exported_ids):
+        k = knowledge_by_id.get(eid)
+        if k:
+            exported_conclusions.append(k.get("label", eid))
+        else:
+            exported_conclusions.append(eid)
+
+    # Count non-helper nodes
+    non_helper = [k for k in ir.get("knowledges", []) if not k.get("label", "").startswith("__")]
+    total_claims = sum(1 for k in non_helper if k.get("type") == "claim")
+    total_beliefs = len(non_helper)
+
+    manifest = {
+        "package_name": ir.get("package_name", ""),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "wiki_pages": wiki_pages,
+        "pages_sections": pages_sections,
+        "assets": assets or [],
+        "exported_conclusions": exported_conclusions,
+        "total_claims": total_claims,
+        "total_beliefs": total_beliefs,
+        "readme_placeholders": [],
+    }
+
+    return json.dumps(manifest, indent=2, ensure_ascii=False)

--- a/gaia/cli/commands/_simplified_mermaid.py
+++ b/gaia/cli/commands/_simplified_mermaid.py
@@ -1,0 +1,239 @@
+"""Simplified Mermaid graph for GitHub wiki overview pages.
+
+Selects a bounded set of the most informative nodes and renders a compact
+``graph TD`` diagram with prior → belief annotations.
+"""
+
+from __future__ import annotations
+
+from gaia.cli.commands._classify import classify_ir, node_role
+
+# ── Mermaid CSS class definitions (self-contained, not imported from _readme) ──
+
+_MERMAID_STYLES = """\
+    classDef setting fill:#f0f0f0,stroke:#999,color:#333
+    classDef premise fill:#ddeeff,stroke:#4488bb,color:#333
+    classDef derived fill:#ddffdd,stroke:#44bb44,color:#333
+    classDef question fill:#fff3dd,stroke:#cc9944,color:#333
+    classDef background fill:#f5f5f5,stroke:#bbb,stroke-dasharray: 5 5,color:#333
+    classDef orphan fill:#fff,stroke:#ccc,stroke-dasharray: 5 5,color:#333
+    classDef exported fill:#d4edda,stroke:#28a745,stroke-width:2px,color:#333
+    classDef weak fill:#fff9c4,stroke:#f9a825,stroke-dasharray: 5 5,color:#333
+    classDef contra fill:#ffebee,stroke:#c62828,color:#333"""
+
+_ROLE_TO_CSS = {
+    "setting": "setting",
+    "question": "question",
+    "derived": "derived",
+    "structural": "derived",
+    "independent": "premise",
+    "background": "background",
+    "orphaned": "orphan",
+}
+
+# Operators rendered with undirected (---) edges between variables
+_UNDIRECTED_OPERATORS = frozenset({"equivalence", "contradiction", "complement"})
+
+_OPERATOR_SYMBOLS = {
+    "contradiction": "\u2297",
+    "equivalence": "\u2261",
+    "complement": "\u2295",
+    "disjunction": "\u2228",
+    "conjunction": "\u2227",
+    "implication": "\u2192",
+}
+
+_DETERMINISTIC_STRATEGIES = frozenset(
+    {
+        "deduction",
+        "reductio",
+        "elimination",
+        "mathematical_induction",
+        "case_analysis",
+    }
+)
+
+
+# ── Node selection (Task 6) ──
+
+
+def select_simplified_nodes(
+    beliefs: dict[str, float],
+    priors: dict[str, float],
+    exported_ids: set[str],
+    max_nodes: int = 15,
+) -> set[str]:
+    """Select nodes for the simplified overview graph.
+
+    1. Always include all exported conclusions
+    2. Fill remaining slots with highest |belief - prior| nodes
+    3. Cap at max_nodes
+    """
+    selected = set(exported_ids)
+    candidates: list[tuple[float, str]] = []
+    for kid, belief in beliefs.items():
+        if kid in selected:
+            continue
+        prior = priors.get(kid, 0.5)
+        delta = abs(belief - prior)
+        candidates.append((delta, kid))
+    candidates.sort(reverse=True)
+    remaining = max_nodes - len(selected)
+    for _, kid in candidates[: max(0, remaining)]:
+        selected.add(kid)
+    return selected
+
+
+# ── Mermaid rendering (Task 7) ──
+
+
+def _is_helper(label: str | None) -> bool:
+    if not label:
+        return True
+    return label.startswith("__") or label.startswith("_anon")
+
+
+def render_simplified_mermaid(
+    ir: dict,
+    beliefs: dict[str, float],
+    priors: dict[str, float],
+    exported_ids: set[str],
+    max_nodes: int = 15,
+) -> str:
+    """Render a simplified Mermaid ``graph TD`` diagram.
+
+    Each node shows ``Label ★ (prior → belief)`` for exported conclusions
+    and ``Label (prior → belief)`` for others.  Only edges whose both
+    endpoints are in the selected set are included.
+    """
+    selected = select_simplified_nodes(beliefs, priors, exported_ids, max_nodes)
+
+    knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    c = classify_ir(ir)
+
+    lines = ["```mermaid", "graph TD"]
+    _rendered_labels: set[str] = set()
+
+    # Render knowledge nodes
+    for k in ir["knowledges"]:
+        kid = k["id"]
+        if kid not in selected:
+            continue
+        label = k.get("label", "")
+        if _is_helper(label):
+            continue
+
+        title = k.get("title") or label
+        is_exported = kid in exported_ids
+        star = " \u2605" if is_exported else ""
+
+        prior_val = priors.get(kid, 0.5)
+        belief_val = beliefs.get(kid, prior_val)
+        annotation = f"{prior_val:.2f} \u2192 {belief_val:.2f}"
+
+        display = f"{title}{star} ({annotation})"
+        display = display.replace('"', "#quot;").replace("*", "#ast;")
+
+        if is_exported:
+            css = "exported"
+        else:
+            role = node_role(kid, k["type"], c)
+            css = _ROLE_TO_CSS.get(role, "orphan")
+
+        lines.append(f'    {label}["{display}"]:::{css}')
+        _rendered_labels.add(label)
+
+    # Render strategy edges between selected nodes
+    for i, s in enumerate(ir.get("strategies", [])):
+        conclusion = s.get("conclusion")
+        if not conclusion or conclusion not in selected:
+            continue
+        conc_label = knowledge_by_id.get(conclusion, {}).get("label", "")
+        if _is_helper(conc_label):
+            continue
+
+        stype = s.get("type", "")
+        sid = f"strat_{i}"
+
+        visible_premises: list[str] = []
+        for p in s.get("premises", []):
+            if p not in selected:
+                continue
+            p_label = knowledge_by_id.get(p, {}).get("label", "")
+            if p_label and not _is_helper(p_label):
+                visible_premises.append(p_label)
+
+        visible_bg: list[str] = []
+        for b in s.get("background") or []:
+            if b not in selected:
+                continue
+            b_label = knowledge_by_id.get(b, {}).get("label", "")
+            if b_label and not _is_helper(b_label):
+                visible_bg.append(b_label)
+
+        if not visible_premises and not visible_bg:
+            continue
+
+        css = "" if stype in _DETERMINISTIC_STRATEGIES else ":::weak"
+        lines.append(f'    {sid}(["{stype}"]){css}')
+
+        for p_label in visible_premises:
+            lines.append(f"    {p_label} --> {sid}")
+        for b_label in visible_bg:
+            lines.append(f"    {b_label} -.-> {sid}")
+        lines.append(f"    {sid} --> {conc_label}")
+
+    # Render operator edges between selected nodes.
+    # When an operator has at least one selected variable, pull in the
+    # missing variables so the constraint renders completely.
+    for i, o in enumerate(ir.get("operators", [])):
+        conclusion = o.get("conclusion")
+        conc_label = knowledge_by_id.get(conclusion, {}).get("label", "") if conclusion else ""
+        conc_visible = conclusion and conclusion in selected and not _is_helper(conc_label)
+
+        otype = o.get("operator", "")
+        symbol = _OPERATOR_SYMBOLS.get(otype, otype)
+        oid = f"oper_{i}"
+        is_undirected = otype in _UNDIRECTED_OPERATORS
+
+        # Collect all non-helper variable labels for this operator
+        all_vars: list[tuple[str, str]] = []  # (kid, label)
+        any_selected = False
+        for v in o.get("variables", []):
+            v_label = knowledge_by_id.get(v, {}).get("label", "")
+            if v_label and not _is_helper(v_label):
+                all_vars.append((v, v_label))
+                if v in selected:
+                    any_selected = True
+
+        if not any_selected and not conc_visible:
+            continue
+
+        css = ":::contra" if otype == "contradiction" else ""
+        lines.append(f'    {oid}{{{{"{symbol}"}}}}{css}')
+
+        # Render all variables (pull in unselected ones so the constraint
+        # is complete — e.g. both sides of a contradiction are shown)
+        edge = " --- " if is_undirected else " --> "
+        for v_kid, v_label in all_vars:
+            # Ensure pulled-in nodes have a node definition
+            if v_kid not in selected and v_label not in _rendered_labels:
+                k = knowledge_by_id.get(v_kid, {})
+                title = k.get("title") or v_label
+                prior_val = priors.get(v_kid, 0.5)
+                belief_val = beliefs.get(v_kid, prior_val)
+                annotation = f"{prior_val:.2f} \u2192 {belief_val:.2f}"
+                display = f"{title} ({annotation})"
+                display = display.replace('"', "#quot;").replace("*", "#ast;")
+                role = node_role(v_kid, k.get("type", "claim"), c)
+                node_css = _ROLE_TO_CSS.get(role, "orphan")
+                lines.append(f'    {v_label}["{display}"]:::{node_css}')
+                _rendered_labels.add(v_label)
+            lines.append(f"    {v_label}{edge}{oid}")
+        if conc_visible:
+            lines.append(f"    {oid}{edge}{conc_label}")
+
+    lines.append("")
+    lines.append(_MERMAID_STYLES)
+    lines.append("```")
+    return "\n".join(lines)

--- a/gaia/cli/commands/_wiki.py
+++ b/gaia/cli/commands/_wiki.py
@@ -1,0 +1,252 @@
+"""Generate agent-optimized Wiki markdown pages from compiled IR."""
+
+from __future__ import annotations
+
+from gaia.cli.commands._classify import classify_ir, node_role
+
+
+def generate_wiki_home(ir: dict, beliefs_data: dict | None = None) -> str:
+    """Generate Wiki Home.md with package overview and claim index."""
+    pkg = ir.get("package_name", "Package")
+    lines = [f"# {pkg}", ""]
+
+    # Module index
+    modules: dict[str, list[dict]] = {}
+    for k in ir["knowledges"]:
+        mod = k.get("module", "Root")
+        modules.setdefault(mod, []).append(k)
+
+    lines.append("## Modules")
+    lines.append("")
+    for mod in modules:
+        count = sum(1 for k in modules[mod] if not k.get("label", "").startswith("__"))
+        page = f"Module-{mod.replace('_', '-')}"
+        lines.append(f"- [{mod}]({page}) ({count} nodes)")
+    lines.append("")
+
+    # Claim index
+    beliefs = {}
+    if beliefs_data:
+        beliefs = {b["knowledge_id"]: b["belief"] for b in beliefs_data.get("beliefs", [])}
+
+    lines.append("## Claim Index")
+    lines.append("")
+    lines.append("| Label | Type | Module | Belief |")
+    lines.append("|-------|------|--------|--------|")
+    for k in ir["knowledges"]:
+        label = k.get("label", "")
+        if label.startswith("__"):
+            continue
+        kid = k["id"]
+        ktype = k["type"]
+        mod = k.get("module", "Root")
+        belief = f"{beliefs[kid]:.2f}" if kid in beliefs else "\u2014"
+        lines.append(f"| {label} | {ktype} | {mod} | {belief} |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def generate_wiki_inference(
+    ir: dict,
+    beliefs_data: dict,
+    param_data: dict | None = None,
+) -> str:
+    """Generate an Inference Results wiki page with diagnostics and a belief table.
+
+    Shows convergence diagnostics and a full table of non-helper nodes sorted by
+    belief descending, with columns: Label, Type, Prior, Belief, Role.
+    """
+    classification = classify_ir(ir)
+
+    # Build lookup maps
+    beliefs: dict[str, float] = {}
+    belief_labels: dict[str, str] = {}
+    if beliefs_data:
+        for b in beliefs_data.get("beliefs", []):
+            beliefs[b["knowledge_id"]] = b["belief"]
+            if "label" in b:
+                belief_labels[b["knowledge_id"]] = b["label"]
+
+    priors: dict[str, float] = {}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+
+    lines = ["# Inference Results", ""]
+
+    # Diagnostics section
+    diag = beliefs_data.get("diagnostics", {}) if beliefs_data else {}
+    converged = diag.get("converged")
+    iterations = diag.get("iterations_run")
+
+    lines.append("## Diagnostics")
+    lines.append("")
+    if converged is not None:
+        lines.append(f"- **Converged:** {'Yes' if converged else 'No'}")
+    if iterations is not None:
+        lines.append(f"- **Iterations:** {iterations}")
+    lines.append("")
+
+    # Belief table — sorted by belief descending, skip helpers
+    knowledges = [k for k in ir["knowledges"] if not k.get("label", "").startswith("__")]
+    knowledges.sort(key=lambda k: beliefs.get(k["id"], 0.0), reverse=True)
+
+    lines.append("## Beliefs")
+    lines.append("")
+    lines.append("| Label | Type | Prior | Belief | Role |")
+    lines.append("|-------|------|-------|--------|------|")
+
+    for k in knowledges:
+        kid = k["id"]
+        label = k.get("label", kid)
+        ktype = k["type"]
+        role = node_role(kid, ktype, classification)
+        prior = f"{priors[kid]:.2f}" if kid in priors else "\u2014"
+        belief = f"{beliefs[kid]:.2f}" if kid in beliefs else "\u2014"
+        lines.append(f"| {label} | {ktype} | {prior} | {belief} | {role} |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def generate_all_wiki(
+    ir: dict,
+    beliefs_data: dict | None = None,
+    param_data: dict | None = None,
+) -> dict[str, str]:
+    """Generate all wiki pages and return them as ``{filename: markdown_content}``.
+
+    Produces:
+    - ``Home.md`` — package overview and claim index
+    - ``Module-{name}.md`` — one page per unique module
+    - ``Inference-Results.md`` — if *beliefs_data* is provided
+    """
+    pages: dict[str, str] = {}
+
+    pages["Home.md"] = generate_wiki_home(ir, beliefs_data=beliefs_data)
+
+    # Collect unique modules
+    modules: set[str] = set()
+    for k in ir["knowledges"]:
+        modules.add(k.get("module", "Root"))
+
+    for mod in sorted(modules):
+        page_name = f"Module-{mod.replace('_', '-')}.md"
+        pages[page_name] = generate_wiki_module(
+            ir, mod, beliefs_data=beliefs_data, param_data=param_data
+        )
+
+    if beliefs_data is not None:
+        pages["Inference-Results.md"] = generate_wiki_inference(
+            ir, beliefs_data, param_data=param_data
+        )
+
+    return pages
+
+
+def generate_wiki_module(
+    ir: dict,
+    module_name: str,
+    *,
+    beliefs_data: dict | None = None,
+    param_data: dict | None = None,
+) -> str:
+    """Generate a structured Wiki page for a single module.
+
+    Each non-helper knowledge node gets: QID, type, role, content, prior,
+    belief, derivation info, reasoning, metadata, and cross-references.
+    """
+    classification = classify_ir(ir)
+
+    # Build lookup maps
+    beliefs: dict[str, float] = {}
+    if beliefs_data:
+        beliefs = {b["knowledge_id"]: b["belief"] for b in beliefs_data.get("beliefs", [])}
+
+    priors: dict[str, float] = {}
+    if param_data:
+        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+
+    # Index strategies by conclusion and by premise for cross-references
+    strategies_by_conclusion: dict[str, list[dict]] = {}
+    strategies_by_premise: dict[str, list[dict]] = {}
+    for s in ir.get("strategies", []):
+        conc = s.get("conclusion")
+        if conc:
+            strategies_by_conclusion.setdefault(conc, []).append(s)
+        for p in s.get("premises", []):
+            strategies_by_premise.setdefault(p, []).append(s)
+
+    # Index operators by premise/variable for cross-references
+    operators_by_variable: dict[str, list[dict]] = {}
+    for o in ir.get("operators", []):
+        for v in o.get("variables", []):
+            operators_by_variable.setdefault(v, []).append(o)
+
+    # Filter knowledges for this module, skip helpers
+    module_knowledges = [
+        k
+        for k in ir["knowledges"]
+        if k.get("module", "Root") == module_name and not k.get("label", "").startswith("__")
+    ]
+
+    lines = [f"# Module: {module_name}", ""]
+
+    for k in module_knowledges:
+        kid = k["id"]
+        label = k.get("label", kid)
+        ktype = k["type"]
+        content = k.get("content", "")
+        role = node_role(kid, ktype, classification)
+
+        lines.append(f"### {label}")
+        lines.append("")
+        lines.append(f"**QID:** `{kid}`")
+        lines.append(f"**Type:** {ktype}")
+        lines.append(f"**Role:** {role}")
+        lines.append(f"**Content:** {content}")
+
+        # Prior
+        if kid in priors:
+            lines.append(f"**Prior:** {priors[kid]:.2f}")
+
+        # Belief
+        if kid in beliefs:
+            lines.append(f"**Belief:** {beliefs[kid]:.2f}")
+
+        # Derivation info (strategies where this node is the conclusion)
+        if kid in strategies_by_conclusion:
+            for s in strategies_by_conclusion[kid]:
+                stype = s.get("type", "unknown")
+                lines.append(f"**Derived from:** {stype}")
+                premises = s.get("premises", [])
+                if premises:
+                    lines.append(f"**Premises:** {', '.join(f'`{p}`' for p in premises)}")
+                reason = s.get("reason", "")
+                if reason:
+                    lines.append(f"**Reasoning:** {reason}")
+
+        # Metadata
+        metadata = k.get("metadata", {})
+        if metadata:
+            for mk, mv in metadata.items():
+                lines.append(f"**{mk}:** {mv}")
+
+        # Referenced by: strategies/operators where this node appears as a premise/variable
+        refs: list[str] = []
+        if kid in strategies_by_premise:
+            for s in strategies_by_premise[kid]:
+                conc = s.get("conclusion", "?")
+                stype = s.get("type", "unknown")
+                refs.append(f"{stype} -> `{conc}`")
+        if kid in operators_by_variable:
+            for o in operators_by_variable[kid]:
+                conc = o.get("conclusion", "?")
+                otype = o.get("type", "unknown")
+                refs.append(f"{otype} -> `{conc}`")
+        if refs:
+            lines.append(f"**Referenced by:** {'; '.join(refs)}")
+
+        lines.append("")
+
+    return "\n".join(lines)

--- a/gaia/cli/commands/compile.py
+++ b/gaia/cli/commands/compile.py
@@ -14,7 +14,10 @@ from gaia.ir.validator import validate_local_graph
 
 def compile_command(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
-    readme: bool = typer.Option(False, "--readme", help="Generate README.md at package root"),
+    readme: bool = typer.Option(False, "--readme", help="(Legacy) Generate README.md. Prefer --github for richer output."),
+    github: bool = typer.Option(
+        False, "--github", help="Generate GitHub presentation (.github-output/)"
+    ),
 ) -> None:
     """Compile a knowledge package to .gaia/ir.json."""
     try:
@@ -42,11 +45,10 @@ def compile_command(
     typer.echo(f"IR hash: {ir['ir_hash'][:16]}...")
     typer.echo(f"Output: {gaia_dir / 'ir.json'}")
 
-    if readme:
-        from gaia.cli.commands._readme import generate_readme
-
-        beliefs_data = None
-        param_data = None
+    # Load beliefs/param data from latest review (shared by --readme and --github)
+    beliefs_data = None
+    param_data = None
+    if readme or github:
         reviews_dir = loaded.pkg_path / ".gaia" / "reviews"
         if reviews_dir.exists():
             review_dirs = sorted(
@@ -63,9 +65,28 @@ def compile_command(
                         param_data = json.loads(param_path.read_text())
                     break
 
+    if readme:
+        from gaia.cli.commands._readme import generate_readme
+
         content = generate_readme(
             ir, loaded.project_config, beliefs_data=beliefs_data, param_data=param_data
         )
         readme_path = loaded.pkg_path / "README.md"
         readme_path.write_text(content)
         typer.echo(f"README: {readme_path}")
+
+    if github:
+        from gaia.cli.commands._github import generate_github_output
+
+        # Collect exported IDs from the compiled IR
+        exported_ids = {k["id"] for k in ir.get("knowledges", []) if k.get("exported")}
+
+        output_dir = generate_github_output(
+            ir,
+            loaded.pkg_path,
+            beliefs_data=beliefs_data,
+            param_data=param_data,
+            exported_ids=exported_ids,
+            pkg_metadata=loaded.project_config,
+        )
+        typer.echo(f"GitHub output: {output_dir}")

--- a/gaia/ir/coarsen.py
+++ b/gaia/ir/coarsen.py
@@ -1,0 +1,273 @@
+"""Coarsen a Gaia IR to show only leaf premises → exported conclusions.
+
+All intermediate nodes are folded away. Each multi-hop reasoning chain
+becomes a single ``infer`` edge connecting a leaf premise to an exported
+conclusion it supports (directly or transitively).
+"""
+
+from __future__ import annotations
+
+
+def coarsen_ir(ir: dict, exported_ids: set[str]) -> dict:
+    """Produce a coarse-grained IR with leaf premises and exported conclusions.
+
+    Parameters
+    ----------
+    ir:
+        Full compiled IR dict with knowledges, strategies, operators.
+    exported_ids:
+        Set of knowledge IDs that are exported conclusions.
+
+    Returns
+    -------
+    A new IR dict (same schema) containing only leaf premises + exported
+    conclusions, connected by ``infer`` strategies representing transitive
+    reasoning chains.
+    """
+    # 1. Identify all nodes concluded by a strategy or operator
+    strat_conclusions = {s["conclusion"] for s in ir["strategies"] if s.get("conclusion")}
+    op_conclusions = {o["conclusion"] for o in ir["operators"] if o.get("conclusion")}
+    all_concluded = strat_conclusions | op_conclusions
+
+    # 2. Identify leaf premises: claims not concluded by any strategy/operator,
+    #    excluding helpers and settings
+    leaf_ids: set[str] = set()
+    for k in ir["knowledges"]:
+        kid = k["id"]
+        label = k.get("label", "")
+        if label.startswith("__") or label.startswith("_anon"):
+            continue
+        if kid not in all_concluded and k["type"] == "claim":
+            leaf_ids.add(kid)
+
+    # 3. Build forward adjacency: for each node, which conclusions does it
+    #    support (as a premise of a strategy or variable of an operator)?
+    forward: dict[str, set[str]] = {}
+    for s in ir["strategies"]:
+        conc = s.get("conclusion")
+        if not conc:
+            continue
+        for p in s.get("premises", []):
+            forward.setdefault(p, set()).add(conc)
+    for o in ir["operators"]:
+        conc = o.get("conclusion")
+        if not conc:
+            continue
+        for v in o.get("variables", []):
+            forward.setdefault(v, set()).add(conc)
+
+    # 4. For each leaf premise, BFS forward to find which exported conclusions
+    #    it transitively supports. Stop at exported conclusions.
+    edges: list[tuple[str, str]] = []
+    for leaf in leaf_ids:
+        visited: set[str] = set()
+        queue = [leaf]
+        while queue:
+            node = queue.pop(0)
+            if node in visited:
+                continue
+            visited.add(node)
+            if node != leaf and node in exported_ids:
+                edges.append((leaf, node))
+                continue
+            for neighbor in forward.get(node, []):
+                if neighbor not in visited:
+                    queue.append(neighbor)
+
+    # 4b. Also find exported → exported edges (one exported supports another)
+    for exp in exported_ids:
+        visited: set[str] = set()
+        queue = list(forward.get(exp, []))
+        while queue:
+            node = queue.pop(0)
+            if node in visited:
+                continue
+            visited.add(node)
+            if node in exported_ids:
+                edges.append((exp, node))
+                continue
+            for neighbor in forward.get(node, []):
+                if neighbor not in visited:
+                    queue.append(neighbor)
+
+    # 5. Deduplicate edges
+    unique_edges = sorted(set(edges))
+
+    # 6. Determine which leaf premises are actually connected to exports
+    connected_leaves = {e[0] for e in unique_edges}
+    connected_exports = {e[1] for e in unique_edges}
+
+    # 7. Build coarse knowledges (only connected nodes)
+    keep_ids = connected_leaves | connected_exports
+    coarse_knowledges = []
+    for k in ir["knowledges"]:
+        if k["id"] in keep_ids:
+            coarse_knowledges.append(k)
+
+    # 8. Build coarse strategies (one infer per edge)
+    coarse_strategies = []
+    by_conclusion: dict[str, list[str]] = {}
+    for src, dst in unique_edges:
+        by_conclusion.setdefault(dst, []).append(src)
+
+    for conc, premises in by_conclusion.items():
+        coarse_strategies.append({
+            "type": "infer",
+            "premises": sorted(premises),
+            "conclusion": conc,
+            "reason": "",
+        })
+
+    # 9. Preserve operators whose variables/conclusion touch keep_ids.
+    #    Also pull in any operator variables not yet in keep_ids so the
+    #    constraint renders completely.
+    coarse_operators = []
+    for o in ir.get("operators", []):
+        conc = o.get("conclusion")
+        variables = o.get("variables", [])
+        all_nodes = set(variables)
+        if conc:
+            all_nodes.add(conc)
+        # Keep operator if at least one endpoint is in keep_ids
+        if all_nodes & keep_ids:
+            coarse_operators.append(o)
+            # Pull in any missing variables/conclusion
+            for nid in all_nodes:
+                if nid not in keep_ids:
+                    keep_ids.add(nid)
+                    k = next((k for k in ir["knowledges"] if k["id"] == nid), None)
+                    if k and not k.get("label", "").startswith("__"):
+                        coarse_knowledges.append(k)
+
+    return {
+        "package_name": ir.get("package_name", ""),
+        "namespace": ir.get("namespace", ""),
+        "knowledges": coarse_knowledges,
+        "strategies": coarse_strategies,
+        "operators": coarse_operators,
+    }
+
+
+def _binary_entropy(p: float) -> float:
+    """H(Bernoulli(p)) in bits."""
+    import math
+    if p <= 0 or p >= 1:
+        return 0.0
+    return -(p * math.log2(p) + (1 - p) * math.log2(1 - p))
+
+
+def mutual_information(
+    cpt: list[float],
+    premise_priors: list[float],
+) -> float:
+    """Compute I(premises; conclusion) in bits from a coarse CPT.
+
+    Parameters
+    ----------
+    cpt:
+        CPT of length 2^k, indexed by binary encoding of premise assignment.
+    premise_priors:
+        Prior probability of each premise being true (length k).
+
+    Returns
+    -------
+    Mutual information in bits.
+    """
+    k = len(premise_priors)
+    assert len(cpt) == (1 << k)
+
+    # P(C=1) marginal and conditional entropy H(C|P)
+    p_c1 = 0.0
+    h_c_given_p = 0.0
+
+    for assignment in range(1 << k):
+        # P(assignment) = product of premise marginals
+        p_assignment = 1.0
+        for bit in range(k):
+            pi = premise_priors[bit]
+            if (assignment >> bit) & 1:
+                p_assignment *= pi
+            else:
+                p_assignment *= (1 - pi)
+
+        p_c1_given_a = cpt[assignment]
+        p_c1 += p_assignment * p_c1_given_a
+        h_c_given_p += p_assignment * _binary_entropy(p_c1_given_a)
+
+    h_c = _binary_entropy(p_c1)
+    return max(0.0, h_c - h_c_given_p)
+
+
+def compute_coarse_cpts(
+    ir: dict,
+    coarse: dict,
+    node_priors: dict[str, float] | None = None,
+    strategy_params: dict[str, list[float]] | None = None,
+    strategy_indices: set[int] | None = None,
+) -> dict[int, list[float]]:
+    """Compute effective CPTs for coarse infer strategies by marginalization.
+
+    For each coarse strategy, clamp its premises to all 2^k assignments
+    and run BP on the **full** factor graph to get P(conclusion=1 | assignment).
+
+    Optimization: the factor graph is built once per strategy; only premise
+    priors are updated between assignments.
+
+    Returns a dict mapping strategy index to CPT (list of 2^k floats).
+    """
+    from gaia.bp.bp import BeliefPropagation
+    from gaia.bp.lowering import lower_local_graph
+    from gaia.ir.graphs import LocalCanonicalGraph
+
+    CLAMP_HI = 1.0 - 1e-6
+    CLAMP_LO = 1e-6
+
+    priors = dict(node_priors or {})
+    strat_params = dict(strategy_params or {})
+    indices = (
+        strategy_indices
+        if strategy_indices is not None
+        else set(range(len(coarse["strategies"])))
+    )
+
+    # Build canonical graph and factor graph ONCE, then reuse
+    canon = LocalCanonicalGraph(
+        **{key: ir[key] for key in
+           ("knowledges", "strategies", "operators", "namespace", "package_name")}
+    )
+    base_fg = lower_local_graph(
+        canon,
+        node_priors=priors,
+        strategy_conditional_params=strat_params,
+    )
+
+    result: dict[int, list[float]] = {}
+
+    for i, s in enumerate(coarse["strategies"]):
+        if i not in indices:
+            continue
+        premises = s["premises"]
+        conclusion = s["conclusion"]
+        k = len(premises)
+        cpt: list[float] = []
+
+        for assignment in range(1 << k):
+            # Update premise priors in-place
+            for bit, pid in enumerate(premises):
+                if pid in base_fg.variables:
+                    base_fg.variables[pid] = (
+                        CLAMP_HI if (assignment >> bit) & 1 else CLAMP_LO
+                    )
+
+            bp = BeliefPropagation(damping=0.5, max_iterations=200)
+            bp_result = bp.run(base_fg)
+            cpt.append(bp_result.beliefs.get(conclusion, 0.5))
+
+        # Restore original priors
+        for pid in premises:
+            if pid in base_fg.variables:
+                base_fg.variables[pid] = priors.get(pid, 0.5)
+
+        result[i] = cpt
+
+    return result

--- a/gaia/ir/linearize.py
+++ b/gaia/ir/linearize.py
@@ -1,0 +1,280 @@
+"""Linearize a coarse reasoning graph into a narrative outline.
+
+Topological sort → layering → connectivity-based grouping → narrative sections.
+Grouping uses high-cohesion/low-coupling: nodes sharing premises or conclusions
+are grouped together, independent of the Python module structure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class NarrativeEntry:
+    """One claim in the narrative outline."""
+
+    kid: str
+    label: str
+    title: str
+    type: str
+    exported: bool
+    prior: float | None
+    belief: float | None
+    derived_from: list[str]
+    supports: list[str]
+    strategy_type: str
+    mi_bits: float
+
+
+@dataclass
+class NarrativeSection:
+    """A group of entries forming a narrative section."""
+
+    title: str
+    layer: int
+    entries: list[NarrativeEntry] = field(default_factory=list)
+
+
+def _union_find_group(
+    nodes: list[str],
+    edges: list[tuple[str, str]],
+) -> list[set[str]]:
+    """Cluster nodes by connectivity using union-find."""
+    parent: dict[str, str] = {n: n for n in nodes}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for a, b in edges:
+        if a in parent and b in parent:
+            union(a, b)
+
+    groups: dict[str, set[str]] = {}
+    for n in nodes:
+        root = find(n)
+        groups.setdefault(root, set()).add(n)
+    return list(groups.values())
+
+
+def linearize_narrative(
+    coarse: dict,
+    beliefs: dict[str, float] | None = None,
+    priors: dict[str, float] | None = None,
+    mi_per_strategy: dict[int, float] | None = None,
+) -> list[NarrativeSection]:
+    """Convert a coarse reasoning DAG into a linear narrative outline.
+
+    Algorithm:
+    1. Build adjacency from coarse strategies + operators
+    2. Topological sort → assign layer to each node
+    3. Within each layer, group nodes by shared connectivity
+       (high cohesion / low coupling — not based on Python modules)
+    4. Name each group by its most prominent claim
+    5. Merge consecutive groups that are tightly connected
+    """
+    beliefs = beliefs or {}
+    priors = priors or {}
+    mi_map = mi_per_strategy or {}
+
+    kid_to_k = {k["id"]: k for k in coarse["knowledges"]}
+    exported_ids = {k["id"] for k in coarse["knowledges"] if k.get("exported")}
+
+    # Build adjacency
+    forward: dict[str, list[str]] = {}
+    backward: dict[str, list[str]] = {}
+    strategy_for_conclusion: dict[str, dict] = {}
+    strategy_idx_for_conclusion: dict[str, int] = {}
+
+    for i, s in enumerate(coarse["strategies"]):
+        conc = s["conclusion"]
+        strategy_for_conclusion[conc] = s
+        strategy_idx_for_conclusion[conc] = i
+        for p in s["premises"]:
+            forward.setdefault(p, []).append(conc)
+            backward.setdefault(conc, []).append(p)
+
+    for o in coarse.get("operators", []):
+        conc = o.get("conclusion")
+        for v in o.get("variables", []):
+            if conc:
+                forward.setdefault(v, []).append(conc)
+                backward.setdefault(conc, []).append(v)
+
+    # Topological sort → layer assignment
+    all_kids = {k["id"] for k in coarse["knowledges"]
+                if not k.get("label", "").startswith("__")}
+    in_degree: dict[str, int] = {kid: 0 for kid in all_kids}
+    for conc, plist in backward.items():
+        if conc in all_kids:
+            in_degree[conc] = len([p for p in plist if p in all_kids])
+
+    layers: dict[str, int] = {}
+    queue = [kid for kid in all_kids if in_degree.get(kid, 0) == 0]
+    layer = 0
+    while queue:
+        next_queue: list[str] = []
+        for kid in queue:
+            layers[kid] = layer
+        for kid in queue:
+            for neighbor in forward.get(kid, []):
+                if neighbor in all_kids and neighbor not in layers:
+                    in_degree[neighbor] -= 1
+                    if in_degree[neighbor] <= 0:
+                        next_queue.append(neighbor)
+        queue = next_queue
+        layer += 1
+
+    for kid in all_kids:
+        if kid not in layers:
+            layers[kid] = layer
+
+    max_layer = max(layers.values()) if layers else 0
+
+    # Build narrative entries
+    entries_by_kid: dict[str, NarrativeEntry] = {}
+    for k in coarse["knowledges"]:
+        kid = k["id"]
+        label = k.get("label", "")
+        if label.startswith("__"):
+            continue
+        if kid not in all_kids:
+            continue
+
+        derived_labels = []
+        stype = ""
+        mi = 0.0
+        if kid in strategy_for_conclusion:
+            s = strategy_for_conclusion[kid]
+            stype = s.get("type", "")
+            derived_labels = [
+                kid_to_k[p].get("label", "?")
+                for p in s["premises"] if p in kid_to_k
+            ]
+            idx = strategy_idx_for_conclusion.get(kid)
+            if idx is not None:
+                mi = mi_map.get(idx, 0.0)
+
+        supports_labels = [
+            kid_to_k[c].get("label", "?")
+            for c in forward.get(kid, []) if c in kid_to_k
+        ]
+
+        entries_by_kid[kid] = NarrativeEntry(
+            kid=kid,
+            label=label,
+            title=k.get("title") or label,
+            type=k.get("type", "claim"),
+            exported=kid in exported_ids,
+            prior=priors.get(kid),
+            belief=beliefs.get(kid),
+            derived_from=derived_labels,
+            supports=supports_labels,
+            strategy_type=stype,
+            mi_bits=mi,
+        )
+
+    # Group within each layer by shared connectivity
+    # Two nodes in the same layer are connected if they share a parent or child
+    sections: list[NarrativeSection] = []
+    for lyr in range(max_layer + 1):
+        layer_kids = [kid for kid in all_kids if layers.get(kid) == lyr and kid in entries_by_kid]
+        if not layer_kids:
+            continue
+
+        # Build affinity edges: two nodes are connected if they share
+        # a common premise, a common conclusion, or a common operator
+        affinity_edges: list[tuple[str, str]] = []
+        # Shared parent: two nodes derived from the same premise
+        parent_to_children: dict[str, list[str]] = {}
+        for kid in layer_kids:
+            for p in backward.get(kid, []):
+                parent_to_children.setdefault(p, []).append(kid)
+        for _parent, children in parent_to_children.items():
+            for i in range(len(children)):
+                for j in range(i + 1, len(children)):
+                    affinity_edges.append((children[i], children[j]))
+
+        # Shared child: two nodes that support the same conclusion
+        child_to_parents: dict[str, list[str]] = {}
+        for kid in layer_kids:
+            for c in forward.get(kid, []):
+                child_to_parents.setdefault(c, []).append(kid)
+        for _child, parents in child_to_parents.items():
+            for i in range(len(parents)):
+                for j in range(i + 1, len(parents)):
+                    affinity_edges.append((parents[i], parents[j]))
+
+        groups = _union_find_group(layer_kids, affinity_edges)
+
+        for group in sorted(groups, key=lambda g: min(
+            entries_by_kid[k].belief or 0 for k in g if k in entries_by_kid
+        )):
+            # Name the group by its most prominent entry
+            group_entries = [entries_by_kid[kid] for kid in group if kid in entries_by_kid]
+            group_entries.sort(key=lambda e: (e.exported, e.belief or 0))
+
+            # Pick a descriptive name: the highest-belief exported claim, or the first entry
+            name_entry = group_entries[-1] if group_entries else None
+            group_title = name_entry.title if name_entry else f"Layer {lyr}"
+
+            sections.append(NarrativeSection(
+                title=group_title,
+                layer=lyr,
+                entries=group_entries,
+            ))
+
+    return sections
+
+
+def render_narrative_outline(sections: list[NarrativeSection]) -> str:
+    """Render narrative sections as markdown for agent consumption."""
+    lines: list[str] = []
+    lines.append("# Narrative Outline")
+    lines.append("")
+    lines.append(
+        "Auto-generated from the coarse reasoning graph. "
+        "Sections are grouped by connectivity (high cohesion, low coupling) "
+        "and ordered by topological layer. Use this as the backbone for "
+        "writing narrative summaries."
+    )
+    lines.append("")
+
+    entry_num = 0
+    for section in sections:
+        lines.append(f"## {section.title}")
+        lines.append("")
+        for entry in section.entries:
+            entry_num += 1
+            star = " ★" if entry.exported else ""
+            prior_str = f"{entry.prior:.2f}" if entry.prior is not None else "0.50"
+            belief_str = f"{entry.belief:.2f}" if entry.belief is not None else "—"
+
+            lines.append(
+                f"{entry_num}. **{entry.title}{star}** "
+                f"(prior: {prior_str} → belief: {belief_str})"
+            )
+
+            if entry.derived_from:
+                mi_str = f" [{entry.mi_bits:.2f} bits]" if entry.mi_bits > 0 else ""
+                lines.append(
+                    f"   - ← {entry.strategy_type}({', '.join(entry.derived_from)})"
+                    f"{mi_str}"
+                )
+
+            if entry.supports:
+                lines.append(
+                    f"   - → supports: {', '.join(entry.supports)}"
+                )
+
+            lines.append("")
+
+    return "\n".join(lines)

--- a/gaia/lang/dsl/knowledge.py
+++ b/gaia/lang/dsl/knowledge.py
@@ -3,6 +3,18 @@
 from gaia.lang.runtime import Knowledge
 
 
+def _flatten_metadata(metadata: dict) -> dict:
+    """Unwrap nested metadata={"metadata": {...}} into a flat dict.
+
+    When users write ``claim(..., metadata={"figure": "..."})``, Python's
+    ``**kwargs`` captures it as ``{"metadata": {"figure": "..."}}``.
+    This function detects and unwraps that single-key nesting.
+    """
+    if "metadata" in metadata and isinstance(metadata["metadata"], dict) and len(metadata) == 1:
+        return metadata["metadata"]
+    return metadata
+
+
 def setting(content: str, *, title: str | None = None, **metadata) -> Knowledge:
     """Declare a background assumption. No probability, no BP participation."""
     provenance = metadata.pop("provenance", None)
@@ -11,7 +23,7 @@ def setting(content: str, *, title: str | None = None, **metadata) -> Knowledge:
         type="setting",
         title=title,
         provenance=provenance or [],
-        metadata=metadata,
+        metadata=_flatten_metadata(metadata),
     )
 
 
@@ -23,7 +35,7 @@ def question(content: str, *, title: str | None = None, **metadata) -> Knowledge
         type="question",
         title=title,
         provenance=provenance or [],
-        metadata=metadata,
+        metadata=_flatten_metadata(metadata),
     )
 
 
@@ -44,5 +56,5 @@ def claim(
         background=background or [],
         parameters=parameters or [],
         provenance=provenance or [],
-        metadata=metadata,
+        metadata=_flatten_metadata(metadata),
     )


### PR DESCRIPTION
## Summary

Follow-up to #353. Adds coarse-grained reasoning graph, mutual information computation, narrative outline generation, and metadata bug fix.

### New modules
- **`gaia/ir/coarsen.py`** — Fold intermediate nodes: leaf premises → exported conclusions with direct infer edges. Preserves operators (contradiction etc). Computes effective CPT by reusing factor graph (premise cap ≤8).
- **`gaia/ir/linearize.py`** — Topological sort + connectivity-based grouping (union-find). Generates narrative outline for `/gaia:publish` agent.
- **`gaia/cli/commands/_github.py`** — Coarse Mermaid graph with MI labels, narrative-outline.md output, [!TIP] callout for total MI.

### Bug fixes
- **metadata flatten** — `claim(metadata={"figure": ...})` was stored as `{"metadata": {"figure": ...}}` due to `**kwargs`. Fixed with `_flatten_metadata()`.
- **CPT performance** — Build factor graph once, update premise priors in-place. Cap at 8 premises (2^8=256 BP runs). RFdiffusion: timeout → 29 seconds.

### E2E tested
- [SuperconductivityElectronLiquids.gaia](https://github.com/kunyuan/SuperconductivityElectronLiquids.gaia) — 78 knowledge, MI 4.0 bits
- [watson-rfdiffusion-2023-gaia](https://github.com/kunyuan/watson-rfdiffusion-2023-gaia) — 128 knowledge, 28 nodes with figures

## Test plan
- [x] 614 tests pass
- [x] Ruff clean
- [x] E2E: Electron Liquids compile --github in 15s
- [x] E2E: RFdiffusion compile --github in 29s (was timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)