### PR TITLE
docs: propose hole and bridge package design

### DIFF
--- a/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
+++ b/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
@@ -1,0 +1,502 @@
+# Gaia Lang Hole / Fills Design
+
+> **Status:** Proposal
+>
+> **Date:** 2026-04-08
+>
+> **Companion docs:** [2026-04-08-registry-hole-bridge-index-design.md](2026-04-08-registry-hole-bridge-index-design.md)
+>
+> **Depends on:** [2026-04-02-gaia-lang-v5-python-dsl-design.md](2026-04-02-gaia-lang-v5-python-dsl-design.md), [../foundations/gaia-ir/02-gaia-ir.md](../foundations/gaia-ir/02-gaia-ir.md)
+
+## 1. Problem
+
+当前 Gaia Lang v5 只有：
+
+- `claim()`
+- `setting()`
+- `question()`
+- 一组 reasoning strategies
+
+这足够表达“论文内部怎么推理”，但不够清楚地表达两类生态语义：
+
+1. **这个 claim 是一个公开缺口（hole）**
+2. **这个 package 在声明：某个结果 fills 某个外部 hole**
+
+今天作者当然可以用普通 `claim()` 和普通 `deduction()` 勉强表达这些意思，但会有两个问题：
+
+- 对人类作者和 reviewer 来说，意图不够显式
+- 对 package / registry 来说，难以稳定抽取 hole / bridge manifests
+
+## 2. Design Goals
+
+1. **Author-facing clarity**
+   作者要能直接写出“这是一个 hole”和“我在 fills 某个 hole”。
+
+2. **No new core IR primitive**
+   Gaia IR 不新增 `HoleKnowledge` 或 `FillsStrategy` 这类 runtime schema。
+
+3. **Registry-extractable**
+   package 和 registry 可以机械地抽取 `holes.json` / `bridges.json`。
+
+4. **Cross-package explicitness**
+   `fills` 必须建立在显式 foreign reference 之上，而不是自由文本。
+
+5. **Keep BP semantics separate**
+   “这是在补洞”是生态意图；“补得有多强”仍然由已有 strategy semantics 决定。
+
+## 3. Key Decisions
+
+### 3.1 `hole` 是独立 authoring API
+
+推荐新增：
+
+```python
+hole(...)
+```
+
+而不是只靠：
+
+```python
+claim(..., metadata={"proof_state": "hole"})
+```
+
+原因：
+
+- 这是作者会高频直接用到的语义，不应埋在 metadata 里
+- 代码审阅时一眼可见
+- 编译器和 registry 提取规则更直接
+
+但在 lowering 层，`hole()` 仍然编译成普通 `Knowledge(type="claim")`，只是 metadata 中带上 hole 标记。
+
+### 3.2 `fills` 是 author-facing relation intent
+
+推荐新增：
+
+```python
+fills(...)
+```
+
+但它**不是**新的 core strategy type。它只是作者层的 intent wrapper。
+
+编译后仍然是普通 strategy：
+
+- `deduction`
+- 或 `infer`
+
+外加 relation metadata，供 package / registry 抽取 bridge relation。
+
+### 3.3 不新增 `Hole` 或 `Bridge` 的 IR schema
+
+Gaia IR 继续保持现有边界：
+
+- imported / exported / cross-package relation 不进入 core schema 变体
+- `hole` 仍然是 `claim`
+- `fills` 仍然是普通 strategy + metadata
+
+这和现有 “foreign QID 是普通 Knowledge，不新增特殊 imported node type” 的边界保持一致。
+
+## 4. `hole()` Design
+
+### 4.1 API
+
+```python
+def hole(
+    content: str,
+    *,
+    title: str | None = None,
+    background: list[Knowledge] | None = None,
+    parameters: list[dict] | None = None,
+    provenance: list[dict[str, str]] | None = None,
+    **metadata,
+) -> Knowledge
+```
+
+返回值仍然是普通 `Knowledge(type="claim")`。
+
+### 4.2 Lowered Form
+
+`hole()` 在运行时等价于：
+
+```python
+claim(
+    content,
+    title=title,
+    background=background,
+    parameters=parameters,
+    provenance=provenance,
+    proof_state="hole",
+    **metadata,
+)
+```
+
+也就是说：
+
+- 不新增 KnowledgeType
+- 只是在 metadata 上固化 `proof_state = "hole"`
+
+### 4.3 Restrictions
+
+`hole()` 不接受 `given=...`。
+
+理由：
+
+- `given=` 会自动创建 in-package support strategy
+- 一个已经被本包直接支撑起来的 claim，通常不应再声明成“公开缺口”
+
+如果作者既想表达“这是当前论文的公开缺口”，又想附上一些弱背景支持，应该用：
+
+- `background=[...]`
+- 或普通 `claim(...)`，而不是 `hole(...)`
+
+### 4.4 Export Semantics
+
+`hole` 只有在进入 `__all__` 时，才成为**公开 hole interface**。
+
+因此有三种层次：
+
+1. `hole(...)` 但不 export
+   只是 package 内部未解子目标
+
+2. `hole(...)` 且 export
+   成为 registry 可索引的 public hole
+
+3. 普通 `claim(...)`
+   不是 hole，即使它当前没有被证明
+
+这很重要，因为我们不希望系统把所有叶子前提都自动暴露成公共接口。
+
+### 4.5 Example
+
+```python
+from gaia.lang import claim, deduction, hole
+
+main_theorem = claim("Main theorem of package A.")
+key_missing_lemma = hole("A still-missing lemma required by the main theorem.")
+
+deduction(
+    premises=[key_missing_lemma],
+    conclusion=main_theorem,
+    reason="If the missing lemma were established, the main theorem would follow.",
+)
+
+__all__ = ["main_theorem", "key_missing_lemma"]
+```
+
+## 5. `fills()` Design
+
+### 5.1 API
+
+推荐最小 API：
+
+```python
+def fills(
+    source: Knowledge,
+    hole: Knowledge,
+    *,
+    mode: Literal["deduction", "infer"] | None = None,
+    strength: Literal["exact", "partial", "conditional"] = "exact",
+    background: list[Knowledge] | None = None,
+    reason: ReasonInput = "",
+) -> Strategy
+```
+
+### 5.2 Why `source` is singular
+
+`fills` 的接口刻意只接受一个 `source` claim，而不是 `premises=[...]`。
+
+原因：
+
+- 生态层的 bridge relation 应该连的是“公开 claim -> 公开 hole”
+- 如果 B 需要多个本地前提，应该先在包内推出一个本地 `source` result
+- 然后再显式声明 `source fills hole`
+
+这样 registry relation 结构最稳定，查询时也最清楚。
+
+### 5.3 Lowering Rule
+
+`fills()` 本身不是新的 strategy primitive，而是 lowering sugar：
+
+- `mode="deduction"` 时：
+  - lower 成 `deduction(premises=[source], conclusion=hole, ...)`
+- `mode="infer"` 时：
+  - lower 成 `infer(premises=[source], conclusion=hole, ...)`
+
+若 `mode is None`，则按 `strength` 推断：
+
+- `exact` -> `deduction`
+- `partial` -> `infer`
+- `conditional` -> `infer`
+
+同时写入 strategy metadata：
+
+```python
+{
+  "ecosystem_relation": {
+    "type": "fills",
+    "strength": "exact",
+    "target_role": "hole"
+  }
+}
+```
+
+### 5.4 Why not make `fills` a new BP primitive
+
+因为这里其实有两个正交维度：
+
+1. **生态意图**
+   这是在填别人的 hole
+
+2. **逻辑强度**
+   这是严格证明、弱支持，还是条件性支持
+
+前者适合 authoring / registry metadata。  
+后者适合继续复用已有的 `deduction` / `infer`。
+
+如果把两者混成一个新的 runtime primitive，反而会污染 core IR。
+
+### 5.5 Validation Intent
+
+`fills(source, hole)` 在 authoring / compile 时应至少校验：
+
+- `source.type == "claim"`
+- `hole.type == "claim"`
+
+在 package / registry 层进一步校验：
+
+- 若 `hole` 是 foreign reference，则它应解析到对方 package 的 exported hole
+- 若不是 foreign hole，则该 relation 不进入 registry bridge index
+
+### 5.6 Example: B directly fills A
+
+```python
+from gaia.lang import claim, fills
+from package_a import key_missing_lemma
+
+b_result = claim("Theorem 3 in package B.")
+
+fills(
+    source=b_result,
+    hole=key_missing_lemma,
+    strength="exact",
+    reason="Theorem 3 proves exactly the missing lemma exposed by package A.",
+)
+
+__all__ = ["b_result"]
+```
+
+### 5.7 Example: C publishes a bridge package
+
+```python
+from gaia.lang import fills
+from package_a import key_missing_lemma
+from package_b import b_result
+
+fills(
+    source=b_result,
+    hole=key_missing_lemma,
+    strength="conditional",
+    mode="infer",
+    reason="Under the assumptions compared in this package, B.result is sufficient to fill A.hole.",
+)
+```
+
+这里 package C 可以没有本地 theorem claim。  
+它的主要公开内容就是 cross-package relation 本身。
+
+## 6. Worked Scenarios
+
+### 6.1 Scenario A: B immediately knows it fills A
+
+这个场景里：
+
+- A 已经把缺失前提写成 exported `hole`
+- B 在 formalize 时就知道自己的结论能填这个 hole
+
+作者层的最小写法是：
+
+```python
+# package_a
+from gaia.lang import claim, deduction, hole
+
+main_theorem = claim("Main theorem of package A.")
+key_missing_lemma = hole("A still-missing lemma required by the main theorem.")
+
+deduction(
+    premises=[key_missing_lemma],
+    conclusion=main_theorem,
+    reason="If the missing lemma were established, the main theorem would follow.",
+)
+
+__all__ = ["main_theorem", "key_missing_lemma"]
+```
+
+```python
+# package_b
+from gaia.lang import claim, fills
+from package_a import key_missing_lemma
+
+b_result = claim("Theorem 3 in package B.")
+
+fills(
+    source=b_result,
+    hole=key_missing_lemma,
+    strength="exact",
+    reason="Theorem 3 proves exactly the missing lemma exposed by package A.",
+)
+
+__all__ = ["b_result"]
+```
+
+这里不需要单独 bridge package。  
+B 自己就是 relation 的 declaring package。
+
+### 6.2 Scenario B: B did not notice, later C discovers it
+
+这个场景里：
+
+- A 已经公开了 hole
+- B 只发布了自己的 paper package，没有写 `fills`
+- 后来 C 发现 `B.result fills A.hole`
+
+那么：
+
+```python
+# package_b
+from gaia.lang import claim
+
+b_result = claim("Theorem 3 in package B.")
+__all__ = ["b_result"]
+```
+
+```python
+# package_c_bridge
+from gaia.lang import fills
+from package_a import key_missing_lemma
+from package_b import b_result
+
+fills(
+    source=b_result,
+    hole=key_missing_lemma,
+    strength="conditional",
+    mode="infer",
+    reason="Under the assumptions compared in this bridge package, B.result is sufficient to fill A.hole.",
+)
+```
+
+这里：
+
+- B 不需要回头修改自己的 package
+- C 用普通 `knowledge-package` 就能发布这条 relation
+- `declared_by_owner_of_source = false` 将在 package / registry 层体现
+
+### 6.3 Boundary Condition: A did not export a hole
+
+如果 A 只是有一个内部前提，但没有把它显式写成 exported `hole`：
+
+- B 仍然可以 import A 的普通 exported claim
+- 但不能把这条关系当成正式的 `fills(hole=...)` 进入 hole/bridge 协议
+
+也就是说，`fills` 的目标必须是显式公开的 hole interface，而不是任意 premise。
+
+## 7. Why Separate APIs Are Better
+
+### 7.1 Thought Experiment: hidden metadata only
+
+如果只允许：
+
+```python
+claim(..., metadata={"proof_state": "hole"})
+deduction(..., conclusion=foreign_hole)
+```
+
+机器当然能跑，但有三个问题：
+
+- 代码一眼看不出作者 intent
+- registry 很难稳定区分普通 cross-package deduction 和 fills relation
+- reviewer 很难快速扫出 package 的 public holes
+
+### 7.2 Thought Experiment: dedicated APIs
+
+如果作者能直接写：
+
+```python
+hole(...)
+fills(...)
+```
+
+那么：
+
+- 代码层 intent 清晰
+- package manifest 提取是机械的
+- registry index 构建也不需要猜测
+
+因此作者层应该有显式 API，runtime 层再 lower 到旧 primitive。
+
+## 8. Interaction with Existing Gaia Lang
+
+### 8.1 `claim`
+
+- 继续是默认的科学断言构造
+- 不自动推断 hole
+
+### 8.2 `__all__`
+
+- 仍然是唯一的 package public surface
+- `hole` 是否公开，只取决于是否 export
+
+### 8.3 Cross-package import
+
+`fills` 不引入新 import 机制。仍然是：
+
+```python
+from package_a import exported_hole
+```
+
+即显式 foreign reference，而不是 registry 层自动绑定。
+
+### 8.4 Review / BP
+
+这次设计不改变 review / BP 核心规则：
+
+- `hole` 仍然是 claim
+- `fills` 仍然是 ordinary strategy
+- package / registry 只是额外理解其生态意图
+
+## 9. Proposed Minimal Runtime Surface
+
+语言层建议新增：
+
+```python
+from gaia.lang import hole, fills
+```
+
+其中：
+
+- `hole` 放在 `gaia.lang.dsl.knowledge`
+- `fills` 放在 `gaia.lang.dsl.strategies`
+
+作者默认导入面变成：
+
+```python
+from gaia.lang import (
+    claim, hole, setting, question,
+    contradiction, equivalence, complement, disjunction,
+    noisy_and, infer, deduction, fills, abduction, analogy,
+    extrapolation, elimination, case_analysis,
+    mathematical_induction, composite,
+)
+```
+
+## 10. Decisions
+
+1. **`hole` 用独立 DSL 构造，不埋在 metadata-only 约定里。**
+2. **`hole` lower 成普通 claim，不新增 IR node type。**
+3. **`fills` 用独立 DSL 构造，但不新增 runtime strategy type。**
+4. **`fills` 的逻辑强度继续复用 `deduction` / `infer`。**
+5. **public hole 由 `hole(...) + export` 共同决定。**
+
+## 11. Open Questions
+
+1. `conditional` fills 是否需要结构化 `conditions=` 字段，而不只是自由文本 `reason`？
+2. 是否需要额外的 `weak_fills()` / `refines_hole()` author sugar，还是统一留给 `fills(..., strength=...)`？
+3. bridge package 如果完全没有本地 claim，README / narrative 应该如何渲染得更自然？

