### PR TITLE
feat: obsidian wiki backend — skill + .gaia-wiki rename + faithful rewrite standard

### DIFF
--- a/docs/specs/2026-04-10-obsidian-wiki-backend.md
+++ b/docs/specs/2026-04-10-obsidian-wiki-backend.md
@@ -36,7 +36,7 @@ What's missing is a **browsable, interlinked knowledge wiki** — one page per c
         ├── beliefs.json        BP results
         └── parameterization.json
 
-.gaia-wiki/                     Human layer (browsing, reading, navigation)
+gaia-wiki/                     Human layer (browsing, reading, navigation)
 ├── _index.md                   Global navigation (3-hop entry point)
 ├── overview.md                 Package overview + Mermaid
 ├── modules/                    One page per module (chapter-level view)
@@ -76,7 +76,7 @@ Phase 2 is optional — Phase 1 alone produces a usable (if thin) wiki. This mat
 ### Directory layout
 
 ```
-.gaia-wiki/
+gaia-wiki/
 ├── .obsidian/                          Obsidian vault config (graph view settings, etc.)
 │   └── graph.json                      Graph view color groups by node type
 ├── _index.md                           Master index
@@ -414,12 +414,12 @@ The wiki layer supports:
    SORT belief ASC
    ```
 3. **Obsidian graph view**: visual exploration of the wikilink graph (which IS the reasoning graph).
-4. **grep**: `grep -r "binder" .gaia-wiki/` always works.
+4. **grep**: `grep -r "binder" gaia-wiki/` always works.
 
 ### IR → Wiki bridging
 
 Every IR node's `label` is also the wiki page's filename (slug). This means:
-- MCP query returns `label: "binder_success_rate"` → human opens `.gaia-wiki/conclusions/binder_success_rate.md`
+- MCP query returns `label: "binder_success_rate"` → human opens `gaia-wiki/conclusions/binder_success_rate.md`
 - Dataview query returns a row → clicking opens the page → page has `qid` in frontmatter → links back to IR
 - Obsidian graph view shows the same topology as the IR reasoning graph (because wikilinks mirror strategy edges)
 
@@ -445,7 +445,7 @@ Extend the existing publish skill to support Obsidian output:
 
 ```bash
 /gaia:publish              # existing: fill .github-output/ narrative
-/gaia:publish --obsidian   # new: fill .gaia-wiki/ narrative
+/gaia:publish --obsidian   # new: fill gaia-wiki/ narrative
 /gaia:publish --all        # both
 ```
 
@@ -466,7 +466,7 @@ Consistent with the existing differentiated strictness model:
 |---|---|---|---|---|
 | `--target docs` | Single `detailed-reasoning.md` | No | No (linear read) | Quick structural check after compile |
 | `--target github` | `.github-output/` (React SPA + wiki + README) | Yes (via `/gaia:publish`) | Yes (React SPA) | Publishing to GitHub for external readers |
-| `--target obsidian` | `.gaia-wiki/` (Obsidian vault) | Yes (via `/gaia:publish --obsidian`) | Yes (Obsidian native) | Personal/team browsing, iterative exploration |
+| `--target obsidian` | `gaia-wiki/` (Obsidian vault) | Yes (via `/gaia:publish --obsidian`) | Yes (Obsidian native) | Personal/team browsing, iterative exploration |
 
 `docs` is the lightweight check. `github` is the public-facing publication. `obsidian` is the working knowledge base.
 
