### PR TITLE
feat(compile): emit package manifests for holes and bridges

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
@@ -50,14 +52,12 @@ def _project_to_import_name(project_name: str) -> str:
 def _parse_gaia_dependencies(dependencies: list[str]) -> dict[str, str]:
     deps: dict[str, str] = {}
     for dep in dependencies:
-        requirement = dep.split(";", 1)[0].strip()
-        idx = 0
-        while idx < len(requirement) and requirement[idx] not in " <>=!~[":
-            idx += 1
-        name = requirement[:idx]
-        specifier = requirement[idx:].strip() or "*"
-        if name.endswith("-gaia"):
-            deps[name] = specifier
+        try:
+            requirement = Requirement(dep)
+        except InvalidRequirement as exc:
+            raise GaiaCliError(f"Error: invalid dependency requirement '{dep}': {exc}") from exc
+        if requirement.name.endswith("-gaia"):
+            deps[requirement.name] = str(requirement.specifier) or "*"
     return deps
 
 

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -384,16 +384,22 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
 
 def compile_loaded_package(loaded: LoadedGaiaPackage) -> dict[str, Any]:
     """Compile an already loaded Gaia package to IR JSON."""
-    from gaia.lang.compiler import compile_package
+    from gaia.lang.compiler import CompileValidationError, compile_package
 
-    return compile_package(loaded.package)
+    try:
+        return compile_package(loaded.package)
+    except CompileValidationError as exc:
+        raise GaiaCliError(f"Error: {exc}") from exc
 
 
 def compile_loaded_package_artifact(loaded: LoadedGaiaPackage):
     """Compile an already loaded Gaia package to IR plus runtime mappings."""
-    from gaia.lang.compiler import compile_package_artifact
+    from gaia.lang.compiler import CompileValidationError, compile_package_artifact
 
