### PR TITLE
fix: gaia init hatch config + remove dead composite metadata + promote pyproject helper (#349, #374, #375)

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
-from gaia.lang.runtime.package import _pyproject_for_module
+from gaia.lang.runtime.package import pyproject_for_module
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
 from packaging.requirements import InvalidRequirement, Requirement
 
@@ -78,7 +78,7 @@ def _assign_labels_for_loaded_modules() -> None:
     for module_name, module in list(sys.modules.items()):
         if module is None or not isinstance(module_name, str):
             continue
-        pyproject = _pyproject_for_module(module_name)
+        pyproject = pyproject_for_module(module_name)
         if pyproject is None:
             continue
         pkg = get_inferred_package(pyproject)
@@ -268,7 +268,7 @@ def _load_json_file(path: Path, *, description: str) -> dict[str, Any]:
 
 
 def _locate_dependency_manifest_root(import_name: str) -> Path | None:
-    pyproject = _pyproject_for_module(import_name)
+    pyproject = pyproject_for_module(import_name)
     if pyproject is not None:
         return pyproject.parent
 

--- a/gaia/cli/commands/init.py
+++ b/gaia/cli/commands/init.py
@@ -63,15 +63,23 @@ def init_command(
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)
 
-    # --- patch pyproject.toml with [tool.gaia] section -------------------------
+    # --- compute import name early (needed for both pyproject patch and rename) --
+    import_name = name.removesuffix("-gaia").replace("-", "_")
+
+    # --- patch pyproject.toml with [tool.hatch] + [tool.gaia] sections ---------
     pyproject_path = pkg_dir / "pyproject.toml"
     gaia_uuid = str(uuid.uuid4())
-    gaia_section = f'\n[tool.gaia]\ntype = "knowledge-package"\nuuid = "{gaia_uuid}"\n'
+    extra_sections = (
+        f"\n[tool.hatch.build.targets.wheel]\n"
+        f'packages = ["src/{import_name}"]\n'
+        f"\n[tool.gaia]\n"
+        f'type = "knowledge-package"\n'
+        f'uuid = "{gaia_uuid}"\n'
+    )
     with open(pyproject_path, "a") as f:
-        f.write(gaia_section)
+        f.write(extra_sections)
 
     # --- rename src/<uv_default_name>/ → src/<import_name>/ --------------------
-    import_name = name.removesuffix("-gaia").replace("-", "_")
     uv_default_name = name.replace("-", "_")
     src_dir = pkg_dir / "src"
     uv_pkg_dir = src_dir / uv_default_name

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -74,7 +74,6 @@ def _composite_strategy(
     sub_strategies: list[Strategy],
     background: list[Knowledge] | None = None,
     reason: ReasonInput = "",
-    metadata: dict | None = None,
 ) -> Strategy:
     if not sub_strategies:
         raise ValueError("composite() requires at least one sub-strategy")
@@ -86,7 +85,7 @@ def _composite_strategy(
         background=background or [],
         reason=reason,
         sub_strategies=list(sub_strategies),
-        metadata=deepcopy(metadata) if metadata is not None else {},
+        metadata={},
     )
     _attach_strategy(conclusion, strategy)
     return strategy

--- a/gaia/lang/runtime/package.py
+++ b/gaia/lang/runtime/package.py
@@ -76,7 +76,7 @@ def _find_pyproject(start: Path) -> Path | None:
     return None
 
 
-def _pyproject_for_module(module_name: str) -> Path | None:
+def pyproject_for_module(module_name: str) -> Path | None:
     if module_name in _module_pyproject_cache:
         return _module_pyproject_cache[module_name]
 
@@ -151,7 +151,7 @@ def infer_package_and_module() -> tuple[CollectedPackage | None, str | None]:
     if not module_name:
         return None, None
 
-    pyproject = _pyproject_for_module(module_name)
+    pyproject = pyproject_for_module(module_name)
     if pyproject is None:
         return None, None
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -86,9 +86,11 @@ def test_init_creates_package(tmp_path, monkeypatch):
     pkg_dir = tmp_path / "my-research-gaia"
     assert pkg_dir.exists()
 
-    # pyproject.toml has [tool.gaia] section
+    # pyproject.toml has [tool.hatch] wheel config and [tool.gaia] section
     pyproject = pkg_dir / "pyproject.toml"
     config = tomllib.loads(pyproject.read_text())
+    # Regression for #349: hatch wheel packages must be present
+    assert config["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == ["src/my_research"]
     assert config["tool"]["gaia"]["type"] == "knowledge-package"
     assert "uuid" in config["tool"]["gaia"]
     # uuid should be a valid UUID string


### PR DESCRIPTION
## Summary

Three small cleanup fixes, one commit each:

### 1. fix(init): add `[tool.hatch.build.targets.wheel]` to generated pyproject.toml (closes #349)

`gaia init` generates pyproject.toml using hatchling but omitted the wheel packages config. Since project names (kebab-case + `-gaia`) always differ from import names (snake_case), `uv add gaia-lang` failed with "Unable to determine which files to ship". Now generates `packages = ["src/<import_name>"]` alongside the `[tool.gaia]` section.

### 2. fix(dsl): remove dead `metadata` param from `_composite_strategy` (closes #374)

`_composite_strategy()` accepted `metadata=` but the public `composite()` never forwarded it, and no caller anywhere passed it. Removed to eliminate the inconsistency.

### 3. refactor: promote `_pyproject_for_module` to public API (closes #375)

The CLI imported a private symbol (`_pyproject_for_module`) from `gaia.lang.runtime.package`. Promoted to `pyproject_for_module` (public) since it's shared infrastructure used by both runtime and CLI.

## Test plan

- [x] `pytest tests/cli/test_init.py` — 6 passed (init template now includes hatch config)
- [x] `pytest tests/gaia/lang tests/cli` — 306 passed, zero regressions
- [x] `ruff check . && ruff format --check .` clean
- [x] No remaining references to `_pyproject_for_module` anywhere in the codebase

Closes #349, #374, #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)