@@ -475,7 +475,7 @@ Consistent with the existing differentiated strictness model:
 ### Phase 1 output (skeleton)
 
 ```
-.gaia-wiki/
+gaia-wiki/
 ├── .obsidian/graph.json          (4 lines — color groups)
 ├── _index.md                     (~50 lines — stats + navigation tables)
 ├── overview.md                   (~30 lines — Mermaid + package abstract stub)
@@ -557,7 +557,7 @@ Same files, but each page now has 2-5 paragraphs of LLM-written narrative, embed
 
 1. **Should `obsidian` be part of `--target all`?** Currently `all` = `docs` + `github`. Adding `obsidian` would create a directory tree every time. Recommendation: keep it opt-in (`--target obsidian` explicit).
 
-2. **Where does `.gaia-wiki/` live?** Inside the package directory (committed to git) or outside (personal/ephemeral)? Recommendation: inside, but add to `.gitignore` template — it's a derived view, not source.
+2. **Where does `gaia-wiki/` live?** Inside the package directory (committed to git) or outside (personal/ephemeral)? Recommendation: inside, but add to `.gitignore` template — it's a derived view, not source.
 
 3. **Should we support incremental wiki updates?** Currently `gaia render` regenerates everything. For large packages, incremental would be valuable. Recommendation: defer to v2 — regeneration is fast for Phase 1, and Phase 2 (LLM) can be incremental by checking which pages' IR data has changed.
 

--- a/gaia/cli/commands/render.py
+++ b/gaia/cli/commands/render.py
@@ -274,7 +274,7 @@ def render_command(
         obsidian_pages = generate_obsidian_vault(
             ir, beliefs_data=beliefs_data, param_data=param_data
         )
-        wiki_dir = loaded.pkg_path / ".gaia-wiki"
+        wiki_dir = loaded.pkg_path / "gaia-wiki"
         wiki_dir.mkdir(exist_ok=True)
         for rel_path, page_content in obsidian_pages.items():
             out = wiki_dir / rel_path

--- a/skills/render-obsidian/SKILL.md
+++ b/skills/render-obsidian/SKILL.md
@@ -73,43 +73,51 @@ Read the original source material in `artifacts/` cover-to-cover. The agent must
 
 #### Conclusion pages (`conclusions/*.md`)
 
-Rewrite into a complete article about this claim:
+Rewrite into a complete article about this claim.
 
-**Completeness standard:** Each page should contain ALL information from the original source that is relevant to its topic. The reader should never need to go back to the paper. Don't aim for a word count — aim for information completeness. A claim that involves a 3-page derivation in the paper needs a proportionally detailed explanation in the wiki.
+**Completeness standard:** The page is a faithful, readable reproduction of everything the original paper says about this topic — including appendix material. Don't summarize or compress; rewrite for readability while preserving all derivations, equations, data, and arguments. If the paper devotes 3 pages to the derivation, the wiki page should reproduce those 3 pages worth of content in a more readable form.
 
-1. **Title**: Keep or translate the `# heading`
-2. **Content**: Replace the terse blockquote with a full explanation of the claim — what it states, what evidence supports it, what method produced it. Include ALL relevant numbers, equations, experimental conditions, and comparisons from the original source. If the paper devotes a paragraph to this claim, the wiki page should contain equivalent information.
-3. **Derivation**: Rewrite in prose. Don't just list premises — explain the complete logical chain: WHY each premise supports this conclusion, what the mathematical/physical argument is. Keep wikilinks but wrap them in explanatory sentences. Reproduce key equations from the paper.
-4. **Supports**: Rewrite as prose — what downstream conclusions depend on this claim and why.
-5. **Context**: Explain the claim's full scientific context from `artifacts/`. Embed all relevant figures with `![[filename]]` and informative captions. Include experimental setup, measurement methods, data tables, comparison with prior work.
-6. **Significance**: Why this matters for the overall argument. What breaks if this claim is wrong?
-7. **Caveats**: Limitations, alternative explanations, sources of uncertainty.
+**Section ordering (top to bottom):**
+
+1. **Title**: Translate the `# heading`
+2. **Content**: Replace the terse blockquote with a full explanation of the claim. Include ALL relevant numbers, equations, experimental conditions.
+3. **Background** (新增, 放在推导之前): The complete scientific context for this claim. What problem does it address? What is known from prior work? What gap exists? Embed relevant figures from `artifacts/images/`. This section sets up the reader to understand the derivation that follows.
+4. **Derivation** (核心, 最详尽的部分): Reproduce the paper's full argument for this claim — not a summary but a readable rewrite of the original derivation. Include:
+   - All key equations with explanation of each step
+   - Physical reasoning behind each mathematical step
+   - Approximations made and why they are justified
+   - Numerical validations cited in the paper
+   - Appendix material that supports this derivation
+   - Keep wikilinks to premises but embed them in explanatory prose
+5. **Supports**: What downstream conclusions depend on this claim.
+6. **Significance**: Why this matters. What breaks if wrong?
+7. **Caveats**: Limitations, alternative explanations, uncertainty sources.
 
 #### Evidence pages (`evidence/*.md`)
 
-Rewrite into a complete source documentation page:
+Rewrite into a complete source documentation page. Evidence pages are leaf nodes — they represent facts the paper takes as given or demonstrates directly.
 
-1. **Content**: Fully describe the evidence — not a one-liner but the complete statement with all quantitative details.
-2. **Source**: Where does this evidence come from? Reproduce the relevant data: experimental method, measurement conditions, precision, error bars, known limitations. If the paper has a table or figure for this data, embed it.
-3. **Supports**: Which conclusions depend on this evidence and why — the logical connection, not just a list.
-4. **Figures**: Embed all relevant figures from `artifacts/images/`.
+1. **Content**: Full statement of the evidence with all quantitative details, equations, and conditions.
+2. **Background**: Scientific context — why this evidence matters, what it establishes, how it was obtained. Reproduce the paper's full discussion of this point including any appendix material.
+3. **Source**: Experimental method, measurement conditions, precision, error bars, known limitations. Embed relevant figures and data tables from the paper.
+4. **Supports**: Which conclusions depend on this evidence — explain the logical connection, not just list names.
 
 #### Module pages (`modules/*.md`)
 
-Rewrite into a comprehensive chapter overview:
+Rewrite into a comprehensive chapter that mirrors the corresponding section of the paper.
 
-1. **Overview**: What scientific question this module addresses, what approach is taken, and the key results. Write as you would a section of a review paper — the reader should understand the module's complete contribution.
-2. **Transition**: How this module builds on previous modules and what it enables for subsequent ones. Name specific concepts and results that flow between modules.
-3. **Claims section**: For each claim:
-   - Exported claims: expand into a substantive summary with key numbers and the reasoning behind them.
-   - Inlined claims: rewrite the content and derivation into readable prose with full explanations. Include equations, data, and physical reasoning — not just "Derived via X from Y."
+1. **Overview**: What scientific question this module addresses, what approach is taken, and the key results. Write as a section of a review paper.
+2. **Transition**: How this module builds on previous modules and enables subsequent ones.
+3. **Claims section**: For each claim, reproduce the paper's full treatment:
+   - Exported claims: substantive summary with all key numbers, equations, and the reasoning chain.
+   - Inlined claims: rewrite the paper's content for this claim in full — equations, derivations, data, physical reasoning. Don't compress a 2-paragraph paper discussion into one sentence.
 
 #### Strategy pages (`reasoning/*.md`)
 
-Rewrite into a complete reasoning explanation:
+Rewrite into a complete reasoning explanation that reproduces the paper's argument in full:
 
-1. **Overview**: What type of reasoning and what it establishes.
-2. **Premises → Conclusion**: For each premise, explain the full scientific argument for WHY it supports the conclusion. Reproduce the mathematical derivation or physical reasoning from the paper.
+1. **Overview**: What type of reasoning, what it establishes, and in which section of the paper.
+2. **Premises → Conclusion**: Reproduce the paper's complete argument — all equations, derivation steps, physical reasoning, and numerical evidence. This is not a summary but a readable rewrite of the original proof/argument.
 3. **Strength assessment**: How strong is this reasoning? What assumptions does it depend on? What could weaken it?
 
 #### Overview page (`overview.md`)
@@ -131,40 +139,60 @@ Add a package description (3-5 sentences) with the most striking quantitative re
 
 ### Quality bar
 
-**The standard is information completeness, not word count.** If the paper devotes 2 pages to a topic, the wiki page should contain equivalent depth. If a claim is a single well-known fact, a short page is fine. Length follows content, not a target.
+**The standard is faithful reproduction, not summarization.** The wiki page should contain the same depth as the paper's treatment of the topic. If the paper devotes 2 pages to a derivation, reproduce those 2 pages in readable form — don't compress to 2 sentences. Appendix material that supports the topic should be included.
+
+**Think of it as:** rewriting the paper into a wiki, not summarizing it into a wiki.
 
 **Every page must include:**
 - ALL relevant numerical values from the original source (with units, error bars)
-- Key equations in LaTeX — reproduce derivations where they are central to the argument
+- ALL key equations with step-by-step explanation
+- ALL derivation steps the paper provides (including appendix material)
 - Cross-references via wikilinks to related pages
 - Figure embeds from `artifacts/images/` for every figure relevant to the topic
 
-**BAD — thin rewrite:**
+**BAD — derivation as summary:**
 ```
-## 背景
-铝的 r_s = 2.07，预测 T_c = 0.96 K，接近实验值 1.2 K。
+## 推导
+
+将第一性原理工作流应用于铝（[[ab_initio_workflow]]），
+代入材料参数，得到 T_c = 0.96 K。
 ```
 
-**GOOD — rich rewrite:**
+**GOOD — derivation reproduces the paper's argument:**
 ```
-## 背景
+## 推导
 
-铝是超导理论的基准测试材料。Wigner-Seitz 半径 $r_s = 2.07$，
-带质量 $m_b = 1.05$，处于弱耦合区间。声子吸引（$\lambda = 0.44$，
-来自 DFPT 计算，$\omega_{\log} = 320$ K）与 Coulomb 排斥
-（$\mu^* = 0.13$，来自 [[mu_vdiagmc_values]] 在 $r_s = 2.07$
-处的值经 BTS 重正化）之间的竞争仅留下很小的净配对相互作用。
+铝的超导转变温度由下折叠 Eliashberg 方程（[[downfolded_bse]]）
+结合第一性原理输入参数预测。
 
-唯象方法预测 $T_c = 1.9$ K，比实验值 1.2 K 高估 58%——根本
-原因是传统取值 $\mu^* \approx 0.10$ 低估了 Coulomb 排斥。
-第一性原理值 $\mu^* = 0.13$ 恰好增大了足够的排斥，将 $T_c$
-降低到 0.96 K，偏差在 20% 以内。
+**库仑赝势的确定：** 铝的 Wigner-Seitz 半径 $r_s = 2.07$，
+带质量 $m_b = 1.05$。从 vDiagMC 参数化
+（[[mu_vdiagmc_values]]）查表得 $\mu_{E_F}(2.07) = 0.56$。
+通过 BTS 重正化关系
 
-![[8_0.jpg]]
-*图 4：vDiagMC 计算的 $\mu_{E_F}(r_s)$（圆圈带误差棒），
-与静态 RPA（虚线）、动态 RPA（点线）和 Morel-Anderson 常数
-（点划线）的对比。改编自 Cai et al., arXiv:2512.19382。*
+$$\mu^*(\omega_D) = \frac{\mu_{E_F}}{1 + \mu_{E_F} \ln(E_F/\omega_D)}$$
+
+取 $E_F = 11.7$ eV，$\omega_D = 36$ meV（对应 Debye 温度
+$\Theta_D = 428$ K），对数因子 $\ln(E_F/\omega_D) = 5.78$，
+得到 $\mu^* = 0.56/(1+0.56 \times 5.78) = 0.13$。
+
+**电声耦合：** DFPT 计算（[[dfpt_reliable_for_simple_metals]]）
+给出 $\lambda = 0.44$，$\omega_{\log} = 320$ K。Allen-Dynes
+公式的有效耦合为 $g = \lambda - \mu^*(1+0.62\lambda) =
+0.44 - 0.13 \times 1.27 = 0.275$。
+
+**$T_c$ 求解：** 将 $\mu^* = 0.13$, $\lambda = 0.44$,
+$\omega_{\log} = 320$ K 代入 PCF 外推得到
+$T_c^{\text{EFT}} = 0.96$ K，与实验值 $T_c^{\text{exp}} = 1.2$ K
+偏差 20%。相比之下，唯象取值 $\mu^* \approx 0.10$ 给出
+$T_c = 1.9$ K，偏差 58%。
+
+![[14_0.jpg]]
+*图 6：铝的 $T_c$ 随压力变化。实心圆为第一性原理预测，
+空心圆为实验数据。改编自 Cai et al., arXiv:2512.19382。*
 ```
+
+The good version reproduces the actual calculation steps, intermediate values, and equations — the reader can follow the derivation without opening the paper.
 
 ### DO NOT
 

--- a/skills/render-obsidian/SKILL.md
+++ b/skills/render-obsidian/SKILL.md
@@ -75,53 +75,47 @@ Read the original source material in `artifacts/` cover-to-cover. The agent must
 
 Rewrite into a complete article about this claim:
 
-1. **Title**: Keep or translate the `# heading`
-2. **Content**: Replace the terse blockquote with 2-3 paragraphs fully explaining the claim — what it states, what evidence supports it, what method produced it. Include specific numbers, equations, experimental conditions.
-3. **Derivation**: Rewrite in prose. Don't just list premises — explain the logical chain: WHY each premise supports this conclusion. Keep wikilinks but wrap them in explanatory sentences.
-4. **Supports**: Rewrite as prose — what downstream conclusions depend on this claim and why.
-5. **Context**: Add 2-3 paragraphs explaining the claim's scientific context from `artifacts/`. Include figures with `![[filename]]`.
-6. **Significance**: 1-2 paragraphs on why this matters for the overall argument.
-7. **Caveats**: Note limitations, alternative explanations, sources of uncertainty.
+**Completeness standard:** Each page should contain ALL information from the original source that is relevant to its topic. The reader should never need to go back to the paper. Don't aim for a word count — aim for information completeness. A claim that involves a 3-page derivation in the paper needs a proportionally detailed explanation in the wiki.
 
-Target: 500-800 words per conclusion page.
+1. **Title**: Keep or translate the `# heading`
+2. **Content**: Replace the terse blockquote with a full explanation of the claim — what it states, what evidence supports it, what method produced it. Include ALL relevant numbers, equations, experimental conditions, and comparisons from the original source. If the paper devotes a paragraph to this claim, the wiki page should contain equivalent information.
+3. **Derivation**: Rewrite in prose. Don't just list premises — explain the complete logical chain: WHY each premise supports this conclusion, what the mathematical/physical argument is. Keep wikilinks but wrap them in explanatory sentences. Reproduce key equations from the paper.
+4. **Supports**: Rewrite as prose — what downstream conclusions depend on this claim and why.
+5. **Context**: Explain the claim's full scientific context from `artifacts/`. Embed all relevant figures with `![[filename]]` and informative captions. Include experimental setup, measurement methods, data tables, comparison with prior work.
+6. **Significance**: Why this matters for the overall argument. What breaks if this claim is wrong?
+7. **Caveats**: Limitations, alternative explanations, sources of uncertainty.
 
 #### Evidence pages (`evidence/*.md`)
 
-Rewrite into a source documentation page:
+Rewrite into a complete source documentation page:
 
-1. **Content**: Expand the terse blockquote into a full description of the evidence.
-2. **Source**: Where does this evidence come from? Specific experiment, dataset, calculation, or literature. Method, precision, known limitations.
-3. **Supports**: Which conclusions depend on this evidence and why.
-4. **Figures**: Embed relevant figures from `artifacts/images/`.
-
-Target: 200-400 words per evidence page.
+1. **Content**: Fully describe the evidence — not a one-liner but the complete statement with all quantitative details.
+2. **Source**: Where does this evidence come from? Reproduce the relevant data: experimental method, measurement conditions, precision, error bars, known limitations. If the paper has a table or figure for this data, embed it.
+3. **Supports**: Which conclusions depend on this evidence and why — the logical connection, not just a list.
+4. **Figures**: Embed all relevant figures from `artifacts/images/`.
 
 #### Module pages (`modules/*.md`)
 
-Rewrite into a chapter-level overview:
+Rewrite into a comprehensive chapter overview:
 
-1. **Overview**: 2-3 paragraphs — what scientific question this module addresses, what approach is taken, key results. Write as a review paper section introduction.
-2. **Transition**: How this module connects to adjacent modules.
-3. **Claims section**: For each claim listed:
-   - Exported claims (with `[[link]] ★`): expand the one-line description into 2-3 sentences.
-   - Inlined claims: rewrite the content and derivation info into readable prose. Don't just say "Derived via X from Y" — explain the reasoning.
-
-Target: 400-800 words per module page.
+1. **Overview**: What scientific question this module addresses, what approach is taken, and the key results. Write as you would a section of a review paper — the reader should understand the module's complete contribution.
+2. **Transition**: How this module builds on previous modules and what it enables for subsequent ones. Name specific concepts and results that flow between modules.
+3. **Claims section**: For each claim:
+   - Exported claims: expand into a substantive summary with key numbers and the reasoning behind them.
+   - Inlined claims: rewrite the content and derivation into readable prose with full explanations. Include equations, data, and physical reasoning — not just "Derived via X from Y."
 
 #### Strategy pages (`reasoning/*.md`)
 
-Rewrite into a reasoning explanation:
+Rewrite into a complete reasoning explanation:
 
-1. **Overview**: What type of reasoning is this and what does it establish?
-2. **Premises → Conclusion**: For each premise, explain WHY it supports the conclusion. Include the mathematical or physical argument.
-3. **Strength assessment**: How strong is this reasoning? What could weaken it?
-
-Target: 300-500 words per strategy page.
+1. **Overview**: What type of reasoning and what it establishes.
+2. **Premises → Conclusion**: For each premise, explain the full scientific argument for WHY it supports the conclusion. Reproduce the mathematical derivation or physical reasoning from the paper.
+3. **Strength assessment**: How strong is this reasoning? What assumptions does it depend on? What could weaken it?
 
 #### Overview page (`overview.md`)
 
-1. **Citation**: Add proper bibliographic reference to original work.
-2. **Abstract**: 3-4 paragraphs summarizing the entire package — central question, methodology, key quantitative results, limitations.
+1. **Citation**: Proper bibliographic reference to original work.
+2. **Abstract**: A comprehensive summary of the entire package — central question, methodology, key quantitative results, limitations. The reader should be able to decide whether to explore further.
 3. **Reasoning graph**: Keep the Mermaid diagram as-is.
 
 Target: 300-500 words.
@@ -137,11 +131,13 @@ Add a package description (3-5 sentences) with the most striking quantitative re
 
 ### Quality bar
 
+**The standard is information completeness, not word count.** If the paper devotes 2 pages to a topic, the wiki page should contain equivalent depth. If a claim is a single well-known fact, a short page is fine. Length follows content, not a target.
+
 **Every page must include:**
-- Specific numerical values (with units, error bars where available)
-- Key equations in LaTeX where they clarify the argument
+- ALL relevant numerical values from the original source (with units, error bars)
+- Key equations in LaTeX — reproduce derivations where they are central to the argument
 - Cross-references via wikilinks to related pages
-- At least one figure embed from `artifacts/images/` if relevant figures exist
+- Figure embeds from `artifacts/images/` for every figure relevant to the topic
 
 **BAD — thin rewrite:**
 ```

--- a/skills/render-obsidian/SKILL.md
+++ b/skills/render-obsidian/SKILL.md
@@ -78,91 +78,122 @@ Build a mental model of:
 
 For each page in `gaia-wiki/`, enrich the skeleton with narrative content. **Do NOT modify frontmatter or wikilinks** — only add prose sections.
 
-### Claim pages (`conclusions/*.md`)
+**Core principle:** Each wiki page is a self-contained knowledge document. After reading a page, the reader should understand the claim, its evidence, and its role in the argument **without needing to read the original source**. The wiki replaces reading the paper, not summarizes it.
 
-Add these sections after the existing skeleton content:
+### Quality standard: thin vs rich
 
-**Context** (2-3 paragraphs): Explain the claim in the context of the original work. Include relevant data, experimental conditions, and figures from `artifacts/`. Write for a domain expert who hasn't read the paper.
-
+**BAD (thin)** — the agent's default tendency:
 ```markdown
 ## Context
-
-The authors tested RFdiffusion-designed binders against five protein targets
-of therapeutic interest...
-
-> [!NOTE]
-> Context expanded from Watson et al. 2023, Extended Data Fig. 5.
-> See `artifacts/paper.pdf` pp. 8-10.
+Aluminum has r_s = 2.07 and the ab initio prediction is 0.96 K,
+close to the experimental value of 1.2 K.
 ```
 
-**Significance** (1 paragraph): Why this claim matters for the package's overall argument. How does it connect to the exported conclusions?
-
-If `artifacts/` has relevant figures, embed them:
+**GOOD (rich)** — what the reader actually needs:
 ```markdown
-![[figure-4-binder-results.png]]
+## Context
+Aluminum is the benchmark test for any superconductivity theory. With
+Wigner-Seitz radius $r_s = 2.07$ and band mass $m_b = 1.05$, it sits
+in the weak-coupling regime where the competition between phonon
+attraction ($\lambda = 0.44$ from DFPT, using $\omega_{\log} = 320$ K)
+and Coulomb repulsion ($\mu^* = 0.13$ from vDiagMC at $r_s = 2.07$
+with BTS renormalization) leaves a small net pairing interaction.
+
+The phenomenological prediction of $T_c = 1.9$ K overshoots the
+experimental $T_c = 1.2$ K by 58%, primarily because the conventional
+$\mu^* \approx 0.10$ underestimates Coulomb repulsion. The ab initio
+value $\mu^* = 0.13$ increases the repulsion just enough to bring
+$T_c$ down to 0.96 K — within 20% of experiment. The remaining
+discrepancy likely reflects the UEG-to-material mapping approximation
+and band structure effects beyond the free-electron model.
+
+![[8_0.jpg]]
+*Fig. 4: Dimensionless bare Coulomb pseudopotential $\mu_{E_F}(r_s)$
+from vDiagMC (circles with error bars), compared with static RPA
+(dashed), dynamic RPA (dotted), and Morel-Anderson constant (dash-dot).
+Adapted from Cai et al., arXiv:2512.19382.*
+```
+
+The difference: the rich version includes all the numbers ($r_s$, $m_b$, $\lambda$, $\omega_{\log}$, $\mu^*$), explains the mechanism (why the prediction differs from phenomenology), embeds figures, and gives the reader enough context to evaluate the claim independently.
+
+### Claim pages (`conclusions/*.md`)
+
+Add after the existing skeleton content:
+
+**Context** (3-5 paragraphs, ~300-500 words):
+- **Paragraph 1**: What is this claim about? Set the scientific context — what question is being answered, what method is used, what physical regime.
+- **Paragraph 2**: The specific data and results. Include ALL relevant numbers: material parameters, computed values with error bars, comparisons with experiment and prior theory. Reproduce key equations if they clarify the argument.
+- **Paragraph 3**: How the result was obtained — what computation, what approximations, what input data. The reader should be able to trace the derivation.
+- **Paragraph 4 (if applicable)**: Caveats, limitations, comparison with alternative approaches.
+- Embed relevant figures from `artifacts/images/` with captions and attribution.
+
+**Significance** (1-2 paragraphs): Why this claim matters for the package's overall argument. What breaks if this claim is wrong? What does it enable downstream?
+
+```markdown
+> [!NOTE]
+> Context expanded from [Author et al.], Section X, pp. Y-Z.
+> See `artifacts/paper.md` for full details.
 ```
 
 ### Module pages (`modules/*.md`)
 
 Add at the top (after frontmatter, before Claims):
 
-**Overview** (1-2 paragraphs): What this module covers and how it fits in the larger argument.
+**Overview** (2-3 paragraphs, ~200-400 words): What scientific question this module addresses, what approach is taken, and what the key results are. Write as you would a section introduction in a review paper — the reader should understand the module's contribution after reading just the overview.
 
-**Transition** (1-2 sentences): How this module connects to previous and next modules in the argument arc.
+**Transition** (2-3 sentences): How this module builds on the previous one and what it enables for the next. Name the specific concepts that flow between modules.
 
 ### Evidence pages (`evidence/*.md`)
 
-Add:
-
-**Source** (1 paragraph): Where this evidence comes from — specific experiment, dataset, observation, or literature reference. Cite from `artifacts/` if available.
+**Source** (1-2 paragraphs): Where this evidence comes from — specific experiment, dataset, calculation, or literature reference. Include: who measured/computed it, what method, what precision, and any known limitations. Cite from `artifacts/` if available.
 
 ### Strategy pages (`reasoning/*.md`)
 
-Expand the existing Reasoning section:
-
-**Explanation** (1-2 paragraphs): For each premise → conclusion link, explain WHY the premise supports the conclusion. Don't just list the premises — tell the reasoning story.
+Expand the Reasoning section into **Explanation** (2-3 paragraphs): For each premise → conclusion link, explain the scientific logic of WHY the premise supports the conclusion. Include the mathematical or physical argument, not just "A implies B." The reader should understand the chain of reasoning as clearly as if they read the relevant section of the paper.
 
 ### Overview page (`overview.md`)
 
-Add:
-
-**Abstract** (1-2 paragraphs): Summarize the entire knowledge package. What question does it address, what does it conclude, and how confident is the reasoning?
+**Abstract** (2-3 paragraphs, ~200-300 words): A self-contained summary of the entire knowledge package. What is the central question? What new methodology is introduced? What are the key quantitative results? What are the limitations? A domain expert should be able to decide whether to explore further based on this abstract alone.
 
 ### `_index.md`
 
-Add after the existing navigation:
-
-**Package Description** (2-3 sentences): Brief description from `pyproject.toml` or module docstrings.
+**Package Description** (3-5 sentences): What this package formalizes, what the source material is, and what the main findings are. Include the most striking quantitative result.
 
 ## Narrative Guidelines
 
-**Audience:** A domain expert who hasn't read the original source material but understands the field.
+**Audience:** A domain expert who hasn't read the original source material but understands the field. They should be able to evaluate the claims based solely on the wiki pages.
 
-**Voice:** Scientific, precise, but readable. Third-person. Cite specific numbers from the paper.
+**Voice:** Scientific, precise, but readable. Third-person. Write as you would for a review article or an extended encyclopedia entry.
+
+**Content depth:** Every page should include:
+- Specific numerical values (with units and error bars where available)
+- Key equations (in LaTeX) where they clarify the argument
+- Comparison with alternative approaches or prior results
+- Figure embeds from `artifacts/images/` with descriptive captions
 
 **DO:**
-- Ground claims in concrete data (numbers, experiments, comparisons)
-- Cite figures from `artifacts/` with `![[filename]]` syntax
-- Use Obsidian callouts for annotation:
-  - `> [!NOTE]` — context expanded from source
-  - `> [!WARNING]` — information unavailable or uncertain
-  - `> [!REASONING]` — expanded reasoning explanation
-- Reference other pages via wikilinks: `[[label]]`
+- Read `artifacts/` thoroughly — find the section corresponding to each claim and extract concrete details
+- Ground every claim in specific data (not "good agreement" but "0.874 K vs 0.875 K, 0.1% error")
+- Embed figures with `![[filename]]` and write informative captions
+- Cross-reference other pages via wikilinks: `[[label]]`
+- Use Obsidian callouts: `> [!NOTE]` for source citations, `> [!WARNING]` for caveats
 
 **DO NOT:**
+- Write thin summaries that could apply to any paper in the field
 - Use Gaia jargon (noisy_and, abduction, factor graph, BP, NAND)
 - Describe graph structure ("this claim derives from two premises via...")
 - Modify frontmatter or existing wikilink sections
 - Remove any skeleton content — only add
+- Leave a page without at least one specific number or equation
 
 ### Handling Missing Information
 
 | Missing | Action | Annotation |
 |---------|--------|------------|
-| Terse claim content (< 20 words) | Expand from `artifacts/` | `> [!NOTE] Content expanded from source` |
-| Strategy has no `reason` field | Reconstruct from premises + source | `> [!NOTE] Reasoning reconstructed from source` |
-| No beliefs (infer not run) | Write structural description only | `> [!WARNING] Beliefs not available` |
-| No `artifacts/` directory | Write from IR content only | `> [!WARNING] Original source not available` |
+| Terse claim content (< 20 words) | Expand from `artifacts/` — read the relevant section and write a full explanation | `> [!NOTE] Content expanded from source` |
+| Strategy has no `reason` field | Reconstruct the scientific argument from premises + source material | `> [!NOTE] Reasoning reconstructed from source` |
+| No beliefs (infer not run) | Write structural description only | `> [!WARNING] Beliefs not available — run gaia infer` |
+| No `artifacts/` directory | Write from IR content only, note the gap prominently | `> [!WARNING] Original source not available — narrative is based on IR content only` |
 
 ## Step 5: Cross-Reference Audit
 

--- a/skills/render-obsidian/SKILL.md
+++ b/skills/render-obsidian/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: render-obsidian
-description: "Use when user wants a browsable Obsidian wiki from a Gaia knowledge package — generates skeleton, fills narrative from IR and original sources, audits cross-references."
+description: "Use when user wants a browsable Obsidian wiki from a Gaia knowledge package — generates skeleton, rewrites all pages as rich knowledge documents from IR and original sources, audits cross-references."
 ---
 
 # Render Obsidian Wiki
 
-Generate a rich, browsable Obsidian vault (`gaia-wiki/`) from a Gaia knowledge package. The agent drives the full pipeline: skeleton generation, narrative filling, and cross-reference audit.
+Generate a rich, browsable Obsidian vault (`gaia-wiki/`) from a Gaia knowledge package. The agent drives the full pipeline: skeleton generation, full rewrite into human-readable knowledge documents, and cross-reference audit.
 
 ## Full Pipeline
 
@@ -14,28 +14,18 @@ Generate a rich, browsable Obsidian vault (`gaia-wiki/`) from a Gaia knowledge p
   ↓
 Step 1: gaia compile + gaia infer (if review exists)
 Step 2: gaia render --target obsidian → gaia-wiki/ skeleton
-Step 3: Read inputs (IR, beliefs, artifacts/)
-Step 4: Fill narrative per page (agent writes directly)
+Step 3: Read inputs (IR, beliefs, artifacts/, DSL source)
+Step 4: Rewrite every page as a complete knowledge document
 Step 5: Cross-reference audit
 Step 6: Report
 ```
 
 ## Step 1: Ensure Compile + Infer
 
-Run in the package directory:
-
 ```bash
 gaia compile .
+ls reviews/ && gaia infer .   # run inference if review exists
 ```
-
-If a review sidecar exists, also run inference:
-
-```bash
-ls reviews/          # check for review sidecars
-gaia infer .         # run if review exists
-```
-
-If compile or infer fails, stop and report the error.
 
 ## Step 2: Generate Skeleton
 
@@ -43,188 +33,180 @@ If compile or infer fails, stop and report the error.
 gaia render . --target obsidian
 ```
 
-This produces `gaia-wiki/` containing:
-- `_index.md` — master navigation with statistics
-- `overview.md` — Mermaid reasoning graph
-- `conclusions/{label}.md` — one page per exported claim / question
-- `evidence/{label}.md` — one page per leaf premise
-- `modules/{module}.md` — one page per module (non-exported claims inlined)
-- `reasoning/{strategy}.md` — one page per complex strategy
-- `meta/beliefs.md` — belief table (if infer was run)
-- `meta/holes.md` — leaf premises summary
-- `.obsidian/graph.json` — graph view color config
-
-All pages have YAML frontmatter and wikilinks. The skeleton is browsable but thin.
+This produces `gaia-wiki/` with YAML frontmatter, wikilinks, and Mermaid graphs on every page. The skeleton provides **structure only** — all prose content will be rewritten by the agent.
 
 ## Step 3: Read Inputs
 
-Read these files to prepare for narrative filling:
+Read thoroughly before writing:
 
 ```bash
-cat .gaia/ir.json                          # Full IR (knowledges, strategies, operators)
-cat .gaia/reviews/*/beliefs.json           # BP results (if available)
-cat .gaia/reviews/*/parameterization.json  # Review priors + strategy params
-ls src/<package>/*.py                      # DSL source (claims, strategies, reasons)
+cat .gaia/ir.json                          # Full IR
+cat .gaia/reviews/*/beliefs.json           # BP results
+cat .gaia/reviews/*/parameterization.json  # Priors + strategy params
+cat src/<package>/*.py                     # DSL source (claims, reasons, strategies)
 ls artifacts/                              # Original paper, figures, data
 ```
 
-Build a mental model of:
-- The package's overall argument (what is it trying to establish?)
-- The reasoning chains (which premises support which conclusions?)
-- The evidence quality (where are beliefs strong vs weak?)
-- The original source material (what context does the paper provide?)
+Read the original source material in `artifacts/` cover-to-cover. The agent must understand the paper's argument, data, and figures before writing any page.
 
-## Step 4: Fill Narrative Per Page
+## Step 4: Rewrite Every Page
 
-For each page in `gaia-wiki/`, enrich the skeleton with narrative content. **Do NOT modify frontmatter or wikilinks** — only add prose sections.
+**Core principle:** The skeleton is scaffolding, not content. The agent rewrites every page into a complete, self-contained knowledge document. After reading a page, the reader should understand the topic **without needing the original source**.
 
-**Core principle:** Each wiki page is a self-contained knowledge document. After reading a page, the reader should understand the claim, its evidence, and its role in the argument **without needing to read the original source**. The wiki replaces reading the paper, not summarizes it.
+**Language:** Follow the user's language. If the user speaks Chinese, write all prose in Chinese. Frontmatter keys, wikilinks `[[label]]`, and Mermaid diagrams stay in English (they are structural identifiers).
 
-### Quality standard: thin vs rich
+### What to preserve vs rewrite
 
-**BAD (thin)** — the agent's default tendency:
-```markdown
-## Context
-Aluminum has r_s = 2.07 and the ab initio prediction is 0.96 K,
-close to the experimental value of 1.2 K.
+| Element | Action |
+|---------|--------|
+| YAML frontmatter | **Preserve exactly** — never modify |
+| Wikilinks `[[label]]` | **Preserve exactly** — never change targets |
+| Mermaid diagrams | **Preserve exactly** |
+| `.obsidian/graph.json` | **Preserve exactly** |
+| Section headings (`## Derivation`, etc.) | **Translate** to user's language |
+| Claim content blockquotes (`> ...`) | **Rewrite** — expand terse claims into full explanations |
+| `> [!REASONING]` callouts | **Rewrite** — translate and expand the reasoning |
+| Premise/conclusion lists | **Rewrite** — keep wikilinks but add explanatory text |
+| Everything else | **Write from scratch** |
+
+### Per-page rewrite guide
+
+#### Conclusion pages (`conclusions/*.md`)
+
+Rewrite into a complete article about this claim:
+
+1. **Title**: Keep or translate the `# heading`
+2. **Content**: Replace the terse blockquote with 2-3 paragraphs fully explaining the claim — what it states, what evidence supports it, what method produced it. Include specific numbers, equations, experimental conditions.
+3. **Derivation**: Rewrite in prose. Don't just list premises — explain the logical chain: WHY each premise supports this conclusion. Keep wikilinks but wrap them in explanatory sentences.
+4. **Supports**: Rewrite as prose — what downstream conclusions depend on this claim and why.
+5. **Context**: Add 2-3 paragraphs explaining the claim's scientific context from `artifacts/`. Include figures with `![[filename]]`.
+6. **Significance**: 1-2 paragraphs on why this matters for the overall argument.
+7. **Caveats**: Note limitations, alternative explanations, sources of uncertainty.
+
+Target: 500-800 words per conclusion page.
+
+#### Evidence pages (`evidence/*.md`)
+
+Rewrite into a source documentation page:
+
+1. **Content**: Expand the terse blockquote into a full description of the evidence.
+2. **Source**: Where does this evidence come from? Specific experiment, dataset, calculation, or literature. Method, precision, known limitations.
+3. **Supports**: Which conclusions depend on this evidence and why.
+4. **Figures**: Embed relevant figures from `artifacts/images/`.
+
+Target: 200-400 words per evidence page.
+
+#### Module pages (`modules/*.md`)
+
+Rewrite into a chapter-level overview:
+
+1. **Overview**: 2-3 paragraphs — what scientific question this module addresses, what approach is taken, key results. Write as a review paper section introduction.
+2. **Transition**: How this module connects to adjacent modules.
+3. **Claims section**: For each claim listed:
+   - Exported claims (with `[[link]] ★`): expand the one-line description into 2-3 sentences.
+   - Inlined claims: rewrite the content and derivation info into readable prose. Don't just say "Derived via X from Y" — explain the reasoning.
+
+Target: 400-800 words per module page.
+
+#### Strategy pages (`reasoning/*.md`)
+
+Rewrite into a reasoning explanation:
+
+1. **Overview**: What type of reasoning is this and what does it establish?
+2. **Premises → Conclusion**: For each premise, explain WHY it supports the conclusion. Include the mathematical or physical argument.
+3. **Strength assessment**: How strong is this reasoning? What could weaken it?
+
+Target: 300-500 words per strategy page.
+
+#### Overview page (`overview.md`)
+
+1. **Citation**: Add proper bibliographic reference to original work.
+2. **Abstract**: 3-4 paragraphs summarizing the entire package — central question, methodology, key quantitative results, limitations.
+3. **Reasoning graph**: Keep the Mermaid diagram as-is.
+
+Target: 300-500 words.
+
+#### `_index.md`
+
+Add a package description (3-5 sentences) with the most striking quantitative results. Keep all statistics tables and navigation as-is.
+
+#### Meta pages (`meta/*.md`)
+
+- `beliefs.md`: Add a brief introduction explaining what the table shows.
+- `holes.md`: Add a brief introduction explaining what leaf premises are and why they matter.
+
+### Quality bar
+
+**Every page must include:**
+- Specific numerical values (with units, error bars where available)
+- Key equations in LaTeX where they clarify the argument
+- Cross-references via wikilinks to related pages
+- At least one figure embed from `artifacts/images/` if relevant figures exist
+
+**BAD — thin rewrite:**
+```
+## 背景
+铝的 r_s = 2.07，预测 T_c = 0.96 K，接近实验值 1.2 K。
 ```
 
-**GOOD (rich)** — what the reader actually needs:
-```markdown
-## Context
-Aluminum is the benchmark test for any superconductivity theory. With
-Wigner-Seitz radius $r_s = 2.07$ and band mass $m_b = 1.05$, it sits
-in the weak-coupling regime where the competition between phonon
-attraction ($\lambda = 0.44$ from DFPT, using $\omega_{\log} = 320$ K)
-and Coulomb repulsion ($\mu^* = 0.13$ from vDiagMC at $r_s = 2.07$
-with BTS renormalization) leaves a small net pairing interaction.
+**GOOD — rich rewrite:**
+```
+## 背景
 
-The phenomenological prediction of $T_c = 1.9$ K overshoots the
-experimental $T_c = 1.2$ K by 58%, primarily because the conventional
-$\mu^* \approx 0.10$ underestimates Coulomb repulsion. The ab initio
-value $\mu^* = 0.13$ increases the repulsion just enough to bring
-$T_c$ down to 0.96 K — within 20% of experiment. The remaining
-discrepancy likely reflects the UEG-to-material mapping approximation
-and band structure effects beyond the free-electron model.
+铝是超导理论的基准测试材料。Wigner-Seitz 半径 $r_s = 2.07$，
+带质量 $m_b = 1.05$，处于弱耦合区间。声子吸引（$\lambda = 0.44$，
+来自 DFPT 计算，$\omega_{\log} = 320$ K）与 Coulomb 排斥
+（$\mu^* = 0.13$，来自 [[mu_vdiagmc_values]] 在 $r_s = 2.07$
+处的值经 BTS 重正化）之间的竞争仅留下很小的净配对相互作用。
+
+唯象方法预测 $T_c = 1.9$ K，比实验值 1.2 K 高估 58%——根本
+原因是传统取值 $\mu^* \approx 0.10$ 低估了 Coulomb 排斥。
+第一性原理值 $\mu^* = 0.13$ 恰好增大了足够的排斥，将 $T_c$
+降低到 0.96 K，偏差在 20% 以内。
 
 ![[8_0.jpg]]
-*Fig. 4: Dimensionless bare Coulomb pseudopotential $\mu_{E_F}(r_s)$
-from vDiagMC (circles with error bars), compared with static RPA
-(dashed), dynamic RPA (dotted), and Morel-Anderson constant (dash-dot).
-Adapted from Cai et al., arXiv:2512.19382.*
+*图 4：vDiagMC 计算的 $\mu_{E_F}(r_s)$（圆圈带误差棒），
+与静态 RPA（虚线）、动态 RPA（点线）和 Morel-Anderson 常数
+（点划线）的对比。改编自 Cai et al., arXiv:2512.19382。*
 ```
 
-The difference: the rich version includes all the numbers ($r_s$, $m_b$, $\lambda$, $\omega_{\log}$, $\mu^*$), explains the mechanism (why the prediction differs from phenomenology), embeds figures, and gives the reader enough context to evaluate the claim independently.
+### DO NOT
 
-### Claim pages (`conclusions/*.md`)
-
-Add after the existing skeleton content:
-
-**Context** (3-5 paragraphs, ~300-500 words):
-- **Paragraph 1**: What is this claim about? Set the scientific context — what question is being answered, what method is used, what physical regime.
-- **Paragraph 2**: The specific data and results. Include ALL relevant numbers: material parameters, computed values with error bars, comparisons with experiment and prior theory. Reproduce key equations if they clarify the argument.
-- **Paragraph 3**: How the result was obtained — what computation, what approximations, what input data. The reader should be able to trace the derivation.
-- **Paragraph 4 (if applicable)**: Caveats, limitations, comparison with alternative approaches.
-- Embed relevant figures from `artifacts/images/` with captions and attribution.
-
-**Significance** (1-2 paragraphs): Why this claim matters for the package's overall argument. What breaks if this claim is wrong? What does it enable downstream?
-
-```markdown
-> [!NOTE]
-> Context expanded from [Author et al.], Section X, pp. Y-Z.
-> See `artifacts/paper.md` for full details.
-```
-
-### Module pages (`modules/*.md`)
-
-Add at the top (after frontmatter, before Claims):
-
-**Overview** (2-3 paragraphs, ~200-400 words): What scientific question this module addresses, what approach is taken, and what the key results are. Write as you would a section introduction in a review paper — the reader should understand the module's contribution after reading just the overview.
-
-**Transition** (2-3 sentences): How this module builds on the previous one and what it enables for the next. Name the specific concepts that flow between modules.
-
-### Evidence pages (`evidence/*.md`)
-
-**Source** (1-2 paragraphs): Where this evidence comes from — specific experiment, dataset, calculation, or literature reference. Include: who measured/computed it, what method, what precision, and any known limitations. Cite from `artifacts/` if available.
-
-### Strategy pages (`reasoning/*.md`)
-
-Expand the Reasoning section into **Explanation** (2-3 paragraphs): For each premise → conclusion link, explain the scientific logic of WHY the premise supports the conclusion. Include the mathematical or physical argument, not just "A implies B." The reader should understand the chain of reasoning as clearly as if they read the relevant section of the paper.
-
-### Overview page (`overview.md`)
-
-**Abstract** (2-3 paragraphs, ~200-300 words): A self-contained summary of the entire knowledge package. What is the central question? What new methodology is introduced? What are the key quantitative results? What are the limitations? A domain expert should be able to decide whether to explore further based on this abstract alone.
-
-### `_index.md`
-
-**Package Description** (3-5 sentences): What this package formalizes, what the source material is, and what the main findings are. Include the most striking quantitative result.
-
-## Narrative Guidelines
-
-**Audience:** A domain expert who hasn't read the original source material but understands the field. They should be able to evaluate the claims based solely on the wiki pages.
-
-**Voice:** Scientific, precise, but readable. Third-person. Write as you would for a review article or an extended encyclopedia entry.
-
-**Content depth:** Every page should include:
-- Specific numerical values (with units and error bars where available)
-- Key equations (in LaTeX) where they clarify the argument
-- Comparison with alternative approaches or prior results
-- Figure embeds from `artifacts/images/` with descriptive captions
-
-**DO:**
-- Read `artifacts/` thoroughly — find the section corresponding to each claim and extract concrete details
-- Ground every claim in specific data (not "good agreement" but "0.874 K vs 0.875 K, 0.1% error")
-- Embed figures with `![[filename]]` and write informative captions
-- Cross-reference other pages via wikilinks: `[[label]]`
-- Use Obsidian callouts: `> [!NOTE]` for source citations, `> [!WARNING]` for caveats
-
-**DO NOT:**
-- Write thin summaries that could apply to any paper in the field
+- Leave any page with only skeleton English content
+- Write thin summaries — every page should be a substantive knowledge document
 - Use Gaia jargon (noisy_and, abduction, factor graph, BP, NAND)
 - Describe graph structure ("this claim derives from two premises via...")
-- Modify frontmatter or existing wikilink sections
-- Remove any skeleton content — only add
-- Leave a page without at least one specific number or equation
+- Modify frontmatter or wikilink targets
+- Skip evidence pages — they are important for completeness
 
-### Handling Missing Information
+### Handling missing information
 
 | Missing | Action | Annotation |
 |---------|--------|------------|
-| Terse claim content (< 20 words) | Expand from `artifacts/` — read the relevant section and write a full explanation | `> [!NOTE] Content expanded from source` |
-| Strategy has no `reason` field | Reconstruct the scientific argument from premises + source material | `> [!NOTE] Reasoning reconstructed from source` |
-| No beliefs (infer not run) | Write structural description only | `> [!WARNING] Beliefs not available — run gaia infer` |
-| No `artifacts/` directory | Write from IR content only, note the gap prominently | `> [!WARNING] Original source not available — narrative is based on IR content only` |
+| Terse claim (< 20 words) | Read `artifacts/`, find relevant section, write full explanation | `> [!NOTE] 内容根据原文扩展` |
+| No `reason` in strategy | Reconstruct from premises + source | `> [!NOTE] 推理根据原文重构` |
+| No beliefs | Write structural description, note gap | `> [!WARNING] 未运行推断` |
+| No `artifacts/` | Write from IR only, note prominently | `> [!WARNING] 原始文献不可用` |
 
 ## Step 5: Cross-Reference Audit
 
-After filling all pages, verify:
-
 ```bash
-# Check for broken wikilinks
 grep -roh '\[\[[^]]*\]\]' gaia-wiki/ | sort -u | while read link; do
-  name=$(echo "$link" | sed 's/\[\[//;s/\]\]//')
+  name=$(echo "$link" | sed 's/\[\[//;s/\]\]//' | sed 's/#.*//' | sed 's/|.*//')
   if ! find gaia-wiki -name "${name}.md" | grep -q .; then
     echo "BROKEN: $link"
   fi
 done
 ```
 
-Fix any broken wikilinks. Update `_index.md` statistics if page count changed.
-
 ## Step 6: Report
 
-Summarize what was done:
-
 ```
