### PR TITLE
feat(compile): emit public premise manifests

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import sys
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -12,6 +14,7 @@ from typing import Any
 
 from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
+from gaia.lang.runtime.package import _pyproject_for_module
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
 
 try:
@@ -22,6 +25,9 @@ except ImportError:
 
 class GaiaCliError(RuntimeError):
     """User-facing CLI error."""
+
+
+_MANIFEST_SCHEMA_VERSION = 1
 
 
 @dataclass
@@ -62,6 +68,19 @@ def _assign_labels(module: ModuleType, pkg: CollectedPackage) -> None:
             obj.label = attr
         if isinstance(obj, Strategy) and id(obj) in local_strategy_ids and obj.label is None:
             obj.label = attr
+
+
+def _assign_labels_for_loaded_modules() -> None:
+    for module_name, module in list(sys.modules.items()):
+        if module is None or not isinstance(module_name, str):
+            continue
+        pyproject = _pyproject_for_module(module_name)
+        if pyproject is None:
+            continue
+        pkg = get_inferred_package(pyproject)
+        if pkg is None:
+            continue
+        _assign_labels(module, pkg)
 
 
 def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
@@ -112,7 +131,7 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
             "directly in the module and export the public surface via __all__ when needed."
         )
 
-    _assign_labels(module, pkg)
+    _assign_labels_for_loaded_modules()
 
     # Record exported labels from __all__ for the compiler
     export_names = getattr(module, "__all__", None)
@@ -164,11 +183,209 @@ def compile_loaded_package_artifact(loaded: LoadedGaiaPackage):
     return compile_package_artifact(loaded.package)
 
 
