### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaia-lang"
-version = "0.2.7"
+version = "0.3.0"
 description = "Gaia Lang — Python DSL for knowledge authoring, compilation, and inference"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "gaia-lang"
-version = "0.2.7"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "faiss-cpu" },


### PR DESCRIPTION
## Summary

Releases the references foundation from #391 as **gaia-lang 0.3.0**. The minor bump (0.2.x → 0.3.0) reflects that this is a new top-level subsystem with user-facing API and on-disk format changes — bigger than the typical 0.2.x patch increment.

## What's new in 0.3.0

### `gaia.lang.refs` module (new)
- `extract(text)` — Pandoc-compatible reference marker scanner with bracket groups, escapes, and Pandoc locator syntax
- `resolve(key, ...)` — three-state classifier (knowledge / citation / unknown)
- `check_collisions(...)` — pre-compile fail-fast on label/citation-key ambiguity
- `validate_groups(...)` — homogeneous-group rule (a `[...]` group cannot mix knowledge refs and citations)
- `load_references(path)` — CSL-JSON loader with key-grammar validation and field type checks
- `ReferenceError`, `RefMarker`, `BracketGroup`, `ExtractionResult`, `RefKind`

### Unified `@`-syntax
- **Strict** `[@key]` — explicit reference. Missing key → compile error.
- **Opportunistic** `@key` — Pandoc narrative form. Missing key → literal text.
- **Escape** `\@` — works in both bare and bracketed contexts.
- Pandoc multi-key groups, prefix/locator/suffix all supported.

### `references.json` (optional, package root)
- CSL-JSON format with dict-by-key layout for O(1) lookup
- Supports all CSL 1.0.2 types (papers, webpages, software, datasets, ...)
- Loader validates key grammar, type allowlist, required fields
- Missing file = empty bibliography (not an error)

### Compile-time provenance metadata
- Every Knowledge node now carries `metadata.gaia.provenance.{cited_refs, referenced_claims}` based on extracted markers
- Enables cross-package "who cites this paper / claim" queries
- Foreign nodes are never mutated — provenance attribution is always to the local owner

### `compile_package_artifact` / `compile_package` API
- New optional `references=` keyword argument
- Defaults to `None` → empty bibliography → backward compatible

## Behavior changes from 0.2.x

| Behavior | 0.2.x | 0.3.0 |
|---|---|---|
| Bare `@label` in strategy reason, label exists | warn-free, recorded in IR | silently resolved + recorded in `provenance.referenced_claims` |
| Bare `@label` in strategy reason, label missing | warning | silent (literal text) |
| `[@xyz]` anywhere in content | literal text | strict reference; compile error if not resolvable |
| `[@a; @b]` mixed knowledge + citation | literal text | compile error |
| Same key in label table AND `references.json` | N/A | compile error |
| Knowledge content scanning | strategy reason only | strategy reason **and** Knowledge content |

## Backward compatibility

- Existing packages using bare `@label` in strategy reasons continue to compile and now auto-populate provenance
- Packages without `references.json` work as before (no behavior change)
- Default `references=None` argument keeps existing call sites working
- Verified end-to-end on a real package (see commit history of #391 for the e2e test against `kunyuan/SuperconductivityElectronLiquids.gaia`)

## Test plan

- [x] Full test suite passes (`pytest tests/gaia/lang tests/cli`)
- [x] Tag `v0.3.0` will trigger `publish.yml` → builds + tests + publishes to PyPI via OIDC
- [x] PR #391 already validated in three review rounds with regression tests for every fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)