-Obsidian wiki generated at gaia-wiki/
+Obsidian wiki: gaia-wiki/
 - X pages total (Y conclusions, Z evidence, W modules)
-- Narrative filled for N pages
+- All pages rewritten in [language]
 - Figures embedded: M
 - Broken wikilinks: 0
-```
 
-Suggest opening in Obsidian:
-```
 Open in Obsidian: File → Open Vault → select gaia-wiki/
-Graph view will show the reasoning structure color-coded by node type.
 ```

--- a/skills/render-obsidian/SKILL.md
+++ b/skills/render-obsidian/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when user wants a browsable Obsidian wiki from a Gaia knowledg
 
 # Render Obsidian Wiki
 
-Generate a rich, browsable Obsidian vault (`.gaia-wiki/`) from a Gaia knowledge package. The agent drives the full pipeline: skeleton generation, narrative filling, and cross-reference audit.
+Generate a rich, browsable Obsidian vault (`gaia-wiki/`) from a Gaia knowledge package. The agent drives the full pipeline: skeleton generation, narrative filling, and cross-reference audit.
 
 ## Full Pipeline
 
@@ -13,7 +13,7 @@ Generate a rich, browsable Obsidian vault (`.gaia-wiki/`) from a Gaia knowledge 
 /gaia:render-obsidian
   ↓
 Step 1: gaia compile + gaia infer (if review exists)
-Step 2: gaia render --target obsidian → .gaia-wiki/ skeleton
+Step 2: gaia render --target obsidian → gaia-wiki/ skeleton
 Step 3: Read inputs (IR, beliefs, artifacts/)
 Step 4: Fill narrative per page (agent writes directly)
 Step 5: Cross-reference audit
@@ -43,7 +43,7 @@ If compile or infer fails, stop and report the error.
 gaia render . --target obsidian
 ```
 
