### PR TITLE
chore: ruff format 4 cli files that slipped past format check

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -277,7 +277,9 @@ def _locate_dependency_manifest_root(import_name: str) -> Path | None:
     return None
 
 
-def _validate_dependency_manifest_freshness(import_name: str, root: Path, stored_ir_hash: str) -> None:
+def _validate_dependency_manifest_freshness(
+    import_name: str, root: Path, stored_ir_hash: str
+) -> None:
     pyproject = root / "pyproject.toml"
     if not pyproject.exists():
         return
@@ -351,7 +353,9 @@ def _relation_id(
 def _resolve_fills_relations(loaded: LoadedGaiaPackage, compiled) -> list[dict[str, Any]]:
     dependency_specs = _parse_gaia_dependencies(loaded.project_config)
     local_package = loaded.package
-    knowledge_by_qid = {knowledge.id: knowledge for knowledge in compiled.graph.knowledges if knowledge.id}
+    knowledge_by_qid = {
+        knowledge.id: knowledge for knowledge in compiled.graph.knowledges if knowledge.id
+    }
     dependency_manifest_cache: dict[str, dict[str, Any]] = {}
     relations: list[dict[str, Any]] = []
     seen_relation_keys: set[tuple[str, str, str]] = set()
@@ -361,7 +365,9 @@ def _resolve_fills_relations(loaded: LoadedGaiaPackage, compiled) -> list[dict[s
         if relation.get("type") != "fills":
             continue
         if len(strategy.premises) != 1 or strategy.conclusion is None:
-            raise GaiaCliError("Error: fills() strategies must have exactly one source and one target.")
+            raise GaiaCliError(
+                "Error: fills() strategies must have exactly one source and one target."
+            )
 
         source = strategy.premises[0]
         target = strategy.conclusion
@@ -500,7 +506,9 @@ def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, di
     graph = compiled.graph
     knowledge_by_qid = {knowledge.id: knowledge for knowledge in graph.knowledges if knowledge.id}
     exported_qids = {
-        knowledge.id for knowledge in graph.knowledges if knowledge.id is not None and knowledge.exported
+        knowledge.id
+        for knowledge in graph.knowledges
+        if knowledge.id is not None and knowledge.exported
     }
     exported_claim_qids = {
         knowledge.id
@@ -547,7 +555,9 @@ def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, di
                 if premise.type != "claim":
                     continue
                 premise_id = id(premise)
-                if premise_id in local_knowledge_ids and local_supports_by_conclusion.get(premise_id):
+                if premise_id in local_knowledge_ids and local_supports_by_conclusion.get(
+                    premise_id
+                ):
                     if premise_id in visited_supported_claims:
                         continue
                     visited_supported_claims.add(premise_id)
@@ -620,11 +630,7 @@ def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, di
         premises.append(entry)
 
     holes = [
-        {
-            key: value
-            for key, value in premise.items()
-            if key != "role" and key != "exported"
-        }
+        {key: value for key, value in premise.items() if key != "role" and key != "exported"}
         for premise in premises
         if premise["role"] == "local_hole"
     ]

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -109,6 +109,8 @@ def _render_deps_toml(deps: dict[str, dict[str, str]]) -> str:
             lines.append(f'"{name}" = "{deps[version][name]}"')
         lines.append("")
     return "\n".join(lines)
+
+
 def _build_pr_body(
     *,
     pypi_name: str,

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -256,7 +256,7 @@ def test_compile_marks_foreign_dependency_public_premise(tmp_path, monkeypatch):
     dep_src = dep_dir / "src" / "dep_pkg"
     dep_src.mkdir(parents=True)
     (dep_src / "__init__.py").write_text(
-        'from gaia.lang import claim\n\n'
+        "from gaia.lang import claim\n\n"
         'dep_result = claim("Dependency theorem.")\n'
         '__all__ = ["dep_result"]\n'
     )
@@ -363,8 +363,8 @@ def test_compile_exported_local_hole_required_by_lists_downstream_exports(tmp_pa
             ],
         }
     ]
- 
- 
+
+
 def test_compile_interface_hash_is_deterministic(tmp_path):
     pkg_dir = tmp_path / "deterministic_pkg"
     pkg_dir.mkdir()
@@ -393,6 +393,8 @@ def test_compile_interface_hash_is_deterministic(tmp_path):
     second_hash = second_manifest["premises"][0]["interface_hash"]
 
     assert first_hash == second_hash
+
+
 def test_compile_fills_validates_foreign_local_hole_target(tmp_path, monkeypatch):
     dep_dir = tmp_path / "dep_pkg_root"
     dep_dir.mkdir()
@@ -435,7 +437,9 @@ def test_compile_fills_validates_foreign_local_hole_target(tmp_path, monkeypatch
     result = runner.invoke(app, ["compile", str(consumer_dir)])
     assert result.exit_code == 0, result.output
 
-    bridges_manifest = json.loads((consumer_dir / ".gaia" / "manifests" / "bridges.json").read_text())
+    bridges_manifest = json.loads(
+        (consumer_dir / ".gaia" / "manifests" / "bridges.json").read_text()
+    )
     assert len(bridges_manifest["bridges"]) == 1
     relation = bridges_manifest["bridges"][0]
     assert relation["relation_type"] == "fills"
@@ -495,7 +499,9 @@ def test_compile_fills_emits_conditional_infer_bridge_metadata(tmp_path, monkeyp
     result = runner.invoke(app, ["compile", str(consumer_dir)])
     assert result.exit_code == 0, result.output
 
-    bridges_manifest = json.loads((consumer_dir / ".gaia" / "manifests" / "bridges.json").read_text())
+    bridges_manifest = json.loads(
+        (consumer_dir / ".gaia" / "manifests" / "bridges.json").read_text()
+    )
     assert len(bridges_manifest["bridges"]) == 1
     relation = bridges_manifest["bridges"][0]
     assert relation["strength"] == "conditional"
@@ -608,7 +614,7 @@ def test_compile_fills_rejects_target_that_is_not_public_hole(tmp_path, monkeypa
     dep_src = dep_dir / "src" / "dep_pkg"
     dep_src.mkdir(parents=True)
     (dep_src / "__init__.py").write_text(
-        'from gaia.lang import claim\n\n'
+        "from gaia.lang import claim\n\n"
         'dep_result = claim("Dependency theorem.")\n'
         '__all__ = ["dep_result"]\n'
     )
@@ -688,9 +694,7 @@ def test_compile_bridge_package_requires_source_dependency_declaration(tmp_path,
     dep_b_src = dep_b_dir / "src" / "dep_b"
     dep_b_src.mkdir(parents=True)
     (dep_b_src / "__init__.py").write_text(
-        'from gaia.lang import claim\n\n'
-        'b_result = claim("B theorem.")\n'
-        '__all__ = ["b_result"]\n'
+        'from gaia.lang import claim\n\nb_result = claim("B theorem.")\n__all__ = ["b_result"]\n'
     )
     monkeypatch.syspath_prepend(str(dep_a_dir / "src"))
     monkeypatch.syspath_prepend(str(dep_b_dir / "src"))
@@ -746,9 +750,7 @@ def test_compile_bridge_package_emits_declared_by_owner_false(tmp_path, monkeypa
     dep_b_src = dep_b_dir / "src" / "dep_b"
     dep_b_src.mkdir(parents=True)
     (dep_b_src / "__init__.py").write_text(
-        'from gaia.lang import claim\n\n'
-        'b_result = claim("B theorem.")\n'
-        '__all__ = ["b_result"]\n'
+        'from gaia.lang import claim\n\nb_result = claim("B theorem.")\n__all__ = ["b_result"]\n'
     )
     monkeypatch.syspath_prepend(str(dep_a_dir / "src"))
     monkeypatch.syspath_prepend(str(dep_b_dir / "src"))
@@ -821,7 +823,7 @@ def test_compile_rejects_duplicate_fills_relation(tmp_path, monkeypatch):
         "from dep_pkg import missing_lemma\n\n"
         'b_result = claim("B theorem.")\n'
         "fills(source=b_result, target=missing_lemma)\n"
-        "fills(source=b_result, target=missing_lemma, reason=\"duplicate\")\n"
+        'fills(source=b_result, target=missing_lemma, reason="duplicate")\n'
         '__all__ = ["b_result"]\n'
     )
 

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -254,9 +254,7 @@ def test_register_dry_run_emits_nonempty_release_manifests(tmp_path, monkeypatch
     bridges_manifest = json.loads(plan["files"][f"{release_dir}/bridges.json"])
 
     assert premises_manifest["premises"][0]["role"] == "local_hole"
-    assert premises_manifest["premises"][0]["required_by"] == [
-        "github:register_bridge::main_claim"
-    ]
+    assert premises_manifest["premises"][0]["required_by"] == ["github:register_bridge::main_claim"]
     assert holes_manifest["holes"][0]["qid"] == "github:register_bridge::local_premise"
     assert bridges_manifest["bridges"][0]["target_qid"] == "github:dep_bridge::missing_lemma"
     assert bridges_manifest["bridges"][0]["target_interface_hash"].startswith("sha256:")


### PR DESCRIPTION
## Summary
- Run \`ruff format\` on 4 files that were merged without passing \`ruff format --check\`:
  - \`gaia/cli/_packages.py\`
  - \`gaia/cli/commands/register.py\`
  - \`tests/cli/test_compile.py\`
  - \`tests/cli/test_register.py\`
- Unblocks unrelated PRs (e.g. #385) that fail CI only due to these pre-existing format drifts

## Test Plan
- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes (176 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)