-    return compile_package_artifact(loaded.package)
+    try:
+        return compile_package_artifact(loaded.package)
+    except CompileValidationError as exc:
+        raise GaiaCliError(f"Error: {exc}") from exc
 
 
 def write_compiled_artifacts(

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import sys
@@ -13,6 +14,7 @@ from typing import Any
 from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
+from gaia.lang.runtime.package import _pyproject_for_module
 
 try:
     import tomllib
@@ -35,6 +37,222 @@ class LoadedGaiaPackage:
     source_root: Path
     module: ModuleType
     package: CollectedPackage
+
+
+def _project_to_registry_name(project_name: str) -> str:
+    return project_name.removesuffix("-gaia")
+
+
+def _project_to_import_name(project_name: str) -> str:
+    return _project_to_registry_name(project_name).replace("-", "_")
+
+
+def _parse_gaia_dependencies(dependencies: list[str]) -> dict[str, str]:
+    deps: dict[str, str] = {}
+    for dep in dependencies:
+        requirement = dep.split(";", 1)[0].strip()
+        idx = 0
+        while idx < len(requirement) and requirement[idx] not in " <>=!~[":
+            idx += 1
+        name = requirement[:idx]
+        specifier = requirement[idx:].strip() or "*"
+        if name.endswith("-gaia"):
+            deps[name] = specifier
+    return deps
+
+
+def _parse_qid(qid: str) -> tuple[str, str, str] | None:
+    parts = qid.split("::", 1)
+    if len(parts) != 2:
+        return None
+    prefix_parts = parts[0].split(":", 1)
+    if len(prefix_parts) != 2:
+        return None
+    return prefix_parts[0], prefix_parts[1], parts[1]
+
+
+def _gaia_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    gaia = (metadata or {}).get("gaia")
+    return gaia if isinstance(gaia, dict) else {}
+
+
+def _is_hole_knowledge(node: dict[str, Any]) -> bool:
+    return _gaia_metadata(node.get("metadata")).get("role") == "hole"
+
+
+def _relation_id(
+    declaring_package: str,
+    declaring_version: str,
+    source_qid: str,
+    target_hole_qid: str,
+    relation_type: str,
+) -> str:
+    payload = (
+        f"{declaring_package}|{declaring_version}|"
+        f"{source_qid}|{target_hole_qid}|{relation_type}"
+    )
+    return f"bridge_{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
+
+
+def _strategy_justification(strategy: dict[str, Any]) -> str | None:
+    metadata = strategy.get("metadata") or {}
+    reason = metadata.get("reason")
+    if isinstance(reason, str) and reason:
+        return reason
+    steps = strategy.get("steps") or []
+    reasoning = [
+        step.get("reasoning", "").strip()
+        for step in steps
+        if isinstance(step, dict) and isinstance(step.get("reasoning"), str) and step.get("reasoning")
+    ]
+    if reasoning:
+        return " ".join(reasoning)
+    return None
+
+
+def build_compiled_manifests(loaded: LoadedGaiaPackage, ir: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Build deterministic local manifests for exports, holes, and bridges."""
+    package_name = _project_to_registry_name(loaded.project_name)
+    import_name = loaded.import_name
+    version = str(loaded.project_config["version"])
+    ir_hash = ir["ir_hash"]
+
+    dependency_spec = loaded.project_config.get("dependencies", [])
+    if not isinstance(dependency_spec, list):
+        raise GaiaCliError("Error: [project].dependencies must be a list if set.")
+    gaia_deps = _parse_gaia_dependencies(dependency_spec)
+    deps_by_import_name = {
+        _project_to_import_name(name): spec for name, spec in gaia_deps.items()
+    }
+
+    knowledges = list(ir.get("knowledges", []))
+    exported_knowledges = [node for node in knowledges if node.get("exported")]
+    knowledge_by_id = {node["id"]: node for node in knowledges if "id" in node}
+    exported_claim_ids = {
+        node["id"]
+        for node in exported_knowledges
+        if node.get("type") == "claim" and isinstance(node.get("id"), str)
+    }
+
+    exports_manifest = {
+        "package": package_name,
+        "version": version,
+        "ir_hash": ir_hash,
+        "exports": [
+            {
+                "qid": node["id"],
+                "label": node.get("label"),
+                "type": node["type"],
+                "content": node.get("content"),
+                "content_hash": node.get("content_hash"),
+            }
+            for node in exported_knowledges
+        ],
+    }
+
+    holes: list[dict[str, Any]] = []
+    strategies = list(ir.get("strategies", []))
+    for node in exported_knowledges:
+        if node.get("type") != "claim" or not _is_hole_knowledge(node):
+            continue
+        required_by: list[str] = []
+        for strategy in strategies:
+            if node["id"] not in strategy.get("premises", []):
+                continue
+            conclusion = strategy.get("conclusion")
+            if isinstance(conclusion, str) and conclusion in exported_claim_ids and conclusion not in required_by:
+                required_by.append(conclusion)
+        holes.append(
+            {
+                "qid": node["id"],
+                "label": node.get("label"),
+                "content": node.get("content"),
+                "content_hash": node.get("content_hash"),
+                "required_by": required_by,
+            }
+        )
+
+    holes_manifest = {
+        "package": package_name,
+        "version": version,
+        "ir_hash": ir_hash,
+        "holes": holes,
+    }
+
+    bridges: list[dict[str, Any]] = []
+    for strategy in strategies:
+        relation = _gaia_metadata(strategy.get("metadata")).get("relation")
+        if not isinstance(relation, dict) or relation.get("type") != "fills":
+            continue
+        premises = strategy.get("premises") or []
+        if len(premises) != 1:
+            raise GaiaCliError("Error: fills relations must have exactly one source premise.")
+        source_qid = premises[0]
+        target_hole_qid = strategy.get("conclusion")
+        if not isinstance(source_qid, str) or not isinstance(target_hole_qid, str):
+            raise GaiaCliError("Error: fills relations must resolve to source and target QIDs.")
+
+        target_node = knowledge_by_id.get(target_hole_qid)
+        if target_node is None or not _is_hole_knowledge(target_node):
+            raise GaiaCliError(
+                f"Error: fills target '{target_hole_qid}' must resolve to a hole claim."
+            )
+
+        target_qid = _parse_qid(target_hole_qid)
+        source_qid_parts = _parse_qid(source_qid)
+        if target_qid is None or source_qid_parts is None:
+            raise GaiaCliError("Error: fills manifests require valid QID references.")
+
+        _, target_import_name, _ = target_qid
+        target_package = target_import_name.replace("_", "-")
+        if target_import_name == import_name:
+            if target_hole_qid not in exported_claim_ids:
+                continue
+            target_version_req = f"=={version}"
+        else:
+            target_version_req = deps_by_import_name.get(target_import_name)
+            if target_version_req is None:
+                raise GaiaCliError(
+                    "Error: fills target "
+                    f"'{target_hole_qid}' requires a Gaia dependency constraint for "
+                    f"'{target_package}-gaia'."
+                )
+
+        source_import_name = source_qid_parts[1]
+        bridge: dict[str, Any] = {
+            "relation_id": _relation_id(
+                package_name,
+                version,
+                source_qid,
+                target_hole_qid,
+                "fills",
+            ),
+            "relation_type": "fills",
+            "source_qid": source_qid,
+            "target_hole_qid": target_hole_qid,
+            "target_package": target_package,
+            "target_version_req": target_version_req,
+            "strength": relation.get("strength", "exact"),
+            "mode": relation.get("mode") or strategy.get("type"),
+            "declared_by_owner_of_source": source_import_name == import_name,
+        }
+        justification = _strategy_justification(strategy)
+        if justification:
+            bridge["justification"] = justification
+        bridges.append(bridge)
+
+    bridges_manifest = {
+        "package": package_name,
+        "version": version,
+        "ir_hash": ir_hash,
+        "bridges": bridges,
+    }
+
+    return {
+        "exports.json": exports_manifest,
+        "holes.json": holes_manifest,
+        "bridges.json": bridges_manifest,
+    }
 
 
 def _import_fresh(import_name: str) -> ModuleType:
@@ -62,6 +280,20 @@ def _assign_labels(module: ModuleType, pkg: CollectedPackage) -> None:
             obj.label = attr
         if isinstance(obj, Strategy) and id(obj) in local_strategy_ids and obj.label is None:
             obj.label = attr
+
+
+def _assign_labels_for_loaded_packages() -> None:
+    """Assign labels for every loaded Gaia package module, including dependencies."""
+    for module_name, module in list(sys.modules.items()):
+        if module is None:
+            continue
+        pyproject = _pyproject_for_module(module_name)
+        if pyproject is None:
+            continue
+        pkg = get_inferred_package(pyproject)
+        if pkg is None:
+            continue
+        _assign_labels(module, pkg)
 
 
 def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
@@ -112,7 +344,7 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
             "directly in the module and export the public surface via __all__ when needed."
         )
 
-    _assign_labels(module, pkg)
+    _assign_labels_for_loaded_packages()
 
     # Record exported labels from __all__ for the compiler
     export_names = getattr(module, "__all__", None)
@@ -164,11 +396,23 @@ def compile_loaded_package_artifact(loaded: LoadedGaiaPackage):
     return compile_package_artifact(loaded.package)
 
 
-def write_compiled_artifacts(pkg_path: Path, ir: dict[str, Any]) -> Path:
+def write_compiled_artifacts(
+    pkg_path: Path,
+    ir: dict[str, Any],
+    *,
+    manifests: dict[str, dict[str, Any]] | None = None,
+) -> Path:
     """Write .gaia compilation artifacts and return the output directory."""
     gaia_dir = pkg_path / ".gaia"
     gaia_dir.mkdir(exist_ok=True)
     ir_json = json.dumps(ir, ensure_ascii=False, indent=2, sort_keys=True)
     (gaia_dir / "ir.json").write_text(ir_json)
     (gaia_dir / "ir_hash").write_text(ir["ir_hash"])
+    if manifests is not None:
+        manifest_dir = gaia_dir / "manifests"
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        for filename, payload in manifests.items():
+            (manifest_dir / filename).write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+            )
     return gaia_dir

--- a/gaia/cli/commands/compile.py
+++ b/gaia/cli/commands/compile.py
@@ -6,8 +6,13 @@ import json
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, compile_loaded_package, load_gaia_package
-from gaia.cli._packages import write_compiled_artifacts
+from gaia.cli._packages import (
+    GaiaCliError,
+    build_compiled_manifests,
+    compile_loaded_package,
+    load_gaia_package,
+    write_compiled_artifacts,
+)
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
 
@@ -42,7 +47,12 @@ def compile_command(
             typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(1)
 
-    gaia_dir = write_compiled_artifacts(loaded.pkg_path, ir)
+    try:
+        manifests = build_compiled_manifests(loaded, ir)
+        gaia_dir = write_compiled_artifacts(loaded.pkg_path, ir, manifests=manifests)
+    except GaiaCliError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1)
 
     typer.echo(
         f"Compiled {len(ir['knowledges'])} knowledge, "

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -10,7 +10,12 @@ from uuid import UUID
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, compile_loaded_package, load_gaia_package
+from gaia.cli._packages import (
+    GaiaCliError,
+    _parse_gaia_dependencies,
+    compile_loaded_package,
+    load_gaia_package,
+)
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
 
@@ -50,21 +55,6 @@ def _normalize_github_url(url: str) -> str:
     if value.endswith(".git"):
         value = value[:-4]
     return value.rstrip("/")
-
-
-def _parse_gaia_dependencies(dependencies: list[str]) -> dict[str, str]:
-    deps: dict[str, str] = {}
-    for dep in dependencies:
-        requirement = dep.split(";", 1)[0].strip()
-        idx = 0
-        while idx < len(requirement) and requirement[idx] not in " <>=!~[":
-            idx += 1
-        name = requirement[:idx]
-        specifier = requirement[idx:].strip() or "*"
-        if name.endswith("-gaia"):
-            deps[name] = specifier
-    return deps
-
 
 def _render_package_toml(
     *,

--- a/gaia/lang/compiler/__init__.py
+++ b/gaia/lang/compiler/__init__.py
@@ -1,3 +1,13 @@
-from gaia.lang.compiler.compile import CompiledPackage, compile_package, compile_package_artifact
+from gaia.lang.compiler.compile import (
+    CompileValidationError,
+    CompiledPackage,
+    compile_package,
+    compile_package_artifact,
+)
 
-__all__ = ["CompiledPackage", "compile_package", "compile_package_artifact"]
+__all__ = [
+    "CompileValidationError",
+    "CompiledPackage",
+    "compile_package",
+    "compile_package_artifact",
+]

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -50,6 +50,10 @@ class CompiledPackage:
         return self.graph.model_dump(mode="json", exclude_none=True, serialize_as_any=True)
 
 
+class CompileValidationError(ValueError):
+    """User-fixable compile-time validation error."""
+
+
 def _content_hash(k: Knowledge) -> str:
     """SHA-256(type + content + sorted(parameters))."""
     params_str = json.dumps(sorted(k.parameters, key=lambda p: p.get("name", "")), sort_keys=True)
@@ -162,7 +166,7 @@ def _validate_fills_strategies(
         target_qid = knowledge_map[id(target)]
         pair = (source_qid, target_qid)
         if pair in seen_pairs:
-            raise ValueError(
+            raise CompileValidationError(
                 "Duplicate fills declaration for "
                 f"{source_qid} -> {target_qid}; merge into a single relation"
             )

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -497,7 +497,7 @@ def test_compile_emits_bridge_manifest_for_direct_fill(tmp_path, monkeypatch):
     assert bridge["source_qid"] == "github:fill_pkg::b_result"
     assert bridge["target_hole_qid"] == "github:dep_hole_pkg::key_missing_lemma"
     assert bridge["target_package"] == "dep-hole-pkg"
-    assert bridge["target_version_req"] == ">=1.4.0,<2.0.0"
+    assert bridge["target_version_req"] == "<2.0.0,>=1.4.0"
     assert bridge["declared_by_owner_of_source"] is True
     assert bridge["justification"] == "Theorem 3 proves the missing lemma."
 
@@ -551,7 +551,47 @@ def test_compile_emits_bridge_manifest_for_zero_local_bridge_package(tmp_path, m
     assert bridge["source_qid"] == "github:bridge_dep_b::b_result"
     assert bridge["target_hole_qid"] == "github:bridge_dep_a::key_missing_lemma"
     assert bridge["declared_by_owner_of_source"] is False
-    assert bridge["target_version_req"] == ">=1.4.0,<2.0.0"
+    assert bridge["target_version_req"] == "<2.0.0,>=1.4.0"
+
+
+def test_compile_emits_bridge_manifest_for_conditional_infer_fill(tmp_path, monkeypatch):
+    dep_dir, _ = _write_package(
+        tmp_path / "conditional_dep_hole_pkg",
+        project_name="conditional-dep-hole-pkg-gaia",
+        body=(
+            "from gaia.lang import hole\n\n"
+            'key_missing_lemma = hole("A missing premise.")\n'
+            '__all__ = ["key_missing_lemma"]\n'
+        ),
+    )
+    pkg_dir, _ = _write_package(
+        tmp_path / "conditional_fill_pkg",
+        project_name="conditional-fill-pkg-gaia",
+        dependencies=["conditional-dep-hole-pkg-gaia>=0.4.0,<1.0.0"],
+        body=(
+            "from gaia.lang import claim, fills\n"
+            "from conditional_dep_hole_pkg import key_missing_lemma\n\n"
+            'b_result = claim("B theorem.")\n'
+            'fills(source=b_result, hole=key_missing_lemma, strength="conditional", '
+            'mode="infer", reason="The theorem partially supports the missing lemma.")\n'
+            '__all__ = ["b_result"]\n'
+        ),
+    )
+
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    bridges = _read_manifest(pkg_dir, "bridges.json")
+    assert len(bridges["bridges"]) == 1
+    bridge = bridges["bridges"][0]
+    assert bridge["relation_type"] == "fills"
+    assert bridge["source_qid"] == "github:conditional_fill_pkg::b_result"
+    assert bridge["target_hole_qid"] == "github:conditional_dep_hole_pkg::key_missing_lemma"
+    assert bridge["target_version_req"] == "<1.0.0,>=0.4.0"
+    assert bridge["strength"] == "conditional"
+    assert bridge["mode"] == "infer"
+    assert bridge["justification"] == "The theorem partially supports the missing lemma."
 
 
 def test_compile_rejects_foreign_fill_without_dependency_constraint(tmp_path, monkeypatch):

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -430,7 +430,6 @@ def test_compile_nested_composite_strategy_collects_recursive_knowledge(tmp_path
     result = validate_local_graph(LocalCanonicalGraph(**ir))
     assert result.valid, result.errors
 
-
 def test_compile_emits_holes_manifest_with_required_by(tmp_path):
     pkg_dir, _ = _write_package(
         tmp_path / "hole_pkg",
@@ -581,3 +580,27 @@ def test_compile_rejects_foreign_fill_without_dependency_constraint(tmp_path, mo
     result = runner.invoke(app, ["compile", str(pkg_dir)])
     assert result.exit_code != 0
     assert "requires a Gaia dependency constraint" in result.output
+
+
+def test_compile_rejects_duplicate_fills_without_traceback(tmp_path):
+    pkg_dir = tmp_path / "dup_fills"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dup-fills-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "dup_fills"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills, hole\n\n"
+        'result = claim("B theorem.")\n'
+        'missing = hole("A missing lemma.")\n'
+        'fills(source=result, hole=missing, strength="exact")\n'
+        'fills(source=result, hole=missing, strength="partial")\n'
+        '__all__ = ["result", "missing"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "Duplicate fills declaration" in result.output
+    assert "Traceback" not in result.output

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -1,7 +1,6 @@
 """Tests for gaia compile command."""
 
 import json
-
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
@@ -9,6 +8,37 @@ from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
 
 runner = CliRunner()
+
+
+def _write_package(
+    root,
+    *,
+    project_name: str,
+    body: str,
+    dependencies: list[str] | None = None,
+    src_layout: bool = True,
+):
+    root.mkdir()
+    deps_block = ""
+    if dependencies:
+        deps_lines = ",\n".join(f'  "{dep}"' for dep in dependencies)
+        deps_block = f"dependencies = [\n{deps_lines}\n]\n\n"
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "{project_name}"\nversion = "1.0.0"\n{deps_block}'
+        '\n[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    import_name = project_name.removesuffix("-gaia").replace("-", "_")
+    package_root = root / ("src" if src_layout else "")
+    if src_layout:
+        package_root.mkdir()
+    pkg_src = package_root / import_name
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(body)
+    return root, pkg_src
+
+
+def _read_manifest(pkg_dir, name: str) -> dict:
+    return json.loads((pkg_dir / ".gaia" / "manifests" / name).read_text())
 
 
 def test_compile_creates_ir_json(tmp_path):
@@ -31,11 +61,21 @@ def test_compile_creates_ir_json(tmp_path):
     gaia_dir = pkg_dir / ".gaia"
     assert (gaia_dir / "ir.json").exists()
     assert (gaia_dir / "ir_hash").exists()
+    assert (gaia_dir / "manifests" / "exports.json").exists()
+    assert (gaia_dir / "manifests" / "holes.json").exists()
+    assert (gaia_dir / "manifests" / "bridges.json").exists()
 
     ir = json.loads((gaia_dir / "ir.json").read_text())
+    exports = _read_manifest(pkg_dir, "exports.json")
+    holes = _read_manifest(pkg_dir, "holes.json")
+    bridges = _read_manifest(pkg_dir, "bridges.json")
     assert ir["package_name"] == "test_pkg"
     assert len(ir["knowledges"]) >= 1
     assert ir["ir_hash"] is not None
+    assert exports["package"] == "test-pkg"
+    assert exports["exports"][0]["label"] == "my_claim"
+    assert holes["holes"] == []
+    assert bridges["bridges"] == []
     result = validate_local_graph(LocalCanonicalGraph(**ir))
     assert result.valid, result.errors
 
@@ -389,3 +429,155 @@ def test_compile_nested_composite_strategy_collects_recursive_knowledge(tmp_path
     assert "github:nested_composite_pkg::hypothesis" in knowledge_ids
     result = validate_local_graph(LocalCanonicalGraph(**ir))
     assert result.valid, result.errors
+
+
+def test_compile_emits_holes_manifest_with_required_by(tmp_path):
+    pkg_dir, _ = _write_package(
+        tmp_path / "hole_pkg",
+        project_name="hole-pkg-gaia",
+        body=(
+            "from gaia.lang import claim, deduction, hole\n\n"
+            'main_theorem = claim("Main theorem.")\n'
+            'key_missing_lemma = hole("A missing lemma.")\n'
+            "deduction(premises=[key_missing_lemma], conclusion=main_theorem)\n"
+            '__all__ = ["main_theorem", "key_missing_lemma"]\n'
+        ),
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    exports = _read_manifest(pkg_dir, "exports.json")
+    holes = _read_manifest(pkg_dir, "holes.json")
+    assert [item["label"] for item in exports["exports"]] == ["main_theorem", "key_missing_lemma"]
+    assert holes["holes"] == [
+        {
+            "qid": "github:hole_pkg::key_missing_lemma",
+            "label": "key_missing_lemma",
+            "content": "A missing lemma.",
+            "content_hash": holes["holes"][0]["content_hash"],
+            "required_by": ["github:hole_pkg::main_theorem"],
+        }
+    ]
+
+
+def test_compile_emits_bridge_manifest_for_direct_fill(tmp_path, monkeypatch):
+    dep_dir, _ = _write_package(
+        tmp_path / "dep_hole_pkg",
+        project_name="dep-hole-pkg-gaia",
+        body=(
+            "from gaia.lang import hole\n\n"
+            'key_missing_lemma = hole("A missing premise.")\n'
+            '__all__ = ["key_missing_lemma"]\n'
+        ),
+    )
+    pkg_dir, _ = _write_package(
+        tmp_path / "fill_pkg",
+        project_name="fill-pkg-gaia",
+        dependencies=["dep-hole-pkg-gaia>=1.4.0,<2.0.0"],
+        body=(
+            "from gaia.lang import claim, fills\n"
+            "from dep_hole_pkg import key_missing_lemma\n\n"
+            'b_result = claim("B theorem.")\n'
+            'fills(source=b_result, hole=key_missing_lemma, reason="Theorem 3 proves the missing lemma.")\n'
+            '__all__ = ["b_result"]\n'
+        ),
+    )
+
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    bridges = _read_manifest(pkg_dir, "bridges.json")
+    exports = _read_manifest(pkg_dir, "exports.json")
+    assert [item["label"] for item in exports["exports"]] == ["b_result"]
+    assert len(bridges["bridges"]) == 1
+    bridge = bridges["bridges"][0]
+    assert bridge["relation_id"].startswith("bridge_")
+    assert bridge["relation_type"] == "fills"
+    assert bridge["source_qid"] == "github:fill_pkg::b_result"
+    assert bridge["target_hole_qid"] == "github:dep_hole_pkg::key_missing_lemma"
+    assert bridge["target_package"] == "dep-hole-pkg"
+    assert bridge["target_version_req"] == ">=1.4.0,<2.0.0"
+    assert bridge["declared_by_owner_of_source"] is True
+    assert bridge["justification"] == "Theorem 3 proves the missing lemma."
+
+
+def test_compile_emits_bridge_manifest_for_zero_local_bridge_package(tmp_path, monkeypatch):
+    dep_a_dir, _ = _write_package(
+        tmp_path / "bridge_dep_a",
+        project_name="bridge-dep-a-gaia",
+        body=(
+            "from gaia.lang import hole\n\n"
+            'key_missing_lemma = hole("A missing premise.")\n'
+            '__all__ = ["key_missing_lemma"]\n'
+        ),
+    )
+    dep_b_dir, _ = _write_package(
+        tmp_path / "bridge_dep_b",
+        project_name="bridge-dep-b-gaia",
+        body=(
+            "from gaia.lang import claim\n\n"
+            'b_result = claim("B theorem.")\n'
+            '__all__ = ["b_result"]\n'
+        ),
+    )
+    pkg_dir, _ = _write_package(
+        tmp_path / "bridge_pkg",
+        project_name="bridge-pkg-gaia",
+        dependencies=[
+            "bridge-dep-a-gaia>=1.4.0,<2.0.0",
+            "bridge-dep-b-gaia>=2.1.0,<3.0.0",
+        ],
+        body=(
+            "from gaia.lang import fills\n"
+            "from bridge_dep_a import key_missing_lemma\n"
+            "from bridge_dep_b import b_result\n\n"
+            'fills(source=b_result, hole=key_missing_lemma, reason="Bridge package links B to A.")\n'
+        ),
+    )
+
+    monkeypatch.syspath_prepend(str(dep_a_dir / "src"))
+    monkeypatch.syspath_prepend(str(dep_b_dir / "src"))
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    exports = _read_manifest(pkg_dir, "exports.json")
+    holes = _read_manifest(pkg_dir, "holes.json")
+    bridges = _read_manifest(pkg_dir, "bridges.json")
+    assert exports["exports"] == []
+    assert holes["holes"] == []
+    assert len(bridges["bridges"]) == 1
+    bridge = bridges["bridges"][0]
+    assert bridge["source_qid"] == "github:bridge_dep_b::b_result"
+    assert bridge["target_hole_qid"] == "github:bridge_dep_a::key_missing_lemma"
+    assert bridge["declared_by_owner_of_source"] is False
+    assert bridge["target_version_req"] == ">=1.4.0,<2.0.0"
+
+
+def test_compile_rejects_foreign_fill_without_dependency_constraint(tmp_path, monkeypatch):
+    dep_dir, _ = _write_package(
+        tmp_path / "missing_dep_hole_pkg",
+        project_name="missing-dep-hole-pkg-gaia",
+        body=(
+            "from gaia.lang import hole\n\n"
+            'key_missing_lemma = hole("A missing premise.")\n'
+            '__all__ = ["key_missing_lemma"]\n'
+        ),
+    )
+    pkg_dir, _ = _write_package(
+        tmp_path / "bad_fill_pkg",
+        project_name="bad-fill-pkg-gaia",
+        body=(
+            "from gaia.lang import claim, fills\n"
+            "from missing_dep_hole_pkg import key_missing_lemma\n\n"
+            'b_result = claim("B theorem.")\n'
+            "fills(source=b_result, hole=key_missing_lemma)\n"
+            '__all__ = ["b_result"]\n'
+        ),
+    )
+
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "requires a Gaia dependency constraint" in result.output

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -95,7 +95,7 @@ def test_register_dry_run_emits_registration_plan(tmp_path):
     assert plan["package"]["pypi_name"] == "register-demo-gaia"
     assert plan["version"]["git_tag"] == "v1.2.0"
     assert plan["version"]["ir_hash"].startswith("sha256:")
-    assert plan["deps"] == {"aristotle-mechanics-gaia": ">= 1.0.0"}
+    assert plan["deps"] == {"aristotle-mechanics-gaia": ">=1.0.0"}
 
 
 def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
@@ -132,7 +132,7 @@ def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
     assert (package_dir / "Deps.toml").exists()
     assert 'name = "register-demo"' in (package_dir / "Package.toml").read_text()
     assert 'git_tag = "v1.2.0"' in (package_dir / "Versions.toml").read_text()
-    assert '"aristotle-mechanics-gaia" = ">= 1.0.0"' in (package_dir / "Deps.toml").read_text()
+    assert '"aristotle-mechanics-gaia" = ">=1.0.0"' in (package_dir / "Deps.toml").read_text()
     assert (
         _run(["git", "branch", "--show-current"], cwd=registry_dir)
         == "register/register-demo-1.2.0"

--- a/tests/gaia/lang/test_compiler.py
+++ b/tests/gaia/lang/test_compiler.py
@@ -19,6 +19,7 @@ from gaia.lang import (
 )
 from gaia.lang.runtime import Strategy
 from gaia.lang.compiler.compile import (
+    CompileValidationError,
     compile_package_artifact,
     _compile_reason,
     _extract_at_labels,
@@ -329,7 +330,7 @@ def test_compile_rejects_duplicate_fills_for_same_pair():
         missing.label = "missing"
         fills(source=result, hole=missing, strength="exact")
         fills(source=result, hole=missing, strength="partial")
-    with pytest.raises(ValueError, match="Duplicate fills declaration"):
+    with pytest.raises(CompileValidationError, match="Duplicate fills declaration"):
         compile_package_artifact(pkg)
 
 


### PR DESCRIPTION
## Summary
- make `gaia compile` emit deterministic `.gaia/manifests/exports.json`, `holes.json`, and `bridges.json` artifacts
- derive `required_by`, `relation_id`, `target_version_req`, and `declared_by_owner_of_source` from the compiled IR plus package dependency metadata
- assign labels for imported Gaia package objects as well, so foreign bridge/hole QIDs stay stable instead of degrading to anonymous ids

## Notes
- stacked on top of #365
- manifests are kept deterministic, so this implementation intentionally omits `generated_at` timestamps

## Testing
- pytest tests/cli/test_compile.py tests/cli/test_register.py tests/gaia/lang/test_core.py tests/gaia/lang/test_strategies.py tests/gaia/lang/test_compiler.py -q
- pytest tests/gaia/lang -q
