### PR TITLE
feat(cli): validate manifests in check and register

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -391,16 +391,22 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
 
 def compile_loaded_package(loaded: LoadedGaiaPackage) -> dict[str, Any]:
     """Compile an already loaded Gaia package to IR JSON."""
-    from gaia.lang.compiler import compile_package
+    from gaia.lang.compiler import CompileValidationError, compile_package
 
-    return compile_package(loaded.package)
+    try:
+        return compile_package(loaded.package)
+    except CompileValidationError as exc:
+        raise GaiaCliError(f"Error: {exc}") from exc
 
 
 def compile_loaded_package_artifact(loaded: LoadedGaiaPackage):
     """Compile an already loaded Gaia package to IR plus runtime mappings."""
-    from gaia.lang.compiler import compile_package_artifact
+    from gaia.lang.compiler import CompileValidationError, compile_package_artifact
 
-    return compile_package_artifact(loaded.package)
+    try:
+        return compile_package_artifact(loaded.package)
+    except CompileValidationError as exc:
+        raise GaiaCliError(f"Error: {exc}") from exc
 
 
 def write_compiled_artifacts(

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -39,6 +39,9 @@ class LoadedGaiaPackage:
     package: CollectedPackage
 
 
+MANIFEST_FILENAMES = ("exports.json", "holes.json", "bridges.json")
+
+
 def _project_to_registry_name(project_name: str) -> str:
     return project_name.removesuffix("-gaia")
 
@@ -294,6 +297,10 @@ def _assign_labels_for_loaded_packages() -> None:
         if pkg is None:
             continue
         _assign_labels(module, pkg)
+
+
+def manifest_dir_for_package(pkg_path: Path) -> Path:
+    return pkg_path / ".gaia" / "manifests"
 
 
 def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
@@ -53,14 +55,12 @@ def _project_to_import_name(project_name: str) -> str:
 def _parse_gaia_dependencies(dependencies: list[str]) -> dict[str, str]:
     deps: dict[str, str] = {}
     for dep in dependencies:
-        requirement = dep.split(";", 1)[0].strip()
-        idx = 0
-        while idx < len(requirement) and requirement[idx] not in " <>=!~[":
-            idx += 1
-        name = requirement[:idx]
-        specifier = requirement[idx:].strip() or "*"
-        if name.endswith("-gaia"):
-            deps[name] = specifier
+        try:
+            requirement = Requirement(dep)
+        except InvalidRequirement as exc:
+            raise GaiaCliError(f"Error: invalid dependency requirement '{dep}': {exc}") from exc
+        if requirement.name.endswith("-gaia"):
+            deps[requirement.name] = str(requirement.specifier) or "*"
     return deps
 
 

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -6,7 +6,14 @@ import json
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, compile_loaded_package, load_gaia_package
+from gaia.cli._packages import (
+    GaiaCliError,
+    MANIFEST_FILENAMES,
+    build_compiled_manifests,
+    compile_loaded_package,
+    load_gaia_package,
+    manifest_dir_for_package,
+)
 from gaia.cli.commands._classify import classify_ir, node_role
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
@@ -105,14 +112,23 @@ def check_command(
     errors.extend(validation.errors)
     warnings.extend(validation.warnings)
 
+    try:
+        expected_manifests = build_compiled_manifests(loaded, ir)
+    except GaiaCliError as exc:
+        errors.append(str(exc))
+        expected_manifests = {}
+
     ir_hash_path = loaded.pkg_path / ".gaia" / "ir_hash"
     ir_json_path = loaded.pkg_path / ".gaia" / "ir.json"
+    manifest_dir = manifest_dir_for_package(loaded.pkg_path)
     if ir_hash_path.exists():
         stored_hash = ir_hash_path.read_text().strip()
         if stored_hash != ir["ir_hash"]:
             errors.append("Compiled artifacts are stale; run `gaia compile` again.")
         if not ir_json_path.exists():
             errors.append("Found .gaia/ir_hash but missing .gaia/ir.json.")
+        if not manifest_dir.exists():
+            errors.append("Found compiled IR but missing .gaia/manifests; run `gaia compile` again.")
     else:
         warnings.append("Compiled artifacts missing; run `gaia compile` before `gaia register`.")
 
@@ -126,6 +142,33 @@ def check_command(
                 errors.append(
                     "Stored .gaia/ir.json does not match current source; run `gaia compile`."
                 )
+
+    for filename in MANIFEST_FILENAMES:
+        expected = expected_manifests.get(filename)
+        if expected is None:
+            continue
+        path = manifest_dir / filename
+        if not path.exists():
+            errors.append(f"Missing compiled manifest .gaia/manifests/{filename}.")
+            continue
+        try:
+            stored = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:
+            errors.append(f".gaia/manifests/{filename} is not valid JSON: {exc}")
+            continue
+        if stored != expected:
+            errors.append(
+                f"Stored .gaia/manifests/{filename} does not match current source; "
+                "run `gaia compile`."
+            )
+
+    holes_manifest = expected_manifests.get("holes.json", {})
+    for hole in holes_manifest.get("holes", []):
+        if not hole.get("required_by"):
+            label = hole.get("label") or hole.get("qid", "<unknown>")
+            warnings.append(
+                f"Exported hole '{label}' has no downstream local use."
+            )
 
     for warning in warnings:
         typer.echo(f"Warning: {warning}")

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -166,6 +166,8 @@ def check_command(
     for hole in holes_manifest.get("holes", []):
         if not hole.get("required_by"):
             label = hole.get("label") or hole.get("qid", "<unknown>")
+            # TODO: add an explicit suppression mechanism for intentionally
+            # public-but-currently-unfilled holes once the manifest contract exists.
             warnings.append(
                 f"Exported hole '{label}' has no downstream local use."
             )

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -13,8 +13,10 @@ import typer
 from gaia.cli._packages import (
     GaiaCliError,
     _parse_gaia_dependencies,
+    build_compiled_manifests,
     compile_loaded_package,
     load_gaia_package,
+    manifest_dir_for_package,
 )
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
@@ -197,6 +199,28 @@ def register_command(
         typer.echo("Error: compiled artifacts are stale; run `gaia compile` again.", err=True)
         raise typer.Exit(1)
 
+    try:
+        manifests = build_compiled_manifests(loaded, ir)
+    except GaiaCliError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1)
+
+    exports_manifest_path = manifest_dir_for_package(loaded.pkg_path) / "exports.json"
+    if not exports_manifest_path.exists():
+        typer.echo("Error: missing .gaia/manifests/exports.json; run `gaia compile` first.", err=True)
+        raise typer.Exit(1)
+    try:
+        stored_exports_manifest = json.loads(exports_manifest_path.read_text())
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Error: .gaia/manifests/exports.json is not valid JSON: {exc}", err=True)
+        raise typer.Exit(1)
+    if stored_exports_manifest != manifests["exports.json"]:
+        typer.echo(
+            "Error: compiled exports manifest is stale; run `gaia compile` again.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
     gaia_uuid = loaded.gaia_config.get("uuid")
     if not isinstance(gaia_uuid, str) or not gaia_uuid:
         typer.echo("Error: [tool.gaia].uuid is required for registration.", err=True)
@@ -278,6 +302,9 @@ def register_command(
         }
     }
     deps_payload = {version: deps}
+    exports_manifest_json = json.dumps(
+        manifests["exports.json"], ensure_ascii=False, indent=2, sort_keys=True
+    )
 
     plan = {
         "package": {
@@ -299,6 +326,7 @@ def register_command(
             f"packages/{package_name}/Package.toml": package_toml,
             f"packages/{package_name}/Versions.toml": _render_versions_toml(versions),
             f"packages/{package_name}/Deps.toml": _render_deps_toml(deps_payload),
+            f"packages/{package_name}/releases/{version}/exports.json": exports_manifest_json,
         },
         "pull_request": {"title": pr_title, "body": pr_body},
     }
@@ -331,9 +359,12 @@ def register_command(
 
     package_dir = registry_path / "packages" / package_name
     package_dir.mkdir(parents=True, exist_ok=True)
+    release_dir = package_dir / "releases" / version
+    release_dir.mkdir(parents=True, exist_ok=True)
     package_toml_path = package_dir / "Package.toml"
     versions_toml_path = package_dir / "Versions.toml"
     deps_toml_path = package_dir / "Deps.toml"
+    exports_manifest_registry_path = release_dir / "exports.json"
 
     if package_toml_path.exists():
         existing_package = tomllib.loads(package_toml_path.read_text())
@@ -353,6 +384,7 @@ def register_command(
     existing_deps = _load_existing_deps(deps_toml_path)
     existing_deps[version] = deps
     deps_toml_path.write_text(_render_deps_toml(existing_deps))
+    exports_manifest_registry_path.write_text(exports_manifest_json)
 
     try:
         _run(["git", "add", str(package_dir.relative_to(registry_path))], cwd=registry_path)

--- a/gaia/lang/compiler/__init__.py
+++ b/gaia/lang/compiler/__init__.py
@@ -1,3 +1,13 @@
-from gaia.lang.compiler.compile import CompiledPackage, compile_package, compile_package_artifact
+from gaia.lang.compiler.compile import (
+    CompileValidationError,
+    CompiledPackage,
+    compile_package,
+    compile_package_artifact,
+)
 
-__all__ = ["CompiledPackage", "compile_package", "compile_package_artifact"]
+__all__ = [
+    "CompileValidationError",
+    "CompiledPackage",
+    "compile_package",
+    "compile_package_artifact",
+]

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -50,6 +50,10 @@ class CompiledPackage:
         return self.graph.model_dump(mode="json", exclude_none=True, serialize_as_any=True)
 
 
+class CompileValidationError(ValueError):
+    """User-fixable compile-time validation error."""
+
+
 def _content_hash(k: Knowledge) -> str:
     """SHA-256(type + content + sorted(parameters))."""
     params_str = json.dumps(sorted(k.parameters, key=lambda p: p.get("name", "")), sort_keys=True)
@@ -162,7 +166,7 @@ def _validate_fills_strategies(
         target_qid = knowledge_map[id(target)]
         pair = (source_qid, target_qid)
         if pair in seen_pairs:
-            raise ValueError(
+            raise CompileValidationError(
                 "Duplicate fills declaration for "
                 f"{source_qid} -> {target_qid}; merge into a single relation"
             )

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -52,3 +52,40 @@ def test_check_fails_when_compiled_artifacts_are_stale(tmp_path):
     result = runner.invoke(app, ["check", str(pkg_dir)])
     assert result.exit_code != 0
     assert "stale" in result.output.lower()
+
+
+def test_check_fails_when_manifest_is_missing(tmp_path):
+    pkg_dir = tmp_path / "check_demo"
+    _write_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    (pkg_dir / ".gaia" / "manifests" / "exports.json").unlink()
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "missing compiled manifest" in result.output.lower()
+
+
+def test_check_warns_for_unused_exported_hole(tmp_path):
+    pkg_dir = tmp_path / "hole_demo"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "hole-demo-gaia"\nversion = "1.2.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "hole_demo"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import hole\n\n"
+        'key_missing_lemma = hole("A missing premise.")\n'
+        '__all__ = ["key_missing_lemma"]\n'
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "has no downstream local use" in result.output

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import shutil
+
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
@@ -21,6 +24,23 @@ def _write_package(pkg_dir, *, content: str = "A test claim.") -> None:
         "from gaia.lang import claim\n\n"
         f'main_claim = claim("{content}")\n'
         '__all__ = ["main_claim"]\n'
+    )
+
+
+def _write_hole_fill_package(pkg_dir) -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "check-hole-fill-gaia"\nversion = "1.2.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "check_hole_fill"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills, hole\n\n"
+        'result = claim("A supporting theorem.")\n'
+        'missing = hole("A missing premise.")\n'
+        'fills(source=result, hole=missing, reason="The theorem establishes the hole.")\n'
+        '__all__ = ["result", "missing"]\n'
     )
 
 
@@ -66,6 +86,56 @@ def test_check_fails_when_manifest_is_missing(tmp_path):
     result = runner.invoke(app, ["check", str(pkg_dir)])
     assert result.exit_code != 0
     assert "missing compiled manifest" in result.output.lower()
+
+
+def test_check_fails_when_manifest_directory_is_missing(tmp_path):
+    pkg_dir = tmp_path / "check_demo"
+    _write_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    shutil.rmtree(pkg_dir / ".gaia" / "manifests")
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "missing .gaia/manifests" in result.output.lower()
+
+
+def test_check_fails_when_holes_manifest_is_tampered(tmp_path):
+    pkg_dir = tmp_path / "check_hole_fill"
+    _write_hole_fill_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    holes_path = pkg_dir / ".gaia" / "manifests" / "holes.json"
+    holes = json.loads(holes_path.read_text())
+    holes["holes"][0]["content"] = "tampered"
+    holes_path.write_text(json.dumps(holes, indent=2, sort_keys=True))
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "holes.json" in result.output
+    assert "does not match current source" in result.output
+
+
+def test_check_fails_when_bridges_manifest_is_tampered(tmp_path):
+    pkg_dir = tmp_path / "check_hole_fill"
+    _write_hole_fill_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    bridges_path = pkg_dir / ".gaia" / "manifests" / "bridges.json"
+    bridges = json.loads(bridges_path.read_text())
+    bridges["bridges"][0]["mode"] = "infer"
+    bridges_path.write_text(json.dumps(bridges, indent=2, sort_keys=True))
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "bridges.json" in result.output
+    assert "does not match current source" in result.output
 
 
 def test_check_warns_for_unused_exported_hole(tmp_path):

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -497,7 +497,7 @@ def test_compile_emits_bridge_manifest_for_direct_fill(tmp_path, monkeypatch):
     assert bridge["source_qid"] == "github:fill_pkg::b_result"
     assert bridge["target_hole_qid"] == "github:dep_hole_pkg::key_missing_lemma"
     assert bridge["target_package"] == "dep-hole-pkg"
-    assert bridge["target_version_req"] == ">=1.4.0,<2.0.0"
+    assert bridge["target_version_req"] == "<2.0.0,>=1.4.0"
     assert bridge["declared_by_owner_of_source"] is True
     assert bridge["justification"] == "Theorem 3 proves the missing lemma."
 
@@ -551,7 +551,47 @@ def test_compile_emits_bridge_manifest_for_zero_local_bridge_package(tmp_path, m
     assert bridge["source_qid"] == "github:bridge_dep_b::b_result"
     assert bridge["target_hole_qid"] == "github:bridge_dep_a::key_missing_lemma"
     assert bridge["declared_by_owner_of_source"] is False
-    assert bridge["target_version_req"] == ">=1.4.0,<2.0.0"
+    assert bridge["target_version_req"] == "<2.0.0,>=1.4.0"
+
+
+def test_compile_emits_bridge_manifest_for_conditional_infer_fill(tmp_path, monkeypatch):
+    dep_dir, _ = _write_package(
+        tmp_path / "conditional_dep_hole_pkg",
+        project_name="conditional-dep-hole-pkg-gaia",
+        body=(
+            "from gaia.lang import hole\n\n"
+            'key_missing_lemma = hole("A missing premise.")\n'
+            '__all__ = ["key_missing_lemma"]\n'
+        ),
+    )
+    pkg_dir, _ = _write_package(
+        tmp_path / "conditional_fill_pkg",
+        project_name="conditional-fill-pkg-gaia",
+        dependencies=["conditional-dep-hole-pkg-gaia>=0.4.0,<1.0.0"],
+        body=(
+            "from gaia.lang import claim, fills\n"
+            "from conditional_dep_hole_pkg import key_missing_lemma\n\n"
+            'b_result = claim("B theorem.")\n'
+            'fills(source=b_result, hole=key_missing_lemma, strength="conditional", '
+            'mode="infer", reason="The theorem partially supports the missing lemma.")\n'
+            '__all__ = ["b_result"]\n'
+        ),
+    )
+
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    bridges = _read_manifest(pkg_dir, "bridges.json")
+    assert len(bridges["bridges"]) == 1
+    bridge = bridges["bridges"][0]
+    assert bridge["relation_type"] == "fills"
+    assert bridge["source_qid"] == "github:conditional_fill_pkg::b_result"
+    assert bridge["target_hole_qid"] == "github:conditional_dep_hole_pkg::key_missing_lemma"
+    assert bridge["target_version_req"] == "<1.0.0,>=0.4.0"
+    assert bridge["strength"] == "conditional"
+    assert bridge["mode"] == "infer"
+    assert bridge["justification"] == "The theorem partially supports the missing lemma."
 
 
 def test_compile_rejects_foreign_fill_without_dependency_constraint(tmp_path, monkeypatch):

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -430,7 +430,6 @@ def test_compile_nested_composite_strategy_collects_recursive_knowledge(tmp_path
     result = validate_local_graph(LocalCanonicalGraph(**ir))
     assert result.valid, result.errors
 
-
 def test_compile_emits_holes_manifest_with_required_by(tmp_path):
     pkg_dir, _ = _write_package(
         tmp_path / "hole_pkg",
@@ -581,3 +580,27 @@ def test_compile_rejects_foreign_fill_without_dependency_constraint(tmp_path, mo
     result = runner.invoke(app, ["compile", str(pkg_dir)])
     assert result.exit_code != 0
     assert "requires a Gaia dependency constraint" in result.output
+
+
+def test_compile_rejects_duplicate_fills_without_traceback(tmp_path):
+    pkg_dir = tmp_path / "dup_fills"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dup-fills-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "dup_fills"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills, hole\n\n"
+        'result = claim("B theorem.")\n'
+        'missing = hole("A missing lemma.")\n'
+        'fills(source=result, hole=missing, strength="exact")\n'
+        'fills(source=result, hole=missing, strength="partial")\n'
+        '__all__ = ["result", "missing"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "Duplicate fills declaration" in result.output
+    assert "Traceback" not in result.output

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -95,7 +95,7 @@ def test_register_dry_run_emits_registration_plan(tmp_path):
     assert plan["package"]["pypi_name"] == "register-demo-gaia"
     assert plan["version"]["git_tag"] == "v1.2.0"
     assert plan["version"]["ir_hash"].startswith("sha256:")
-    assert plan["deps"] == {"aristotle-mechanics-gaia": ">= 1.0.0"}
+    assert plan["deps"] == {"aristotle-mechanics-gaia": ">=1.0.0"}
     exports_path = "packages/register-demo/releases/1.2.0/exports.json"
     assert exports_path in plan["files"]
     exports = json.loads(plan["files"][exports_path])
@@ -137,7 +137,7 @@ def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
     assert (package_dir / "Deps.toml").exists()
     assert 'name = "register-demo"' in (package_dir / "Package.toml").read_text()
     assert 'git_tag = "v1.2.0"' in (package_dir / "Versions.toml").read_text()
-    assert '"aristotle-mechanics-gaia" = ">= 1.0.0"' in (package_dir / "Deps.toml").read_text()
+    assert '"aristotle-mechanics-gaia" = ">=1.0.0"' in (package_dir / "Deps.toml").read_text()
     exports_path = package_dir / "releases" / "1.2.0" / "exports.json"
     assert exports_path.exists()
     exports = json.loads(exports_path.read_text())

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -96,6 +96,11 @@ def test_register_dry_run_emits_registration_plan(tmp_path):
     assert plan["version"]["git_tag"] == "v1.2.0"
     assert plan["version"]["ir_hash"].startswith("sha256:")
     assert plan["deps"] == {"aristotle-mechanics-gaia": ">= 1.0.0"}
+    exports_path = "packages/register-demo/releases/1.2.0/exports.json"
+    assert exports_path in plan["files"]
+    exports = json.loads(plan["files"][exports_path])
+    assert exports["package"] == "register-demo"
+    assert [item["label"] for item in exports["exports"]] == ["exported_claim"]
 
 
 def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
@@ -133,7 +138,41 @@ def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
     assert 'name = "register-demo"' in (package_dir / "Package.toml").read_text()
     assert 'git_tag = "v1.2.0"' in (package_dir / "Versions.toml").read_text()
     assert '"aristotle-mechanics-gaia" = ">= 1.0.0"' in (package_dir / "Deps.toml").read_text()
+    exports_path = package_dir / "releases" / "1.2.0" / "exports.json"
+    assert exports_path.exists()
+    exports = json.loads(exports_path.read_text())
+    assert [item["label"] for item in exports["exports"]] == ["exported_claim"]
     assert (
         _run(["git", "branch", "--show-current"], cwd=registry_dir)
         == "register/register-demo-1.2.0"
     )
+
+
+def test_register_fails_when_exports_manifest_is_stale(tmp_path):
+    pkg_dir = tmp_path / "register_demo"
+    remote_dir = tmp_path / "register_demo_remote.git"
+    _write_package(pkg_dir)
+    _init_git_repo(pkg_dir, remote_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    exports_path = pkg_dir / ".gaia" / "manifests" / "exports.json"
+    exports = json.loads(exports_path.read_text())
+    exports["exports"][0]["content"] = "tampered"
+    exports_path.write_text(json.dumps(exports, indent=2, sort_keys=True))
+
+    _run(["git", "tag", "v1.2.0"], cwd=pkg_dir)
+    _run(["git", "push", "origin", "v1.2.0"], cwd=pkg_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "register",
+            str(pkg_dir),
+            "--repo",
+            "https://github.com/example/RegisterDemo.gaia",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "exports manifest is stale" in result.output.lower()

--- a/tests/gaia/lang/test_compiler.py
+++ b/tests/gaia/lang/test_compiler.py
@@ -19,6 +19,7 @@ from gaia.lang import (
 )
 from gaia.lang.runtime import Strategy
 from gaia.lang.compiler.compile import (
+    CompileValidationError,
     compile_package_artifact,
     _compile_reason,
     _extract_at_labels,
@@ -329,7 +330,7 @@ def test_compile_rejects_duplicate_fills_for_same_pair():
         missing.label = "missing"
         fills(source=result, hole=missing, strength="exact")
         fills(source=result, hole=missing, strength="partial")
-    with pytest.raises(ValueError, match="Duplicate fills declaration"):
+    with pytest.raises(CompileValidationError, match="Duplicate fills declaration"):
         compile_package_artifact(pkg)
 
 


### PR DESCRIPTION
## Summary
- make `gaia check` validate `.gaia/manifests/*.json` freshness against the current source-derived manifests
- add an exported-hole warning for holes with no downstream local use
- make Phase 1 `gaia register` require a fresh `exports.json` manifest and include `packages/<name>/releases/<version>/exports.json` in the registry payload

## Notes
- stacked on top of #366
- Phase 1 still uploads only `exports.json`; `holes.json` and `bridges.json` remain local preview artifacts

## Testing
- pytest tests/cli/test_check.py tests/cli/test_register.py tests/cli/test_compile.py -q
- pytest tests/gaia/lang/test_core.py tests/gaia/lang/test_strategies.py tests/gaia/lang/test_compiler.py tests/cli/test_check.py tests/cli/test_register.py tests/cli/test_compile.py -q