--- a/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
+++ b/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
@@ -1,0 +1,462 @@
+# Gaia Package Hole / Bridge Manifest Design
+
+> **Status:** Proposal
+>
+> **Date:** 2026-04-08
+>
+> **Companion docs:** [2026-04-08-gaia-lang-hole-fills-design.md](2026-04-08-gaia-lang-hole-fills-design.md), [2026-04-08-registry-hole-bridge-index-design.md](2026-04-08-registry-hole-bridge-index-design.md)
+>
+> **Depends on:** [../foundations/gaia-lang/package.md](../foundations/gaia-lang/package.md), [2026-04-02-gaia-registry-design.md](2026-04-02-gaia-registry-design.md)
+
+## 1. Problem
+
+当前 package model 里，public surface 主要只有：
+
+- `__all__`
+- compiled IR
+- register 时写入的 `Package.toml / Versions.toml / Deps.toml`
+
+这对“普通知识包注册”足够，但对新的 `hole / fills` 生态还差一层 package contract：
+
+1. package 本地如何把 public holes 明确产出成制品？
+2. package 本地如何把 fills relations 明确产出成制品？
+3. `gaia register` 如何把这些信息安全地带进 registry，而不引入 PR hotspot？
+
+## 2. Design Goals
+
+1. **Keep package as the source unit**
+   package 仍然是 authoring、versioning、registration 的基本单位。
+
+2. **Deterministic local artifacts**
+   `exports / holes / bridges` 必须能从当前 package source 机械生成。
+
+3. **Registry-ready manifests**
+   本地产物应能直接被 `gaia register` 带入 registry。
+
+4. **No new package class required**
+   bridge package 仍然是普通 `knowledge-package`，不引入强制的新 package type。
+
+5. **Version-aware**
+   manifests 必须和当前 package version 一起发布、一起审计。
+
+## 3. Key Decisions
+
+### 3.1 `.gaia/manifests/` 成为本地产物
+
+推荐在 package 本地新增：
+
+```text
+.gaia/
+├── ir.json
+├── ir_hash
+└── manifests/
+    ├── exports.json
+    ├── holes.json
+    └── bridges.json
+```
+
+这些文件都是 deterministic derived artifacts，应由 `gaia compile` 生成。
+
+### 3.2 `__all__` 仍然是唯一 public surface
+
+我们不新增 `__holes__` 或 `__bridges__`。
+
+规则保持简单：
+
+- exported = 在 `__all__`
+- public hole = exported claim + `proof_state = "hole"`
+- bridge relation = local strategy metadata 中声明 `ecosystem_relation.type = "fills"`
+
+### 3.3 Bridge package 不是新的 package type
+
+bridge package 仍然是：
+
+```toml
+[tool.gaia]
+type = "knowledge-package"
+```
+
+它只是一个**用途上的子类**，不是新的协议对象。
+
+原因：
+
+- package lifecycle 不需要分叉
+- IR schema 不需要分叉
+- register / add / compile / infer 全都可以复用
+
+如果未来确实需要更强的 UX 区分，再加 optional metadata 即可。
+
+## 4. Local Artifact Layout
+
+### 4.1 Current
+
+当前 package 本地产物主要是：
+
+```text
+.gaia/
+├── ir.json
+├── ir_hash
+└── reviews/
+    └── ...
+```
+
+### 4.2 Proposed
+
+扩展为：
+
+```text
+.gaia/
+├── ir.json
+├── ir_hash
+├── manifests/
+│   ├── exports.json
+│   ├── holes.json
+│   └── bridges.json
+└── reviews/
+    └── ...
+```
+
+这些 manifests 和 IR 一样，都应该是 git-tracked compiled artifacts。
+
+## 5. Extraction Rules
+
+### 5.1 `exports.json`
+
+记录 package 的公开接口。
+
+建议结构：
+
+```json
+{
+  "package": "package-b",
+  "version": "2.1.0",
+  "ir_hash": "sha256:...",
+  "generated_at": "2026-04-08T12:00:00Z",
+  "exports": [
+    {
+      "qid": "github:package_b::main_result",
+      "label": "main_result",
+      "type": "claim",
+      "content": "B's main theorem.",
+      "content_hash": "sha256:..."
+    }
+  ]
+}
+```
+
+提取规则：
+
+- 来自 IR 中 `exported = true` 的 `Knowledge`
+- 包含 `claim / setting / question`
+- registry 侧目前重点消费 `claim`，但 manifest 保留完整 exported knowledge surface
+
+### 5.2 `holes.json`
+
+记录 package 公开暴露的 holes。
+
+```json
+{
+  "package": "package-a",
+  "version": "1.4.0",
+  "ir_hash": "sha256:...",
+  "generated_at": "2026-04-08T12:00:00Z",
+  "holes": [
+    {
+      "qid": "github:package_a::key_missing_lemma",
+      "label": "key_missing_lemma",
+      "content": "A missing premise required by the main theorem.",
+      "content_hash": "sha256:...",
+      "required_by": ["github:package_a::main_theorem"]
+    }
+  ]
+}
+```
+
+提取规则：
+
+- 仅从 IR 中 `exported = true` 的 claim 提取
+- 且其 metadata 标记 `proof_state = "hole"`
+- `required_by` 由图结构派生，不由作者手填
+
+### 5.2.1 `required_by` 的最小规则
+
+Phase 1 先用最简单的可解释规则：
+
+- 找出所有直接把该 hole 作为 premise 的 local strategies
+- 若这些 strategy 的 conclusion 是 exported claim，则记入 `required_by`
+
+以后如果要更强，可以再扩展成“最近 exported downstream claims”。
+
+### 5.3 `bridges.json`
+
+记录 package 当前版本声明的 fills relations。
+
+```json
+{
+  "package": "package-b",
+  "version": "2.1.0",
+  "ir_hash": "sha256:...",
+  "generated_at": "2026-04-08T12:00:00Z",
+  "bridges": [
+    {
+      "relation_id": "bridge_sha256_...",
+      "relation_type": "fills",
+      "source_qid": "github:package_b::main_result",
+      "target_hole_qid": "github:package_a::key_missing_lemma",
+      "strength": "exact",
+      "mode": "deduction",
+      "declared_by_owner_of_source": true,
+      "justification": "Theorem 3 proves exactly the missing lemma in package A."
+    }
+  ]
+}
+```
+
+提取规则：
+
+- 扫描 local strategies
+- 找出 metadata 中 `ecosystem_relation.type == "fills"` 的 strategy
+- 提取其 `conclusion` 作为 `target_hole_qid`
+- 提取其唯一 premise 作为 `source_qid`
+
+如果 `fills` 后续允许 richer metadata，则按 metadata 补全 `strength / mode / justification`。
+
+## 6. Package Authoring Conventions
+
+### 6.1 Public hole
+
+作者如果想公开一个可被别人填补的 hole，需要同时做到：
+
+1. 用 `hole(...)` 声明
+2. 放进 `__all__`
+
+只做其一都不够：
+
+- 只有 `hole(...)` 没有 export：内部 hole
+- 只有 export 没有 `hole(...)`：普通 public claim
+
+### 6.2 Direct fill in a paper package
+
+如果 B 自己知道某个结果 fills A 的 hole，推荐直接写在 B 里。
+
+```python
+from gaia.lang import claim, fills
+from package_a import key_missing_lemma
+
+b_result = claim("Theorem 3.")
+fills(source=b_result, hole=key_missing_lemma, reason="...")
+```
+
+这会让：
+
+- IR 中出现 ordinary cross-package strategy
+- `.gaia/manifests/bridges.json` 中出现一条 fills relation
+
+### 6.3 Third-party bridge package
+
+如果 C 后来才发现这层关系，C 可以发一个普通 package：
+
+- 引入 A 的 exported hole
+- 引入 B 的 exported claim
+- 写 `fills(...)`
+
+不要求额外 package type。
+
+## 7. Worked Scenarios
+
+### 7.1 Scenario A: B immediately knows it fills A
+
+package A 编译后，关键本地产物会是：
+
+- `.gaia/manifests/exports.json`：包含 `main_theorem` 和 `key_missing_lemma`
+- `.gaia/manifests/holes.json`：包含 `key_missing_lemma`
+- `.gaia/manifests/bridges.json`：为空
+
+package B 编译后，关键本地产物会是：
+
+- `.gaia/manifests/exports.json`：包含 `b_result`
+- `.gaia/manifests/holes.json`：为空
+- `.gaia/manifests/bridges.json`：包含一条 `source_qid = b_result`、`target_hole_qid = key_missing_lemma` 的 relation
+
+这里 `declared_by_owner_of_source = true`，因为 relation 是由 B 自己声明的。
+
+### 7.2 Scenario B: B did not notice, later C discovers it
+
+package B 编译后：
+
+- `.gaia/manifests/exports.json`：包含 `b_result`
+- `.gaia/manifests/bridges.json`：为空
+
+package C bridge 编译后：
+
+- `.gaia/manifests/exports.json`：可以为空或只含少量本地 summary nodes
+- `.gaia/manifests/holes.json`：通常为空
+- `.gaia/manifests/bridges.json`：包含 `source_qid = package_b::b_result`、`target_hole_qid = package_a::key_missing_lemma`
+
+这里 `declared_by_owner_of_source = false`，因为 relation 由第三方声明。
+
+### 7.3 Boundary Condition: A did not export a hole
+
+如果 A 没有公开 hole interface：
+
+- package A 的 `holes.json` 中不会出现该前提
+- package B/C 即使写了某种普通 cross-package deduction，也不应进入 `bridges.json`
+
+也就是说，package 层的 bridge manifest 只承认“指向 exported hole 的 fills relation”。
+
+## 8. Package Semantics
+
+### 8.1 Public API
+
+package 的稳定 API 仍然首先由 exported nodes 决定。
+
+因此：
+
+- exported claims / holes 是 import-facing API
+- bridge relations 是 discovery-facing public metadata
+
+这两者都公开，但稳定性级别不同。
+
+### 8.2 Semver Guidance
+
+推荐规则：
+
+| Change | Version level | Reason |
+|--------|---------------|--------|
+| 新增 exported hole | MINOR | 新增公共接口 |
+| 修改 / 删除 exported hole 语义 | MAJOR | 破坏 hole API |
+| 新增 fills relation | MINOR | 新增公开 relation metadata |
+| 修改 / 删除 fills relation | MINOR | 影响 discovery surface，但不破坏 import API |
+
+解释：
+
+- hole 是 package API 的一部分
+- fills 更像对外公开的 relation metadata，不建议把它当成 import-breaking API
+
+## 9. `gaia compile` Changes
+
+推荐 `gaia compile` 扩展为：
+
+1. 正常生成 `.gaia/ir.json`
+2. 正常生成 `.gaia/ir_hash`
+3. 额外生成 `.gaia/manifests/exports.json`
+4. 额外生成 `.gaia/manifests/holes.json`
+5. 额外生成 `.gaia/manifests/bridges.json`
+
+### 9.1 Why compile, not register
+
+如果等到 `gaia register` 才临时构造这些 manifests，会带来两个问题：
+
+- 作者本地难以预览 package 对外暴露了哪些 holes / bridges
+- register 阶段逻辑变重，难以本地审计
+
+而这些文件本质上都只是 IR 和 metadata 的 deterministic projection，所以更适合放在 compile 阶段。
+
+## 10. `gaia check` Changes
+
+推荐新增 package-level 校验：
+
+### 10.1 Hole checks
+
+- every exported hole is a claim
+- every exported hole appears in `exports.json`
+- every exported hole has at least one downstream local use, unless explicitly suppressed
+
+最后一条是 warning，不是 hard error。因为有些 package 会先发布 hole interface，再等待别人填补。
+
+### 10.2 Bridge checks
+
+- every fills relation has exactly one `source_qid`
+- `source_qid` resolves to claim
+- `target_hole_qid` resolves to claim
+- if target is local and not exported hole, do not emit to bridge manifest
+- if target is foreign, dependency resolution must succeed
+
+## 11. `gaia register` Changes
+
+当前 `gaia register` 只准备：
+
+- `Package.toml`
+- `Versions.toml`
+- `Deps.toml`
+
+推荐扩展为同时携带：
+
+- `packages/<name>/releases/<version>/exports.json`
+- `packages/<name>/releases/<version>/holes.json`
+- `packages/<name>/releases/<version>/bridges.json`
+
+### 11.1 Register payload shape
+
+计划输出中新增：
+
+```json
+{
+  "files": {
+    "packages/package-a/Package.toml": "...",
+    "packages/package-a/Versions.toml": "...",
+    "packages/package-a/Deps.toml": "...",
+    "packages/package-a/releases/1.4.0/exports.json": "...",
+    "packages/package-a/releases/1.4.0/holes.json": "...",
+    "packages/package-a/releases/1.4.0/bridges.json": "..."
+  }
+}
+```
+
+这样 register PR 依然是 package-local 的，不直接碰 `index/**`。
+
+## 12. Bridge Package UX
+
+### 12.1 No mandatory local summary claim
+
+bridge package 不强制要求作者额外写一个本地 summary claim。
+
+原因：
+
+- package 的主要公开对象就是 cross-package relation 本身
+- 强制再写一个 summary claim 只会制造样板噪声
+
+如果作者愿意写本地 summary claim，用于 README narrative，可以作为可选增强。
+
+### 12.2 Discovery
+
+bridge package 在 registry 中的 discoverability，主要依靠：
+
+- `bridges.json`
+- registry 的 derived indexes
+
+而不是依赖 exported claims。
+
+## 13. Why This Package Layer Matters
+
+### 13.1 Thought Experiment: no local manifests
+
+如果 package 本地没有 `exports / holes / bridges` manifests：
+
+- register 时必须重新从 source 和 IR 临时推断
+- 作者本地看不到 registry 会看到什么
+- registry 和 package 很难保证同一套抽取规则
+
+### 13.2 Thought Experiment: manifests generated at compile time
+
+如果 manifests 是 compile artifact：
+
+- 作者本地可审计
+- CI 可重放
+- register 只是搬运 deterministic outputs
+
+这更符合当前 Gaia 的 artifact philosophy。
+
+## 14. Decisions
+
+1. **package 继续是唯一发布单位。**
+2. **`__all__` 继续是唯一 public interface 开关。**
+3. **`.gaia/manifests/` 新增 `exports / holes / bridges`。**
+4. **这些 manifests 由 `gaia compile` 生成，而不是 `gaia register` 临时拼。**
+5. **bridge package 仍然是普通 `knowledge-package`，不是新的 package type。**
+
+## 15. Open Questions
+
+1. `.gaia/manifests/*.json` 是否也要像 `ir_hash` 一样参与 freshness / check contract？
+2. `required_by` 是否需要同时输出直接下游和最近 exported 下游两种视图？
+3. 是否需要在 `pyproject.toml` 里加 optional metadata，显式标注 package 的主要用途为 `bridge`？

