### PR TITLE
docs: clarify local_hole semantics in build_package_manifests + spec

### DIFF
--- a/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
+++ b/docs/specs/2026-04-08-gaia-lang-hole-fills-design.md
@@ -88,6 +88,26 @@
 - 作者不能通过 `hole(...)` 直接“声明” hole 身份
 - 旧原型实现若已存在，应在 replacement implementation 中删除
 
+#### 命名说明：为什么叫 "hole"？
+
+⚠️ "hole" 这个词在日常英文里常让人误以为是"缺失/未解引用"，但在本协议里它的准确含义是：
+
+> 当前 package 里**已声明**的叶子 claim（没有本地支持策略），它在这个 release 的接口层面可以被下游包通过 `fills` **选择性精炼**。
+
+关键点：
+
+- **一个 `local_hole` 不是 bug，也不是未完成状态**。它是包的合法公开前提 —— 作者把某个命题作为原始证据/观察/abduction 替代方案留在叶子位置，让论文整体结构保持真实。
+- **一个 `local_hole` 不会阻塞编译、推理或注册**。它在 `ir.json` 里是普通的 `claim` node，在 BP 里按 review sidecar 给的 prior 参与推理。
+- **一个 `local_hole` 是否被下游 fill 是可选的**。大多数 self-contained 的论文包永远不会被下游 fill，这是正常状态。
+
+反例（便于排歧义）：
+
+- ❌ `local_hole` ≠ "未解引用" — 未解引用会让 validator 报错，根本进不到 manifest
+- ❌ `local_hole` ≠ "缺失依赖" — 跨包依赖的 leaf 走 `foreign_dependency` 角色，不是 `local_hole`
+- ❌ `local_hole` ≠ "TODO 标记" — 作者不需要"填补"本地 hole；整个包完全 self-contained 时所有 hole 都会一直是 hole
+
+如果你读完 `holes.json` 里有 32 个 entry 却没有任何 fill 关系，这是**正确**的状态 —— 它只是告诉下游生态"这 32 个原始证据位置**可能**可以被更强的观察工作 refine"。真实例子见 `watson-rfdiffusion-2023-gaia@0.1.1`：32 个 local holes，其中 20 个是原始观察（如 denoising_process 的实验描述），12 个是 abduction 的替代解释（如 alt_nonspecific_binding_p53_mdm2）。包本身完全合法，这些 holes 也不需要被填。
+
 ### 3.3 `fills` 仍然保留，但 target 不再语义化为“永久 hole object”
 
 推荐的 author-facing API 改成：

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -501,7 +501,55 @@ def _knowledge_manifest_entry(knowledge) -> dict[str, Any]:
 
 
 def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, dict[str, Any]]:
-    """Build package-level interface manifests from compiled IR plus runtime package state."""
+    """Build package-level interface manifests from compiled IR plus runtime package state.
+
+    Emits four sibling manifest files under ``.gaia/manifests/``:
+
+    - ``exports.json`` — every knowledge node in the package flagged ``exported``.
+      These are the package's public interface claims that downstream packages
+      may depend on.
+    - ``premises.json`` — every **leaf** claim (a claim with no supporting
+      strategy in the local package) that feeds into an exported conclusion.
+      Each entry carries a ``role`` field:
+
+        * ``local_hole`` — the leaf claim is declared in the **current** package
+          but has no derivation chain. These are the package's primary evidence
+          and abduction alternatives — i.e. the propositions the author accepts
+          as given inputs to the reasoning graph.
+        * ``foreign_dependency`` — the leaf claim originates in an upstream
+          ``*-gaia`` dependency and is consumed by a local strategy via the
+          dependency's ``exports.json``.
+
+    - ``holes.json`` — the subset of ``premises.json`` entries whose role is
+      ``local_hole``. Despite the name, a "hole" here does **not** mean an
+      unresolved cross-package reference (foreign dependencies already have
+      their own resolution path via the dep's exports). A ``local_hole`` is a
+      local leaf claim that a *downstream* package could optionally "fill" with
+      more specific evidence via the ``fills`` relation — but the current
+      package is perfectly valid with its leaves unfilled.
+    - ``bridges.json`` — ``fills`` relations declared in the local package that
+      point at hole qids in an upstream dependency's manifest. Empty for
+      packages with no upstream deps.
+
+    Concrete example from the ``watson-rfdiffusion-2023-gaia`` package:
+
+    - 7 exports (the paper's exported conclusions, e.g. ``binder_success_rate``)
+    - 32 local holes: 20 primary observations (e.g. ``denoising_process``,
+      ``binder_specificity``) + 12 abduction alternatives
+      (``alt_nonspecific_binding_p53_mdm2``, etc.)
+    - 0 foreign dependencies (watson has no upstream ``*-gaia`` deps)
+    - 0 bridges (watson doesn't fill any upstream holes)
+
+    All 32 holes are **declared claims** in the local package — they appear in
+    ``ir.json`` as regular knowledge nodes with ``exported=false`` and no
+    supporting strategy. They are reported as "holes" because the `holes.json`
+    manifest is indexing *local leaves that downstream packages could optionally
+    refine*, not *unresolved references*.
+
+    See ``docs/specs/2026-04-08-gaia-lang-hole-fills-design.md`` §3.2 for the
+    full rationale on why "hole" is a release-scoped interface role rather than
+    a source primitive.
+    """
     fills_relations = _resolve_fills_relations(loaded, compiled)
     graph = compiled.graph
     knowledge_by_qid = {knowledge.id: knowledge for knowledge in graph.knowledges if knowledge.id}