-This produces `.gaia-wiki/` containing:
+This produces `gaia-wiki/` containing:
 - `_index.md` — master navigation with statistics
 - `overview.md` — Mermaid reasoning graph
 - `conclusions/{label}.md` — one page per exported claim / question
@@ -76,7 +76,7 @@ Build a mental model of:
 
 ## Step 4: Fill Narrative Per Page
 
-For each page in `.gaia-wiki/`, enrich the skeleton with narrative content. **Do NOT modify frontmatter or wikilinks** — only add prose sections.
+For each page in `gaia-wiki/`, enrich the skeleton with narrative content. **Do NOT modify frontmatter or wikilinks** — only add prose sections.
 
 ### Claim pages (`conclusions/*.md`)
 
@@ -170,9 +170,9 @@ After filling all pages, verify:
 
 ```bash
 # Check for broken wikilinks
-grep -roh '\[\[[^]]*\]\]' .gaia-wiki/ | sort -u | while read link; do
+grep -roh '\[\[[^]]*\]\]' gaia-wiki/ | sort -u | while read link; do
   name=$(echo "$link" | sed 's/\[\[//;s/\]\]//')
-  if ! find .gaia-wiki -name "${name}.md" | grep -q .; then
+  if ! find gaia-wiki -name "${name}.md" | grep -q .; then
     echo "BROKEN: $link"
   fi
 done
@@ -185,7 +185,7 @@ Fix any broken wikilinks. Update `_index.md` statistics if page count changed.
 Summarize what was done:
 
 ```
