### PR TITLE
docs: redesign public premise and bridge contracts

### DIFF
--- a/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
+++ b/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
@@ -1,200 +1,183 @@
-# Gaia Lang Hole / Fills Design
+# Gaia Lang Public Premise / Fills Design
 
 > **Status:** Proposal
 >
 > **Date:** 2026-04-08
 >
-> **Companion docs:** [2026-04-08-registry-hole-bridge-index-design.md](2026-04-08-registry-hole-bridge-index-design.md)
+> **Companion docs:** [2026-04-08-gaia-package-hole-bridge-design.md](2026-04-08-gaia-package-hole-bridge-design.md), [2026-04-08-registry-hole-bridge-index-design.md](2026-04-08-registry-hole-bridge-index-design.md)
 >
 > **Depends on:** [2026-04-02-gaia-lang-v5-python-dsl-design.md](2026-04-02-gaia-lang-v5-python-dsl-design.md), [../foundations/gaia-ir/02-gaia-ir.md](../foundations/gaia-ir/02-gaia-ir.md)
 
 ## 1. Problem
 
-当前 Gaia Lang v5 只有：
+前一版 hole / fills 设计把 `hole` 当成作者显式写出来的 source-level object：
 
-- `claim()`
-- `setting()`
-- `question()`
-- 一组 reasoning strategies
+- `hole(...)`
+- `fills(source=..., hole=...)`
 
-这足够表达“论文内部怎么推理”，但不够清楚地表达两类生态语义：
+这在 authoring 上直观，但有两个根本问题：
 
-1. **这个 claim 是一个公开缺口（hole）**
-2. **这个 package 在声明：某个结果 fills 某个外部 hole**
+1. **`hole` 不是永久本体类型**
+   同一个 claim 在 `A@1.0.0` 里可能是未解前提，在 `A@1.1.0` 里可能已被内部证明，在 `A@1.2.0` 里甚至可能变成 foreign dependency。  
+   所以 `hole` 更像某个 package release 上的接口角色，而不是 IR 里永久存在的 node type。
 
-今天作者当然可以用普通 `claim()` 和普通 `deduction()` 勉强表达这些意思，但会有两个问题：
+2. **公开缺口不应依赖作者手工标注**
+   对一篇 package 来说，凡是被 exported claims 依赖、且没有在本包内部 discharge 的 boundary premise，本质上就是这篇工作的公开前提接口。  
+   如果这些东西只有作者手写 `hole(...)` 才出现，协议会偏离论文结构本身。
 
-- 对人类作者和 reviewer 来说，意图不够显式
-- 对 package / registry 来说，难以稳定抽取 hole / bridge manifests
+因此，本设计改用下面的核心模型：
+
+- 源码里继续用普通 `claim(...)`
+- `__all__` 继续表示作者显式公开的结果面
+- 编译器从 export surface 自动推出 `public premises`
+- `public premises` 再按当前 release 分类成：
+  - `local_hole`
+  - `foreign_dependency`
+- `fills` 绑定的是 **release-scoped premise interface snapshot**，不是“永远叫 hole 的对象”
 
 ## 2. Design Goals
 
-1. **Author-facing clarity**
-   作者要能直接写出“这是一个 hole”和“我在 fills 某个 hole”。
+1. **First-principles package semantics**
+   公开缺口来自 exported claims 的推理边界，而不是来自作者额外写了什么 marker。
 
-2. **No new core IR primitive**
-   Gaia IR 不新增 `HoleKnowledge` 或 `FillsStrategy` 这类 runtime schema。
+2. **No new core IR node type**
+   Gaia IR 里不引入 `HoleKnowledge`。`hole` 是 manifest / registry 层的 release-scoped role。
 
-3. **Registry-extractable**
-   package 和 registry 可以机械地抽取 `holes.json` / `bridges.json`。
+3. **Stable cross-package relations**
+   `fills` 必须绑定到具体 release 的 premise interface，而不是漂浮的 source symbol。
 
-4. **Cross-package explicitness**
-   `fills` 必须建立在显式 foreign reference 之上，而不是自由文本。
+4. **Keep authoring simple**
+   作者继续写普通 `claim()` 和普通推理；bridge 作者只需显式声明 `fills(...)`。
 
-5. **Keep BP semantics separate**
-   “这是在补洞”是生态意图；“补得有多强”仍然由已有 strategy semantics 决定。
+5. **Separate reasoning from packaging**
+   `content_hash` / `ir_hash` 仍属于 IR；interface-level hashing 留在 package manifests，不进入 core IR。
 
 ## 3. Key Decisions
 
-### 3.1 `hole` 是独立 authoring API
+### 3.1 `__all__` 只表示 author-declared public exports
 
-推荐新增：
+`__all__` 仍然是 package 作者显式声明的 public surface。
 
-```python
-hole(...)
-```
+它不直接等价于：
 
-而不是只靠：
+- holes
+- public premises
+- bridge targets
 
-```python
-claim(..., metadata={"gaia": {"role": "hole"}})
-```
+它只回答一个问题：
 
-原因：
+- “这个 package 想把哪些知识节点当成公开结果 / 公开接口暴露出去？”
 
-- 这是作者会高频直接用到的语义，不应埋在 metadata 里
-- 代码审阅时一眼可见
-- 编译器和 registry 提取规则更直接
+后续哪些节点构成 `public premises`，由编译器从这些 exports 的依赖闭包中自动推出。
 
-但在 lowering 层，`hole()` 仍然编译成普通 `Knowledge(type="claim")`，只是 metadata 中带上 hole 标记。
+### 3.2 `hole` 是 release-scoped interface role，不是 source primitive
 
-### 3.2 `fills` 是 author-facing relation intent
+本设计不再把 `hole(...)` 作为协议核心。
 
-推荐新增：
+如果未来保留 `hole(...)`，它也只能是 authoring convenience sugar，不能成为 registry contract 的来源。真正的 hole 身份由编译结果决定：
 
-```python
-fills(...)
-```
+- 对 exported claims 的依赖分析结果
+- 相对于某个具体 release
+- 以 manifest 中的 `role = "local_hole"` 体现
 
-但它**不是**新的 core strategy type。它只是作者层的 intent wrapper。
+### 3.3 `fills` 仍然保留，但 target 不再语义化为“永久 hole object”
 
-编译后仍然是普通 strategy：
-
-- `deduction`
-- 或 `infer`
-
-外加 relation metadata，供 package / registry 抽取 bridge relation。
-
-### 3.3 不新增 `Hole` 或 `Bridge` 的 IR schema
-
-Gaia IR 继续保持现有边界：
-
-- imported / exported / cross-package relation 不进入 core schema 变体
-- `hole` 仍然是 `claim`
-- `fills` 仍然是普通 strategy + metadata
-
-这和现有 “foreign QID 是普通 Knowledge，不新增特殊 imported node type” 的边界保持一致。
-
-## 4. `hole()` Design
-
-### 4.1 API
+推荐的 author-facing API 改成：
 
 ```python
-def hole(
-    content: str,
-    *,
-    title: str | None = None,
-    background: list[Knowledge] | None = None,
-    parameters: list[dict] | None = None,
-    provenance: list[dict[str, str]] | None = None,
-    **metadata,
-) -> Knowledge
+fills(source=..., target=...)
 ```
 
-返回值仍然是普通 `Knowledge(type="claim")`。
-
-### 4.2 Lowered Form
-
-`hole()` 在运行时等价于：
+而不是：
 
 ```python
-claim(
-    content,
-    title=title,
-    background=background,
-    parameters=parameters,
-    provenance=provenance,
-    metadata={"gaia": {"role": "hole"}},
-    **metadata,
-)
+fills(source=..., hole=...)
 ```
 
-也就是说：
+原因不是“target 可以不是 hole”，而是：
 
-- 不新增 KnowledgeType
-- 只是在 namespaced metadata 上固化 `metadata["gaia"]["role"] = "hole"`
-- 不占用通用 `proof_state` key，避免和未来更一般的证明状态语义冲突
+- target 在 source 层只是一个 claim reference
+- 它是否属于可填补的 public premise
+- 以及它在当前 release 上是不是 `local_hole`
 
-### 4.3 Restrictions
+都应由编译阶段根据 manifests 决定，而不是依赖 imported Python object 上有没有 hole marker。
 
-`hole()` 不接受 `given=...`。
+### 3.4 `public premise` 与 `exported conclusion` 必须区分
 
-这里的 `given=` 是 [2026-04-02-gaia-lang-v5-python-dsl-design.md](2026-04-02-gaia-lang-v5-python-dsl-design.md) 中规划的 target-design 参数；当前主线实现还没有该参数，这里先把约束定清楚。
+同一个 claim 在 package 接口里可能同时扮演两个角色：
 
-理由：
+- 它是作者显式 export 的 public claim
+- 它又是另一个 exported claim 的 boundary premise
 
-- `given=` 会自动创建 in-package support strategy
-- 一个已经被本包直接支撑起来的 claim，通常不应再声明成“公开缺口”
+因此 manifest 层必须允许同一 QID 同时出现在：
 
-如果作者既想表达“这是当前论文的公开缺口”，又想附上一些弱背景支持，应该用：
+- `exports.json`
+- `premises.json`
 
-- `background=[...]`
-- 或普通 `claim(...)`，而不是 `hole(...)`
+角色不是互斥的，而是相对于接口视角定义的。
 
-### 4.4 Export Semantics
+## 4. Public Premise Derivation
 
-`hole` 只有在进入 `__all__` 时，才成为**公开 hole interface**。
+### 4.1 Definitions
 
-因此有三种层次：
+对某个 package release：
 
-1. `hole(...)` 但不 export
-   只是 package 内部未解子目标
+- **export root**
+  - 任何出现在 `__all__` 中的 claim
+- **local support**
+  - 当前 package 内某条 strategy 的 `conclusion == claim`
+- **boundary premise**
+  - 位于某个 export root 上游依赖闭包中，但没有被本包继续向上 discharge 的 claim
 
-2. `hole(...)` 且 export
-   成为 registry 可索引的 public hole
+boundary premise 再分成：
 
-3. 普通 `claim(...)`
-   不是 hole，即使它当前没有被证明
+- `local_hole`
+  - boundary premise 是本包本地 claim
+- `foreign_dependency`
+  - boundary premise 是 foreign imported claim
 
-这很重要，因为我们不希望系统把所有叶子前提都自动暴露成公共接口。
+### 4.2 Phase 1 Algorithm
 
-### 4.5 Example
+对每个 exported claim root：
 
-```python
-from gaia.lang import claim, deduction, hole
+1. 从该 root 反向收集所有 local supporting strategies
+2. 对这些 strategies 的 `premises` 递归继续向上追溯
+3. 遇到没有 local support 的 claim 时停止
+4. 将其记为一个 `public premise`
 
-main_theorem = claim("Main theorem of package A.")
-key_missing_lemma = hole("A still-missing lemma required by the main theorem.")
+分类规则：
 
-deduction(
-    premises=[key_missing_lemma],
-    conclusion=main_theorem,
-    reason="If the missing lemma were established, the main theorem would follow.",
-)
+- `qid.package == current_package` -> `local_hole`
+- `qid.package != current_package` -> `foreign_dependency`
 
-__all__ = ["main_theorem", "key_missing_lemma"]
-```
+Phase 1 只分析 claim premises，不把 `background` 自动升级成 public premise。
+
+### 4.3 Important Consequences
+
+1. **不是所有 leaf 都公开**
+   只有落在 exported claims 依赖闭包中的 boundary premise 才进入 public premise surface。
+
+2. **不是所有 public premise 都是 hole**
+   foreign imported claim 是 `foreign_dependency`，不是 `local_hole`。
+
+3. **hole 会过时**
+   同一个 QID 在不同 release 上可以：
+   - 是 `local_hole`
+   - 不是 public premise
+   - 是 `foreign_dependency`
+
+因此 bridge 不能只绑定 QID，必须绑定 interface snapshot。
 
 ## 5. `fills()` Design
 
 ### 5.1 API
 
-推荐最小 API：
+推荐的最小 author-facing API：
 
 ```python
 def fills(
     source: Knowledge,
-    hole: Knowledge,
+    target: Knowledge,
     *,
     mode: Literal["deduction", "infer"] | None = None,
     strength: Literal["exact", "partial", "conditional"] = "exact",
@@ -203,34 +186,26 @@ def fills(
 ) -> Strategy
 ```
 
-### 5.2 Why `source` is singular
+其中：
 
-`fills` 的接口刻意只接受一个 `source` claim，而不是 `premises=[...]`。
+- `source` 是支持性结果
+- `target` 是一个 claim reference
+- `target` 是否真的是可填补 hole，不由 source object 决定，而由 compile-time interface validation 决定
 
-原因：
+### 5.2 Lowering Rule
 
-- 生态层的 bridge relation 应该连的是“公开 claim -> 公开 hole”
-- 如果 B 需要多个本地前提，应该先在包内推出一个本地 `source` result
-- 然后再显式声明 `source fills hole`
+`fills()` 仍然不是新的 core strategy primitive。
 