### PR DESCRIPTION
## Summary

Clarify the `local_hole` vs `foreign_dependency` distinction in `build_package_manifests`, and add a naming-rationale subsection to the hole-fills spec so future readers don't hit the same colloquial-vs-protocol confusion.

## Context

During e2e testing of `gaia render` on the watson package (see https://github.com/SiliconEinstein/gaia-registry/pull/29), the 32 entries in `watson/.gaia/manifests/holes.json` initially looked like a misclassification bug — "hole" in everyday English reads as "unresolved reference / missing dep", but all 32 entries were actually **declared claims in the local package**. Only after reading `build_package_manifests` source + the spec doc did it become clear that `local_hole` is a release-scoped interface role for declared leaf claims, not an error state.

The confusion was avoidable: the code docstring was a one-liner and the spec buried the naming rationale. This PR fixes both.

## Changes

**`gaia/cli/_packages.py`** — expand `build_package_manifests` docstring
- Explain each of the four manifest files (exports/premises/holes/bridges) and what belongs in them
- Document the `local_hole` vs `foreign_dependency` distinction explicitly
- Add a concrete worked example using watson: 7 exports / 32 local holes (20 primary observations + 12 abduction alternatives) / 0 foreign deps / 0 bridges
- Pointer to the canonical spec doc `docs/specs/2026-04-08-gaia-lang-hole-fills-design.md` §3.2

**`docs/specs/2026-04-08-gaia-lang-hole-fills-design.md` §3.2** — add "命名说明" subsection
- Explicit warning about the colloquial-vs-protocol meaning of "hole"
- Positive definition: a `local_hole` is a legitimate leaf claim, not a bug/TODO/unfinished state
- Negative examples: what a `local_hole` is NOT (not an unresolved ref, not a missing dep, not a TODO marker)
- Reference to watson@0.1.1 as a real-world example (32 local holes, 0 fills, completely valid package)

## Why docs-only

The alternatives are more invasive:
- **Rename `local_hole` → `local_leaf` in code + schema**: breaking change, coordinates gaia-registry updates, and watson@0.1.1 (the first manifest-bearing registry entry) would need re-registration
- **Split holes.json into two files**: even bigger schema break

Since the real confusion came from missing docs (not bad naming per se), fixing the docs is the minimal useful intervention. The spec doc and registered content (watson) already use `local_hole`, so keeping the name stable avoids downstream churn.

## Test plan

- [x] No code behavior change — `uv run pytest tests/cli` → 152 passed (no regressions)
- [x] `ruff check . && ruff format --check .` clean
- [x] Docstring renders correctly (no syntax issues)

## Part of a series

This is one of four e2e-driven improvements from the watson e2e session:

- ✅ Issue 3 (done): watson uv.lock refresh to gaia-lang 0.2.7 (`kunyuan/watson-rfdiffusion-2023-gaia@0216374`)
- ✅ Issue 2 (done): record `gaia_lang_version` in Versions.toml (#392)
- ⬆ **This PR**: Issue 1(A) — clarify `local_hole` semantics in code + spec
- ⏭ Issue 4 (tracking): registry CI has no manifest-bearing fixture tests — about to open a tracking issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)