### PR TITLE
refactor: extract validate_fills_relations + fix stale skill namespace (#378, #389)

### DIFF
--- a/.claude/skills/gaia-ir-authoring/SKILL.md
+++ b/.claude/skills/gaia-ir-authoring/SKILL.md
@@ -49,7 +49,7 @@ dependencies = []                  # Other *-gaia packages if needed
 include = ["my_package*"]
 
 [tool.gaia]
-namespace = "reg"                  # "reg" for registry, "paper" for papers
+namespace = "github"               # Source registry namespace
 type = "knowledge-package"         # Required exactly
 uuid = "..."                       # Unique UUID v4
 

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -508,6 +508,16 @@ def _knowledge_manifest_entry(knowledge) -> dict[str, Any]:
     return entry
 
 
+def validate_fills_relations(loaded: LoadedGaiaPackage, compiled) -> None:
+    """Validate fills() relations without building full manifests.
+
+    Raises GaiaCliError if any fills() strategy has an invalid source,
+    target, or dependency configuration. Use this for ``gaia check``
+    where manifests are not needed — only validation matters.
+    """
+    _resolve_fills_relations(loaded, compiled)
+
+
 def build_package_manifests(loaded: LoadedGaiaPackage, compiled) -> dict[str, dict[str, Any]]:
     """Build package-level interface manifests from compiled IR plus runtime package state.
 

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -6,7 +6,7 @@ import json
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, build_package_manifests, load_gaia_package
+from gaia.cli._packages import GaiaCliError, load_gaia_package, validate_fills_relations
 from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.cli.commands._classify import classify_ir, node_role
 from gaia.ir import LocalCanonicalGraph
@@ -93,7 +93,7 @@ def check_command(
         loaded = load_gaia_package(path)
         compiled = compile_loaded_package_artifact(loaded)
         ir = compiled.to_json()
-        build_package_manifests(loaded, compiled)
+        validate_fills_relations(loaded, compiled)
     except GaiaCliError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary

### 1. refactor(cli): extract `validate_fills_relations` (closes #378)

`gaia check` called `build_package_manifests()` solely for the fills validation side effect, discarding the returned manifests. Extracted `validate_fills_relations()` as a thin public wrapper so check.py calls it directly — no manifest computation, clearer intent.

### 2. fix(skills): update stale namespace in gaia-ir-authoring (partial #389)

The skill file still had `namespace = "reg"` from before the namespace change to `"github"`. Updated to match current convention. Full skill consolidation (the rest of #389) is a larger effort tracked separately.

## Test plan

- [x] `pytest tests/cli/test_compile.py tests/cli/test_register.py tests/cli/test_check.py` — 41 passed
- [x] ruff clean

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)