-这样 registry relation 结构最稳定，查询时也最清楚。
+lowering 规则保持不变：
 
-### 5.3 Lowering Rule
+- `mode="deduction"` -> lower 成 `deduction`
+- `mode="infer"` -> lower 成 `infer`
+- `mode is None`
+  - `exact` -> `deduction`
+  - `partial` -> `infer`
+  - `conditional` -> `infer`
 
-`fills()` 本身不是新的 strategy primitive，而是 lowering sugar：
-
-- `mode="deduction"` 时：
-  - lower 成 `deduction(premises=[source], conclusion=hole, ...)`
-- `mode="infer"` 时：
-  - lower 成 `infer(premises=[source], conclusion=hole, ...)`
-
-若 `mode is None`，则按 `strength` 推断：
-
-- `exact` -> `deduction`
-- `partial` -> `infer`
-- `conditional` -> `infer`
-
-同时写入 strategy metadata：
+同时写入 namespaced relation metadata：
 
 ```python
 {
@@ -238,295 +213,180 @@ def fills(
     "relation": {
       "type": "fills",
       "strength": "exact",
-      "target_role": "hole"
+      "mode": "deduction"
     }
   }
 }
 ```
 
-### 5.4 Why not make `fills` a new BP primitive
+### 5.3 Compile-Time Validation
 
-因为这里其实有两个正交维度：
+`fills(source, target)` 在 compile 时必须通过两层校验：
 
-1. **生态意图**
-   这是在填别人的 hole
+1. **source 校验**
+   - `source` 必须是 claim
+   - 若 source 是 foreign claim，则其 package 必须出现在依赖约束中
 
-2. **逻辑强度**
-   这是严格证明、弱支持，还是条件性支持
+2. **target 校验**
+   - `target` 必须是 claim
+   - 编译器不能只看 source object metadata
+   - 必须根据当前 release 对应的 interface manifests，确认 target 在被引用 release 上是 `local_hole`
 
-前者适合 authoring / registry metadata。  
-后者适合继续复用已有的 `deduction` / `infer`。
+如果 target 当前只是：
 
-如果把两者混成一个新的 runtime primitive，反而会污染 core IR。
+- 普通 exported claim
+- foreign dependency
+- 已被后续版本内部消解的旧 hole
 
-### 5.5 Validation Intent
+则该 `fills` 不成立，编译应报错或要求更新 target snapshot。
 
-`fills(source, hole)` 在 authoring / compile 时应至少校验：
+## 6. Release-Scoped Target Binding
 
-- `source.type == "claim"`
-- `hole.type == "claim"`
-- `hole` 对应的 local 或 foreign `Knowledge.metadata["gaia"]["role"] == "hole"`
+### 6.1 Why QID Alone Is Not Enough
 
-在 package / registry 层进一步校验：
+只记录：
 
-- 若 `hole` 是 foreign reference，则它应解析到对方 package 的 exported hole
-- 若不是 foreign hole，则该 relation 不进入 registry bridge index
+- `target_qid = github:package_a::key_missing_lemma`
 
-如果 target 不带 canonical hole marker，`gaia compile` 应直接报错，而不是等到 registry 阶段才拒绝。
+是不够的，因为下面三种情况都会发生：
 
-### 5.6 Uniqueness Rule
+1. `A@1.0.0` 中它是 `local_hole`
+2. `A@1.1.0` 中它已被内部证明，不再是 hole
+3. `A@1.2.0` 中内容改写了，但 QID 没变
 
-同一个 package version 内，`fills` 对同一组 `(source_qid, target_hole_qid)` 最多只能声明一次。
+所以 `fills` 必须绑定到一个 **premise interface snapshot**。
 
-也就是说，下列写法应被视为非法：
+### 6.2 Target Snapshot Fields
 
-```python
-fills(source=b_result, hole=a_hole, strength="exact")
-fills(source=b_result, hole=a_hole, strength="conditional", mode="infer")
-```
+bridge relation 的 target 至少要携带：
+
+- `target_qid`
+- `target_resolved_version`
+- `target_interface_hash`
+
+其中：
+
+- `target_qid` 标识“这是哪个 claim”
+- `target_resolved_version` 标识“这是哪个 release”
+- `target_interface_hash` 标识“在这个 release 上它的接口状态是什么”
+
+### 6.3 `interface_hash` 不进入 Gaia IR
+
+`interface_hash` 属于 package / manifest 层，而不是 Gaia IR。
 
 原因：
 
-- `fills` 是生态 relation declaration，不是同一对节点上的多重边容器
-- 同一对 `(source, hole)` 的多次声明会在当前 IR `strategy_id` 规则下产生冲突
+- 它依赖 `public premise` 分类结果
+- 它是 release-scoped
+- 它是为了 package compatibility / bridge stability 服务
 
-如果作者想改变 `strength` 或 `mode`，应修改同一条 relation，而不是在同一 package version 内重复声明。
+因此边界应是：
 
-### 5.7 Example: B directly fills A
+- `content_hash`: node IR
+- `ir_hash`: graph IR
+- `interface_hash`: manifest
 
-```python
-from gaia.lang import claim, fills
-from package_a import key_missing_lemma
+## 7. Scenario Walkthroughs
 
-b_result = claim("Theorem 3 in package B.")
+### 7.1 Scenario A: B 直接 fills A 的缺口
 
-fills(
-    source=b_result,
-    hole=key_missing_lemma,
-    strength="exact",
-    reason="Theorem 3 proves exactly the missing lemma exposed by package A.",
-)
-
-__all__ = ["b_result"]
-```
-
-### 5.8 Example: C publishes a bridge package
-
-bridge package 通常不需要 import `claim`。
+A 的源码只需要正常表达论文结构：
 
 ```python
-from gaia.lang import fills
-from package_a import key_missing_lemma
-from package_b import b_result
+from gaia.lang import claim, deduction
 
-fills(
-    source=b_result,
-    hole=key_missing_lemma,
-    strength="conditional",
-    mode="infer",
-    reason="Under the assumptions compared in this package, B.result is sufficient to fill A.hole.",
-)
-```
-
-这里 package C 可以没有本地 theorem claim。  
-它的主要公开内容就是 cross-package relation 本身。
-
-## 6. Worked Scenarios
-
-### 6.1 Scenario A: B immediately knows it fills A
-
-这个场景里：
-
-- A 已经把缺失前提写成 exported `hole`
-- B 在 formalize 时就知道自己的结论能填这个 hole
-
-作者层的最小写法是：
-
-```python
-# package_a
-from gaia.lang import claim, deduction, hole
-
-main_theorem = claim("Main theorem of package A.")
-key_missing_lemma = hole("A still-missing lemma required by the main theorem.")
+main_theorem = claim("Main theorem.")
+key_missing_lemma = claim("A missing lemma.")
 
 deduction(
     premises=[key_missing_lemma],
     conclusion=main_theorem,
-    reason="If the missing lemma were established, the main theorem would follow.",
+    reason="Main theorem depends on the lemma.",
 )
 
-__all__ = ["main_theorem", "key_missing_lemma"]
+__all__ = ["main_theorem"]
 ```
 
+编译 A 后：
+
+- `exports.json` 中有 `main_theorem`
+- `premises.json` 中自动出现 `key_missing_lemma`
+- 且其 role 为 `local_hole`
+
+B 写：
+
 ```python
-# package_b
 from gaia.lang import claim, fills
 from package_a import key_missing_lemma
 
-b_result = claim("Theorem 3 in package B.")
+b_result = claim("Theorem 3 proves the missing lemma.")
 
 fills(
     source=b_result,
-    hole=key_missing_lemma,
-    strength="exact",
-    reason="Theorem 3 proves exactly the missing lemma exposed by package A.",
+    target=key_missing_lemma,
+    reason="Theorem 3 establishes A's missing premise.",
 )
 
 __all__ = ["b_result"]
 ```
 
-这里不需要单独 bridge package。  
-B 自己就是 relation 的 declaring package。
+compile B 时：
 
-### 6.2 Scenario B: B did not notice, later C discovers it
+- 读取 A 在依赖版本上的 premise interface manifest
+- 确认 `key_missing_lemma` 在该 release 上是 `local_hole`
+- 在 B 的 `bridges.json` 中记录一条 release-scoped bridge relation
 
-这个场景里：
+### 7.2 Scenario B: B 没发现，后来 C 才发现
 
-- A 已经公开了 hole
-- B 只发布了自己的 paper package，没有写 `fills`
-- 后来 C 发现 `B.result fills A.hole`
+B 只是正常发布自己的 package。
 
-那么：
-
-```python
-# package_b
-from gaia.lang import claim
-
-b_result = claim("Theorem 3 in package B.")
-__all__ = ["b_result"]
-```
+后来 C 做一个小 bridge package：
 
 ```python
-# package_c_bridge
 from gaia.lang import fills
 from package_a import key_missing_lemma
 from package_b import b_result
 
 fills(
     source=b_result,
-    hole=key_missing_lemma,
-    strength="conditional",
-    mode="infer",
-    reason="Under the assumptions compared in this bridge package, B.result is sufficient to fill A.hole.",
+    target=key_missing_lemma,
+    reason="B's result fills A's public premise interface.",
 )
 ```
 
-这里：
+这个 package 可以没有本地 claim。  
+它的价值完全在于：
 
-- B 不需要回头修改自己的 package
-- C 用普通 `knowledge-package` 就能发布这条 relation
-- `declared_by_owner_of_source = false` 将在 package / registry 层体现
+- 将 `B.result -> A@version.premise_snapshot` 公开成 bridge relation
 
-### 6.3 Boundary Condition: A did not export a hole
+## 8. Compatibility / Migration
 
-如果 A 只是有一个内部前提，但没有把它显式写成 exported `hole`：
+### 8.1 Earlier `hole()` Prototype
 
-- B 仍然可以 import A 的普通 exported claim
-- 但不能把这条关系当成正式的 `fills(hole=...)` 进入 hole/bridge 协议
+如果代码库里已经存在 `hole(...)` 原型实现，应将其降级为：
 
-也就是说，`fills` 的目标必须是显式公开的 hole interface，而不是任意 premise。
+- transitional authoring sugar
+- 或 internal annotation aid
 
-## 7. Why Separate APIs Are Better
+但不能继续作为 package / registry 协议的 source of truth。
 
-### 7.1 Thought Experiment: hidden metadata only
+### 8.2 Earlier `fills(..., hole=...)`
 
-如果只允许：
-
-```python
-claim(..., metadata={"gaia": {"role": "hole"}})
-deduction(..., conclusion=foreign_hole)
-```
-
-机器当然能跑，但有三个问题：
-
-- 代码一眼看不出作者 intent
-- registry 很难稳定区分普通 cross-package deduction 和 fills relation
-- reviewer 很难快速扫出 package 的 public holes
-
-### 7.2 Thought Experiment: dedicated APIs
-
-如果作者能直接写：
+如果已有实现使用：
 
 ```python
-hole(...)
-fills(...)
+fills(source=..., hole=...)
 ```
 
-那么：
+迁移方向应是：
 
-- 代码层 intent 清晰
-- package manifest 提取是机械的
-- registry index 构建也不需要猜测
+- 参数名改成 `target`
+- compile validation 改成查 target interface manifest
+- 不再要求 imported object 自带 hole marker
 
-因此作者层应该有显式 API，runtime 层再 lower 到旧 primitive。
+## 9. Non-Goals
 
-## 8. Interaction with Existing Gaia Lang
-
-### 8.1 `claim`
-
-- 继续是默认的科学断言构造
-- 不自动推断 hole
-
-### 8.2 `__all__`
-
-- 仍然是唯一的 package public surface
-- `hole` 是否公开，只取决于是否 export
-
-### 8.3 Cross-package import
-
-`fills` 不引入新 import 机制。仍然是：
-
-```python
-from package_a import exported_hole
-```
-
-即显式 foreign reference，而不是 registry 层自动绑定。
-
-### 8.4 Review / BP
-
-这次设计不改变 review / BP 核心规则：
-
-- `hole` 仍然是 claim
-- `fills` 仍然是 ordinary strategy
-- package / registry 只是额外理解其生态意图
-
-## 9. Proposed Minimal Runtime Surface
-
-语言层建议新增：
-
-```python
-from gaia.lang import hole, fills
-```
-
-其中：
-
-- `hole` 放在 `gaia.lang.dsl.knowledge`
-- `fills` 放在 `gaia.lang.dsl.strategies`
-
-作者默认导入面变成：
-
-```python
-from gaia.lang import (
-    claim, hole, setting, question,
-    contradiction, equivalence, complement, disjunction,
-    noisy_and, infer, deduction, fills, abduction, analogy,
-    extrapolation, elimination, case_analysis,
-    mathematical_induction, composite,
-)
-```
-
-## 10. Decisions
-
-1. **`hole` 用独立 DSL 构造，不埋在 metadata-only 约定里。**
-2. **`hole` lower 成普通 claim，不新增 IR node type。**
-3. **`fills` 用独立 DSL 构造，但不新增 runtime strategy type。**
-4. **`fills` 的逻辑强度继续复用 `deduction` / `infer`。**
-5. **public hole 由 `hole(...) + export` 共同决定。**
-6. **hole marker 使用 namespaced metadata：`metadata["gaia"]["role"] = "hole"`。**
-7. **同一 package version 内禁止重复声明同一 `(source_qid, target_hole_qid)` 的 `fills` relation。**
-
-## 11. Open Questions
-
-1. `conditional` fills 是否需要结构化 `conditions=` 字段，而不只是自由文本 `reason`？
-2. 是否需要额外的 `weak_fills()` / `refines_hole()` author sugar，还是统一留给 `fills(..., strength=...)`？
-3. bridge package 如果完全没有本地 claim，README / narrative 应该如何渲染得更自然？
+- 不在 Lang 层引入 global canonicalization
+- 不把 bridge relation 变成新的 BP primitive
+- 不要求作者显式枚举所有 premise interfaces
+- 不要求 `hole` 身份跨版本稳定

