### PR TITLE
feat(compile): emit hole and bridge manifests

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -310,9 +310,47 @@ def _resolve_dependency_premises_manifest(import_name: str) -> tuple[Path, dict[
     return root, premises_manifest
 
 
-def _validate_fills_relations(loaded: LoadedGaiaPackage, compiled) -> None:
+def _reason_to_text(reason: Any) -> str | None:
+    if isinstance(reason, str):
+        return reason or None
+    if not isinstance(reason, list):
+        return None
+    parts: list[str] = []
+    for entry in reason:
+        if isinstance(entry, str):
+            if entry:
+                parts.append(entry)
+            continue
+        text = getattr(entry, "reason", None)
+        if isinstance(text, str) and text:
+            parts.append(text)
+    return "\n\n".join(parts) or None
+
+
+def _relation_id(
+    *,
+    declaring_package: str,
+    declaring_version: str,
+    source_qid: str,
+    source_content_hash: str,
+    target_qid: str,
+    target_interface_hash: str,
+    relation_type: str,
+) -> str:
+    raw = (
+        f"{declaring_package}|{declaring_version}|{source_qid}|{source_content_hash}|"
+        f"{target_qid}|{target_interface_hash}|{relation_type}"
+    )
+    return f"bridge_{hashlib.sha256(raw.encode()).hexdigest()[:16]}"
+
+
+def _resolve_fills_relations(loaded: LoadedGaiaPackage, compiled) -> list[dict[str, Any]]:
     dependency_specs = _parse_gaia_dependencies(loaded.project_config)
     local_package = loaded.package
+    knowledge_by_qid = {knowledge.id: knowledge for knowledge in compiled.graph.knowledges if knowledge.id}
+    dependency_manifest_cache: dict[str, dict[str, Any]] = {}
+    relations: list[dict[str, Any]] = []
+    seen_relation_keys: set[tuple[str, str, str]] = set()
 
     for strategy in loaded.package.strategies:
         relation = strategy.metadata.get("gaia", {}).get("relation", {})
@@ -346,14 +384,22 @@ def _validate_fills_relations(loaded: LoadedGaiaPackage, compiled) -> None:
                 "[project].dependencies."
             )
 
-        _, premises_manifest = _resolve_dependency_premises_manifest(target_owner.name)
+        premises_manifest = dependency_manifest_cache.get(target_owner.name)
+        if premises_manifest is None:
+            _, premises_manifest = _resolve_dependency_premises_manifest(target_owner.name)
+            dependency_manifest_cache[target_owner.name] = premises_manifest
         premises = premises_manifest.get("premises", [])
         if not isinstance(premises, list):
             raise GaiaCliError("Error: dependency premises manifest must contain a premises list.")
 
+        source_qid = compiled.knowledge_ids_by_object.get(id(source))
         target_qid = compiled.knowledge_ids_by_object.get(id(target))
-        if target_qid is None:
-            raise GaiaCliError("Error: could not resolve fills() target QID during compile.")
+        if source_qid is None or target_qid is None:
+            raise GaiaCliError("Error: could not resolve fills() source/target QID during compile.")
+
+        source_knowledge = knowledge_by_qid.get(source_qid)
+        if source_knowledge is None or source_knowledge.content_hash is None:
+            raise GaiaCliError(f"Error: could not resolve source content hash for '{source_qid}'.")
 
         entry = next(
             (
@@ -374,6 +420,61 @@ def _validate_fills_relations(loaded: LoadedGaiaPackage, compiled) -> None:
                 f"found role={entry.get('role')!r}."
             )
 
+        target_interface_hash = entry.get("interface_hash")
+        if not isinstance(target_interface_hash, str) or not target_interface_hash:
+            raise GaiaCliError(
+                f"Error: dependency premise '{target_qid}' is missing interface_hash."
+            )
+        target_resolved_version = premises_manifest.get("version")
+        if not isinstance(target_resolved_version, str) or not target_resolved_version:
+            raise GaiaCliError(
+                f"Error: dependency premises manifest for '{target_owner.name}' is missing version."
+            )
+        target_package = premises_manifest.get("package")
+        if not isinstance(target_package, str) or not target_package:
+            raise GaiaCliError(
+                f"Error: dependency premises manifest for '{target_owner.name}' is missing package."
+            )
+
+        relation_key = (source_qid, target_qid, target_interface_hash)
+        if relation_key in seen_relation_keys:
+            raise GaiaCliError(
+                f"Error: duplicate fills() relation for source '{source_qid}' and target "
+                f"'{target_qid}' on interface '{target_interface_hash}'."
+            )
+        seen_relation_keys.add(relation_key)
+
+        relation_type = str(relation.get("type"))
+        justification = _reason_to_text(strategy.reason)
+        relation_record = {
+            "relation_id": _relation_id(
+                declaring_package=_manifest_package_name(loaded),
+                declaring_version=loaded.project_config["version"],
+                source_qid=source_qid,
+                source_content_hash=source_knowledge.content_hash,
+                target_qid=target_qid,
+                target_interface_hash=target_interface_hash,
+                relation_type=relation_type,
+            ),
+            "relation_type": relation_type,
+            "source_qid": source_qid,
+            "source_content_hash": source_knowledge.content_hash,
+            "target_qid": target_qid,
+            "target_package": target_package,
+            "target_dependency_req": dependency_specs[target_dist],
+            "target_resolved_version": target_resolved_version,
+            "target_role": entry["role"],
+            "target_interface_hash": target_interface_hash,
+            "strength": relation.get("strength"),
+            "mode": relation.get("mode"),
+            "declared_by_owner_of_source": source_owner == local_package,
+        }
+        if justification:
+            relation_record["justification"] = justification
+        relations.append(relation_record)
+
+    return sorted(relations, key=lambda item: item["relation_id"])
+
 
 def _knowledge_manifest_entry(knowledge) -> dict[str, Any]:
     entry = {
@@ -391,7 +492,7 @@ def _knowledge_manifest_entry(knowledge) -> dict[str, Any]:
 
 def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, dict[str, Any]]:
     """Build package-level interface manifests from compiled IR plus runtime package state."""
-    _validate_fills_relations(loaded, compiled)
+    fills_relations = _resolve_fills_relations(loaded, compiled)
     graph = compiled.graph
     knowledge_by_qid = {knowledge.id: knowledge for knowledge in graph.knowledges if knowledge.id}
     exported_qids = {
@@ -514,6 +615,16 @@ def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, di
             entry["parameters"] = parameters
         premises.append(entry)
 
+    holes = [
+        {
+            key: value
+            for key, value in premise.items()
+            if key != "role" and key != "exported"
+        }
+        for premise in premises
+        if premise["role"] == "local_hole"
+    ]
+
     manifests = {
         "exports.json": {
             **_manifest_base(loaded, ir_hash=graph.ir_hash or ""),
@@ -522,6 +633,14 @@ def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, di
         "premises.json": {
             **_manifest_base(loaded, ir_hash=graph.ir_hash or ""),
             "premises": premises,
+        },
+        "holes.json": {
+            **_manifest_base(loaded, ir_hash=graph.ir_hash or ""),
+            "holes": holes,
+        },
+        "bridges.json": {
+            **_manifest_base(loaded, ir_hash=graph.ir_hash or ""),
+            "bridges": fills_relations,
         },
     }
     return manifests

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -43,6 +43,8 @@ def test_compile_creates_ir_json(tmp_path):
     premises_manifest = json.loads((gaia_dir / "manifests" / "premises.json").read_text())
     assert exports_manifest["manifest_schema_version"] == 1
     assert premises_manifest["manifest_schema_version"] == 1
+    holes_manifest = json.loads((gaia_dir / "manifests" / "holes.json").read_text())
+    bridges_manifest = json.loads((gaia_dir / "manifests" / "bridges.json").read_text())
     assert exports_manifest["package"] == "test-pkg"
     assert exports_manifest["version"] == "1.0.0"
     assert exports_manifest["exports"] == [
@@ -55,6 +57,8 @@ def test_compile_creates_ir_json(tmp_path):
         }
     ]
     assert premises_manifest["premises"] == []
+    assert holes_manifest["holes"] == []
+    assert bridges_manifest["bridges"] == []
 
 
 def test_compile_no_pyproject(tmp_path):
@@ -218,6 +222,7 @@ def test_compile_emits_public_premise_manifest_for_local_hole(tmp_path):
 
     premises_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
     assert premises_manifest["manifest_schema_version"] == 1
+    holes_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "holes.json").read_text())
     assert premises_manifest["package"] == "premise-pkg"
     assert premises_manifest["version"] == "1.0.0"
     assert len(premises_manifest["premises"]) == 1
@@ -228,6 +233,16 @@ def test_compile_emits_public_premise_manifest_for_local_hole(tmp_path):
     assert premise["exported"] is False
     assert premise["required_by"] == ["github:premise_pkg::main_theorem"]
     assert premise["interface_hash"].startswith("sha256:")
+    assert holes_manifest["holes"] == [
+        {
+            "content": "A missing lemma.",
+            "content_hash": premise["content_hash"],
+            "interface_hash": premise["interface_hash"],
+            "label": "missing_lemma",
+            "qid": "github:premise_pkg::missing_lemma",
+            "required_by": ["github:premise_pkg::main_theorem"],
+        }
+    ]
 
 
 def test_compile_marks_foreign_dependency_public_premise(tmp_path, monkeypatch):
@@ -406,6 +421,23 @@ def test_compile_fills_validates_foreign_local_hole_target(tmp_path, monkeypatch
 
     result = runner.invoke(app, ["compile", str(consumer_dir)])
     assert result.exit_code == 0, result.output
+
+    bridges_manifest = json.loads((consumer_dir / ".gaia" / "manifests" / "bridges.json").read_text())
+    assert len(bridges_manifest["bridges"]) == 1
+    relation = bridges_manifest["bridges"][0]
+    assert relation["relation_type"] == "fills"
+    assert relation["source_qid"] == "github:consumer_pkg::b_result"
+    assert relation["target_qid"] == "github:dep_pkg::missing_lemma"
+    assert relation["target_package"] == "dep-pkg"
+    assert relation["target_dependency_req"] == ">=0.4.0"
+    assert relation["target_resolved_version"] == "0.4.0"
+    assert relation["target_role"] == "local_hole"
+    assert relation["strength"] == "exact"
+    assert relation["mode"] == "deduction"
+    assert relation["declared_by_owner_of_source"] is True
+    assert relation["justification"] == "Theorem 3 establishes A."
+    assert relation["relation_id"].startswith("bridge_")
+    assert relation["target_interface_hash"].startswith("sha256:")
 
 
 def test_compile_fills_requires_dependency_manifest(tmp_path, monkeypatch):
@@ -623,6 +655,116 @@ def test_compile_bridge_package_requires_source_dependency_declaration(tmp_path,
     result = runner.invoke(app, ["compile", str(bridge_dir)])
     assert result.exit_code != 0
     assert "source dependency 'dep-b-gaia' is not declared" in result.output
+
+
+def test_compile_bridge_package_emits_declared_by_owner_false(tmp_path, monkeypatch):
+    dep_a_dir = tmp_path / "dep_a_root"
+    dep_a_dir.mkdir()
+    (dep_a_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-a-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_a_src = dep_a_dir / "src" / "dep_a"
+    dep_a_src.mkdir(parents=True)
+    (dep_a_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+
+    dep_b_dir = tmp_path / "dep_b_root"
+    dep_b_dir.mkdir()
+    (dep_b_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-b-gaia"\nversion = "0.5.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_b_src = dep_b_dir / "src" / "dep_b"
+    dep_b_src.mkdir(parents=True)
+    (dep_b_src / "__init__.py").write_text(
+        'from gaia.lang import claim\n\n'
+        'b_result = claim("B theorem.")\n'
+        '__all__ = ["b_result"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_a_dir / "src"))
+    monkeypatch.syspath_prepend(str(dep_b_dir / "src"))
+    assert runner.invoke(app, ["compile", str(dep_a_dir)]).exit_code == 0
+    assert runner.invoke(app, ["compile", str(dep_b_dir)]).exit_code == 0
+
+    bridge_dir = tmp_path / "bridge_pkg"
+    bridge_dir.mkdir()
+    (bridge_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "bridge-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-a-gaia>=0.4.0", "dep-b-gaia>=0.5.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    bridge_src = bridge_dir / "bridge_pkg"
+    bridge_src.mkdir()
+    (bridge_src / "__init__.py").write_text(
+        "from gaia.lang import fills\n"
+        "from dep_a import missing_lemma\n"
+        "from dep_b import b_result\n\n"
+        'bridge = fills(source=b_result, target=missing_lemma, reason="Third-party bridge.")\n'
+        '__all__ = ["bridge"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(bridge_dir)])
+    assert result.exit_code == 0, result.output
+
+    bridges_manifest = json.loads((bridge_dir / ".gaia" / "manifests" / "bridges.json").read_text())
+    assert len(bridges_manifest["bridges"]) == 1
+    relation = bridges_manifest["bridges"][0]
+    assert relation["source_qid"] == "github:dep_b::b_result"
+    assert relation["target_qid"] == "github:dep_a::missing_lemma"
+    assert relation["declared_by_owner_of_source"] is False
+    assert relation["target_dependency_req"] == ">=0.4.0"
+
+
+def test_compile_rejects_duplicate_fills_relation(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_pkg_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-pkg-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_pkg"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    assert runner.invoke(app, ["compile", str(dep_dir)]).exit_code == 0
+
+    consumer_dir = tmp_path / "consumer_pkg"
+    consumer_dir.mkdir()
+    (consumer_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "consumer-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-pkg-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    consumer_src = consumer_dir / "consumer_pkg"
+    consumer_src.mkdir()
+    (consumer_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_pkg import missing_lemma\n\n"
+        'b_result = claim("B theorem.")\n'
+        "fills(source=b_result, target=missing_lemma)\n"
+        "fills(source=b_result, target=missing_lemma, reason=\"duplicate\")\n"
+        '__all__ = ["b_result"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(consumer_dir)])
+    assert result.exit_code != 0
+    assert "duplicate fills() relation" in result.output
 
 
 def test_compile_named_strategy_uses_ir_canonical_formalization(tmp_path):

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -317,18 +317,18 @@ def test_compile_public_premise_required_by_uses_nearest_exported_claim(tmp_path
     assert premise["required_by"] == ["github:nearest_root_pkg::helper_claim"]
 
 
-def test_compile_exported_public_premise_lists_other_exported_roots(tmp_path):
-    pkg_dir = tmp_path / "exp_premise_pkg"
+def test_compile_exported_local_hole_required_by_lists_downstream_exports(tmp_path):
+    pkg_dir = tmp_path / "exported_hole_pkg"
     pkg_dir.mkdir()
     (pkg_dir / "pyproject.toml").write_text(
-        '[project]\nname = "exp-premise-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[project]\nname = "exported-hole-pkg-gaia"\nversion = "1.0.0"\n\n'
         '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
     )
-    pkg_src = pkg_dir / "exp_premise_pkg"
+    pkg_src = pkg_dir / "exported_hole_pkg"
     pkg_src.mkdir()
     (pkg_src / "__init__.py").write_text(
         "from gaia.lang import claim, deduction\n\n"
-        'shared_premise = claim("Shared premise.")\n'
+        'shared_premise = claim("Shared premise exported as hole.")\n'
         'theorem_a = claim("Theorem A.")\n'
         'theorem_b = claim("Theorem B.")\n'
         "deduction(premises=[shared_premise], conclusion=theorem_a)\n"
@@ -340,16 +340,30 @@ def test_compile_exported_public_premise_lists_other_exported_roots(tmp_path):
     assert result.exit_code == 0, result.output
 
     premises_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "premises.json").read_text())
+    holes_manifest = json.loads((pkg_dir / ".gaia" / "manifests" / "holes.json").read_text())
     assert len(premises_manifest["premises"]) == 1
     premise = premises_manifest["premises"][0]
-    assert premise["qid"] == "github:exp_premise_pkg::shared_premise"
+    assert premise["qid"] == "github:exported_hole_pkg::shared_premise"
     assert premise["exported"] is True
     assert premise["required_by"] == [
-        "github:exp_premise_pkg::theorem_a",
-        "github:exp_premise_pkg::theorem_b",
+        "github:exported_hole_pkg::theorem_a",
+        "github:exported_hole_pkg::theorem_b",
     ]
-
-
+    assert holes_manifest["holes"] == [
+        {
+            "content": "Shared premise exported as hole.",
+            "content_hash": premise["content_hash"],
+            "interface_hash": premise["interface_hash"],
+            "label": "shared_premise",
+            "qid": "github:exported_hole_pkg::shared_premise",
+            "required_by": [
+                "github:exported_hole_pkg::theorem_a",
+                "github:exported_hole_pkg::theorem_b",
+            ],
+        }
+    ]
+ 
+ 
 def test_compile_interface_hash_is_deterministic(tmp_path):
     pkg_dir = tmp_path / "deterministic_pkg"
     pkg_dir.mkdir()
@@ -378,8 +392,6 @@ def test_compile_interface_hash_is_deterministic(tmp_path):
     second_hash = second_manifest["premises"][0]["interface_hash"]
 
     assert first_hash == second_hash
-
-
 def test_compile_fills_validates_foreign_local_hole_target(tmp_path, monkeypatch):
     dep_dir = tmp_path / "dep_pkg_root"
     dep_dir.mkdir()
@@ -438,6 +450,56 @@ def test_compile_fills_validates_foreign_local_hole_target(tmp_path, monkeypatch
     assert relation["justification"] == "Theorem 3 establishes A."
     assert relation["relation_id"].startswith("bridge_")
     assert relation["target_interface_hash"].startswith("sha256:")
+
+
+def test_compile_fills_emits_conditional_infer_bridge_metadata(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_pkg_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "dep-pkg-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_pkg"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    dep_compile = runner.invoke(app, ["compile", str(dep_dir)])
+    assert dep_compile.exit_code == 0, dep_compile.output
+
+    consumer_dir = tmp_path / "consumer_pkg"
+    consumer_dir.mkdir()
+    (consumer_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "consumer-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["dep-pkg-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    consumer_src = consumer_dir / "consumer_pkg"
+    consumer_src.mkdir()
+    (consumer_src / "__init__.py").write_text(
+        "from gaia.lang import claim, fills\n"
+        "from dep_pkg import missing_lemma\n\n"
+        'b_result = claim("B theorem.")\n'
+        'bridge = fills(source=b_result, target=missing_lemma, strength="conditional", mode="infer", reason="Only under extra assumptions.")\n'
+        '__all__ = ["b_result", "bridge"]\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(consumer_dir)])
+    assert result.exit_code == 0, result.output
+
+    bridges_manifest = json.loads((consumer_dir / ".gaia" / "manifests" / "bridges.json").read_text())
+    assert len(bridges_manifest["bridges"]) == 1
+    relation = bridges_manifest["bridges"][0]
+    assert relation["strength"] == "conditional"
+    assert relation["mode"] == "infer"
+    assert relation["justification"] == "Only under extra assumptions."
 
 
 def test_compile_fills_requires_dependency_manifest(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- emit `.gaia/manifests/holes.json` as the `local_hole` subset of `premises.json`
- emit `.gaia/manifests/bridges.json` from validated `fills()` relations
- derive stable `relation_id` values and record release-scoped target interface fields

## Context
This is the fourth replacement implementation PR after the public-premise redesign in #369.
It completes the package-level manifest surface by adding `holes.json` and `bridges.json` on top of the prior exports/premises + validation stack.

## Tests
- `pytest tests/cli/test_compile.py -q`
- `pytest tests/gaia/lang/test_core.py tests/gaia/lang/test_strategies.py tests/gaia/lang/test_compiler.py tests/cli/test_compile.py tests/cli/test_check.py tests/cli/test_register.py -q`
