### PR TITLE
feat(cli): validate fills targets against dependency manifests

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -16,6 +16,7 @@ from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
 from gaia.lang.runtime.package import _pyproject_for_module
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
+from packaging.requirements import InvalidRequirement, Requirement
 
 try:
     import tomllib
@@ -219,6 +220,161 @@ def _interface_hash(
     )
 
 
+def _distribution_name(import_name: str) -> str:
+    return f"{import_name.replace('_', '-')}-gaia"
+
+
+def _parse_gaia_dependencies(project_config: dict[str, Any]) -> dict[str, str]:
+    dependencies = project_config.get("dependencies", [])
+    if not isinstance(dependencies, list):
+        raise GaiaCliError("Error: [project].dependencies must be a list if set.")
+    parsed: dict[str, str] = {}
+    for raw in dependencies:
+        if not isinstance(raw, str):
+            raise GaiaCliError("Error: [project].dependencies entries must be strings.")
+        try:
+            requirement = Requirement(raw)
+        except InvalidRequirement as exc:
+            raise GaiaCliError(f"Error: invalid dependency requirement '{raw}': {exc}") from exc
+        if requirement.name.endswith("-gaia"):
+            parsed[requirement.name] = str(requirement.specifier) or "*"
+    return parsed
+
+
+def _import_module(import_name: str) -> ModuleType:
+    module = sys.modules.get(import_name)
+    if module is not None:
+        return module
+    return importlib.import_module(import_name)
+
+
+def _load_json_file(path: Path, *, description: str) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise GaiaCliError(f"Error: {description} is not valid JSON: {exc}") from exc
+
+
+def _locate_dependency_manifest_root(import_name: str) -> Path | None:
+    pyproject = _pyproject_for_module(import_name)
+    if pyproject is not None:
+        return pyproject.parent
+
+    module = _import_module(import_name)
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        return None
+    module_path = Path(module_file).resolve()
+    package_dir = module_path.parent
+    candidates = [package_dir, package_dir.parent, package_dir.parent.parent]
+    for candidate in candidates:
+        if (candidate / ".gaia" / "manifests" / "premises.json").exists():
+            return candidate
+    return None
+
+
+def _validate_dependency_manifest_freshness(import_name: str, root: Path, stored_ir_hash: str) -> None:
+    pyproject = root / "pyproject.toml"
+    if not pyproject.exists():
+        return
+    loaded = load_gaia_package(root)
+    compiled = compile_loaded_package_artifact(loaded)
+    current_ir_hash = compiled.graph.ir_hash or ""
+    if current_ir_hash != stored_ir_hash:
+        raise GaiaCliError(
+            f"Error: dependency '{import_name}' has stale .gaia manifests; "
+            f"run `gaia compile` in {root}."
+        )
+
+
+def _resolve_dependency_premises_manifest(import_name: str) -> tuple[Path, dict[str, Any]]:
+    root = _locate_dependency_manifest_root(import_name)
+    if root is None:
+        raise GaiaCliError(
+            f"Error: could not locate Gaia package root for dependency '{import_name}'."
+        )
+    premises_path = root / ".gaia" / "manifests" / "premises.json"
+    if not premises_path.exists():
+        raise GaiaCliError(
+            f"Error: dependency '{import_name}' is missing .gaia/manifests/premises.json; "
+            f"run `gaia compile` in {root}."
+        )
+    premises_manifest = _load_json_file(
+        premises_path,
+        description=f"{import_name} dependency manifest {premises_path}",
+    )
+    stored_ir_hash = premises_manifest.get("ir_hash")
+    if not isinstance(stored_ir_hash, str) or not stored_ir_hash:
+        raise GaiaCliError(f"Error: dependency manifest {premises_path} is missing ir_hash.")
+    _validate_dependency_manifest_freshness(import_name, root, stored_ir_hash)
+    return root, premises_manifest
+
+
+def _validate_fills_relations(loaded: LoadedGaiaPackage, compiled) -> None:
+    dependency_specs = _parse_gaia_dependencies(loaded.project_config)
+    local_package = loaded.package
+
+    for strategy in loaded.package.strategies:
+        relation = strategy.metadata.get("gaia", {}).get("relation", {})
+        if relation.get("type") != "fills":
+            continue
+        if len(strategy.premises) != 1 or strategy.conclusion is None:
+            raise GaiaCliError("Error: fills() strategies must have exactly one source and one target.")
+
+        source = strategy.premises[0]
+        target = strategy.conclusion
+        source_owner = source._package
+        target_owner = target._package
+
+        if target_owner is None or target_owner == local_package:
+            raise GaiaCliError(
+                "Error: fills() target must be a foreign claim resolved from a dependency package."
+            )
+
+        if source_owner is not None and source_owner != local_package:
+            source_dist = _distribution_name(source_owner.name)
+            if source_dist not in dependency_specs:
+                raise GaiaCliError(
+                    f"Error: fills() source dependency '{source_dist}' is not declared in "
+                    "[project].dependencies."
+                )
+
+        target_dist = _distribution_name(target_owner.name)
+        if target_dist not in dependency_specs:
+            raise GaiaCliError(
+                f"Error: fills() target dependency '{target_dist}' is not declared in "
+                "[project].dependencies."
+            )
+
+        _, premises_manifest = _resolve_dependency_premises_manifest(target_owner.name)
+        premises = premises_manifest.get("premises", [])
+        if not isinstance(premises, list):
+            raise GaiaCliError("Error: dependency premises manifest must contain a premises list.")
+
+        target_qid = compiled.knowledge_ids_by_object.get(id(target))
+        if target_qid is None:
+            raise GaiaCliError("Error: could not resolve fills() target QID during compile.")
+
+        entry = next(
+            (
+                premise
+                for premise in premises
+                if isinstance(premise, dict) and premise.get("qid") == target_qid
+            ),
+            None,
+        )
+        if entry is None:
+            raise GaiaCliError(
+                f"Error: fills() target '{target_qid}' is not a public premise in dependency "
+                f"'{target_owner.name}'."
+            )
+        if entry.get("role") != "local_hole":
+            raise GaiaCliError(
+                f"Error: fills() target '{target_qid}' must resolve to a dependency local_hole, "
+                f"found role={entry.get('role')!r}."
+            )
+
+
 def _knowledge_manifest_entry(knowledge) -> dict[str, Any]:
     entry = {
         "qid": knowledge.id,
@@ -235,6 +391,7 @@ def _knowledge_manifest_entry(knowledge) -> dict[str, Any]:
 
 def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, dict[str, Any]]:
     """Build package-level interface manifests from compiled IR plus runtime package state."""