-Obsidian wiki generated at .gaia-wiki/
+Obsidian wiki generated at gaia-wiki/
 - X pages total (Y conclusions, Z evidence, W modules)
 - Narrative filled for N pages
 - Figures embedded: M
@@ -194,6 +194,6 @@ Obsidian wiki generated at .gaia-wiki/
 
 Suggest opening in Obsidian:
 ```
-Open in Obsidian: File → Open Vault → select .gaia-wiki/
+Open in Obsidian: File → Open Vault → select gaia-wiki/
 Graph view will show the reasoning structure color-coded by node type.
 ```

--- a/tests/cli/test_render.py
+++ b/tests/cli/test_render.py
@@ -453,3 +453,24 @@ def test_render_fails_when_review_sidecar_edited_after_infer(tmp_path):
     assert "review" in result.output.lower()
     assert "changed" in result.output.lower() or "content_hash" in result.output.lower()
     assert "gaia infer" in result.output
+
+
+def test_render_target_obsidian_writes_vault(tmp_path):
+    """Obsidian target creates gaia-wiki/ with _index.md and module pages."""
+    pkg_dir = _prepare_inferred_package(tmp_path, name="obsidian_demo")
+    result = runner.invoke(app, ["render", str(pkg_dir), "--target", "obsidian"])
+    assert result.exit_code == 0, result.output
+    wiki_dir = pkg_dir / "gaia-wiki"
+    assert wiki_dir.is_dir()
+    assert (wiki_dir / "_index.md").exists()
+    assert (wiki_dir / "overview.md").exists()
+    assert (wiki_dir / ".obsidian" / "graph.json").exists()
+    assert "Obsidian:" in result.output
+
+
+def test_render_target_all_does_not_include_obsidian(tmp_path):
+    """Obsidian is opt-in — --target all should NOT create gaia-wiki/."""
+    pkg_dir = _prepare_inferred_package(tmp_path, name="all_no_obsidian")
+    result = runner.invoke(app, ["render", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert not (pkg_dir / "gaia-wiki").exists()


### PR DESCRIPTION
## Summary

Follow-up to PR #409 (merged). Completes the Obsidian Wiki Backend with:

- **`.gaia-wiki` → `gaia-wiki`** — Obsidian can't see hidden directories. Output path renamed.
- **`/gaia:render-obsidian` skill** (`skills/render-obsidian/SKILL.md`) — Agent-driven workflow for generating rich Obsidian wikis:
  - Step 1-2: compile + infer + render skeleton
  - Step 3-4: Agent reads original sources, rewrites every page as a complete knowledge document
  - Faithful reproduction standard: derivations reproduce the paper's full argument, not summaries
  - Background before derivation (provides context needed to understand the argument)
  - Language follows user preference
- **Spec + plan updates** — All references updated to `gaia-wiki/`

E2E tested on SuperconductivityElectronLiquids.gaia: 53 pages, 3210 lines of Chinese content, 12 figure embeds, 0 broken wikilinks.

## Test plan

- [x] 51 tests pass (28 obsidian + 23 render)
- [x] `ruff check` + `ruff format` clean
- [x] E2E: electron liquid package → 53 pages, complete Chinese rewrite with faithful derivations
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)