-def write_compiled_artifacts(pkg_path: Path, ir: dict[str, Any]) -> Path:
+def _manifest_package_name(loaded: LoadedGaiaPackage) -> str:
+    return loaded.project_name.removesuffix("-gaia")
+
+
+def _manifest_base(loaded: LoadedGaiaPackage, *, ir_hash: str) -> dict[str, Any]:
+    return {
+        "manifest_schema_version": _MANIFEST_SCHEMA_VERSION,
+        "package": _manifest_package_name(loaded),
+        "version": loaded.project_config["version"],
+        "ir_hash": ir_hash,
+    }
+
+
+def _canonical_json_hash(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return f"sha256:{hashlib.sha256(raw.encode()).hexdigest()}"
+
+
+def _interface_hash(
+    *,
+    qid: str,
+    content_hash: str,
+    role: str,
+    parameters: list[dict[str, Any]],
+) -> str:
+    return _canonical_json_hash(
+        {
+            "manifest_schema_version": _MANIFEST_SCHEMA_VERSION,
+            "qid": qid,
+            "content_hash": content_hash,
+            "role": role,
+            "parameters": parameters,
+        }
+    )
+
+
+def _knowledge_manifest_entry(knowledge) -> dict[str, Any]:
+    entry = {
+        "qid": knowledge.id,
+        "label": knowledge.label,
+        "type": str(knowledge.type),
+        "content": knowledge.content,
+        "content_hash": knowledge.content_hash,
+    }
+    parameters = [parameter.model_dump(mode="json") for parameter in knowledge.parameters]
+    if parameters:
+        entry["parameters"] = parameters
+    return entry
+
+
+def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, dict[str, Any]]:
+    """Build package-level interface manifests from compiled IR plus runtime package state."""
+    graph = compiled.graph
+    knowledge_by_qid = {knowledge.id: knowledge for knowledge in graph.knowledges if knowledge.id}
+    exported_qids = {
+        knowledge.id for knowledge in graph.knowledges if knowledge.id is not None and knowledge.exported
+    }
+    exported_claim_qids = {
+        knowledge.id
+        for knowledge in graph.knowledges
+        if knowledge.id is not None and knowledge.exported and str(knowledge.type) == "claim"
+    }
+
+    exports = [
+        _knowledge_manifest_entry(knowledge)
+        for knowledge in sorted(graph.knowledges, key=lambda item: item.id or "")
+        if knowledge.exported and knowledge.id is not None
+    ]
+
+    local_knowledge_ids = {id(knowledge) for knowledge in loaded.package.knowledge}
+    local_supports_by_conclusion: dict[int, list[Strategy]] = defaultdict(list)
+    downstream_conclusions_by_premise: dict[int, list[Knowledge]] = defaultdict(list)
+    downstream_seen: dict[int, set[int]] = defaultdict(set)
+
+    for strategy in loaded.package.strategies:
+        conclusion = strategy.conclusion
+        if (
+            conclusion is None
+            or conclusion.type != "claim"
+            or id(conclusion) not in local_knowledge_ids
+        ):
+            continue
+        local_supports_by_conclusion[id(conclusion)].append(strategy)
+        for premise in strategy.premises:
+            if premise.type != "claim":
+                continue
+            premise_id = id(premise)
+            conclusion_id = id(conclusion)
+            if conclusion_id in downstream_seen[premise_id]:
+                continue
+            downstream_seen[premise_id].add(conclusion_id)
+            downstream_conclusions_by_premise[premise_id].append(conclusion)
+
+    public_premise_objects: dict[int, Knowledge] = {}
+    visited_supported_claims: set[int] = set()
+
+    def walk_supported_claim(claim_node: Knowledge) -> None:
+        for strategy in local_supports_by_conclusion.get(id(claim_node), []):
+            for premise in strategy.premises:
+                if premise.type != "claim":
+                    continue
+                premise_id = id(premise)
+                if premise_id in local_knowledge_ids and local_supports_by_conclusion.get(premise_id):
+                    if premise_id in visited_supported_claims:
+                        continue
+                    visited_supported_claims.add(premise_id)
+                    walk_supported_claim(premise)
+                    continue
+                public_premise_objects[premise_id] = premise
+
+    exported_claim_roots = [
+        knowledge
+        for knowledge in loaded.package.knowledge
+        if knowledge.type == "claim"
+        and compiled.knowledge_ids_by_object.get(id(knowledge)) in exported_claim_qids
+    ]
+    for root in exported_claim_roots:
+        root_id = id(root)
+        if root_id in visited_supported_claims:
+            continue
+        visited_supported_claims.add(root_id)
+        walk_supported_claim(root)
+
+    premises: list[dict[str, Any]] = []
+    for premise in sorted(
+        public_premise_objects.values(),
+        key=lambda item: compiled.knowledge_ids_by_object.get(id(item), ""),
+    ):
+        premise_qid = compiled.knowledge_ids_by_object.get(id(premise))
+        if premise_qid is None:
+            continue
+        knowledge = knowledge_by_qid.get(premise_qid)
+        if knowledge is None or knowledge.content_hash is None:
+            continue
+        role = "local_hole" if id(premise) in local_knowledge_ids else "foreign_dependency"
+        if premise_qid in exported_claim_qids:
+            required_by = [premise_qid]
+        else:
+            queue: deque[Knowledge] = deque([premise])
+            seen_claims = {id(premise)}
+            required_by_set: set[str] = set()
+            while queue:
+                current = queue.popleft()
+                for conclusion in downstream_conclusions_by_premise.get(id(current), []):
+                    conclusion_id = id(conclusion)
+                    if conclusion_id in seen_claims:
+                        continue
+                    seen_claims.add(conclusion_id)
+                    conclusion_qid = compiled.knowledge_ids_by_object.get(conclusion_id)
+                    if conclusion_qid is None:
+                        continue
+                    if conclusion_qid in exported_claim_qids:
+                        required_by_set.add(conclusion_qid)
+                        continue
+                    queue.append(conclusion)
+            required_by = sorted(required_by_set)
+
+        parameters = [parameter.model_dump(mode="json") for parameter in knowledge.parameters]
+        entry = {
+            "qid": premise_qid,
+            "label": knowledge.label,
+            "content": knowledge.content,
+            "content_hash": knowledge.content_hash,
+            "role": role,
+            "interface_hash": _interface_hash(
+                qid=premise_qid,
+                content_hash=knowledge.content_hash,
+                role=role,
+                parameters=parameters,
+            ),
+            "exported": premise_qid in exported_qids,
+            "required_by": required_by,
+        }
+        if parameters:
+            entry["parameters"] = parameters
+        premises.append(entry)
+
+    manifests = {
+        "exports.json": {
+            **_manifest_base(loaded, ir_hash=graph.ir_hash or ""),
+            "exports": exports,
+        },
+        "premises.json": {
+            **_manifest_base(loaded, ir_hash=graph.ir_hash or ""),
+            "premises": premises,
+        },
+    }
+    return manifests
+
+
+def write_compiled_artifacts(
+    pkg_path: Path, ir: dict[str, Any], *, manifests: dict[str, dict[str, Any]] | None = None
+) -> Path:
     """Write .gaia compilation artifacts and return the output directory."""
     gaia_dir = pkg_path / ".gaia"
     gaia_dir.mkdir(exist_ok=True)
     ir_json = json.dumps(ir, ensure_ascii=False, indent=2, sort_keys=True)
     (gaia_dir / "ir.json").write_text(ir_json)
     (gaia_dir / "ir_hash").write_text(ir["ir_hash"])