+    _validate_fills_relations(loaded, compiled)
     graph = compiled.graph
     knowledge_by_qid = {knowledge.id: knowledge for knowledge in graph.knowledges if knowledge.id}
     exported_qids = {

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -6,7 +6,8 @@ import json
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, compile_loaded_package, load_gaia_package
+from gaia.cli._packages import GaiaCliError, build_package_manifests, load_gaia_package
+from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.cli.commands._classify import classify_ir, node_role
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
@@ -90,7 +91,9 @@ def check_command(
     """Validate structure and artifact consistency for a Gaia knowledge package."""
     try:
         loaded = load_gaia_package(path)
-        ir = compile_loaded_package(loaded)
+        compiled = compile_loaded_package_artifact(loaded)
+        ir = compiled.to_json()
+        build_package_manifests(loaded, compiled)
     except GaiaCliError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -10,7 +10,8 @@ from uuid import UUID
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, compile_loaded_package, load_gaia_package
+from gaia.cli._packages import GaiaCliError, build_package_manifests, load_gaia_package
+from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
 
@@ -187,7 +188,9 @@ def register_command(
     """Prepare or submit a registration for a tagged GitHub-backed Gaia package."""
     try:
         loaded = load_gaia_package(path)
-        ir = compile_loaded_package(loaded)
+        compiled = compile_loaded_package_artifact(loaded)
+        ir = compiled.to_json()
+        build_package_manifests(loaded, compiled)
     except GaiaCliError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -52,3 +52,45 @@ def test_check_fails_when_compiled_artifacts_are_stale(tmp_path):
     result = runner.invoke(app, ["check", str(pkg_dir)])
     assert result.exit_code != 0
     assert "stale" in result.output.lower()
+
+
+def test_check_fails_on_invalid_fills_target(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_check_missing_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-check-missing-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_check_missing"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+
+    pkg_dir = tmp_path / "check_demo"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "check-demo-gaia"\n'
+        'version = "1.2.0"\n'
+        'dependencies = ["dep-check-missing-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "check_demo"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_check_missing import missing_lemma\n\n"
+        'main_claim = claim("A test claim.")\n'
+        "fills(source=main_claim, target=missing_lemma)\n"
+        '__all__ = ["main_claim"]\n'
+    )
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "missing .gaia/manifests/premises.json" in result.output

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -365,6 +365,266 @@ def test_compile_interface_hash_is_deterministic(tmp_path):
     assert first_hash == second_hash
 
 
+def test_compile_fills_validates_foreign_local_hole_target(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_pkg_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-pkg-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_pkg"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    dep_compile = runner.invoke(app, ["compile", str(dep_dir)])
+    assert dep_compile.exit_code == 0, dep_compile.output
+
+    consumer_dir = tmp_path / "consumer_pkg"
+    consumer_dir.mkdir()
+    (consumer_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "consumer-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-pkg-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    consumer_src = consumer_dir / "consumer_pkg"
+    consumer_src.mkdir()
+    (consumer_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_pkg import missing_lemma\n\n"
+        'b_result = claim("B theorem.")\n'
+        'bridge = fills(source=b_result, target=missing_lemma, reason="Theorem 3 establishes A.")\n'
+        '__all__ = ["b_result", "bridge"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(consumer_dir)])
+    assert result.exit_code == 0, result.output
+
+
+def test_compile_fills_requires_dependency_manifest(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_missing_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-missing-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_missing"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+
+    consumer_dir = tmp_path / "consumer_pkg"
+    consumer_dir.mkdir()
+    (consumer_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "consumer-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-missing-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    consumer_src = consumer_dir / "consumer_pkg"
+    consumer_src.mkdir()
+    (consumer_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_missing import missing_lemma\n\n"
+        'b_result = claim("B theorem.")\n'
+        "fills(source=b_result, target=missing_lemma)\n"
+        '__all__ = ["b_result"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(consumer_dir)])
+    assert result.exit_code != 0
+    assert "missing .gaia/manifests/premises.json" in result.output
+
+
+def test_compile_fills_rejects_stale_dependency_manifest(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_pkg_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-pkg-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_pkg"
+    dep_src.mkdir(parents=True)
+    dep_init = dep_src / "__init__.py"
+    dep_init.write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    dep_compile = runner.invoke(app, ["compile", str(dep_dir)])
+    assert dep_compile.exit_code == 0, dep_compile.output
+
+    dep_init.write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("An updated missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+
+    consumer_dir = tmp_path / "consumer_pkg"
+    consumer_dir.mkdir()
+    (consumer_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "consumer-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-pkg-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    consumer_src = consumer_dir / "consumer_pkg"
+    consumer_src.mkdir()
+    (consumer_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_pkg import missing_lemma\n\n"
+        'b_result = claim("B theorem.")\n'
+        "fills(source=b_result, target=missing_lemma)\n"
+        '__all__ = ["b_result"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(consumer_dir)])
+    assert result.exit_code != 0
+    assert "stale .gaia manifests" in result.output
+
+
+def test_compile_fills_rejects_target_that_is_not_public_hole(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_pkg_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-pkg-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_pkg"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'dep_result = claim("Dependency theorem.")\n'
+        '__all__ = ["dep_result"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    dep_compile = runner.invoke(app, ["compile", str(dep_dir)])
+    assert dep_compile.exit_code == 0, dep_compile.output
+
+    consumer_dir = tmp_path / "consumer_pkg"
+    consumer_dir.mkdir()
+    (consumer_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "consumer-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-pkg-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    consumer_src = consumer_dir / "consumer_pkg"
+    consumer_src.mkdir()
+    (consumer_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_pkg import dep_result\n\n"
+        'b_result = claim("B theorem.")\n'
+        "fills(source=b_result, target=dep_result)\n"
+        '__all__ = ["b_result"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(consumer_dir)])
+    assert result.exit_code != 0
+    assert "is not a public premise" in result.output
+
+
+def test_compile_fills_requires_foreign_target(tmp_path):
+    pkg_dir = tmp_path / "local_fills_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "local-fills-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "local_fills_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n\n"
+        'source_claim = claim("Source theorem.")\n'
+        'target_claim = claim("Local target.")\n'
+        "fills(source=source_claim, target=target_claim)\n"
+        '__all__ = ["source_claim"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "target must be a foreign claim" in result.output
+
+
+def test_compile_bridge_package_requires_source_dependency_declaration(tmp_path, monkeypatch):
+    dep_a_dir = tmp_path / "dep_a_root"
+    dep_a_dir.mkdir()
+    (dep_a_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-a-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_a_src = dep_a_dir / "src" / "dep_a"
+    dep_a_src.mkdir(parents=True)
+    (dep_a_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+
+    dep_b_dir = tmp_path / "dep_b_root"
+    dep_b_dir.mkdir()
+    (dep_b_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-b-gaia"\nversion = "0.5.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_b_src = dep_b_dir / "src" / "dep_b"
+    dep_b_src.mkdir(parents=True)
+    (dep_b_src / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'b_result = claim("B theorem.")\n'
+        '__all__ = ["b_result"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_a_dir / "src"))
+    monkeypatch.syspath_prepend(str(dep_b_dir / "src"))
+    assert runner.invoke(app, ["compile", str(dep_a_dir)]).exit_code == 0
+    assert runner.invoke(app, ["compile", str(dep_b_dir)]).exit_code == 0
+
+    bridge_dir = tmp_path / "bridge_pkg"
+    bridge_dir.mkdir()
+    (bridge_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "bridge-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-a-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    bridge_src = bridge_dir / "bridge_pkg"
+    bridge_src.mkdir()
+    (bridge_src / "__init__.py").write_text(
+        "from gaia.lang import fills\n"
+        "from dep_a import missing_lemma\n"
+        "from dep_b import b_result\n\n"
+        "fills(source=b_result, target=missing_lemma)\n"
+    )
+
+    result = runner.invoke(app, ["compile", str(bridge_dir)])
+    assert result.exit_code != 0
+    assert "source dependency 'dep-b-gaia' is not declared" in result.output
+
+
 def test_compile_named_strategy_uses_ir_canonical_formalization(tmp_path):
     """Named strategies should be formalized through gaia.ir.formalize during compile."""
     pkg_dir = tmp_path / "abduction_pkg"

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -137,3 +137,67 @@ def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
         _run(["git", "branch", "--show-current"], cwd=registry_dir)
         == "register/register-demo-1.2.0"
     )
+
+
+def test_register_fails_on_invalid_fills_target(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_register_missing_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-register-missing-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_register_missing"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+
+    pkg_dir = tmp_path / "register_demo"
+    remote_dir = tmp_path / "register_demo_remote.git"
+    _write_package(pkg_dir)
+    (pkg_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "register-demo-gaia"\n'
+        'version = "1.2.0"\n'
+        'description = "Registration demo"\n'
+        "dependencies = [\n"
+        '  "gaia-lang>=0.1.0",\n'
+        '  "dep-register-missing-gaia >= 0.4.0",\n'
+        "]\n\n"
+        "[tool.gaia]\n"
+        'namespace = "github"\n'
+        'type = "knowledge-package"\n'
+        'uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"\n'
+    )
+    (pkg_dir / "register_demo" / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_register_missing import missing_lemma\n\n"
+        'exported_claim = claim("A release-ready claim.")\n'
+        "fills(source=exported_claim, target=missing_lemma)\n"
+        '__all__ = ["exported_claim"]\n'
+    )
+    _init_git_repo(pkg_dir, remote_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code != 0
+    assert "missing .gaia/manifests/premises.json" in compile_result.output
+
+    _run(["git", "tag", "v1.2.0"], cwd=pkg_dir)
+    _run(["git", "push", "origin", "v1.2.0"], cwd=pkg_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "register",
+            str(pkg_dir),
+            "--repo",
+            "https://github.com/example/RegisterDemo.gaia",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "missing .gaia/manifests/premises.json" in result.output


### PR DESCRIPTION
## Summary
- validate `fills()` source/target dependencies against `[project].dependencies`
- require `fills()` targets to resolve to foreign `local_hole` entries in dependency `premises.json`
- fail fast on missing or stale dependency manifests across `compile`, `check`, and `register`

## Context
This is the third replacement implementation PR after the public-premise redesign in #369.
It adds dependency manifest resolution and compile-time `fills` validation, but still stops short of emitting `bridges.json`.

## Tests
- `pytest tests/cli/test_compile.py tests/cli/test_check.py tests/cli/test_register.py -q`
- `pytest tests/gaia/lang/test_core.py tests/gaia/lang/test_strategies.py tests/gaia/lang/test_compiler.py tests/cli/test_compile.py tests/cli/test_check.py tests/cli/test_register.py -q`