--- a/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
+++ b/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
@@ -7,6 +7,8 @@
 > **Companion docs:** [2026-04-08-gaia-package-hole-bridge-design.md](2026-04-08-gaia-package-hole-bridge-design.md), [2026-04-08-registry-hole-bridge-index-design.md](2026-04-08-registry-hole-bridge-index-design.md)
 >
 > **Depends on:** [2026-04-02-gaia-lang-v5-python-dsl-design.md](2026-04-02-gaia-lang-v5-python-dsl-design.md), [../foundations/gaia-ir/02-gaia-ir.md](../foundations/gaia-ir/02-gaia-ir.md)
+>
+> **Supersedes:** the earlier hole / fills proposal merged via PRs #362 and #364. Open implementation PRs #365 / #366 / #367 target the superseded design and should be replaced rather than merged as-is.
 
 ## 1. Problem
 
@@ -72,13 +74,19 @@
 
 ### 3.2 `hole` 是 release-scoped interface role，不是 source primitive
 
-本设计不再把 `hole(...)` 作为协议核心。
+本设计不再把 `hole(...)` 作为协议核心，并且明确决定将其从主线 authoring surface 中移除。
 
-如果未来保留 `hole(...)`，它也只能是 authoring convenience sugar，不能成为 registry contract 的来源。真正的 hole 身份由编译结果决定：
+真正的 hole 身份由编译结果决定：
 
 - 对 exported claims 的依赖分析结果
 - 相对于某个具体 release
 - 以 manifest 中的 `role = "local_hole"` 体现
+
+因此：
+
+- 唯一稳定的 source primitive 仍然是 `claim(...)`
+- 作者不能通过 `hole(...)` 直接“声明” hole 身份
+- 旧原型实现若已存在，应在 replacement implementation 中删除
 
 ### 3.3 `fills` 仍然保留，但 target 不再语义化为“永久 hole object”
 
@@ -219,6 +227,8 @@ lowering 规则保持不变：
 }
 ```
 
+本 lowering 规则与上一版 proposal 的强弱映射保持一致，不把这次 redesign 的成本扩散到 BP 语义层。
+
 ### 5.3 Compile-Time Validation
 
 `fills(source, target)` 在 compile 时必须通过两层校验：
@@ -239,6 +249,28 @@ lowering 规则保持不变：
 - 已被后续版本内部消解的旧 hole
 
 则该 `fills` 不成立，编译应报错或要求更新 target snapshot。
+
+### 5.4 `target_resolved_version` Resolution Rule
+
+当 `fills(target=foreign_claim)` 指向依赖包时，compile 必须同时确定：
+
+- 作者声明的 dependency range
+- 当前环境实际验证到的 dependency release
+
+本设计明确采用：
+
+- `target_dependency_req`
+  - 来自 `pyproject.toml` 的依赖约束
+- `target_resolved_version`
+  - 来自当前 Python 环境中实际安装并被 import 解析到的 dependency version
+
+也就是说，Phase 1 不做：
+
+- “满足约束的最新 registry 版本”查询
+- “满足约束的最低版本”推断
+- 离线情况下的 registry lookup
+
+compile 只对“当前环境里实际被解析到的那个依赖 release”负责。
 
 ## 6. Release-Scoped Target Binding
 
@@ -363,12 +395,13 @@ fills(
 
 ### 8.1 Earlier `hole()` Prototype
 
-如果代码库里已经存在 `hole(...)` 原型实现，应将其降级为：
+如果代码库里已经存在 `hole(...)` 原型实现，本设计的明确迁移决策是：
 
-- transitional authoring sugar
-- 或 internal annotation aid
+- 删除 `hole()` 作为公开 source primitive
+- 删除相关 DSL 校验与测试
+- 不提供“作者声明 hole 身份”的兼容语义
 
-但不能继续作为 package / registry 协议的 source of truth。
+这样可以避免 source marker 和 compiler 派生角色发生分歧。
 
 ### 8.2 Earlier `fills(..., hole=...)`
 
@@ -383,6 +416,8 @@ fills(source=..., hole=...)
 - 参数名改成 `target`
 - compile validation 改成查 target interface manifest
 - 不再要求 imported object 自带 hole marker
+
+因为旧实现尚未合入主线，本设计不提供 `hole=` -> `target=` 的长期兼容 alias。
 
 ## 9. Non-Goals
 

--- a/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
+++ b/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
@@ -1,4 +1,4 @@
-# Gaia Package Hole / Bridge Manifest Design
+# Gaia Package Public Premise / Bridge Manifest Design
 
 > **Status:** Proposal
 >
@@ -10,40 +10,47 @@
 
 ## 1. Problem
 
-当前 package model 里，public surface 主要只有：
+如果 Lang 层把 `hole` 改成“编译器自动推出的 release-scoped public premise role”，那么 package 层也必须随之改变：
 
-- `__all__`
-- compiled IR
-- register 时写入的 `Package.toml / Versions.toml / Deps.toml`
+1. 不能再把 `holes.json` 设计成“作者显式 export 的 hole”
+2. 必须区分：
+   - author-declared exports
+   - compiler-derived public premises
+   - local holes
+   - bridge relations
+3. bridge relation 不能只记录 `target_hole_qid`
+   因为 target 是否还是 hole，会随着 release 改变
 
-这对“普通知识包注册”足够，但对新的 `hole / fills` 生态还差一层 package contract：
+因此，package contract 需要从：
 
-1. package 本地如何把 public holes 明确产出成制品？
-2. package 本地如何把 fills relations 明确产出成制品？
-3. `gaia register` 如何把这些信息安全地带进 registry，而不引入 PR hotspot？
+- `exports / holes / bridges`
+
+升级成：
+
+- `exports / premises / holes / bridges`
 
 ## 2. Design Goals
 
 1. **Keep package as the source unit**
-   package 仍然是 authoring、versioning、registration 的基本单位。
+   package 仍然是 authoring、compile、versioning、registration 的基本单位。
 
-2. **Deterministic local artifacts**
-   `exports / holes / bridges` 必须能从当前 package source 机械生成。
+2. **Compiler-derived public premise surface**
+   `premises.json` 必须完全从 package source + dependency interfaces 机械推导。
 
-3. **Registry-ready manifests**
-   本地产物应能直接被 `gaia register` 带入 registry。
+3. **Release-scoped bridge targets**
+   `bridges.json` 必须记录 target interface snapshot，而不是漂浮的 hole symbol。
 
-4. **No new package class required**
-   bridge package 仍然是普通 `knowledge-package`，不引入强制的新 package type。
+4. **Manifest-level separation of roles**
+   `exported conclusion`、`public premise`、`local hole`、`foreign dependency` 必须在 manifests 里清晰区分。
 
-5. **Version-aware**
-   manifests 必须和当前 package version 一起发布、一起审计。
+5. **No extra source-level package class**
+   bridge package 仍然是普通 `knowledge-package`。
 
 ## 3. Key Decisions
 
-### 3.1 `.gaia/manifests/` 成为本地产物
+### 3.1 `.gaia/manifests/` 扩展为四个文件
 
-推荐在 package 本地新增：
+推荐 layout：
 
 ```text
 .gaia/
@@ -51,123 +58,67 @@
 ├── ir_hash
 └── manifests/
     ├── exports.json
