### PR TITLE
fix(render): require parameterization.json for --target github (#398)

### DIFF
--- a/gaia/cli/commands/render.py
+++ b/gaia/cli/commands/render.py
@@ -209,6 +209,30 @@ def render_command(
         )
         want_github = False
 
+    # github strictly requires parameterization alongside beliefs (#398):
+    # without it, the presentation code falls back to 0.5 defaults for
+    # priors/params, producing a published site whose prior columns don't
+    # match the review that produced the beliefs.
+    if want_github and beliefs_data is not None and param_data is None:
+        if target == RenderTarget.github:
+            review_name = loaded_review.name if loaded_review else "unknown"
+            typer.echo(
+                f"Error: --target github requires both beliefs.json and "
+                f"parameterization.json, but parameterization.json is missing "
+                f"for review {review_name!r}. Without it, the published site "
+                f"would show default 0.5 priors instead of the actual review "
+                f"parameters. Run `gaia infer --review {review_name}` to "
+                f"regenerate both files.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        # --target all: degrade to docs-only with a warning.
+        typer.echo(
+            "Warning: missing parameterization.json; skipping --target github "
+            "to avoid publishing with default priors.",
+        )
+        want_github = False
+
     # docs target renders even without beliefs — warn once so the user knows why
     # the output is missing belief values.
     if want_docs and beliefs_data is None:

--- a/tests/cli/test_render.py
+++ b/tests/cli/test_render.py
@@ -234,6 +234,35 @@ def test_render_fails_when_parameterization_stale(tmp_path):
     assert "parameterization" in result.output.lower()
 
 
+def test_render_target_github_fails_when_parameterization_missing(tmp_path):
+    """Regression for #398: --target github with beliefs but missing
+    parameterization.json must error instead of silently using 0.5 defaults."""
+    pkg_dir = _prepare_inferred_package(tmp_path, name="missing_param")
+    param_path = pkg_dir / ".gaia" / "reviews" / "self_review" / "parameterization.json"
+    param_path.unlink()  # delete parameterization but keep beliefs
+
+    result = runner.invoke(app, ["render", str(pkg_dir), "--target", "github"])
+    assert result.exit_code != 0, (
+        f"Expected error when parameterization.json is missing but beliefs.json "
+        f"is present. Without it, github output would show default 0.5 priors. "
+        f"Got: {result.output}"
+    )
+    assert "parameterization" in result.output.lower()
+
+
+def test_render_target_all_degrades_when_parameterization_missing(tmp_path):
+    """--target all with beliefs but missing parameterization → skip github, render docs."""
+    pkg_dir = _prepare_inferred_package(tmp_path, name="missing_param_all")
+    param_path = pkg_dir / ".gaia" / "reviews" / "self_review" / "parameterization.json"
+    param_path.unlink()
+
+    result = runner.invoke(app, ["render", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert (pkg_dir / "docs" / "detailed-reasoning.md").exists()
+    assert "parameterization" in result.output.lower()
+    assert "skipping" in result.output.lower()
+
+
 def _write_second_review(pkg_dir, package_name: str, review_name: str) -> None:
     reviews_dir = pkg_dir / package_name / "reviews"
     (reviews_dir / f"{review_name}.py").write_text(


### PR DESCRIPTION
## Summary

Fixes #398: `gaia render --target github` silently fell back to 0.5 default priors when `parameterization.json` was missing but `beliefs.json` was present, producing a published site with internally inconsistent data.

**Note:** The original PR also included a fix for #340 (abduction prior), but empirical verification showed the issue's severity was overstated — the existing code already gives correct abduction results within Cromwell-ε tolerance. The #340 commit was removed from this PR and the issue closed as not-a-bug.

## Fix

Add a parallel guard after the existing beliefs check in `render_command()`:

- `--target github` with beliefs but missing parameterization → **hard error** with actionable message
- `--target all` with the same condition → degrades to docs-only with warning (matches the pattern for missing beliefs)

## Test plan

- [x] `test_render_target_github_fails_when_parameterization_missing` — new
- [x] `test_render_target_all_degrades_when_parameterization_missing` — new
- [x] All 23 render tests pass
- [x] Full suite passes (excluding pre-existing opt_einsum/clickhouse deps)
- [x] ruff clean

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)