+    if manifests:
+        manifests_dir = gaia_dir / "manifests"
+        manifests_dir.mkdir(exist_ok=True)
+        for filename, payload in manifests.items():
+            rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+            (manifests_dir / filename).write_text(rendered)
     return gaia_dir

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -318,27 +318,24 @@ def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, di
         if knowledge is None or knowledge.content_hash is None:
             continue
         role = "local_hole" if id(premise) in local_knowledge_ids else "foreign_dependency"
-        if premise_qid in exported_claim_qids:
-            required_by = [premise_qid]
-        else:
-            queue: deque[Knowledge] = deque([premise])
-            seen_claims = {id(premise)}
-            required_by_set: set[str] = set()
-            while queue:
-                current = queue.popleft()
-                for conclusion in downstream_conclusions_by_premise.get(id(current), []):
-                    conclusion_id = id(conclusion)
-                    if conclusion_id in seen_claims:
-                        continue
-                    seen_claims.add(conclusion_id)
-                    conclusion_qid = compiled.knowledge_ids_by_object.get(conclusion_id)
-                    if conclusion_qid is None:
-                        continue
-                    if conclusion_qid in exported_claim_qids:
-                        required_by_set.add(conclusion_qid)
-                        continue
-                    queue.append(conclusion)
-            required_by = sorted(required_by_set)
+        queue: deque[Knowledge] = deque([premise])
+        seen_claims = {id(premise)}
+        required_by_set: set[str] = set()
+        while queue:
+            current = queue.popleft()
+            for conclusion in downstream_conclusions_by_premise.get(id(current), []):
+                conclusion_id = id(conclusion)
+                if conclusion_id in seen_claims:
+                    continue
+                seen_claims.add(conclusion_id)
+                conclusion_qid = compiled.knowledge_ids_by_object.get(conclusion_id)
+                if conclusion_qid is None:
+                    continue
+                if conclusion_qid in exported_claim_qids:
+                    required_by_set.add(conclusion_qid)
+                    continue
+                queue.append(conclusion)
+        required_by = sorted(required_by_set)
 
         parameters = [parameter.model_dump(mode="json") for parameter in knowledge.parameters]
         entry = {

--- a/gaia/cli/commands/compile.py
+++ b/gaia/cli/commands/compile.py
@@ -6,7 +6,8 @@ import json
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, compile_loaded_package, load_gaia_package
+from gaia.cli._packages import GaiaCliError, build_package_manifests, load_gaia_package
+from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.cli._packages import write_compiled_artifacts
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
@@ -29,7 +30,9 @@ def compile_command(
     """Compile a knowledge package to .gaia/ir.json."""
     try:
         loaded = load_gaia_package(path)
-        ir = compile_loaded_package(loaded)
+        compiled = compile_loaded_package_artifact(loaded)
+        ir = compiled.to_json()
+        manifests = build_package_manifests(loaded, compiled)
     except GaiaCliError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)
@@ -42,7 +45,7 @@ def compile_command(
             typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(1)
 
-    gaia_dir = write_compiled_artifacts(loaded.pkg_path, ir)
+    gaia_dir = write_compiled_artifacts(loaded.pkg_path, ir, manifests=manifests)
 
     typer.echo(
         f"Compiled {len(ir['knowledges'])} knowledge, "

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -39,6 +39,21 @@ def test_compile_creates_ir_json(tmp_path):
     result = validate_local_graph(LocalCanonicalGraph(**ir))
     assert result.valid, result.errors
 
+    exports_manifest = json.loads((gaia_dir / "manifests" / "exports.json").read_text())
+    premises_manifest = json.loads((gaia_dir / "manifests" / "premises.json").read_text())
+    assert exports_manifest["package"] == "test-pkg"
+    assert exports_manifest["version"] == "1.0.0"
+    assert exports_manifest["exports"] == [
+        {
+            "content": "A test claim.",
+            "content_hash": ir["knowledges"][0]["content_hash"],
+            "label": "my_claim",
+            "qid": "github:test_pkg::my_claim",
+            "type": "claim",
+        }
+    ]
+    assert premises_manifest["premises"] == []
+
 
 def test_compile_no_pyproject(tmp_path):
     """Error when no pyproject.toml exists."""
@@ -177,6 +192,111 @@ def test_compile_preserves_structured_steps_and_provenance(tmp_path):
             "premises": ["github:step_pkg::evidence_a", "github:step_pkg::evidence_b"],
         }
     ]
+
+
+def test_compile_emits_public_premise_manifest_for_local_hole(tmp_path):
+    pkg_dir = tmp_path / "premise_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "premise-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "premise_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    premises_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    assert premises_manifest["package"] == "premise-pkg"
+    assert premises_manifest["version"] == "1.0.0"
+    assert len(premises_manifest["premises"]) == 1
+    premise = premises_manifest["premises"][0]
+    assert premise["qid"] == "github:premise_pkg::missing_lemma"
+    assert premise["label"] == "missing_lemma"
+    assert premise["role"] == "local_hole"
+    assert premise["exported"] is False
+    assert premise["required_by"] == ["github:premise_pkg::main_theorem"]
+    assert premise["interface_hash"].startswith("sha256:")
+
+
+def test_compile_marks_foreign_dependency_public_premise(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_pkg_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-pkg-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_pkg"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'dep_result = claim("Dependency theorem.")\n'
+        '__all__ = ["dep_result"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+
+    pkg_dir = tmp_path / "consumer_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "consumer-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "consumer_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n"
+        "from dep_pkg import dep_result\n\n"
+        'main_theorem = claim("Consumer theorem.")\n'
+        "deduction(premises=[dep_result], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    premises_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    assert len(premises_manifest["premises"]) == 1
+    premise = premises_manifest["premises"][0]
+    assert premise["qid"] == "github:dep_pkg::dep_result"
+    assert premise["role"] == "foreign_dependency"
+    assert premise["required_by"] == ["github:consumer_pkg::main_theorem"]
+
+
+def test_compile_public_premise_required_by_uses_nearest_exported_claim(tmp_path):
+    pkg_dir = tmp_path / "nearest_root_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "nearest-root-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "nearest_root_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'shared_premise = claim("Shared premise.")\n'
+        'helper_claim = claim("Helper claim.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[shared_premise], conclusion=helper_claim)\n"
+        "deduction(premises=[helper_claim], conclusion=main_theorem)\n"
+        '__all__ = ["helper_claim", "main_theorem"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    premises_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    assert len(premises_manifest["premises"]) == 1
+    premise = premises_manifest["premises"][0]
+    assert premise["qid"] == "github:nearest_root_pkg::shared_premise"
+    assert premise["required_by"] == ["github:nearest_root_pkg::helper_claim"]
 
 
 def test_compile_named_strategy_uses_ir_canonical_formalization(tmp_path):

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -41,6 +41,8 @@ def test_compile_creates_ir_json(tmp_path):
 
     exports_manifest = json.loads((gaia_dir / "manifests" / "exports.json").read_text())
     premises_manifest = json.loads((gaia_dir / "manifests" / "premises.json").read_text())
+    assert exports_manifest["manifest_schema_version"] == 1
+    assert premises_manifest["manifest_schema_version"] == 1
     assert exports_manifest["package"] == "test-pkg"
     assert exports_manifest["version"] == "1.0.0"
     assert exports_manifest["exports"] == [
@@ -215,6 +217,7 @@ def test_compile_emits_public_premise_manifest_for_local_hole(tmp_path):
     assert result.exit_code == 0, result.output
 
     premises_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    assert premises_manifest["manifest_schema_version"] == 1
     assert premises_manifest["package"] == "premise-pkg"
     assert premises_manifest["version"] == "1.0.0"
     assert len(premises_manifest["premises"]) == 1
@@ -297,6 +300,69 @@ def test_compile_public_premise_required_by_uses_nearest_exported_claim(tmp_path
     premise = premises_manifest["premises"][0]
     assert premise["qid"] == "github:nearest_root_pkg::shared_premise"
     assert premise["required_by"] == ["github:nearest_root_pkg::helper_claim"]
+
+
+def test_compile_exported_public_premise_lists_other_exported_roots(tmp_path):
+    pkg_dir = tmp_path / "exp_premise_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "exp-premise-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "exp_premise_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'shared_premise = claim("Shared premise.")\n'
+        'theorem_a = claim("Theorem A.")\n'
+        'theorem_b = claim("Theorem B.")\n'
+        "deduction(premises=[shared_premise], conclusion=theorem_a)\n"
+        "deduction(premises=[shared_premise], conclusion=theorem_b)\n"
+        '__all__ = ["shared_premise", "theorem_a", "theorem_b"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    premises_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    assert len(premises_manifest["premises"]) == 1
+    premise = premises_manifest["premises"][0]
+    assert premise["qid"] == "github:exp_premise_pkg::shared_premise"
+    assert premise["exported"] is True
+    assert premise["required_by"] == [
+        "github:exp_premise_pkg::theorem_a",
+        "github:exp_premise_pkg::theorem_b",
+    ]
+
+
+def test_compile_interface_hash_is_deterministic(tmp_path):
+    pkg_dir = tmp_path / "deterministic_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "deterministic-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "deterministic_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+
+    first = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert first.exit_code == 0, first.output
+    first_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    first_hash = first_manifest["premises"][0]["interface_hash"]
+
+    second = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert second.exit_code == 0, second.output
+    second_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    second_hash = second_manifest["premises"][0]["interface_hash"]
+
+    assert first_hash == second_hash
 
 
 def test_compile_named_strategy_uses_ir_canonical_formalization(tmp_path):


### PR DESCRIPTION
## Summary
- emit `.gaia/manifests/exports.json` during `gaia compile`
- derive Phase 1 `premises.json` from exported claim roots and local support closure
- classify public premises as `local_hole` or `foreign_dependency` and compute stable `interface_hash`

## Context
This is the second replacement implementation PR after the public-premise redesign in #369.
It intentionally stops at Phase 1 package manifests and does not implement `holes.json`, `bridges.json`, or dependency manifest resolution yet.

## Tests
- `pytest tests/cli/test_compile.py tests/gaia/lang/test_compiler.py tests/gaia/lang/test_strategies.py tests/gaia/lang/test_core.py -q`
- `pytest tests/cli/test_check.py tests/cli/test_register.py -q`