--- a/docs/specs/2026-04-08-registry-hole-bridge-index-design.md
+++ b/docs/specs/2026-04-08-registry-hole-bridge-index-design.md
@@ -1,0 +1,573 @@
+# Gaia Registry Hole / Bridge Index Design
+
+> **Status:** Proposal
+>
+> **Date:** 2026-04-08
+>
+> **Companion docs:** [2026-04-08-gaia-lang-hole-fills-design.md](2026-04-08-gaia-lang-hole-fills-design.md), [2026-04-08-gaia-package-hole-bridge-design.md](2026-04-08-gaia-package-hole-bridge-design.md)
+>
+> **Depends on:** [2026-04-02-gaia-registry-design.md](2026-04-02-gaia-registry-design.md), [../foundations/ecosystem/04-registry-operations.md](../foundations/ecosystem/04-registry-operations.md)
+
+## 1. Problem
+
+Gaia 的 Official Registry 在当前设计里是一个 GitHub repo，主要记录：
+
+- package identity
+- version -> git tag / git sha / ir_hash
+- explicit dependencies
+
+这足够支持“已知包名 -> 拉元数据 -> 安装 / 引用”，但不够支持下面这些生态问题：
+
+1. A 包公开了一个可复用的缺口，未来谁能补它？
+2. B 包已经知道自己的结论可以填 A 的 hole，如何让别人发现？
+3. C 后来发现 “B.result fills A.hole”，如何在不改 A/B 的情况下公开这个关系？
+4. 当 package 很多时，如何避免每次查询都扫描整个 registry repo？
+
+本设计不引入 global canonicalization，也不要求运行时数据库。前提保持不变：
+
+- Registry 仍然只是一个 GitHub repo
+- package 仍然是 authoring / publishing 的基本单位
+- bridge relation 只是显式关系，不是 identity merge 或裁决
+
+## 2. Design Goals
+
+### 2.1 必须满足
+
+1. **GitHub-native**
+   一切 source of truth 都是 git 文件，所有变更都通过 PR。
+
+2. **Package-owned authoring**
+   作者只需要在 package 或 bridge package 中声明关系，不直接手改全局索引。
+
+3. **Static-query friendly**
+   查询 `hole -> fillers`、`claim -> filled holes` 时，客户端不能靠全仓扫描。
+
+4. **No central semantic adjudication**
+   Registry 记录谁声明了什么关系，但不在注册阶段裁决“这是否真的是同一个命题”。
+
+5. **Conflict-resistant**
+   注册很多 package 后，PR 不能频繁碰撞到同一个全局文件。
+
+### 2.2 明确不做
+
+- 不做 duplicate merge / equivalence merge
+- 不做 single official bridge truth
+- 不要求桥接关系必须由 source package 作者本人声明
+- 不把 fuzzy discovery 变成注册时的硬 gate
+
+## 3. Core Idea
+
+核心分层是：
+
+1. **package 内声明**
+   `hole` 和 `bridge relation` 写在 package 里。
+
+2. **registry 内保存 package-local manifests**
+   注册时把该版本的 `exports / holes / bridges` 作为静态 manifest 记录下来。
+
+3. **bot 生成 derived indexes**
+   merge 后由 GitHub Action 生成全局静态索引文件，供 CLI / 网站 / 人类查询。
+
+一句话：
+
+**package 是写关系的地方，registry 是找关系的地方。**
+
+## 4. Object Model
+
+### 4.1 Exported Hole
+
+`hole` 是作者显式导出的公共缺口，不是自动从所有叶子前提推导出来的。
+
+一个 node 只有同时满足下面条件，才应被导出为 `hole`：
+
+1. 它是某条公开结论链的 load-bearing premise
+2. 当前 package 没有在本包内部把它证明完
+3. 作者希望未来其他 package 能显式填补它
+4. 它的语义足够稳定，值得成为公共接口
+
+因此：
+
+- 不是所有 leaf premise 都是 hole
+- hole 是 package API 的一部分
+- hole 可以被别的 package import / fill
+
+### 4.2 Bridge Relation
+
+`bridge relation` 是一个显式生态断言：
+
+- 某个 `source claim`
+- 可以填补某个 `target hole`
+- 这个主张由某个 `declaring package` 给出
+
+它不是新的逻辑 primitive，也不是 global identity claim。它只是一个 package-level relation record。
+
+最小字段：
+
+- `relation_type = "fills"`
+- `source_qid`
+- `target_hole_qid`
+- `declaring_package`
+- `declaring_version`
+- `strength`
+- `justification`
+
+### 4.3 Declaring Package
+
+`bridge relation` 可以来自两类 package：
+
+1. **paper package**
+   B 自己知道 `B.result fills A.hole`，于是直接在 B 内声明
+
+2. **bridge package**
+   后来 C 发现 `B.result fills A.hole`，由 C 发布一个小 package 专门声明该关系
+
+Registry 不区分“哪类更真”，只记录声明来源。
+
+## 5. Repository Layout
+
+在当前 registry 目录结构基础上，新增两层：
+
+- `packages/<name>/releases/<version>/...`：该 package version 的 source manifests
+- `index/...`：bot 生成的全局静态索引
+
+```text
+gaia-registry/
+├── packages/
+│   ├── package-a/
+│   │   ├── Package.toml
+│   │   ├── Versions.toml
+│   │   ├── Deps.toml
+│   │   └── releases/
+│   │       ├── 1.0.0/
+│   │       │   ├── exports.json
+│   │       │   ├── holes.json
+│   │       │   └── bridges.json
+│   │       └── 1.1.0/
+│   │           └── ...
+│   └── package-b/
+│       └── ...
+├── index/
+│   ├── holes/
+│   │   ├── by-package/
+│   │   └── by-qid/
+│   ├── bridges/
+│   │   ├── by-target/
+│   │   ├── by-source/
+│   │   └── by-declaring-package/
+│   └── manifests/
+│       └── stats.json
+└── .github/workflows/
+    ├── register.yml
+    └── build-index.yml
+```
+
+## 6. Package-Local Source Manifests
+
+这些文件是 source of truth，由 `gaia register` 生成或拷贝到 registry PR 中。作者 PR 只修改自己 package 的目录。
+
+### 6.1 `exports.json`
+
+记录该版本公开导出的 node interface。
+
+```json
+{
+  "package": "package-b",
+  "version": "2.1.0",
+  "generated_at": "2026-04-08T12:00:00Z",
+  "exports": [
+    {
+      "qid": "github:package_b::main_result",
+      "label": "main_result",
+      "type": "claim",
+      "content": "B's main theorem.",
+      "content_hash": "sha256:..."
+    }
+  ]
+}
+```
+
+### 6.2 `holes.json`
+
+只列出作者显式公开的 hole。
+
+```json
+{
+  "package": "package-a",
+  "version": "1.4.0",
+  "generated_at": "2026-04-08T12:00:00Z",
+  "holes": [
+    {
+      "qid": "github:package_a::key_missing_lemma",
+      "label": "key_missing_lemma",
+      "content": "A missing premise required by the main theorem.",
+      "content_hash": "sha256:...",
+      "required_by": [
+        "github:package_a::main_theorem"
+      ],
+      "tags": ["open-hole", "public-interface"]
+    }
+  ]
+}
+```
+
+约束：
+
+- `holes.json` 中的每个 hole 必须也是该版本的 exported claim
+- hole 不能是自动扫描产物，必须来自作者显式标记
+
+### 6.3 `bridges.json`
+
+记录该版本声明的 bridge relations。
+
+```json
+{
+  "package": "package-b",
+  "version": "2.1.0",
+  "generated_at": "2026-04-08T12:00:00Z",
+  "bridges": [
+    {
+      "relation_id": "bridge_sha256_...",
+      "relation_type": "fills",
+      "source_qid": "github:package_b::main_result",
+      "target_hole_qid": "github:package_a::key_missing_lemma",
+      "target_package": "package-a",
+      "target_version_req": ">=1.4.0,<2.0.0",
+      "strength": "exact",
+      "justification": "Theorem 3 in package B proves exactly the missing premise exposed by package A.",
+      "declared_by_owner_of_source": true
+    }
+  ]
+}
+```
+
+第三方 bridge package 也用同样格式，只是：
+
+- `source_qid` 可能是 foreign
+- `declared_by_owner_of_source = false`
+
+## 7. Validation Rules
+
+`register.yml` 在现有校验基础上，新增以下机械规则。
+
+### 7.1 `exports.json`
+
+- 每个 `qid` 必须存在于该 package version 的 compiled IR
+- 每个导出必须属于本 package namespace
+
+### 7.2 `holes.json`
+
+- 每个 `hole.qid` 必须出现在 `exports.json`
+- 每个 `required_by` 必须是本 package version 中存在的 exported claim
+- 同一版本内 `hole.qid` 不可重复
+
+### 7.3 `bridges.json`
+
+- `source_qid` 必须可解析
+  - 若属于 declaring package，则必须在该版本 `exports.json` 中
+  - 若属于 foreign package，则该 package / version requirement 必须出现在 dependencies 中
+- `target_hole_qid` 必须可解析到一个已注册 package 的 exported hole
+- `target_version_req` 必须可满足至少一个已注册版本
+- `relation_type` 当前只允许 `fills`
+- `strength` 当前只允许 `exact | partial | conditional`
+
+### 7.4 PR Ownership Rule
+
+注册 package version 的 PR：
+
+- **允许**修改 `packages/<self>/**`
+- **禁止**手工修改 `index/**`
+
+这样可以避免所有作者 PR 同时争抢全局索引文件。
+
+## 8. Derived Indexes
+
+`index/**` 不是 author-authored source of truth，而是 merge 到 `main` 后由 bot 生成的派生文件。
+
+### 8.1 Hole Index
+
+#### `index/holes/by-package/<package>.json`
+
+```json
+{
+  "package": "package-a",
+  "holes": [
+    {
+      "qid": "github:package_a::key_missing_lemma",
+      "introduced_in": "1.4.0",
+      "latest_version": "1.6.0"
+    }
+  ]
+}
+```
+
+#### `index/holes/by-qid/<shard>/<encoded-qid>.json`
+
+```json
+{
+  "qid": "github:package_a::key_missing_lemma",
+  "owner_package": "package-a",
+  "versions": [
+    {
+      "version": "1.4.0",
+      "content": "A missing premise required by the main theorem.",
+      "required_by": ["github:package_a::main_theorem"]
+    }
+  ]
+}
+```
+
+### 8.2 Bridge Index
+
+#### `index/bridges/by-target/<shard>/<encoded-hole-qid>.json`
+
+这是最核心的查询入口：`hole -> who claims to fill it`
+
+```json
+{
+  "target_hole_qid": "github:package_a::key_missing_lemma",
+  "bridges": [
+    {
+      "relation_id": "bridge_sha256_...",
+      "source_qid": "github:package_b::main_result",
+      "declaring_package": "package-b",
+      "declaring_version": "2.1.0",
+      "strength": "exact",
+      "declared_by_owner_of_source": true,
+      "justification": "..."
+    },
+    {
+      "relation_id": "bridge_sha256_other",
+      "source_qid": "github:bridge_c::adapter_claim",
+      "declaring_package": "package-c-bridge",
+      "declaring_version": "0.1.0",
+      "strength": "conditional",
+      "declared_by_owner_of_source": false,
+      "justification": "..."
+    }
+  ]
+}
+```
+
+#### `index/bridges/by-source/<shard>/<encoded-claim-qid>.json`
+
+反向查询：`claim -> what holes does it claim to fill`
+
+#### `index/bridges/by-declaring-package/<package>.json`
+
+查看某 package 发布过哪些 bridge relations。
+
+## 9. Build Flow
+
+### 9.1 Registration PR
+
+作者或 bot 提交 package version PR 时：
+
+1. 更新 `Package.toml / Versions.toml / Deps.toml`
+2. 新增 `releases/<version>/exports.json`
+3. 新增 `releases/<version>/holes.json`
+4. 新增 `releases/<version>/bridges.json`
+5. 不修改 `index/**`
+
+### 9.2 Post-Merge Index Build
+
+`build-index.yml` 在 `main` 上运行：
+
+1. 遍历 `packages/*/releases/*/{holes,bridges}.json`
+2. 重建 `index/holes/**`
+3. 重建 `index/bridges/**`
+4. 更新 `index/manifests/stats.json`
+5. 由 bot commit 回 registry repo
+
+这意味着：
+
+- package PR merge 不依赖热点索引文件冲突
+- 索引是 deterministic derived artifact
+- 任意人都可以在本地重建并审计
+
+## 10. Worked Scenarios
+
+### 10.1 Scenario A: B immediately knows it fills A
+
+前提：
+
+- A 已注册，并公开了 `key_missing_lemma` 这个 exported hole
+- B 在自己的 package 里直接声明 `fills(b_result, key_missing_lemma)`
+
+那么 registry 层会看到：
+
+1. `packages/package-a/releases/<version>/holes.json`
+   含 `github:package_a::key_missing_lemma`
+2. `packages/package-b/releases/<version>/bridges.json`
+   含 `source_qid = github:package_b::b_result`
+   和 `target_hole_qid = github:package_a::key_missing_lemma`
+3. bot 生成：
+   `index/bridges/by-target/.../github:package_a::key_missing_lemma.json`
+
+该 index 文件中，这条 relation 的：
+
+- `declaring_package = package-b`
+- `declared_by_owner_of_source = true`
+
+### 10.2 Scenario B: B did not notice, later C discovers it
+
+前提：
+
+- A 已注册，并公开了 `key_missing_lemma`
+- B 已注册，只导出了 `b_result`，但没有 bridge relation
+- 后来 C 发布 bridge package，声明 `fills(package_b::b_result, package_a::key_missing_lemma)`
+
+那么 registry 层会看到：
+
+1. `packages/package-b/releases/<version>/bridges.json`
+   仍然为空
+2. `packages/package-c-bridge/releases/<version>/bridges.json`
+   含这条 relation
+3. bot 重建 `index/bridges/by-target/.../github:package_a::key_missing_lemma.json`
+
+于是最终查询 A 的 hole 时，仍然能看到这条 bridge，只是：
+
+- `declaring_package = package-c-bridge`
+- `declared_by_owner_of_source = false`
+
+这里不需要修改 A 或 B 的 registry 目录。
+
+### 10.3 Boundary Condition: A did not export a hole
+
+如果 A 没有在自己的 package manifests 中公开某个 hole：
+
+- registry 不会为它建立 `index/holes/by-qid/...`
+- B 或 C 也不能把指向它的关系注册成正式 bridge relation
+
+所以 registry 只索引：
+
+- 明确公开的 hole interfaces
+- 明确声明的 fills relations
+
+不会自动把任意 premise 升格成公共 hole。
+
+## 11. Why This Works on a GitHub Repo
+
+### 11.1 思想实验 A: 1000 个 packages
+
+如果没有全局静态索引：
+
+- 查询一个 hole 是否被填，需要扫所有 package manifests
+
+这对人类和 CLI 都很差。
+
+有 `index/bridges/by-target/<hole>.json` 后：
+
+- 只要一次精确 fetch
+
+所以这个规模下，静态派生索引已经值得做。
+
+### 11.2 思想实验 B: 5 万个 packages
+
+如果每个注册 PR 都直接改一个全局 `bridges.json`：
+
+- 热门 hole 会让 PR 冲突频发
+- bot 和人类都很难稳定合并
+
+所以全局 bridge index 不能是 PR-authored 文件，只能是 post-merge derived artifact。
+
+### 11.3 思想实验 C: 20 万条 bridge relations
+
+如果只有单个总文件：
+
+- diff 很大
+- 下载成本高
+- GitHub API 单文件读取变笨重
+
+所以索引必须分片。推荐：
+
+- 按 encoded qid 的 hash prefix 做二级 shard
+- 单文件只服务一个 key 的精确查询
+
+这样 GitHub repo 仍然能承载这个业务逻辑，因为它处理的是：
+
+- 很多小的静态文件
+- 低冲突写入
+- 高频精确读取
+
+而不是动态 join 查询。
+
+### 11.4 思想实验 D: “帮我发现可能能填这个 hole 的包”
+
+这是 discovery，不是 registry source-of-truth。
+
+正确做法是：
+
+- 离线 job 跑 embedding / text match / dependency heuristics
+- 把结果写成 suggestion artifacts 或 GitHub issues
+- 由人或 agent 再决定是否写成正式 bridge relation
+
+不应该把这类 fuzzy logic 塞进注册主路径。
+
+## 12. Query Model
+
+在 GitHub-backed registry 下，推荐的读取模式是：
+
+1. **精确定位 package**
+   继续走 `packages/<name>/...`
+
+2. **精确定位 hole**
+   读取 `index/holes/by-qid/...`
+
+3. **精确定位 bridge target**
+   读取 `index/bridges/by-target/...`
+
+4. **精确定位 bridge source**
+   读取 `index/bridges/by-source/...`
+
+不推荐：
+
+- 运行时扫描全仓
+- 在客户端做跨 package join
+- 把 GitHub code search 当主要 API
+
+GitHub code search 可以作为人类 fallback，不应成为 CLI 的基础协议。
+
+## 13. Migration Path
+
+建议分三步落地。
+
+### Phase 1
+
+- 仅支持 `exports.json`
+- 为未来 `holes` / `bridges` 留目录结构
+
+### Phase 2
+
+- 支持 `holes.json`
+- 生成 `index/holes/**`
+
+### Phase 3
+
+- 支持 `bridges.json`
+- 生成 `index/bridges/**`
+- 提供 CLI / 网页查询
+
+这样不会一次把 package DSL、registry CI、discovery、网站全部绑死。
+
+## 14. Decisions
+
+1. **需要 bridge layer，但不需要第二个 registry**
+   仍然是一个统一 GitHub repo。
+
+2. **bridge relation 来源在 package，查询不靠扫 package**
+   关系写在 package manifests 中，读取走 derived indexes。
+
+3. **所有全局索引必须是 bot 生成，不允许作者 PR 直接改**
+   否则规模一上来一定产生 merge hotspot。
+
+4. **hole 是显式公共接口，不是自动叶子前提枚举**
+   否则 registry 会充满 package 内部建模细节，无法作为生态接口。
+
+5. **registry 记录声明，不裁决真理**
+   多个 package 可以同时声称填同一个 hole。
+
+## 15. Open Questions
+
+1. `strength = partial / conditional` 时，是否需要结构化 `conditions` 字段？
+2. bridge package 是否应该有更轻量的模板与 semver 规则？
+3. registry 是否需要额外的 `suggestions/` 目录来承接未确认 discovery 结果？


### PR DESCRIPTION
## Summary
- add a Gaia Lang proposal for explicit `hole()` and `fills()` authoring APIs
- add a package-level proposal for deterministic `.gaia/manifests/{exports,holes,bridges}.json`
- add a registry-level proposal for GitHub-backed hole/bridge indexes and worked scenarios

## Notes
- docs-only change
- no tests run
