### PR TITLE
feat(cli): register release manifests in registry payload

### DIFF
--- a/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
+++ b/docs/specs/2026-04-08-gaia-package-hole-bridge-design.md
@@ -421,29 +421,35 @@ relation_id = "bridge_" + sha256(
 
 ### 6.4 Phase Rollout
 
-旧方案的 phased rollout 是：
+PR 369 的 redesign 之后，旧的 phased rollout 计划已经不再适用。
 
-- Phase 1: `exports.json`
-- Phase 2: `holes.json`
-- Phase 3: `bridges.json`
+在当前设计里，四份 manifest 共同组成 release-scoped package interface：
 
-新方案下必须对齐为：
+- `exports.json`
+  - author-declared public surface
+- `premises.json`
+  - compiler-derived public premise interface
+  - 是 hole classification 和 bridge target validation 的 source of truth
+- `holes.json`
+  - `premises.json` 中 `role == "local_hole"` 的 convenience subset
+- `bridges.json`
+  - 本 release 声明的 fills relations
 
-- **Phase 1**
-  - 生成并上传 `exports.json`
-  - 生成并上传 `premises.json`
-- **Phase 2**
-  - 生成并上传 `holes.json`
-  - 开始建设 `index/premises/**` 与 `index/holes/**`
-- **Phase 3**
-  - 生成并上传 `bridges.json`
-  - 开始建设 `index/bridges/**`
+因此当前 contract 应对齐为：
+
+- `gaia compile`
+  - 生成全部四份 manifest
+- `gaia register`
+  - 一次性上传全部四份 manifest 到 `packages/<name>/releases/<version>/`
+- registry index builder
+  - 以 `premises.json` 为 source of truth
+  - 派生 `index/premises/**`、`index/holes/**`、`index/bridges/**`
 
 原因：
 
-- `premises.json` 是 `holes.json` 的 source of truth
-- `premises.json` 也是 bridge target validation 的 source of truth
-- 因此它不能晚于 `holes.json` 和 `bridges.json`
+- 没有 `premises.json`，registry 无法验证 bridge target 的 interface snapshot
+- `holes.json` 只是 `premises.json` 的 filter view，单独 phase 化没有技术意义
+- `bridges.json` 的 target validation 依赖同版本的 `premises.json`
 
 ## 7. Scenario Walkthroughs
 

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -202,6 +202,10 @@ def _canonical_json_hash(payload: dict[str, Any]) -> str:
     return f"sha256:{hashlib.sha256(raw.encode()).hexdigest()}"
 
 
+def render_manifest_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
 def _interface_hash(
     *,
     qid: str,
@@ -659,6 +663,5 @@ def write_compiled_artifacts(
         manifests_dir = gaia_dir / "manifests"
         manifests_dir.mkdir(exist_ok=True)
         for filename, payload in manifests.items():
-            rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
-            (manifests_dir / filename).write_text(rendered)
+            (manifests_dir / filename).write_text(render_manifest_json(payload))
     return gaia_dir

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -110,6 +110,10 @@ def _render_deps_toml(deps: dict[str, dict[str, str]]) -> str:
     return "\n".join(lines)
 
 
+def _render_manifest_json(payload: dict[str, object]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
 def _build_pr_body(
     *,
     pypi_name: str,
@@ -190,7 +194,7 @@ def register_command(
         loaded = load_gaia_package(path)
         compiled = compile_loaded_package_artifact(loaded)
         ir = compiled.to_json()
-        build_package_manifests(loaded, compiled)
+        manifests = build_package_manifests(loaded, compiled)
     except GaiaCliError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)
@@ -291,6 +295,11 @@ def register_command(
         }
     }
     deps_payload = {version: deps}
+    release_dir = f"packages/{package_name}/releases/{version}"
+    release_files = {
+        f"{release_dir}/{filename}": _render_manifest_json(payload)
+        for filename, payload in manifests.items()
+    }
 
     plan = {
         "package": {
@@ -312,6 +321,7 @@ def register_command(
             f"packages/{package_name}/Package.toml": package_toml,
             f"packages/{package_name}/Versions.toml": _render_versions_toml(versions),
             f"packages/{package_name}/Deps.toml": _render_deps_toml(deps_payload),
+            **release_files,
         },
         "pull_request": {"title": pr_title, "body": pr_body},
     }
@@ -344,6 +354,7 @@ def register_command(
 
     package_dir = registry_path / "packages" / package_name
     package_dir.mkdir(parents=True, exist_ok=True)
+    release_path = package_dir / "releases" / version
     package_toml_path = package_dir / "Package.toml"
     versions_toml_path = package_dir / "Versions.toml"
     deps_toml_path = package_dir / "Deps.toml"
@@ -360,12 +371,22 @@ def register_command(
     if version in existing_versions:
         typer.echo(f"Error: version already exists in registry metadata: {version}", err=True)
         raise typer.Exit(1)
+    if release_path.exists():
+        typer.echo(
+            f"Error: release metadata already exists in registry checkout: {release_path}",
+            err=True,
+        )
+        raise typer.Exit(1)
     existing_versions[version] = versions[version]
     versions_toml_path.write_text(_render_versions_toml(existing_versions))
 
     existing_deps = _load_existing_deps(deps_toml_path)
     existing_deps[version] = deps
     deps_toml_path.write_text(_render_deps_toml(existing_deps))
+
+    release_path.mkdir(parents=True, exist_ok=False)
+    for filename, payload in manifests.items():
+        (release_path / filename).write_text(_render_manifest_json(payload))
 
     try:
         _run(["git", "add", str(package_dir.relative_to(registry_path))], cwd=registry_path)

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -12,6 +12,7 @@ import typer
 
 from gaia.cli._packages import GaiaCliError, build_package_manifests, load_gaia_package
 from gaia.cli._packages import compile_loaded_package_artifact
+from gaia.cli._packages import render_manifest_json
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
 
@@ -108,12 +109,6 @@ def _render_deps_toml(deps: dict[str, dict[str, str]]) -> str:
             lines.append(f'"{name}" = "{deps[version][name]}"')
         lines.append("")
     return "\n".join(lines)
-
-
-def _render_manifest_json(payload: dict[str, object]) -> str:
-    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-
-
 def _build_pr_body(
     *,
     pypi_name: str,
@@ -297,7 +292,7 @@ def register_command(
     deps_payload = {version: deps}
     release_dir = f"packages/{package_name}/releases/{version}"
     release_files = {
-        f"{release_dir}/{filename}": _render_manifest_json(payload)
+        f"{release_dir}/{filename}": render_manifest_json(payload)
         for filename, payload in manifests.items()
     }
 
@@ -386,7 +381,7 @@ def register_command(
 
     release_path.mkdir(parents=True, exist_ok=False)
     for filename, payload in manifests.items():
-        (release_path / filename).write_text(_render_manifest_json(payload))
+        (release_path / filename).write_text(render_manifest_json(payload))
 
     try:
         _run(["git", "add", str(package_dir.relative_to(registry_path))], cwd=registry_path)

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -45,6 +45,7 @@ def test_compile_creates_ir_json(tmp_path):
     assert premises_manifest["manifest_schema_version"] == 1
     holes_manifest = json.loads((gaia_dir / "manifests" / "holes.json").read_text())
     bridges_manifest = json.loads((gaia_dir / "manifests" / "bridges.json").read_text())
+    assert (gaia_dir / "manifests" / "exports.json").read_text().endswith("\n")
     assert exports_manifest["package"] == "test-pkg"
     assert exports_manifest["version"] == "1.0.0"
     assert exports_manifest["exports"] == [

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -96,6 +96,16 @@ def test_register_dry_run_emits_registration_plan(tmp_path):
     assert plan["version"]["git_tag"] == "v1.2.0"
     assert plan["version"]["ir_hash"].startswith("sha256:")
     assert plan["deps"] == {"aristotle-mechanics-gaia": ">= 1.0.0"}
+    release_dir = "packages/register-demo/releases/1.2.0"
+    assert f"{release_dir}/exports.json" in plan["files"]
+    assert f"{release_dir}/premises.json" in plan["files"]
+    assert f"{release_dir}/holes.json" in plan["files"]
+    assert f"{release_dir}/bridges.json" in plan["files"]
+    exports_manifest = json.loads(plan["files"][f"{release_dir}/exports.json"])
+    premises_manifest = json.loads(plan["files"][f"{release_dir}/premises.json"])
+    assert exports_manifest["manifest_schema_version"] == 1
+    assert exports_manifest["exports"][0]["label"] == "exported_claim"
+    assert premises_manifest["premises"] == []
 
 
 def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
@@ -130,9 +140,22 @@ def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
     assert (package_dir / "Package.toml").exists()
     assert (package_dir / "Versions.toml").exists()
     assert (package_dir / "Deps.toml").exists()
+    release_dir = package_dir / "releases" / "1.2.0"
+    assert (release_dir / "exports.json").exists()
+    assert (release_dir / "premises.json").exists()
+    assert (release_dir / "holes.json").exists()
+    assert (release_dir / "bridges.json").exists()
     assert 'name = "register-demo"' in (package_dir / "Package.toml").read_text()
     assert 'git_tag = "v1.2.0"' in (package_dir / "Versions.toml").read_text()
     assert '"aristotle-mechanics-gaia" = ">= 1.0.0"' in (package_dir / "Deps.toml").read_text()
+    exports_manifest = json.loads((release_dir / "exports.json").read_text())
+    premises_manifest = json.loads((release_dir / "premises.json").read_text())
+    holes_manifest = json.loads((release_dir / "holes.json").read_text())
+    bridges_manifest = json.loads((release_dir / "bridges.json").read_text())
+    assert exports_manifest["exports"][0]["qid"] == "github:register_demo::exported_claim"
+    assert premises_manifest["premises"] == []
+    assert holes_manifest["holes"] == []
+    assert bridges_manifest["bridges"] == []
     assert (
         _run(["git", "branch", "--show-current"], cwd=registry_dir)
         == "register/register-demo-1.2.0"

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -43,6 +43,61 @@ def _write_package(pkg_dir) -> None:
     )
 
 
+def _write_dependency_with_local_hole(dep_dir) -> None:
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "dep-bridge-gaia"\n'
+        'version = "0.4.0"\n'
+        "dependencies = [\n"
+        '  "gaia-lang>=0.1.0",\n'
+        "]\n\n"
+        "[tool.gaia]\n"
+        'namespace = "github"\n'
+        'type = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "dep_bridge"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+
+
+def _write_package_with_local_hole_and_bridge(pkg_dir) -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / ".gitignore").write_text(".gaia/\n")
+    (pkg_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "register-bridge-gaia"\n'
+        'version = "1.2.0"\n'
+        'description = "Registration demo with public premises and bridges"\n'
+        "dependencies = [\n"
+        '  "gaia-lang>=0.1.0",\n'
+        '  "dep-bridge-gaia >= 0.4.0",\n'
+        "]\n\n"
+        "[tool.gaia]\n"
+        'namespace = "github"\n'
+        'type = "knowledge-package"\n'
+        'uuid = "08e78748-e1d5-5881-b72a-af9cc22550ac"\n'
+    )
+    pkg_src = pkg_dir / "register_bridge"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction, fills\n"
+        "from dep_bridge import missing_lemma\n\n"
+        'local_premise = claim("A local missing lemma.")\n'
+        'main_claim = claim("A release-ready claim.")\n'
+        'bridge_claim = claim("A bridge claim.")\n'
+        "deduction(premises=[local_premise], conclusion=main_claim)\n"
+        'fills(source=bridge_claim, target=missing_lemma, reason="Theorem 3 establishes A.")\n'
+        '__all__ = ["main_claim", "bridge_claim"]\n'
+    )
+
+
 def _init_git_repo(pkg_dir, remote_dir) -> None:
     _run(["git", "init"], cwd=pkg_dir)
     _run(["git", "config", "user.name", "Gaia Test"], cwd=pkg_dir)
@@ -145,6 +200,7 @@ def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
     assert (release_dir / "premises.json").exists()
     assert (release_dir / "holes.json").exists()
     assert (release_dir / "bridges.json").exists()
+    assert (release_dir / "exports.json").read_text().endswith("\n")
     assert 'name = "register-demo"' in (package_dir / "Package.toml").read_text()
     assert 'git_tag = "v1.2.0"' in (package_dir / "Versions.toml").read_text()
     assert '"aristotle-mechanics-gaia" = ">= 1.0.0"' in (package_dir / "Deps.toml").read_text()
@@ -160,6 +216,133 @@ def test_register_writes_registry_metadata_to_local_checkout(tmp_path):
         _run(["git", "branch", "--show-current"], cwd=registry_dir)
         == "register/register-demo-1.2.0"
     )
+
+
+def test_register_dry_run_emits_nonempty_release_manifests(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_bridge"
+    pkg_dir = tmp_path / "register_bridge"
+    remote_dir = tmp_path / "register_bridge_remote.git"
+    _write_dependency_with_local_hole(dep_dir)
+    _write_package_with_local_hole_and_bridge(pkg_dir)
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+
+    dep_compile = runner.invoke(app, ["compile", str(dep_dir)])
+    assert dep_compile.exit_code == 0, dep_compile.output
+
+    _init_git_repo(pkg_dir, remote_dir)
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    _run(["git", "tag", "v1.2.0"], cwd=pkg_dir)
+    _run(["git", "push", "origin", "v1.2.0"], cwd=pkg_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "register",
+            str(pkg_dir),
+            "--repo",
+            "https://github.com/example/RegisterBridge.gaia",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    plan = json.loads(result.output)
+    release_dir = "packages/register-bridge/releases/1.2.0"
+    premises_manifest = json.loads(plan["files"][f"{release_dir}/premises.json"])
+    holes_manifest = json.loads(plan["files"][f"{release_dir}/holes.json"])
+    bridges_manifest = json.loads(plan["files"][f"{release_dir}/bridges.json"])
+
+    assert premises_manifest["premises"][0]["role"] == "local_hole"
+    assert premises_manifest["premises"][0]["required_by"] == [
+        "github:register_bridge::main_claim"
+    ]
+    assert holes_manifest["holes"][0]["qid"] == "github:register_bridge::local_premise"
+    assert bridges_manifest["bridges"][0]["target_qid"] == "github:dep_bridge::missing_lemma"
+    assert bridges_manifest["bridges"][0]["target_interface_hash"].startswith("sha256:")
+    assert bridges_manifest["bridges"][0]["declared_by_owner_of_source"] is True
+
+
+def test_register_writes_nonempty_release_manifests_to_local_checkout(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "dep_bridge"
+    pkg_dir = tmp_path / "register_bridge"
+    remote_dir = tmp_path / "register_bridge_remote.git"
+    registry_dir = tmp_path / "gaia-registry"
+    _write_dependency_with_local_hole(dep_dir)
+    _write_package_with_local_hole_and_bridge(pkg_dir)
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+
+    dep_compile = runner.invoke(app, ["compile", str(dep_dir)])
+    assert dep_compile.exit_code == 0, dep_compile.output
+
+    _init_git_repo(pkg_dir, remote_dir)
+    _init_registry_repo(registry_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    _run(["git", "tag", "v1.2.0"], cwd=pkg_dir)
+    _run(["git", "push", "origin", "v1.2.0"], cwd=pkg_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "register",
+            str(pkg_dir),
+            "--repo",
+            "https://github.com/example/RegisterBridge.gaia",
+            "--registry-dir",
+            str(registry_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    release_dir = registry_dir / "packages" / "register-bridge" / "releases" / "1.2.0"
+    premises_manifest = json.loads((release_dir / "premises.json").read_text())
+    holes_manifest = json.loads((release_dir / "holes.json").read_text())
+    bridges_manifest = json.loads((release_dir / "bridges.json").read_text())
+
+    assert premises_manifest["premises"][0]["qid"] == "github:register_bridge::local_premise"
+    assert holes_manifest["holes"][0]["required_by"] == ["github:register_bridge::main_claim"]
+    assert bridges_manifest["bridges"][0]["target_package"] == "dep-bridge"
+    assert bridges_manifest["bridges"][0]["target_dependency_req"] == ">=0.4.0"
+    assert bridges_manifest["bridges"][0]["justification"] == "Theorem 3 establishes A."
+
+
+def test_register_fails_when_release_dir_already_exists(tmp_path):
+    pkg_dir = tmp_path / "register_demo"
+    remote_dir = tmp_path / "register_demo_remote.git"
+    registry_dir = tmp_path / "gaia-registry"
+    _write_package(pkg_dir)
+    _init_git_repo(pkg_dir, remote_dir)
+    _init_registry_repo(registry_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    package_dir = registry_dir / "packages" / "register-demo"
+    release_dir = package_dir / "releases" / "1.2.0"
+    release_dir.mkdir(parents=True)
+    (release_dir / "exports.json").write_text("{}\n")
+    _run(["git", "add", "."], cwd=registry_dir)
+    _run(["git", "commit", "-m", "precreate release dir"], cwd=registry_dir)
+
+    _run(["git", "tag", "v1.2.0"], cwd=pkg_dir)
+    _run(["git", "push", "origin", "v1.2.0"], cwd=pkg_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "register",
+            str(pkg_dir),
+            "--repo",
+            "https://github.com/example/RegisterDemo.gaia",
+            "--registry-dir",
+            str(registry_dir),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "release metadata already exists in registry checkout" in result.output
 
 
 def test_register_fails_on_invalid_fills_target(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- include release manifests under `packages/<name>/releases/<version>/` in `gaia register` dry-run payloads
- write the same manifests into local registry checkouts during `gaia register`
- align the package spec with the redesign contract: `gaia register` now uploads `exports.json`, `premises.json`, `holes.json`, and `bridges.json` together
- unify manifest JSON rendering between `.gaia/manifests/` and registry release files
- extend register tests to cover non-empty hole/bridge payload propagation and pre-existing release metadata

## Testing
- `pytest tests/cli/test_compile.py tests/cli/test_check.py tests/cli/test_register.py -q`