+    ├── premises.json
     ├── holes.json
     └── bridges.json
 ```
 
-这些文件都是 deterministic derived artifacts，应由 `gaia compile` 生成。
+其中：
 
-### 3.2 `__all__` 仍然是唯一 public surface
+- `exports.json`
+  - 作者显式 export 的公开节点
+- `premises.json`
+  - 从 exports 的依赖闭包中自动推出的 public premises
+- `holes.json`
+  - `premises.json` 中 `role == "local_hole"` 的子集
+- `bridges.json`
+  - 当前 package release 声明的 fills relations
 
-我们不新增 `__holes__` 或 `__bridges__`。
+### 3.2 `__all__` 仍是 source-level public surface
 
-规则保持简单：
+本设计不新增：
 
-- exported = 在 `__all__`
-- public hole = exported claim + `metadata["gaia"]["role"] = "hole"`
-- bridge relation = local strategy metadata 中声明 `metadata["gaia"]["relation"]["type"] = "fills"`
+- `__holes__`
+- `__premises__`
+- `__bridges__`
 
-### 3.3 Bridge package 不是新的 package type
+因为：
 
-bridge package 仍然是：
+- premise surface 是编译派生物
+- bridge surface 来自 strategies
+- source 层只需维护一个作者显式导出的 public surface
 
-```toml
-[tool.gaia]
-type = "knowledge-package"
-```
+### 3.3 `hole` 不再由 source marker 决定
 
-它只是一个**用途上的子类**，不是新的协议对象。
+package manifests 不再以：
 
-原因：
+- `metadata["gaia"]["role"] == "hole"`
 
-- package lifecycle 不需要分叉
-- IR schema 不需要分叉
-- register / add / compile / infer 全都可以复用
+作为 hole 的根本来源。
 
-如果未来确实需要更强的 UX 区分，再加 optional metadata 即可。
+如果源码里保留 `hole()` sugar，它最多只能作为 authoring hint。真正进入 `holes.json` 的条件是：
 
-## 4. Local Artifact Layout
+- 该 claim 落在 exported claim 的 public premise closure 中
+- 且在当前 release 上角色为 `local_hole`
 
-### 4.1 Current
+## 4. Manifest Schemas
 
-当前 package 本地产物主要是：
+### 4.1 `exports.json`
 
-```text
-.gaia/
-├── ir.json
-├── ir_hash
-└── reviews/
-    └── ...
-```
-
-### 4.2 Proposed
-
-扩展为：
-
-```text
-.gaia/
-├── ir.json
-├── ir_hash
-├── manifests/
-│   ├── exports.json
-│   ├── holes.json
-│   └── bridges.json
-└── reviews/
-    └── ...
-```
-
-这些 manifests 和 IR 一样，都应该是 git-tracked compiled artifacts。
-
-## 5. Extraction Rules
-
-### 5.1 `exports.json`
-
-记录 package 的公开接口。
-
-建议结构：
-
-```json
-{
-  "package": "package-b",
-  "version": "2.1.0",
-  "ir_hash": "sha256:...",
-  "generated_at": "2026-04-08T12:00:00Z",
-  "exports": [
-    {
-      "qid": "github:package_b::main_result",
-      "label": "main_result",
-      "type": "claim",
-      "content": "B's main theorem.",
-      "content_hash": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12f4f4a0a2b9f7f1c4d5e6a7b8"
-    }
-  ]
-}
-```
-
-提取规则：
-
-- 来自 IR 中 `exported = true` 的 `Knowledge`
-- 包含 `claim / setting / question`
-- registry 侧目前重点消费 `claim`，但 manifest 保留完整 exported knowledge surface
-- `content_hash` 与 IR `Knowledge.content_hash` 保持一致，使用裸的 64 位 hex；只有 `ir_hash` 使用 `sha256:` 前缀
-
-### 5.2 `holes.json`
-
-记录 package 公开暴露的 holes。
+记录作者显式导出的节点。
 
 ```json
 {
   "package": "package-a",
   "version": "1.4.0",
   "ir_hash": "sha256:...",
-  "generated_at": "2026-04-08T12:00:00Z",
-  "holes": [
+  "exports": [
     {
-      "qid": "github:package_a::key_missing_lemma",
-      "label": "key_missing_lemma",
-      "content": "A missing premise required by the main theorem.",
-      "content_hash": "7f6a5b4c3d2e1f0099887766554433221100ffeeddccbbaa9988776655443322",
-      "required_by": ["github:package_a::main_theorem"]
+      "qid": "github:package_a::main_theorem",
+      "label": "main_theorem",
+      "type": "claim",
+      "content": "Main theorem.",
+      "content_hash": "2fd4e1..."
     }
   ]
 }
@@ -175,374 +126,309 @@ type = "knowledge-package"
 
 提取规则：
 
-- 仅从 IR 中 `exported = true` 的 claim 提取
-- 且其 metadata 标记 `metadata["gaia"]["role"] = "hole"`
-- `required_by` 由图结构派生，不由作者手填
+- 直接来自 IR 中 `exported = true` 的 knowledge
+- 仍保留 `claim / setting / question`
+- `content_hash` 使用 IR 的 node-level hash
 
-### 5.2.1 `required_by` 的最小规则
+### 4.2 `premises.json`
 
-Phase 1 先用最简单的可解释规则：
+记录 exported claims 的 release-scoped public premise interface。
 
-- 找出所有直接把该 hole 作为 premise 的 local strategies
-- 若这些 strategy 的 conclusion 是 exported claim，则记入 `required_by`
+```json
+{
+  "package": "package-a",
+  "version": "1.4.0",
+  "ir_hash": "sha256:...",
+  "premises": [
+    {
+      "qid": "github:package_a::key_missing_lemma",
+      "label": "key_missing_lemma",
+      "content": "A missing lemma.",
+      "content_hash": "7f6a5b...",
+      "role": "local_hole",
+      "interface_hash": "sha256:...",
+      "exported": false,
+      "required_by": [
+        "github:package_a::main_theorem"
+      ]
+    }
+  ]
+}
+```
 
-以后如果要更强，可以再扩展成“最近 exported downstream claims”。
+字段约束：
 
-### 5.3 `bridges.json`
+- `role`
+  - `local_hole`
+  - `foreign_dependency`
+- `interface_hash`
+  - package/manifest 层派生字段，不进入 Gaia IR
+- `exported`
+  - 该 premise 是否也在 `__all__` 中
+- `required_by`
+  - 当前 release 上最接近的 exported claims roots
 
-记录 package 当前版本声明的 fills relations。
+### 4.3 `holes.json`
+
+`holes.json` 是 `premises.json` 的 convenience subset：
+
+```json
+{
+  "package": "package-a",
+  "version": "1.4.0",
+  "ir_hash": "sha256:...",
+  "holes": [
+    {
+      "qid": "github:package_a::key_missing_lemma",
+      "label": "key_missing_lemma",
+      "content": "A missing lemma.",
+      "content_hash": "7f6a5b...",
+      "interface_hash": "sha256:...",
+      "required_by": [
+        "github:package_a::main_theorem"
+      ]
+    }
+  ]
+}
+```
+
+提取规则：
+
+- 来自 `premises.json`
+- 只保留 `role == "local_hole"` 的条目
+
+### 4.4 `bridges.json`
+
+bridge relation 必须绑定 target interface snapshot。
 
 ```json
 {
   "package": "package-b",
   "version": "2.1.0",
   "ir_hash": "sha256:...",
-  "generated_at": "2026-04-08T12:00:00Z",
   "bridges": [
     {
       "relation_id": "bridge_4a1f9d3c2b7e8f10",
       "relation_type": "fills",
-      "source_qid": "github:package_b::main_result",
-      "target_hole_qid": "github:package_a::key_missing_lemma",
+      "source_qid": "github:package_b::b_result",
+      "source_content_hash": "88aa77...",
+      "target_qid": "github:package_a::key_missing_lemma",
       "target_package": "package-a",
-      "target_version_req": ">=1.4.0,<2.0.0",
+      "target_dependency_req": ">=1.4.0,<2.0.0",
+      "target_resolved_version": "1.4.0",
+      "target_role": "local_hole",
+      "target_interface_hash": "sha256:...",
       "strength": "exact",
       "mode": "deduction",
       "declared_by_owner_of_source": true,
-      "justification": "Theorem 3 proves exactly the missing lemma in package A."
+      "justification": "Theorem 3 proves A's missing lemma."
     }
   ]
 }
 ```
 
-`relation_id` 的稳定规则定义为：
+相比旧设计，关键变化是：
+
+- `target_hole_qid` -> `target_qid`
+- 新增 `target_resolved_version`
+- 新增 `target_interface_hash`
+- `target_role` 是编译时验证结果，不来自 source marker
+
+## 5. Derivation Rules
+
+### 5.1 Export Roots
+
+Phase 1 先把所有 exported claims 当作 export roots。
+
+如果未来需要把“公开结论”和“公开 supporting claim”再细分，可以在 manifest 层继续加 role，但不影响 premise derivation 的核心协议。
+
+### 5.2 Public Premise Discovery
+
+对每个 export root：
+
+1. 找出其 local supporting strategies
+2. 递归向上遍历这些 strategy 的 `premises`
+3. 遇到没有 local support 的 claim 时停止
+4. 生成一个 public premise record
+
+分类：
+
+- local claim -> `local_hole`
+- foreign claim -> `foreign_dependency`
+
+### 5.3 `required_by`
+
+`required_by` 不应是整张图上所有下游节点，而应保持为稳定的 interface summary。
+
+Phase 1 规则：
+
+- 记录该 public premise 所支撑的 exported claim roots
+- 去重后排序输出
+
+注意：
+
+- `required_by` 不进入 `interface_hash`
+- 否则新增一个 exported conclusion 就会让所有旧 bridge 全部失效
+
+### 5.4 `interface_hash`
+
+`interface_hash` 推荐由下面字段 canonicalize 后求 hash：
+
+- `qid`
+- `content_hash`
+- `role`
+- `parameters`
+- `schema_version`
+
+明确不包含：
+
+- `required_by`
+- `generated_at`
+- `package version`
+
+原因：
+
+- 这是 premise interface 的 identity hash
+- 不是 whole-release hash
+- 更不应该被无关展示字段污染
+
+### 5.5 `relation_id`
+
+`relation_id` 推荐定义为：
 
 ```text
 relation_id = "bridge_" + sha256(
   declaring_package + "|" + declaring_version + "|" +
-  source_qid + "|" + target_hole_qid + "|" + relation_type
+  source_qid + "|" + source_content_hash + "|" +
+  target_qid + "|" + target_interface_hash + "|" +
+  relation_type
 )[:16]
 ```
 
-提取规则：
+这样：
 
-- 扫描 local strategies
-- 找出 metadata 中 `gaia.relation.type == "fills"` 的 strategy
-- 提取其 `conclusion` 作为 `target_hole_qid`
-- 提取其唯一 premise 作为 `source_qid`
-- `target_package` 来自 `target_hole_qid` 中的 package 段
-- `target_version_req` 来自当前 package `pyproject.toml` 中对 `target_package` 的依赖约束；若 target 为 foreign hole 且没有对应依赖约束，`gaia compile` / `gaia check` 应报错
-- `declared_by_owner_of_source = (QID(source_qid).package == current_package.name)`，由编译器自动计算
-- 同一 package version 内，若出现重复的 `(source_qid, target_hole_qid)`，编译器应直接报错
+- target interface 变了，relation_id 会变
+- source 内容变了，relation_id 也会变
 
-如果 `fills` 后续允许 richer metadata，则按 metadata 补全 `strength / mode / justification`。
+## 6. Validation Rules
 
-## 6. Package Authoring Conventions
+### 6.1 `premises.json`
 
-### 6.1 Public hole
+- 每个 premise 必须是 claim
+- 同一 `(qid, role, interface_hash)` 不可重复
+- `role == "local_hole"` 时，qid 必须属于当前 package
+- `role == "foreign_dependency"` 时，qid 必须属于 foreign package
 
-作者如果想公开一个可被别人填补的 hole，需要同时做到：
+### 6.2 `holes.json`
 
-1. 用 `hole(...)` 声明
-2. 放进 `__all__`
+- 每个 hole 必须在 `premises.json` 中存在
+- 且其 `role == "local_hole"`
+- `interface_hash` 必须与 `premises.json` 对应条目一致
 
-只做其一都不够：
+### 6.3 `bridges.json`
 
-- 只有 `hole(...)` 没有 export：内部 hole
-- 只有 export 没有 `hole(...)`：普通 public claim
+- `source_qid` 必须可解析
+- `source_content_hash` 必须与 source node 匹配
+- `target_qid` 必须可解析
+- `target_dependency_req` 必须来自 declaring package 的依赖约束
+- `target_resolved_version` 必须是 compile 时实际验证到的版本
+- `target_interface_hash` 必须与 target release 的 `premises.json` / `holes.json` 对应
+- `target_role` 当前必须是 `local_hole`
+- 同一 package version 内，重复 `(source_qid, target_qid, target_interface_hash)` 必须报错
 
-### 6.2 Direct fill in a paper package
+## 7. Scenario Walkthroughs
 
-如果 B 自己知道某个结果 fills A 的 hole，推荐直接写在 B 里。
+### 7.1 Scenario A: B 直接声明 fills A 的缺口
+
+A 源码：
+
+```python
+from gaia.lang import claim, deduction
+
+main_theorem = claim("Main theorem.")
+key_missing_lemma = claim("A missing lemma.")
+
+deduction(
+    premises=[key_missing_lemma],
+    conclusion=main_theorem,
+)
+
+__all__ = ["main_theorem"]
+```
+
+编译 A 后：
+
+- `exports.json`
+  - `main_theorem`
+- `premises.json`
+  - `key_missing_lemma`, role=`local_hole`
+- `holes.json`
+  - `key_missing_lemma`
+
+B 源码：
 
 ```python
 from gaia.lang import claim, fills
 from package_a import key_missing_lemma
 
 b_result = claim("Theorem 3.")
-fills(source=b_result, hole=key_missing_lemma, reason="...")
+
+fills(source=b_result, target=key_missing_lemma, reason="...")
+
+__all__ = ["b_result"]
 ```
 
-这会让：
+编译 B 时：
 
-- IR 中出现 ordinary cross-package strategy
-- `.gaia/manifests/bridges.json` 中出现一条 fills relation
+- 从依赖接口中读到 `package_a@1.4.0`
+- 确认 `key_missing_lemma` 在该 release 上是 `local_hole`
+- 生成一条带 `target_resolved_version` 和 `target_interface_hash` 的 bridge
 
-### 6.3 Third-party bridge package
+### 7.2 Scenario B: C 做第三方 bridge package
 
-如果 C 后来才发现这层关系，C 可以发一个普通 package：
+C 可以是 zero-local package：
 
-- 引入 A 的 exported hole
-- 引入 B 的 exported claim
-- 写 `fills(...)`
+```python
+from gaia.lang import fills
+from package_a import key_missing_lemma
+from package_b import b_result
 
-不要求额外 package type。
-
-## 7. Worked Scenarios
-
-### 7.1 Scenario A: B immediately knows it fills A
-
-package A 编译后，关键本地产物会是：
-
-- `.gaia/manifests/exports.json`：包含 `main_theorem` 和 `key_missing_lemma`
-- `.gaia/manifests/holes.json`：包含 `key_missing_lemma`
-- `.gaia/manifests/bridges.json`：为空
-
-package B 编译后，关键本地产物会是：
-
-- `.gaia/manifests/exports.json`：包含 `b_result`
-- `.gaia/manifests/holes.json`：为空
-- `.gaia/manifests/bridges.json`：包含一条 `source_qid = b_result`、`target_hole_qid = key_missing_lemma` 的 relation
-
-这里 `declared_by_owner_of_source = true`，因为 relation 是由 B 自己声明的。
-
-### 7.2 Scenario B: B did not notice, later C discovers it
-
-package B 编译后：
-
-- `.gaia/manifests/exports.json`：包含 `b_result`
-- `.gaia/manifests/bridges.json`：为空
-
-package C bridge 编译后：
-
-- `.gaia/manifests/exports.json`：可以为空或只含少量本地 summary nodes
-- `.gaia/manifests/holes.json`：通常为空
-- `.gaia/manifests/bridges.json`：包含 `source_qid = package_b::b_result`、`target_hole_qid = package_a::key_missing_lemma`
-
-这里 `declared_by_owner_of_source = false`，因为 relation 由第三方声明。
-
-在纯 bridge package 场景下，`exports.json` 的空数组是合法的；package 的主要对外产物是 `bridges.json`，不是 exported claims。
-
-### 7.3 Boundary Condition: A did not export a hole
-
-如果 A 没有公开 hole interface：
-
-- package A 的 `holes.json` 中不会出现该前提
-- package B/C 即使写了某种普通 cross-package deduction，也不应进入 `bridges.json`
-
-也就是说，package 层的 bridge manifest 只承认“指向 exported hole 的 fills relation”。
-
-## 8. Package Semantics
-
-### 8.1 Public API
-
-package 的稳定 API 仍然首先由 exported nodes 决定。
-
-因此：
-
-- exported claims / holes 是 import-facing API
-- bridge relations 是 discovery-facing public metadata
-
-这两者都公开，但稳定性级别不同。
-
-### 8.2 Semver Guidance
-
-推荐规则：
-
-| Change | Version level | Reason |
-|--------|---------------|--------|
-| 新增 exported hole | MINOR | 新增公共接口 |
-| 修改 / 删除 exported hole 语义 | MAJOR | 破坏 hole API |
-| 新增 fills relation | MINOR | 新增公开 relation metadata |
-| 修改 / 删除 fills relation | MINOR | 影响 discovery surface，但不破坏 import API |
-
-解释：
-
-- hole 是 package API 的一部分
-- fills 更像对外公开的 relation metadata，不建议把它当成 import-breaking API
-
-## 9. `gaia compile` Changes
-
-推荐 `gaia compile` 在目标稳态下扩展为：
-
-1. 正常生成 `.gaia/ir.json`
-2. 正常生成 `.gaia/ir_hash`
-3. 额外生成 `.gaia/manifests/exports.json`
-4. 额外生成 `.gaia/manifests/holes.json`
-5. 额外生成 `.gaia/manifests/bridges.json`
-
-与 registry rollout 的对齐规则是：
-
-- **Phase 1**：`exports.json` 是必须产物；`holes.json` / `bridges.json` 可以作为本地 preview artifact 存在，但不会被 `gaia register` 上传
-- **Phase 2**：`holes.json` 成为正式 contract
-- **Phase 3**：`bridges.json` 成为正式 contract
-
-### 9.1 Why compile, not register
-
-如果等到 `gaia register` 才临时构造这些 manifests，会带来两个问题：
-
-- 作者本地难以预览 package 对外暴露了哪些 holes / bridges
-- register 阶段逻辑变重，难以本地审计
-
-而这些文件本质上都只是 IR 和 metadata 的 deterministic projection，所以更适合放在 compile 阶段。
-
-## 10. `gaia check` Changes
-
-推荐新增 package-level 校验：
-
-### 10.1 Hole checks
-
-- every exported hole is a claim
-- every exported hole appears in `exports.json`
-- every exported hole has at least one downstream local use, unless explicitly suppressed
-
-最后一条是 warning，不是 hard error。因为有些 package 会先发布 hole interface，再等待别人填补。
-
-### 10.2 Bridge checks
-
-- every fills relation has exactly one `source_qid`
-- `source_qid` resolves to claim
-- `target_hole_qid` resolves to claim
-- every target knowledge, local or foreign, carries the canonical hole marker `metadata["gaia"]["role"] = "hole"`
-- if target is local and not exported hole, do not emit to bridge manifest
-- if target is foreign, dependency resolution must succeed
-- if target is foreign, `target_version_req` must be derivable from the package dependency spec
-- duplicate `(source_qid, target_hole_qid)` fills declarations are hard errors
-
-## 11. `gaia register` Changes
-
-当前 `gaia register` 只准备：
-
-- `Package.toml`
-- `Versions.toml`
-- `Deps.toml`
-
-推荐扩展为分阶段携带：
-
-- **Phase 1**：`packages/<name>/releases/<version>/exports.json`
-- **Phase 2**：再加 `packages/<name>/releases/<version>/holes.json`
-- **Phase 3**：再加 `packages/<name>/releases/<version>/bridges.json`
-
-也就是说，本地 compile 可以先于 registry rollout 生成 preview manifests，但 `gaia register` 只会上传当前 phase 正式支持的那部分文件。
-
-### 11.1 Register payload shape
-
-Phase 3 的完整 payload 形态是：
-
-计划输出中新增：
-
-```json
-{
-  "files": {
-    "packages/package-a/Package.toml": "...",
-    "packages/package-a/Versions.toml": "...",
-    "packages/package-a/Deps.toml": "...",
-    "packages/package-a/releases/1.4.0/exports.json": "...",
-    "packages/package-a/releases/1.4.0/holes.json": "...",
-    "packages/package-a/releases/1.4.0/bridges.json": "..."
-  }
-}
+fills(source=b_result, target=key_missing_lemma, reason="...")
 ```
 
-这样 register PR 依然是 package-local 的，不直接碰 `index/**`。
+编译后：
 
-## 12. Bridge Package UX
+- `exports.json` 可以为空
+- `premises.json` 可以为空
+- `bridges.json` 仍然合法
+- `declared_by_owner_of_source = false`
 
-### 12.1 No mandatory local summary claim
+## 8. Compatibility Notes
 
-bridge package 不强制要求作者额外写一个本地 summary claim。
+### 8.1 Earlier `hole()`-driven extraction
 
-原因：
+如果已有实现基于：
 
-- package 的主要公开对象就是 cross-package relation 本身
-- 强制再写一个 summary claim 只会制造样板噪声
+- exported claim + `metadata["gaia"]["role"] == "hole"`
 
-如果作者愿意写本地 summary claim，用于 README narrative，可以作为可选增强。
+来生成 `holes.json`，应视为 prototype。
 
-### 12.2 Discovery
+迁移方向应是：
 
-bridge package 在 registry 中的 discoverability，主要依靠：
+- 新增 `premises.json`
+- 先从 dependency closure 自动推出 premise role
+- `holes.json` 退化成 `premises.json` 的 subset
 
-- `bridges.json`
-- registry 的 derived indexes
+### 8.2 Why `target_dependency_req` and `target_resolved_version` must coexist
 
-而不是依赖 exported claims。
+只写 dependency range 不够，因为：
 
-### 12.3 Zero-Local-Knowledge Bridge Packages
+- `>=1.4.0,<2.0.0` 可能覆盖多个 release
+- 而 hole 身份可能只在其中某些 release 上成立
 
-纯 bridge package 是允许的。一个最小例子可以是：
+所以：
 
-- 没有本地 exported claim
-- 只有 foreign `source_qid`
-- 只有 foreign `target_hole_qid`
-- 以及一条本地声明的 `fills` relation
+- `target_dependency_req` 表示作者声明的兼容范围
+- `target_resolved_version` 表示当前 compile 实际验证到的 release
 
-其期望产物形态是：
-
-```json
-// .gaia/manifests/exports.json
-{
-  "package": "package-c-bridge",
-  "version": "0.1.0",
-  "exports": []
-}
-```
-
-```json
-// .gaia/manifests/holes.json
-{
-  "package": "package-c-bridge",
-  "version": "0.1.0",
-  "holes": []
-}
-```
-
-```json
-// .gaia/manifests/bridges.json
-{
-  "package": "package-c-bridge",
-  "version": "0.1.0",
-  "bridges": [
-    {
-      "relation_id": "bridge_4a1f9d3c2b7e8f10",
-      "relation_type": "fills",
-      "source_qid": "github:package_b::b_result",
-      "target_hole_qid": "github:package_a::key_missing_lemma",
-      "target_package": "package-a",
-      "target_version_req": ">=1.4.0,<2.0.0",
-      "strength": "conditional",
-      "mode": "infer",
-      "declared_by_owner_of_source": false,
-      "justification": "..."
-    }
-  ]
-}
-```
-
-实现 rollout 的 acceptance criteria 之一应是：一个真实的零本地 bridge package 能走通 `gaia compile && gaia check`，并在 Phase 3 走通 `gaia register`。
-
-## 13. Why This Package Layer Matters
-
-### 13.1 Thought Experiment: no local manifests
-
-如果 package 本地没有 `exports / holes / bridges` manifests：
-
-- register 时必须重新从 source 和 IR 临时推断
-- 作者本地看不到 registry 会看到什么
-- registry 和 package 很难保证同一套抽取规则
-
-### 13.2 Thought Experiment: manifests generated at compile time
-
-如果 manifests 是 compile artifact：
-
-- 作者本地可审计
-- CI 可重放
-- register 只是搬运 deterministic outputs
-
-这更符合当前 Gaia 的 artifact philosophy。
-
-## 14. Decisions
-
-1. **package 继续是唯一发布单位。**
-2. **`__all__` 继续是唯一 public interface 开关。**
-3. **`.gaia/manifests/` 新增 `exports / holes / bridges`。**
-4. **这些 manifests 由 `gaia compile` 生成，而不是 `gaia register` 临时拼。**
-5. **bridge package 仍然是普通 `knowledge-package`，不是新的 package type。**
-6. **`content_hash` 与 IR 保持同格式：裸 64 位 hex，不带 `sha256:` 前缀。**
-7. **同一 package version 内禁止重复声明同一 `(source_qid, target_hole_qid)` 的 `fills` relation。**
-
-## 15. Open Questions
-
-1. `.gaia/manifests/*.json` 是否也要像 `ir_hash` 一样参与 freshness / check contract？
-2. `required_by` 是否需要同时输出直接下游和最近 exported 下游两种视图？
-3. 是否需要在 `pyproject.toml` 里加 optional metadata，显式标注 package 的主要用途为 `bridge`？
+二者缺一不可。

--- a/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
+++ b/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
@@ -7,6 +7,8 @@
 > **Companion docs:** [2026-04-08-gaia-lang-hole-fills-design.md](2026-04-08-gaia-lang-hole-fills-design.md), [2026-04-08-registry-hole-bridge-index-design.md](2026-04-08-registry-hole-bridge-index-design.md)
 >
 > **Depends on:** [../foundations/gaia-lang/package.md](../foundations/gaia-lang/package.md), [2026-04-02-gaia-registry-design.md](2026-04-02-gaia-registry-design.md)
+>
+> **Supersedes:** the earlier hole / bridge package proposal merged via PRs #362 and #364. Open implementation PRs #365 / #366 / #367 target the superseded design and should be replaced rather than merged as-is.
 
 ## 1. Problem
 
@@ -109,6 +111,7 @@ package manifests 不再以：
 
 ```json
 {
+  "manifest_schema_version": 1,
   "package": "package-a",
   "version": "1.4.0",
   "ir_hash": "sha256:...",
@@ -136,6 +139,7 @@ package manifests 不再以：
 
 ```json
 {
+  "manifest_schema_version": 1,
   "package": "package-a",
   "version": "1.4.0",
   "ir_hash": "sha256:...",
@@ -164,7 +168,8 @@ package manifests 不再以：
 - `interface_hash`
   - package/manifest 层派生字段，不进入 Gaia IR
 - `exported`
-  - 该 premise 是否也在 `__all__` 中
+  - 当且仅当该 claim 同时出现在同版本的 `exports.json` 中时为 `true`
+  - `false` 表示它只是被派生为 public premise，不是作者显式导出的 public conclusion
 - `required_by`
   - 当前 release 上最接近的 exported claims roots
 
@@ -174,6 +179,7 @@ package manifests 不再以：
 
 ```json
 {
+  "manifest_schema_version": 1,
   "package": "package-a",
   "version": "1.4.0",
   "ir_hash": "sha256:...",
@@ -203,6 +209,7 @@ bridge relation 必须绑定 target interface snapshot。
 
 ```json
 {
+  "manifest_schema_version": 1,
   "package": "package-b",
   "version": "2.1.0",
   "ir_hash": "sha256:...",
@@ -234,6 +241,16 @@ bridge relation 必须绑定 target interface snapshot。
 - 新增 `target_interface_hash`
 - `target_role` 是编译时验证结果，不来自 source marker
 
+其中 `target_resolved_version` 的定义是：
+
+- compile 当前环境里实际 import 解析到的 dependency release version
+
+而不是：
+
+- 满足约束的最新 registry version
+- 满足约束的最低 version
+- 作者手工填写的任意版本号
+
 ## 5. Derivation Rules
 
 ### 5.1 Export Roots
@@ -262,13 +279,16 @@ Phase 1 先把所有 exported claims 当作 export roots。
 
 Phase 1 规则：
 
-- 记录该 public premise 所支撑的 exported claim roots
+- 对每个 public premise，自底向下做 BFS
+- 遇到 exported claim root 时停止该分支
+- 记录这些“最接近的下游 exported roots”
 - 去重后排序输出
 
 注意：
 
 - `required_by` 不进入 `interface_hash`
 - 否则新增一个 exported conclusion 就会让所有旧 bridge 全部失效
+- 这是一种有意的简化；代价是同一 premise 在不同 release 上服务于不同 exported roots 集合时，仍可能被视为同一接口
 
 ### 5.4 `interface_hash`
 
@@ -278,7 +298,7 @@ Phase 1 规则：
 - `content_hash`
 - `role`
 - `parameters`
-- `schema_version`
+- `manifest_schema_version`
 
 明确不包含：
 
@@ -292,7 +312,70 @@ Phase 1 规则：
 - 不是 whole-release hash
 - 更不应该被无关展示字段污染
 
-### 5.5 `relation_id`
+这里的 `manifest_schema_version` 指的是 manifest 协议版本，而不是：
+
+- `gaia-lang` 的包版本
+- Gaia IR schema 版本
+- package 自己的 semver
+
+当前固定定义为：
+
+- `manifest_schema_version = 1`
+
+并且应写入所有 package-level manifests 的顶层。
+
+变化矩阵：
+
+| 变化 | `interface_hash` 是否变化 |
+|------|---------------------------|
+| claim content 改动 | 变化 |
+| claim parameters 改动 | 变化 |
+| role 从 `local_hole` 变为 `foreign_dependency` | 变化 |
+| `required_by` 改动 | 不变化 |
+| `manifest_schema_version` bump | 变化 |
+| `gaia-lang` 升级 | 不变化 |
+| Gaia IR 升级 | 不变化 |
+
+Trade-off:
+
+- `required_by` 被排除在 `interface_hash` 之外，避免“新增一个 exported conclusion 就让所有 bridge 全部 stale”
+- 代价是同一 premise 在不同 release 上被更多 exported roots 复用时，仍可能被看作同一接口
+- Phase 1 接受这个 trade-off；若未来发现 bridge 语义漂移是实际问题，可新增 `context_hash` 或更显式的 root-targeting relation
+
+### 5.5 Dependency Manifest Resolution
+
+当 package compile 遇到：
+
+```python
+fills(source=..., target=foreign_claim)
+```
+
+时，必须读取 dependency 的 compiled premise interface manifests。
+
+Phase 1 规则：
+
+1. 先根据当前 Python import 实际解析到的 dependency module 定位安装路径
+2. 若该 dependency 是 editable/source install，则优先使用该 source tree 下的：
+   - `.gaia/manifests/premises.json`
+   - `.gaia/manifests/holes.json`
+3. 若该 dependency 是 wheel/site-packages install，则读取对应安装目录中的同名 manifest
+
+缺失策略：
+
+- 如果 dependency manifest 不存在，compile 应 hard error
+- 错误消息应明确要求作者先在 dependency package 上运行 `gaia compile`
+
+staleness 策略：
+
+- compile 应把 dependency manifest 的 `ir_hash` 与该 dependency 当前 source/build 的 compile 结果对比
+- 若 manifest stale，应 hard error，而不是静默写入过期的 `target_interface_hash`
+
+兼容旧包策略：
+
+- 对于 manifest schema 引入前发布的旧 package，需要显式迁移后才能作为 `fills` target
+- Phase 1 不做“无 manifest 时降级 warning”或“自动编译 dependency”
+
+### 5.6 `relation_id`
 
 `relation_id` 推荐定义为：
 
@@ -335,6 +418,32 @@ relation_id = "bridge_" + sha256(
 - `target_interface_hash` 必须与 target release 的 `premises.json` / `holes.json` 对应
 - `target_role` 当前必须是 `local_hole`
 - 同一 package version 内，重复 `(source_qid, target_qid, target_interface_hash)` 必须报错
+
+### 6.4 Phase Rollout
+
+旧方案的 phased rollout 是：
+
+- Phase 1: `exports.json`
+- Phase 2: `holes.json`
+- Phase 3: `bridges.json`
+
+新方案下必须对齐为：
+
+- **Phase 1**
+  - 生成并上传 `exports.json`
+  - 生成并上传 `premises.json`
+- **Phase 2**
+  - 生成并上传 `holes.json`
+  - 开始建设 `index/premises/**` 与 `index/holes/**`
+- **Phase 3**
+  - 生成并上传 `bridges.json`
+  - 开始建设 `index/bridges/**`
+
+原因：
+
+- `premises.json` 是 `holes.json` 的 source of truth
+- `premises.json` 也是 bridge target validation 的 source of truth
+- 因此它不能晚于 `holes.json` 和 `bridges.json`
 
 ## 7. Scenario Walkthroughs
 
@@ -418,6 +527,7 @@ fills(source=b_result, target=key_missing_lemma, reason="...")
 - 新增 `premises.json`
 - 先从 dependency closure 自动推出 premise role
 - `holes.json` 退化成 `premises.json` 的 subset
+- 删除 `hole()` 作为主线 source primitive
 
 ### 8.2 Why `target_dependency_req` and `target_resolved_version` must coexist
 

--- a/docs/specs/2026-04-08-registry-hole-bridge-index-design.md
+++ b/docs/specs/2026-04-08-registry-hole-bridge-index-design.md
@@ -1,4 +1,4 @@
-# Gaia Registry Hole / Bridge Index Design
+# Gaia Registry Public Premise / Bridge Index Design
 
 > **Status:** Proposal
 >
@@ -10,125 +10,151 @@
 
 ## 1. Problem
 
-Gaia 的 Official Registry 在当前设计里是一个 GitHub repo，主要记录：
+在新的 package 设计里：
 
-- package identity
-- version -> git tag / git sha / ir_hash
-- explicit dependencies
+- `hole` 不再是作者显式 source marker
+- 而是某个 release 上编译出来的 `public premise` 角色
 
-这足够支持“已知包名 -> 拉元数据 -> 安装 / 引用”，但不够支持下面这些生态问题：
+这会直接改变 registry 要存什么、索引什么：
 
-1. A 包公开了一个可复用的缺口，未来谁能补它？
-2. B 包已经知道自己的结论可以填 A 的 hole，如何让别人发现？
-3. C 后来发现 “B.result fills A.hole”，如何在不改 A/B 的情况下公开这个关系？
-4. 当 package 很多时，如何避免每次查询都扫描整个 registry repo？
+1. 不能只存 “exported holes”
+   因为 hole 身份可能跨版本变化
+2. 不能只让 bridge relation 指向 `target_hole_qid`
+   因为 QID 相同并不保证 interface 状态相同
+3. 不能把 package manifests 简化成 `exports / holes / bridges`
+   因为 `premises` 才是 bridge 目标验证的真正 source of truth
 
-本设计不引入 global canonicalization，也不要求运行时数据库。前提保持不变：
+因此，registry 需要从旧的：
 
-- Registry 仍然只是一个 GitHub repo
-- package 仍然是 authoring / publishing 的基本单位
-- bridge relation 只是显式关系，不是 identity merge 或裁决
+- package-local hole list
+- static hole -> fillers index
+
+升级成：
+
+- versioned public premise snapshots
+- hole history
+- bridge relations keyed by target interface snapshot
 
 ## 2. Design Goals
 
-### 2.1 必须满足
-
 1. **GitHub-native**
-   一切 source of truth 都是 git 文件，所有变更都通过 PR。
+   source of truth 仍然全部是 git 文件，通过 PR 维护。
 
-2. **Package-owned authoring**
-   作者只需要在 package 或 bridge package 中声明关系，不直接手改全局索引。
+2. **Release-scoped semantics**
+   registry 必须保留“某个 qid 在某个 release 上扮演什么接口角色”。
 
-3. **Static-query friendly**
-   查询 `hole -> fillers`、`claim -> filled holes` 时，客户端不能靠全仓扫描。
+3. **No second registry**
+   仍然只有一个 registry repo，不拆独立 bridge registry。
 
-4. **No central semantic adjudication**
-   Registry 记录谁声明了什么关系，但不在注册阶段裁决“这是否真的是同一个命题”。
+4. **Static query friendliness**
+   查询不能靠扫描所有 package manifests，必须有 bot 生成的静态索引。
 
-5. **Conflict-resistant**
-   注册很多 package 后，PR 不能频繁碰撞到同一个全局文件。
-
-### 2.2 明确不做
-
-- 不做 duplicate merge / equivalence merge
-- 不做 single official bridge truth
-- 不要求桥接关系必须由 source package 作者本人声明
-- 不把 fuzzy discovery 变成注册时的硬 gate
+5. **Historical correctness**
+   A 的 hole 在新版本消失后，旧 bridge 仍应作为历史记录保留。
 
 ## 3. Core Idea
 
-核心分层是：
+registry 继续保持三层：
 
-1. **package 内声明**
-   `hole` 和 `bridge relation` 写在 package 里。
+1. **package-local manifests**
+   - 注册 PR 只提交自己 package release 的 manifests
 
-2. **registry 内保存 package-local manifests**
-   注册时把该版本的 `exports / holes / bridges` 作为静态 manifest 记录下来。
+2. **derived indexes**
+   - merge 后由 bot 生成
 
-3. **bot 生成 derived indexes**
-   merge 后由 GitHub Action 生成全局静态索引文件，供 CLI / 网站 / 人类查询。
+3. **query layer**
+   - CLI / Web 只查静态索引，不全仓扫描
 
-一句话：
+但 source manifests 现在变成：
 
-**package 是写关系的地方，registry 是找关系的地方。**
+- `exports.json`
+- `premises.json`
+- `holes.json`
+- `bridges.json`
+
+其中：
+
+- `premises.json` 是 interface source of truth
+- `holes.json` 只是 `premises.json` 的 `local_hole` 子集
 
 ## 4. Object Model
 
-### 4.1 Exported Hole
+### 4.1 Exported Node
 
-`hole` 是作者显式导出的公共缺口，不是自动从所有叶子前提推导出来的。
+`exports.json` 记录作者显式导出的节点。
 
-一个 node 只有同时满足下面条件，才应被导出为 `hole`：
+它回答：
 
-1. 它是某条公开结论链的 load-bearing premise
-2. 当前 package 没有在本包内部把它证明完
-3. 作者希望未来其他 package 能显式填补它
-4. 它的语义足够稳定，值得成为公共接口
+- “这个 release 想公开哪些节点？”
 
-因此：
+它不回答：
 
-- 不是所有 leaf premise 都是 hole
-- hole 是 package API 的一部分
-- hole 可以被别的 package import / fill
+- 哪些节点是 public premises
+- 哪些节点是 holes
 
-### 4.2 Bridge Relation
+### 4.2 Public Premise Snapshot
 
-`bridge relation` 是一个显式生态断言：
+`premises.json` 里的每一条记录，都是一个 **release-scoped premise interface snapshot**。
 
-- 某个 `source claim`
-- 可以填补某个 `target hole`
-- 这个主张由某个 `declaring package` 给出
+它回答：
 
-它不是新的逻辑 primitive，也不是 global identity claim。它只是一个 package-level relation record。
+- 某个 qid 在这个 release 上是不是 public premise
+- 如果是，它的角色是什么
+- 它的 interface identity 是什么
 
 最小字段：
 
-- `relation_type = "fills"`
+- `qid`
+- `role`
+  - `local_hole`
+  - `foreign_dependency`
+- `interface_hash`
+- `required_by`
+- `exported`
+
+### 4.3 Hole History
+
+`holes.json` 不是单独的语义来源，只是为 discovery 优化的 subset。
+
+hole 的真正语义应通过：
+
+- `premises.json` 中 `role == "local_hole"`
+
+来判定。
+
+这样同一个 qid 才能自然经历：
+
+- `A@1.0.0`: `local_hole`
+- `A@1.1.0`: no longer public premise
+- `A@1.2.0`: `foreign_dependency`
+
+### 4.4 Bridge Relation
+
+bridge relation 是显式生态断言：
+
+- 某个 source claim
+- fills 某个 target premise snapshot
+
+最小字段：
+
 - `source_qid`
-- `target_hole_qid`
+- `source_content_hash`
+- `target_qid`
+- `target_resolved_version`
+- `target_interface_hash`
+- `target_role`
 - `declaring_package`
 - `declaring_version`
-- `strength`
-- `justification`
 
-### 4.3 Declaring Package
+它不是：
 
-`bridge relation` 可以来自两类 package：
-
-1. **paper package**
-   B 自己知道 `B.result fills A.hole`，于是直接在 B 内声明
-
-2. **bridge package**
-   后来 C 发现 `B.result fills A.hole`，由 C 发布一个小 package 专门声明该关系
-
-Registry 不区分“哪类更真”，只记录声明来源。
+- global canonicalization
+- semantic adjudication
+- “这两个 claim 永远等价”的官方结论
 
 ## 5. Repository Layout
 
-在当前 registry 目录结构基础上，新增两层：
-
-- `packages/<name>/releases/<version>/...`：该 package version 的 source manifests
-- `index/...`：bot 生成的全局静态索引
+推荐目录：
 
 ```text
 gaia-registry/
@@ -140,19 +166,23 @@ gaia-registry/
 │   │   └── releases/
 │   │       ├── 1.0.0/
 │   │       │   ├── exports.json
+│   │       │   ├── premises.json
 │   │       │   ├── holes.json
 │   │       │   └── bridges.json
-│   │       └── 1.1.0/
-│   │           └── ...
+│   │       └── ...
 │   └── package-b/
 │       └── ...
 ├── index/
+│   ├── premises/
+│   │   ├── by-package/
+│   │   └── by-qid/
 │   ├── holes/
 │   │   ├── by-package/
 │   │   └── by-qid/
 │   ├── bridges/
-│   │   ├── by-target/
-│   │   ├── by-source/
+│   │   ├── by-target-qid/
+│   │   ├── by-target-interface/
+│   │   ├── by-source-qid/
 │   │   └── by-declaring-package/
 │   └── manifests/
 │       └── stats.json
@@ -163,46 +193,28 @@ gaia-registry/
 
 ## 6. Package-Local Source Manifests
 
-这些文件是 source of truth，由 `gaia register` 生成或拷贝到 registry PR 中。作者 PR 只修改自己 package 的目录。
-
 ### 6.1 `exports.json`
 
-记录该版本公开导出的 node interface。
+与 package layer 一致，记录该 release 的 author-declared exports。
 
-```json
-{
-  "package": "package-b",
-  "version": "2.1.0",
-  "generated_at": "2026-04-08T12:00:00Z",
-  "exports": [
-    {
-      "qid": "github:package_b::main_result",
-      "label": "main_result",
-      "type": "claim",
-      "content": "B's main theorem.",
-      "content_hash": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12f4f4a0a2b9f7f1c4d5e6a7b8"
-    }
-  ]
-}
-```
+### 6.2 `premises.json`
 
-这里的 `content_hash` 与 IR `Knowledge.content_hash` 保持同格式，使用裸 64 位 hex；只有 `ir_hash` 使用 `sha256:` 前缀。
+这是 registry 验证 bridge target 的核心文件。
 
-### 6.2 `holes.json`
-
-只列出作者显式公开的 hole。
+示例：
 
 ```json
 {
   "package": "package-a",
   "version": "1.4.0",
-  "generated_at": "2026-04-08T12:00:00Z",
-  "holes": [
+  "ir_hash": "sha256:...",
+  "premises": [
     {
       "qid": "github:package_a::key_missing_lemma",
-      "label": "key_missing_lemma",
-      "content": "A missing premise required by the main theorem.",
-      "content_hash": "7f6a5b4c3d2e1f0099887766554433221100ffeeddccbbaa9988776655443322",
+      "role": "local_hole",
+      "content_hash": "7f6a5b...",
+      "interface_hash": "sha256:...",
+      "exported": false,
       "required_by": [
         "github:package_a::main_theorem"
       ]
@@ -211,384 +223,245 @@ gaia-registry/
 }
 ```
 
-约束：
+### 6.3 `holes.json`
 
-- `holes.json` 中的每个 hole 必须也是该版本的 exported claim
-- hole 不能是自动扫描产物，必须来自作者显式标记
-- `required_by` 的生成规则与 package-level extraction 保持一致，见 [2026-04-08-gaia-package-hole-bridge-design.md](2026-04-08-gaia-package-hole-bridge-design.md) §5.2.1
+`holes.json` 只保留 `premises.json` 中 `role == "local_hole"` 的条目。
 
-### 6.3 `bridges.json`
+它的主要价值是：
 
-记录该版本声明的 bridge relations。
+- 让 CLI / Web 快速发现“当前 release 上有哪些 local holes”
+
+### 6.4 `bridges.json`
+
+bridge relation 示例：
 
 ```json
 {
   "package": "package-b",
   "version": "2.1.0",
-  "generated_at": "2026-04-08T12:00:00Z",
+  "ir_hash": "sha256:...",
   "bridges": [
     {
       "relation_id": "bridge_4a1f9d3c2b7e8f10",
       "relation_type": "fills",
-      "source_qid": "github:package_b::main_result",
-      "target_hole_qid": "github:package_a::key_missing_lemma",
+      "source_qid": "github:package_b::b_result",
+      "source_content_hash": "88aa77...",
+      "target_qid": "github:package_a::key_missing_lemma",
       "target_package": "package-a",
-      "target_version_req": ">=1.4.0,<2.0.0",
+      "target_dependency_req": ">=1.4.0,<2.0.0",
+      "target_resolved_version": "1.4.0",
+      "target_role": "local_hole",
+      "target_interface_hash": "sha256:...",
       "strength": "exact",
-      "justification": "Theorem 3 in package B proves exactly the missing premise exposed by package A.",
-      "declared_by_owner_of_source": true
+      "mode": "deduction",
+      "declared_by_owner_of_source": true,
+      "justification": "Theorem 3 proves A's missing lemma."
     }
   ]
 }
 ```
 
-第三方 bridge package 也用同样格式，只是：
-
-- `source_qid` 可能是 foreign
-- `declared_by_owner_of_source = false`
-
-其中：
-
-- `relation_id` 使用 package-level 规定的稳定 hash 规则，见 [2026-04-08-gaia-package-hole-bridge-design.md](2026-04-08-gaia-package-hole-bridge-design.md) §5.3
-- `target_version_req` 来自 declaring package 对 `target_package` 的依赖约束
-- `declared_by_owner_of_source = (QID(source_qid).package == declaring_package)`
-
 ## 7. Validation Rules
 
-`register.yml` 在现有校验基础上，新增以下机械规则。
+### 7.1 `premises.json`
 
-### 7.1 `exports.json`
+`register.yml` 应新增：
 
-- 每个 `qid` 必须存在于该 package version 的 compiled IR
-- 每个导出必须属于本 package namespace
-- `exports: []` 是合法的；纯 bridge package 可以没有 exported claims
+- premise `qid` 必须存在于 compiled IR closure 中
+- `role == "local_hole"` 时，qid 必须属于当前 package
+- `role == "foreign_dependency"` 时，qid 必须属于 foreign package
+- `interface_hash` 必须与 registry 当前 schema version 的计算规则一致
 
 ### 7.2 `holes.json`
 
-- 每个 `hole.qid` 必须出现在 `exports.json`
-- 每个 `required_by` 必须是本 package version 中存在的 exported claim
-- 同一版本内 `hole.qid` 不可重复
+- 每个 hole 必须在同版本 `premises.json` 中存在
+- 且其 role 必须是 `local_hole`
+- 同一版本内不可重复
 
 ### 7.3 `bridges.json`
 
 - `source_qid` 必须可解析
-  - 若属于 declaring package，则必须在该版本 `exports.json` 中
-  - 若属于 foreign package，则该 package / version requirement 必须出现在 dependencies 中
-- `target_hole_qid` 必须可解析到一个已注册 package 的 exported hole
-- `target_version_req` 必须来自对 `target_package` 的依赖约束，并且可满足至少一个已注册版本
-- `relation_type` 当前只允许 `fills`
-- `strength` 当前只允许 `exact | partial | conditional`
-- 对同一 `declaring_package@declaring_version`，重复的 `(source_qid, target_hole_qid)` relation 必须被拒绝
+- 若 source 属于 declaring package，则必须在本 release 的 `exports.json` 中
+- 若 source 属于 foreign package，则必须可由依赖约束解析
+- `target_qid` 必须可解析到某个 package release 的 `premises.json`
+- `target_resolved_version` 必须真实存在
+- `target_interface_hash` 必须与该 release 上的 premise snapshot 一致
+- `target_role` 当前只允许 `local_hole`
+- `target_dependency_req` 必须来自 declaring package 对 target package 的依赖约束
 
 ### 7.4 PR Ownership Rule
 
-注册 package version 的 PR：
+作者 PR：
 
-- **允许**修改 `packages/<self>/**`
-- **禁止**手工修改 `index/**`
+- **允许**改 `packages/<self>/**`
+- **禁止**手改 `index/**`
 
-这样可以避免所有作者 PR 同时争抢全局索引文件。
+所有 `index/**` 都由 merge 后 bot 生成。
 
 ## 8. Derived Indexes
 
-`index/**` 不是 author-authored source of truth，而是 merge 到 `main` 后由 bot 生成的派生文件。
+### 8.1 `index/premises/by-package/<package>.json`
 
-### 8.1 Hole Index
-
-#### `index/holes/by-package/<package>.json`
+按 package 查看各 release 的 premise snapshots。
 
 ```json
 {
   "package": "package-a",
-  "holes": [
-    {
-      "qid": "github:package_a::key_missing_lemma",
-      "introduced_in": "1.4.0",
-      "latest_version": "1.6.0"
+  "versions": {
+    "1.4.0": {
+      "premises": [
+        {
+          "qid": "github:package_a::key_missing_lemma",
+          "role": "local_hole",
+          "interface_hash": "sha256:..."
+        }
+      ]
     }
-  ]
+  }
 }
 ```
 
-#### `index/holes/by-qid/<shard>/<encoded-qid>.json`
+### 8.2 `index/premises/by-qid/<shard>/<encoded-qid>.json`
+
+按 qid 查看跨版本 interface history。
 
 ```json
 {
   "qid": "github:package_a::key_missing_lemma",
-  "owner_package": "package-a",
-  "versions": [
+  "history": [
     {
+      "package": "package-a",
       "version": "1.4.0",
-      "content": "A missing premise required by the main theorem.",
-      "required_by": ["github:package_a::main_theorem"]
+      "role": "local_hole",
+      "interface_hash": "sha256:..."
+    },
+    {
+      "package": "package-a",
+      "version": "1.5.0",
+      "role": "foreign_dependency",
+      "interface_hash": "sha256:..."
     }
   ]
 }
 ```
 
-### 8.2 Bridge Index
+### 8.3 `index/holes/by-qid/<shard>/<encoded-qid>.json`
 
-#### `index/bridges/by-target/<shard>/<encoded-hole-qid>.json`
-
-这是最核心的查询入口：`hole -> who claims to fill it`
+只索引 hole history：
 
 ```json
 {
-  "target_hole_qid": "github:package_a::key_missing_lemma",
-  "bridges": [
+  "qid": "github:package_a::key_missing_lemma",
+  "hole_versions": [
     {
-      "relation_id": "bridge_4a1f9d3c2b7e8f10",
-      "source_qid": "github:package_b::main_result",
-      "declaring_package": "package-b",
-      "declaring_version": "2.1.0",
-      "strength": "exact",
-      "declared_by_owner_of_source": true,
-      "justification": "..."
-    },
-    {
-      "relation_id": "bridge_95c62be0ad1f4e23",
-      "source_qid": "github:bridge_c::adapter_claim",
-      "declaring_package": "package-c-bridge",
-      "declaring_version": "0.1.0",
-      "strength": "conditional",
-      "declared_by_owner_of_source": false,
-      "justification": "..."
+      "version": "1.4.0",
+      "interface_hash": "sha256:..."
     }
   ]
 }
 ```
 
-#### `index/bridges/by-source/<shard>/<encoded-claim-qid>.json`
+### 8.4 `index/bridges/by-target-qid/<shard>/<encoded-qid>.json`
 
-反向查询：`claim -> what holes does it claim to fill`
+按 target qid 聚合所有 bridge declarations。
 
-#### `index/bridges/by-declaring-package/<package>.json`
+```json
+{
+  "target_qid": "github:package_a::key_missing_lemma",
+  "bridges": [
+    {
+      "declaring_package": "package-b",
+      "declaring_version": "2.1.0",
+      "source_qid": "github:package_b::b_result",
+      "target_resolved_version": "1.4.0",
+      "target_interface_hash": "sha256:..."
+    }
+  ]
+}
+```
 
-查看某 package 发布过哪些 bridge relations。
+### 8.5 `index/bridges/by-target-interface/<shard>/<interface-hash>.json`
 
-## 9. Build Flow
+这是“当前这个具体 hole snapshot 有哪些 fillers”最稳的查询入口。
 
-### 9.1 Registration PR
+```json
+{
+  "target_interface_hash": "sha256:...",
+  "target_qid": "github:package_a::key_missing_lemma",
+  "bridges": [
+    {
+      "declaring_package": "package-b",
+      "declaring_version": "2.1.0",
+      "source_qid": "github:package_b::b_result",
+      "relation_id": "bridge_4a1f9d3c2b7e8f10"
+    }
+  ]
+}
+```
 
-作者或 bot 提交 package version PR 时：
+## 9. Query Semantics
 
-1. 更新 `Package.toml / Versions.toml / Deps.toml`
-2. 按 rollout phase 新增 `releases/<version>/...` manifests
-3. 不修改 `index/**`
+### 9.1 “A 这个 hole 现在谁能填？”
 
-phase 对应关系是：
+正确流程不是：
 
-- **Phase 1**：只提交 `exports.json`
-- **Phase 2**：再提交 `holes.json`
-- **Phase 3**：再提交 `bridges.json`
+- 只按 `target_qid` 查 bridge
 
-package 本地编译可以先行生成后续 phase 的 preview manifests，但 registry 只接收当前 phase 正式支持的文件。
+而是：
 
-### 9.2 Post-Merge Index Build
+1. 先查 `premises/holes` index，定位 A 最新 release 上该 qid 是否仍是 `local_hole`
+2. 若是，拿到当前 `interface_hash`
+3. 再查 `index/bridges/by-target-interface/<interface_hash>.json`
 
-`build-index.yml` 在 `main` 上运行：
+这样才能避免旧 bridge 被错误地投射到新 release。
 
-1. 遍历 `packages/*/releases/*/{holes,bridges}.json`
-2. 重建 `index/holes/**`
-3. 重建 `index/bridges/**`
-4. 更新 `index/manifests/stats.json`
-5. 由 bot commit 回 registry repo
+### 9.2 “历史上谁填过这个 qid？”
 
-这意味着：
+查：
 
-- package PR merge 不依赖热点索引文件冲突
-- 索引是 deterministic derived artifact
-- 任意人都可以在本地重建并审计
+- `index/bridges/by-target-qid/<qid>.json`
 
-## 10. Worked Scenarios
+这给的是历史视角，不是 current compatibility 视角。
 
-### 10.1 Scenario A: B immediately knows it fills A
+### 9.3 “B 的某个结果被拿去填了哪些 holes？”
 
-前提：
+查：
 
-- A 已注册，并公开了 `key_missing_lemma` 这个 exported hole
-- B 在自己的 package 里直接声明 `fills(b_result, key_missing_lemma)`
+- `index/bridges/by-source-qid/<qid>.json`
 
-authoring example 见 [2026-04-08-gaia-lang-hole-fills-design.md](2026-04-08-gaia-lang-hole-fills-design.md) §6.1。
+## 10. Scenario Walkthroughs
 
-那么 registry 层会看到：
+### 10.1 Scenario A: B 直接声明 fills A 的缺口
 
-1. `packages/package-a/releases/<version>/holes.json`
-   含 `github:package_a::key_missing_lemma`
-2. `packages/package-b/releases/<version>/bridges.json`
-   含 `source_qid = github:package_b::b_result`
-   和 `target_hole_qid = github:package_a::key_missing_lemma`
-3. bot 生成：
-   `index/bridges/by-target/.../github:package_a::key_missing_lemma.json`
+registry 中会出现：
 
-该 index 文件中，这条 relation 的：
+- `packages/package-a/releases/1.4.0/premises.json`
+  - `key_missing_lemma`, role=`local_hole`
+- `packages/package-b/releases/2.1.0/bridges.json`
+  - 指向 `A@1.4.0` 的 interface snapshot
 
-- `declaring_package = package-b`
-- `declared_by_owner_of_source = true`
+如果 `A@1.5.0` 把它内部证明掉：
 
-### 10.2 Scenario B: B did not notice, later C discovers it
+- `index/premises/by-qid/...` 会反映 role 改变
+- `index/bridges/by-target-qid/...` 仍保留历史 bridge
+- `index/bridges/by-target-interface/...` 不会把 `A@1.5.0` 和旧 bridge 混起来
 
-前提：
+### 10.2 Scenario B: C 作为第三方 bridge package
 
-- A 已注册，并公开了 `key_missing_lemma`
-- B 已注册，只导出了 `b_result`，但没有 bridge relation
-- 后来 C 发布 bridge package，声明 `fills(package_b::b_result, package_a::key_missing_lemma)`
+C 发布 `bridge-package` 后：
 
-authoring example 见 [2026-04-08-gaia-lang-hole-fills-design.md](2026-04-08-gaia-lang-hole-fills-design.md) §6.2。
+- source of truth 仍然是 `packages/bridge-package/releases/.../bridges.json`
+- derived indexes 会把这条关系同时挂到：
+  - target qid 视图
+  - target interface 视图
+  - source qid 视图
+  - declaring package 视图
 
-那么 registry 层会看到：
+A 和 B 本身都不需要修改。
 
-1. `packages/package-b/releases/<version>/bridges.json`
-   仍然为空
-2. `packages/package-c-bridge/releases/<version>/bridges.json`
-   含这条 relation
-3. bot 重建 `index/bridges/by-target/.../github:package_a::key_missing_lemma.json`
+## 11. Non-Goals
 
-于是最终查询 A 的 hole 时，仍然能看到这条 bridge，只是：
-
-- `declaring_package = package-c-bridge`
-- `declared_by_owner_of_source = false`
-
-这里不需要修改 A 或 B 的 registry 目录。
-
-### 10.3 Boundary Condition: A did not export a hole
-
-如果 A 没有在自己的 package manifests 中公开某个 hole：
-
-- registry 不会为它建立 `index/holes/by-qid/...`
-- B 或 C 也不能把指向它的关系注册成正式 bridge relation
-
-所以 registry 只索引：
-
-- 明确公开的 hole interfaces
-- 明确声明的 fills relations
-
-不会自动把任意 premise 升格成公共 hole。
-
-## 11. Why This Works on a GitHub Repo
-
-### 11.1 思想实验 A: 1000 个 packages
-
-如果没有全局静态索引：
-
-- 查询一个 hole 是否被填，需要扫所有 package manifests
-
-这对人类和 CLI 都很差。
-
-有 `index/bridges/by-target/<hole>.json` 后：
-
-- 只要一次精确 fetch
-
-所以这个规模下，静态派生索引已经值得做。
-
-### 11.2 思想实验 B: 5 万个 packages
-
-如果每个注册 PR 都直接改一个全局 `bridges.json`：
-
-- 热门 hole 会让 PR 冲突频发
-- bot 和人类都很难稳定合并
-
-所以全局 bridge index 不能是 PR-authored 文件，只能是 post-merge derived artifact。
-
-### 11.3 思想实验 C: 20 万条 bridge relations
-
-如果只有单个总文件：
-
-- diff 很大
-- 下载成本高
-- GitHub API 单文件读取变笨重
-
-所以索引必须分片。推荐：
-
-- 按 encoded qid 的 hash prefix 做二级 shard
-- 单文件只服务一个 key 的精确查询
-
-这样 GitHub repo 仍然能承载这个业务逻辑，因为它处理的是：
-
-- 很多小的静态文件
-- 低冲突写入
-- 高频精确读取
-
-而不是动态 join 查询。
-
-### 11.4 思想实验 D: “帮我发现可能能填这个 hole 的包”
-
-这是 discovery，不是 registry source-of-truth。
-
-正确做法是：
-
-- 离线 job 跑 embedding / text match / dependency heuristics
-- 把结果写成 suggestion artifacts 或 GitHub issues
-- 由人或 agent 再决定是否写成正式 bridge relation
-
-不应该把这类 fuzzy logic 塞进注册主路径。
-
-## 12. Query Model
-
-在 GitHub-backed registry 下，推荐的读取模式是：
-
-1. **精确定位 package**
-   继续走 `packages/<name>/...`
-
-2. **精确定位 hole**
-   读取 `index/holes/by-qid/...`
-
-3. **精确定位 bridge target**
-   读取 `index/bridges/by-target/...`
-
-4. **精确定位 bridge source**
-   读取 `index/bridges/by-source/...`
-
-不推荐：
-
-- 运行时扫描全仓
-- 在客户端做跨 package join
-- 把 GitHub code search 当主要 API
-
-GitHub code search 可以作为人类 fallback，不应成为 CLI 的基础协议。
-
-## 13. Migration Path
-
-建议分三步落地。
-
-### Phase 1
-
-- 仅支持 `exports.json`
-- 为未来 `holes` / `bridges` 留目录结构
-- local compiler MAY already emit preview `holes.json` / `bridges.json`，但 registry 不消费
-
-### Phase 2
-
-- 支持 `holes.json`
-- 生成 `index/holes/**`
-
-### Phase 3
-
-- 支持 `bridges.json`
-- 生成 `index/bridges/**`
-- 提供 CLI / 网页查询
-
-这样不会一次把 package DSL、registry CI、discovery、网站全部绑死。
-
-## 14. Decisions
-
-1. **需要 bridge layer，但不需要第二个 registry**
-   仍然是一个统一 GitHub repo。
-
-2. **bridge relation 来源在 package，查询不靠扫 package**
-   关系写在 package manifests 中，读取走 derived indexes。
-
-3. **所有全局索引必须是 bot 生成，不允许作者 PR 直接改**
-   否则规模一上来一定产生 merge hotspot。
-
-4. **hole 是显式公共接口，不是自动叶子前提枚举**
-   否则 registry 会充满 package 内部建模细节，无法作为生态接口。
-
-5. **registry 记录声明，不裁决真理**
-   多个 package 可以同时声称填同一个 hole。
-
-## 15. Open Questions
-
-1. `strength = partial / conditional` 时，是否需要结构化 `conditions` 字段？
-2. bridge package 是否应该有更轻量的模板与 semver 规则？
-3. registry 是否需要额外的 `suggestions/` 目录来承接未确认 discovery 结果？
+- 不做 global canonicalization
+- 不在 registry 层裁决“哪个 bridge 才是真的”
+- 不要求 hole 身份跨版本稳定
+- 不让作者 PR 直接维护全局索引文件

--- a/docs/specs/2026-04-08-registry-hole-bridge-index-design.md
+++ b/docs/specs/2026-04-08-registry-hole-bridge-index-design.md
@@ -7,6 +7,8 @@
 > **Companion docs:** [2026-04-08-gaia-lang-hole-fills-design.md](2026-04-08-gaia-lang-hole-fills-design.md), [2026-04-08-gaia-package-hole-bridge-design.md](2026-04-08-gaia-package-hole-bridge-design.md)
 >
 > **Depends on:** [2026-04-02-gaia-registry-design.md](2026-04-02-gaia-registry-design.md), [../foundations/ecosystem/04-registry-operations.md](../foundations/ecosystem/04-registry-operations.md)
+>
+> **Supersedes:** the earlier hole / bridge registry proposal merged via PRs #362 and #364. Open implementation PRs #365 / #366 / #367 target the superseded design and should be replaced rather than merged as-is.
 
 ## 1. Problem
 
@@ -205,6 +207,7 @@ gaia-registry/
 
 ```json
 {
+  "manifest_schema_version": 1,
   "package": "package-a",
   "version": "1.4.0",
   "ir_hash": "sha256:...",
@@ -237,6 +240,7 @@ bridge relation 示例：
 
 ```json
 {
+  "manifest_schema_version": 1,
   "package": "package-b",
   "version": "2.1.0",
   "ir_hash": "sha256:...",
@@ -270,7 +274,8 @@ bridge relation 示例：
 - premise `qid` 必须存在于 compiled IR closure 中
 - `role == "local_hole"` 时，qid 必须属于当前 package
 - `role == "foreign_dependency"` 时，qid 必须属于 foreign package
-- `interface_hash` 必须与 registry 当前 schema version 的计算规则一致
+- `manifest_schema_version` 当前必须等于 `1`
+- `interface_hash` 必须与 registry 当前 `manifest_schema_version` 的计算规则一致
 
 ### 7.2 `holes.json`
 
@@ -361,6 +366,8 @@ bridge relation 示例：
 }
 ```
 
+`index/holes/by-qid/` 是 `index/premises/by-qid/` 在 `role == "local_hole"` 条件下的派生 filter view，不是独立 source of truth。
+
 ### 8.4 `index/bridges/by-target-qid/<shard>/<encoded-qid>.json`
 
 按 target qid 聚合所有 bridge declarations。
@@ -429,7 +436,81 @@ bridge relation 示例：
 
 - `index/bridges/by-source-qid/<qid>.json`
 
-## 10. Scenario Walkthroughs
+## 10. Scale Notes
+
+### 10.1 `index/premises/by-package/<package>.json`
+
+这个文件会随着 release 数量线性增长。
+
+Phase 1 先接受：
+
+- 单 package 一个聚合文件
+
+但应预留触发条件：
+
+- 当单文件超过约 1 MB
+- 或单 package 历史 release 超过约 100 个
+
+时，升级为 version-sharded layout，例如：
+
+```text
+index/premises/by-package/<package>/<version>.json
+```
+
+### 10.2 `index/bridges/by-target-interface/`
+
+`by-target-interface/` 会随着 interface 演化不断产生新文件。
+
+Phase 1 接受这种 key-space 爆炸，因为它换来了最稳的 current-compatibility 查询。  
+但应预留 compacted view：
+
+```text
+index/bridges/by-target-qid/<qid>/all-interfaces.json
+```
+
+用于在单个 qid 拥有大量历史 `interface_hash` 时集中展示 history。
+
+### 10.3 Rebuild Cost
+
+bot 重建 index 的成本最终取决于：
+
+- package 数量
+- 每个 release 的 public premise 数量
+- bridge relation 数量
+
+Phase 1 不要求提前做到精确容量规划，但 registry 设计必须承认：
+
+- `premises` 和 `bridges` 两个 index 族都可能成为高 churn 区域
+- 一旦出现 rebuild 时间或单文件体积问题，优先通过分片与 compacted views 解决，而不是回退到 client-side 全仓扫描
+
+## 11. Phase Rollout
+
+旧的 phased rollout 是：
+
+- Phase 1: `exports.json`
+- Phase 2: `holes.json`
+- Phase 3: `bridges.json`
+
+在新设计下应改为：
+
+- **Phase 1**
+  - 接收 `exports.json`
+  - 接收 `premises.json`
+- **Phase 2**
+  - 接收 `holes.json`
+  - 生成 `index/premises/**` 与 `index/holes/**`
+- **Phase 3**
+  - 接收 `bridges.json`
+  - 生成 `index/bridges/**`
+
+原因：
+
+- `premises.json` 是 `holes.json` 的 source of truth
+- `premises.json` 也是 bridge target validation 的 source of truth
+
+因此 registry 不应再维持“Phase 1 only exports.json”的旧假设。
+
+## 12. Scenario Walkthroughs
 
 ### 10.1 Scenario A: B 直接声明 fills A 的缺口
 
@@ -459,7 +540,7 @@ C 发布 `bridge-package` 后：
 
 A 和 B 本身都不需要修改。
 
-## 11. Non-Goals
+## 13. Non-Goals
 
 - 不做 global canonicalization
 - 不在 registry 层裁决“哪个 bridge 才是真的”


### PR DESCRIPTION
## Summary
- replace the explicit `hole()`-driven contract with compiler-derived public premises
- redefine holes as release-scoped premise roles and add `premises.json` to the package/registry design
- bind bridge relations to target interface snapshots instead of bare hole QIDs

## Supersession
- this proposal supersedes the earlier hole / fills proposal merged via PRs #362 and #364
- the open implementation stack in #365, #366, and #367 targets the superseded design and should be replaced rather than merged as-is
- recommended disposition: close #365 / #366 / #367 after this redesign is accepted, then restart implementation from fresh branches based on the new contract

## Replacement Implementation Plan
- PR-A: update lang authoring and validation around `fills(source, target)` and remove `hole()` as a core source primitive
- PR-B: implement compiler-derived public premise closure, `premises.json`, `interface_hash`, and release-scoped bridge target binding
- PR-C: add dependency manifest resolution and staleness checks for foreign `fills` targets
- PR-D: update `check` / `register` / registry phasing and indexes to consume `premises.json`, then layer `holes.json` and `bridges.json` back in

## Notes
- docs only
- no tests run