### PR TITLE
feat(obsidian): Phase 3 — claims taxonomy, topo numbering, justification, weak points

### DIFF
--- a/docs/plans/2026-04-12-warrant-based-redesign.md
+++ b/docs/plans/2026-04-12-warrant-based-redesign.md
@@ -1,0 +1,1097 @@
+# Warrant-Based Operator/Strategy Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the warrant-based audit framework: implication becomes a Relation operator, new `support()` and `compare()` DSL primitives, abduction/induction as binary CompositeStrategies with composition warrants.
+
+**Architecture:** The core change is implication moving from Directed (1 variable) to Relation (2 variables, generates helper claim H). This enables `support()` (two IMPLIES) and `compare()` (two equivalences) as FormalStrategy primitives. Abduction and induction become binary CompositeStrategies built from support + compare.
+
+**Tech Stack:** Python 3.12+, Pydantic v2, pytest
+
+**Spec:** `docs/specs/2026-04-06-operator-strategy-redesign.md` (PR #412 merged, PR #414 open)
+
+---
+
+## File Map
+
+| File | Responsibility | Action |
+|------|---------------|--------|
+| `gaia/ir/operator.py` | Operator schema + arity validation | Modify: implication arity 1→2 |
+| `gaia/ir/formalize.py` | Named strategy → FormalExpr expansion | Modify: all builders using implication |
+| `gaia/bp/potentials.py` | Factor potential functions | Modify: implication_potential signature |
+| `gaia/bp/lowering.py` | IR → FactorGraph lowering | Modify: implication factor construction |
+| `gaia/lang/runtime/nodes.py` | DSL Strategy dataclass | Modify: add composition_warrant field |
+| `gaia/lang/dsl/strategies.py` | DSL strategy functions | Modify: deduction, abduction, induction; Add: support, compare |
+| `gaia/lang/dsl/operators.py` | DSL operator functions | No change (equivalence etc. already Relation) |
+| `gaia/lang/__init__.py` | Public API exports | Modify: add support, compare |
+| `gaia/lang/compiler/compile.py` | DSL → IR compilation | Modify: handle composition_warrant, new strategy types |
+| `tests/ir/test_operator.py` | Operator arity tests | Modify: implication arity 1→2 |
+| `tests/ir/test_formalize.py` | Formalization tests | Modify: deduction builds |
+| `tests/gaia/lang/test_strategies.py` | DSL strategy tests | Add: support, compare, new abduction/induction |
+| `tests/gaia/bp/test_potentials.py` | BP potential tests | Modify: implication potential |
+
+---
+
+## Chunk 1: Implication Operator Change (Phase 0)
+
+The foundation: implication moves from Directed (1 variable, conclusion = consequent) to Relation (2 variables, conclusion = helper claim H asserting "A→B").
+
+### Task 1: Update Implication Arity + Reclassify as Relation
+
+**Files:**
+- Modify: `gaia/ir/operator.py` (arity validator, ~line 50)
+- Modify: `gaia/bp/lowering.py:27` (add IMPLICATION to `_RELATION_OPS`)
+- Modify: `gaia/cli/commands/_detailed_reasoning.py:113` (add "implication" to `_UNDIRECTED_OPERATORS`)
+- Modify: `gaia/cli/commands/_simplified_mermaid.py:35` (same)
+- Modify: `gaia/cli/commands/_github.py:337` (add "implication" to `_UNDIRECTED`)
+- Test: `tests/ir/test_operator.py`
+
+- [ ] **Step 1: Write failing test — implication now accepts 2 variables**
+
+```python
+# tests/ir/test_operator.py — add new test
+def test_implication_binary():
+    """Implication now takes 2 variables (antecedent + consequent) and a helper claim conclusion."""
+    op = Operator(
+        operator=OperatorType.IMPLICATION,
+        variables=["claim_A", "claim_B"],
+        conclusion="helper_implies_A_B",
+    )
+    assert op.variables == ["claim_A", "claim_B"]
+    assert op.conclusion == "helper_implies_A_B"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ir/test_operator.py::test_implication_binary -v`
+Expected: FAIL — arity validator rejects 2 variables for implication (currently requires exactly 1)
+
+- [ ] **Step 3: Update arity validator**
+
+In `gaia/ir/operator.py`, find the `@model_validator` that checks arity. Change implication's expected arity from 1 to 2:
+
+```python
+# In the arity validation section, change:
+#   OperatorType.IMPLICATION: 1
+# To:
+#   OperatorType.IMPLICATION: 2
+```
+
+- [ ] **Step 4: Reclassify implication as Relation in lowering and rendering**
+
+In `gaia/bp/lowering.py:27`, add IMPLICATION to `_RELATION_OPS`:
+```python
+_RELATION_OPS = frozenset({
+    OperatorType.EQUIVALENCE,
+    OperatorType.CONTRADICTION,
+    OperatorType.COMPLEMENT,
+    OperatorType.IMPLICATION,  # NEW: implication is now Relation
+})
+```
+
+In `gaia/cli/commands/_detailed_reasoning.py:113` and `_simplified_mermaid.py:35`, add "implication" to `_UNDIRECTED_OPERATORS`:
+```python
+_UNDIRECTED_OPERATORS = frozenset({"equivalence", "contradiction", "complement", "implication"})
+```
+
+In `gaia/cli/commands/_github.py:337`:
+```python
+_UNDIRECTED = {"equivalence", "contradiction", "complement", "implication"}
+```
+
+This means implication conclusions now get `π = 1-ε` default in lowering (same as other Relation operators) until review sets the actual value.
+
+- [ ] **Step 5: Update existing test that expects arity 1**
+
+In `tests/ir/test_operator.py`, find the test that validates implication with 1 variable and update it to expect 2. Also update the "wrong arity" test to reject 1 variable.
+
+- [ ] **Step 6: Run all operator tests + lowering tests + mermaid tests**
+
+Run: `pytest tests/ir/test_operator.py tests/gaia/bp/ tests/cli/ -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/ir/operator.py gaia/bp/lowering.py \
+       gaia/cli/commands/_detailed_reasoning.py \
+       gaia/cli/commands/_simplified_mermaid.py \
+       gaia/cli/commands/_github.py \
+       tests/ir/test_operator.py
+git commit -m "feat(ir): implication arity 1→2, reclassify Directed→Relation (Computation vs Relation)"
+```
+
+### Task 2: Update Implication Potential Function
+
+**Files:**
+- Modify: `gaia/bp/potentials.py` (~line 25)
+- Test: `tests/gaia/bp/test_potentials.py` (or equivalent)
+
+- [ ] **Step 1: Write failing test — implication potential with 3 variables (A, B, H)**
+
+The new implication factor is a 3-variable factor f(A, B, H) where H = "A→B holds":
+
+| A | B | H=1 (holds) | H=0 (violated) |
+|---|---|-------------|----------------|
+| 0 | 0 | HIGH | LOW |
+| 0 | 1 | HIGH | LOW |
+| 1 | 0 | LOW | HIGH |
+| 1 | 1 | HIGH | LOW |
+
+```python
+def test_implication_potential_ternary():
+    """Implication is now a ternary factor f(antecedent, consequent, helper)."""
+    from gaia.bp.potentials import implication_potential, CROMWELL_EPS
+
+    HIGH = 1.0 - CROMWELL_EPS
+    LOW = CROMWELL_EPS
+
+    # H=1: standard truth table
+    assert implication_potential({"A": 0, "B": 0, "H": 1}, "A", "B", "H") == pytest.approx(HIGH)
+    assert implication_potential({"A": 0, "B": 1, "H": 1}, "A", "B", "H") == pytest.approx(HIGH)
+    assert implication_potential({"A": 1, "B": 0, "H": 1}, "A", "B", "H") == pytest.approx(LOW)
+    assert implication_potential({"A": 1, "B": 1, "H": 1}, "A", "B", "H") == pytest.approx(HIGH)
+
+    # H=0: complement of truth table
+    assert implication_potential({"A": 1, "B": 0, "H": 0}, "A", "B", "H") == pytest.approx(HIGH)
+    assert implication_potential({"A": 1, "B": 1, "H": 0}, "A", "B", "H") == pytest.approx(LOW)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/gaia/bp/test_potentials.py::test_implication_potential_ternary -v`
+Expected: FAIL — current signature doesn't accept helper variable
+
+- [ ] **Step 3: Update implication_potential to ternary**
+
+```python
+def implication_potential(
+    assignment: Assignment,
+    antecedent: str,
+    consequent: str,
+    helper: str,
+) -> float:
+    """Ternary implication factor: f(A, B, H).
+    
+    H=1: standard implication truth table (A=1,B=0 forbidden).
+    H=0: complement (A=1,B=0 allowed, others forbidden).
+    """
+    a, b, h = assignment[antecedent], assignment[consequent], assignment[helper]
+    truth_table_holds = not (a == 1 and b == 0)
+    if h == 1:
+        return _HIGH if truth_table_holds else _LOW
+    else:
+        return _LOW if truth_table_holds else _HIGH
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `pytest tests/gaia/bp/test_potentials.py -v`
+Expected: PASS (new test passes, check existing tests — may need updates)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/bp/potentials.py tests/gaia/bp/test_potentials.py
+git commit -m "feat(bp): update implication to ternary factor f(A, B, H)"
+```
+
+### Task 3: Update Formalization — Deduction Builder
+
+**Files:**
+- Modify: `gaia/ir/formalize.py` (~line 220, `_build_deduction`)
+- Test: `tests/ir/test_formalize.py`
+
+- [ ] **Step 1: Write failing test — deduction generates binary implication with helper claim**
+
+```python
+def test_deduction_single_premise_generates_helper():
+    """Single-premise deduction: implication([A, C], conclusion=H) where H is a helper claim."""
+    # Build a minimal strategy
+    result = formalize_named_strategy(
+        strategy_type="deduction",
+        premises=["premise_A"],
+        conclusion="conclusion_C",
+        # ... (fill in required params based on existing test patterns)
+    )
+    # Find the implication operator
+    impl_ops = [op for op in result.strategy.formal_expr.operators if op.operator == "implication"]
+    assert len(impl_ops) == 1
+    impl = impl_ops[0]
+    # Binary: 2 variables
+    assert len(impl.variables) == 2
+    assert impl.variables == ["premise_A", "conclusion_C"]
+    # Conclusion is a NEW helper claim, not conclusion_C
+    assert impl.conclusion != "conclusion_C"
+    assert impl.conclusion.startswith("__")  # helper claim naming convention
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ir/test_formalize.py::test_deduction_single_premise_generates_helper -v`
+Expected: FAIL — current deduction uses 1-variable implication
+
+- [ ] **Step 3: Update `_build_deduction` in formalize.py**
+
+```python
+def _build_deduction(builder: _TemplateBuilder) -> list[Operator]:
+    if len(builder.premises) == 1:
+        # Single premise: implication([premise, conclusion], helper_H)
+        h = builder.add_helper("implication", f"implies({builder.premises[0]}, {builder.conclusion})")
+        return [
+            Operator(
+                operator="implication",
+                variables=[builder.premises[0], builder.conclusion],
+                conclusion=h.id,
+            ),
+        ]
+    else:
+        # Multiple premises: conjunction + implication
+        conj = builder.add_helper("conjunction", _all_true_name(builder.premises))
+        h = builder.add_helper("implication", f"implies({conj.id}, {builder.conclusion})")
+        return [
+            Operator(
+                operator="conjunction",
+                variables=builder.premises,
+                conclusion=conj.id,
+            ),
+            Operator(
+                operator="implication",
+                variables=[conj.id, builder.conclusion],
+                conclusion=h.id,
+            ),
+        ]
+```
+
+- [ ] **Step 4: Update all other builders that use implication**
+
+Search `formalize.py` for `operator="implication"` and update each to use 2 variables + helper claim conclusion. Affected builders:
+- `_build_deduction` (done above)
+- `_build_mathematical_induction`
+- `_build_elimination`
+- `_build_case_analysis`
+- `_build_analogy`
+- `_build_extrapolation`
+
+Each needs the same pattern: `variables=[antecedent, consequent]` with a new helper claim as conclusion.
+
+- [ ] **Step 5: Run all formalization tests**
+
+Run: `pytest tests/ir/test_formalize.py -v`
+Expected: Some may need updates — fix them
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/ir/formalize.py tests/ir/test_formalize.py
+git commit -m "feat(ir): update all formalization builders for binary implication"
+```
+
+### Task 4: Update Lowering for Binary Implication
+
+**Files:**
+- Modify: `gaia/bp/lowering.py`
+- Test: `tests/gaia/bp/test_lowering.py` (or equivalent)
+
+- [ ] **Step 1: Write failing test — lowering creates 3-variable factor for implication**
+
+```python
+def test_lower_implication_ternary_factor():
+    """Implication operator lowers to a 3-variable factor (antecedent, consequent, helper)."""
+    # Create a minimal LocalCanonicalGraph with one implication operator
+    # ... (follow existing lowering test patterns)
+    fg = lower_local_graph(graph)
+    # Find the implication factor
+    impl_factors = [f for f in fg.factors if f.type == FactorType.IMPLICATION]
+    assert len(impl_factors) == 1
+    assert len(impl_factors[0].variables) == 3  # A, B, H
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+- [ ] **Step 3: Update lowering to pass antecedent + consequent + helper to factor**
+
+In `gaia/bp/lowering.py`, find where implication operators are lowered. Currently it likely maps `variables[0]` (antecedent) and `conclusion` (consequent) to a 2-variable factor. Change to: `variables[0]` (antecedent), `variables[1]` (consequent), `conclusion` (helper claim) → 3-variable factor.
+
+- [ ] **Step 4: Run all lowering + BP tests**
+
+Run: `pytest tests/gaia/bp/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/bp/lowering.py tests/gaia/bp/
+git commit -m "feat(bp): lower binary implication to 3-variable factor"
+```
+
+### Task 5: Warrant Metadata on Helper Claims
+
+**Files:**
+- Modify: `gaia/ir/formalize.py` (helper claim generation)
+- Modify: `gaia/lang/dsl/operators.py` (DSL operator helper claims)
+- Test: `tests/ir/test_formalize.py`
+
+- [ ] **Step 1: Write failing test — relation operator helper claims have warrant metadata**
+
+```python
+def test_implication_helper_has_warrant_metadata():
+    """Implication helper claim should have question + warrant in metadata."""
+    result = formalize_named_strategy(
+        strategy_type="deduction",
+        premises=["A"],
+        conclusion="B",
+        reason="mathematical derivation",
+        # ...
+    )
+    # Find the helper claim for implication
+    helpers = [k for k in result.knowledges if k.metadata.get("helper_kind") == "implication_result"]
+    assert len(helpers) == 1
+    h = helpers[0]
+    assert "question" in h.metadata
+    assert "warrant" in h.metadata
+    assert h.metadata["warrant"] == "mathematical derivation"
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+- [ ] **Step 3: Update helper claim generation to include question + warrant**
+
+In `gaia/ir/formalize.py`, update `_TemplateBuilder.add_helper()` to include question template and warrant text:
+
+```python
+def add_helper(self, operator_name: str, canonical_name: str, warrant: str = "") -> Knowledge:
+    # ... existing logic ...
+    metadata = {
+        # ... existing metadata ...
+        "question": self._question_template(operator_name, variables),
+        "warrant": warrant or "显而易见",
+    }
+    # ...
+
+def _question_template(self, operator_name: str, variables: list[str]) -> str:
+    templates = {
+        "implication": f"Does {variables[0]} imply {variables[1]}?",
+        "equivalence": f"Are {variables[0]} and {variables[1]} equivalent?",
+        "contradiction": f"Can {variables[0]} and {variables[1]} not both be true?",
+        "complement": f"Is exactly one of {variables[0]}, {variables[1]} true?",
+    }
+    return templates.get(operator_name, "")
+```
+
+- [ ] **Step 4: Propagate reason from DSL to warrant metadata**
+
+In `gaia/lang/compiler/compile.py`, ensure Strategy.reason is passed through to formalize_named_strategy so it reaches the helper claim's metadata["warrant"].
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/ir/test_formalize.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/ir/formalize.py gaia/lang/compiler/compile.py tests/ir/test_formalize.py
+git commit -m "feat(ir): add warrant metadata (question + reason) to relation operator helper claims"
+```
+
+---
+
+## Chunk 2: New DSL Primitives (Phase 1)
+
+### Task 6: Add `support()` DSL Function
+
+**Files:**
+- Modify: `gaia/lang/dsl/strategies.py`
+- Modify: `gaia/lang/__init__.py`
+- Create: `tests/gaia/lang/test_support.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/gaia/lang/test_support.py
+from gaia.lang import claim, support
+
+def test_support_basic():
+    """support() creates a Strategy with type='support' and stores reverse_reason."""
+    a = claim("Theory A")
+    b = claim("Observation B")
+    s = support(
+        [a], b,
+        reason="A predicts B",
+        reverse_reason="B confirms A",
+    )
+    assert s.type == "support"
+    assert s.premises == [a]
+    assert s.conclusion is b
+    assert s.reason == "A predicts B"
+    assert s.metadata.get("reverse_reason") == "B confirms A"
+
+def test_support_requires_at_least_one_premise():
+    with pytest.raises(ValueError):
+        support([], claim("B"))
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+Run: `pytest tests/gaia/lang/test_support.py -v`
+Expected: FAIL — `support` not importable
+
+- [ ] **Step 3: Implement `support()`**
+
+```python
+# gaia/lang/dsl/strategies.py
+def support(
+    premises: list[Knowledge],
+    conclusion: Knowledge,
+    *,
+    background: list[Knowledge] | None = None,
+    reason: ReasonInput = "",
+    reverse_reason: ReasonInput = "",
+) -> Strategy:
+    """Bidirectional support (sufficiency + necessity). Compiles to two IMPLIES.
+
+    reason → forward implication warrant (sufficiency: A → B).
+    reverse_reason → reverse implication warrant (necessity: B → A).
+    """
+    if len(premises) < 1:
+        raise ValueError("support() requires at least 1 premise")
+    return _named_strategy(
+        "support",
+        premises=premises,
+        conclusion=conclusion,
+        background=background,
+        reason=reason,
+        metadata={"reverse_reason": reverse_reason},
+    )
+```
+
+- [ ] **Step 4: Add to exports**
+
+In `gaia/lang/__init__.py`, add `support` to imports and `__all__`.
+
+- [ ] **Step 5: Run test**
+
+Run: `pytest tests/gaia/lang/test_support.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/lang/dsl/strategies.py gaia/lang/__init__.py tests/gaia/lang/test_support.py
+git commit -m "feat(dsl): add support() — bidirectional reasoning primitive"
+```
+
+### Task 7: Add `support` Formalization Builder
+
+**Files:**
+- Modify: `gaia/ir/formalize.py`
+- Modify: `gaia/ir/strategy.py` (add SUPPORT to StrategyType)
+- Test: `tests/ir/test_formalize.py`
+
+- [ ] **Step 1: Write failing test — support formalizes to two IMPLIES**
+
+```python
+def test_formalize_support():
+    """Support generates forward + reverse IMPLIES, each with helper claim."""
+    result = formalize_named_strategy(
+        strategy_type="support",
+        premises=["A"],
+        conclusion="B",
+        reason="A predicts B",
+        metadata={"reverse_reason": "B confirms A"},
+    )
+    ops = result.strategy.formal_expr.operators
+    impl_ops = [op for op in ops if op.operator == "implication"]
+    assert len(impl_ops) == 2
+
+    # Forward: [A, B] → H_fwd
+    fwd = impl_ops[0]
+    assert fwd.variables == ["A", "B"]
+
+    # Reverse: [B, A] → H_rev
+    rev = impl_ops[1]
+    assert rev.variables == ["B", "A"]
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+- [ ] **Step 3: Add SUPPORT to StrategyType and implement builder**
+
+In `gaia/ir/strategy.py`:
+```python
+class StrategyType(StrEnum):
+    # ... existing ...
+    SUPPORT = "support"
+```
+
+In `gaia/ir/formalize.py`:
+```python
+def _build_support(builder: _TemplateBuilder) -> list[Operator]:
+    """Support: forward IMPLIES + reverse IMPLIES."""
+    reverse_reason = builder.metadata.get("reverse_reason", "")
+
+    if len(builder.premises) == 1:
+        antecedent = builder.premises[0]
+    else:
+        conj = builder.add_helper("conjunction", _all_true_name(builder.premises))
+        antecedent = conj.id
+
+    h_fwd = builder.add_helper(
+        "implication",
+        f"implies({antecedent}, {builder.conclusion})",
+        warrant=builder.reason,
+    )
+    h_rev = builder.add_helper(
+        "implication",
+        f"implies({builder.conclusion}, {antecedent})",
+        warrant=reverse_reason,
+    )
+
+    ops = []
+    if len(builder.premises) > 1:
+        ops.append(Operator(
+            operator="conjunction",
+            variables=builder.premises,
+            conclusion=conj.id,
+        ))
+    ops.extend([
+        Operator(operator="implication", variables=[antecedent, builder.conclusion], conclusion=h_fwd.id),
+        Operator(operator="implication", variables=[builder.conclusion, antecedent], conclusion=h_rev.id),
+    ])
+    return ops
+```
+
+Register in the builder dispatch map.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/ir/test_formalize.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/ir/strategy.py gaia/ir/formalize.py tests/ir/test_formalize.py
+git commit -m "feat(ir): add support formalization — two IMPLIES with independent warrants"
+```
+
+### Task 8: Add `compare()` DSL Function + Formalization
+
+**Files:**
+- Modify: `gaia/lang/dsl/strategies.py`
+- Modify: `gaia/ir/formalize.py`
+- Modify: `gaia/ir/strategy.py` (add COMPARE)
+- Modify: `gaia/lang/__init__.py`
+- Create: `tests/gaia/lang/test_compare.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/gaia/lang/test_compare.py
+from gaia.lang import claim, compare
+
+def test_compare_basic():
+    """compare() creates a Strategy with auto-generated comparison claim."""
+    pred_h = claim("H predicts 0.97K")
+    pred_alt = claim("Alt predicts 2K")
+    obs = claim("Measured 1.2K")
+
+    comp = compare(pred_h, pred_alt, obs, reason="same experiment")
+    assert comp.type == "compare"
+    assert comp.conclusion is not None
+    assert comp.conclusion.type == "claim"
+    assert "comparison" in comp.conclusion.metadata.get("helper_kind", "")
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+- [ ] **Step 3: Implement compare()**
+
+```python
+# gaia/lang/dsl/strategies.py
+def compare(
+    pred_h: Knowledge,
+    pred_alt: Knowledge,
+    observation: Knowledge,
+    *,
+    background: list[Knowledge] | None = None,
+    reason: ReasonInput = "",
+) -> Strategy:
+    """Compare two predictions against observation. First arg is claimed-better.
+
+    Compiles to: equivalence(pred_h, obs) + equivalence(pred_alt, obs).
+    Conclusion: auto-generated comparison claim (pi=0.5, no warrant).
+    """
+    comparison_claim = Knowledge(
+        content=f"comparison({pred_h.label or 'H'}, {pred_alt.label or 'Alt'}, {observation.label or 'Obs'})",
+        type="claim",
+        metadata={"helper_kind": "comparison_result", "generated": True},
+    )
+    return _named_strategy(
+        "compare",
+        premises=[pred_h, pred_alt, observation],
+        conclusion=comparison_claim,
+        background=background,
+        reason=reason,
+    )
+```
+
+- [ ] **Step 4: Add COMPARE to StrategyType and formalization builder**
+
+```python
+# gaia/ir/strategy.py
+COMPARE = "compare"
+
+# gaia/ir/formalize.py
+def _build_compare(builder: _TemplateBuilder) -> list[Operator]:
+    """Compare: two equivalences (pred_h vs obs, pred_alt vs obs)."""
+    pred_h, pred_alt, observation = builder.premises[0], builder.premises[1], builder.premises[2]
+
+    h_eq1 = builder.add_helper("equivalence", f"matches({pred_h}, {observation})")
+    h_eq2 = builder.add_helper("equivalence", f"matches({pred_alt}, {observation})")
+
+    return [
+        Operator(operator="equivalence", variables=[pred_h, observation], conclusion=h_eq1.id),
+        Operator(operator="equivalence", variables=[pred_alt, observation], conclusion=h_eq2.id),
+    ]
+```
+
+- [ ] **Step 5: Add to exports, run tests**
+
+Run: `pytest tests/gaia/lang/test_compare.py tests/ir/test_formalize.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/lang/dsl/strategies.py gaia/ir/strategy.py gaia/ir/formalize.py \
+       gaia/lang/__init__.py tests/gaia/lang/test_compare.py
+git commit -m "feat: add compare() — prediction matching primitive with comparison claim"
+```
+
+---
+
+## Chunk 3: Composite Strategies (Phase 2)
+
+### Task 9: Add composition_warrant to Strategy Dataclass
+
+**Files:**
+- Modify: `gaia/lang/runtime/nodes.py`
+- Test: `tests/gaia/lang/test_strategies.py`
+
+- [ ] **Step 1: Write test**
+
+```python
+def test_strategy_composition_warrant():
+    """Strategy can hold a composition warrant claim."""
+    warrant = Knowledge(content="validity check", type="claim")
+    s = Strategy(type="abduction", composition_warrant=warrant)
+    assert s.composition_warrant is warrant
+```
+
+- [ ] **Step 2: Add field to Strategy**
+
+```python
+# gaia/lang/runtime/nodes.py, in Strategy dataclass
+composition_warrant: Knowledge | None = None
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/gaia/lang/ -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lang/runtime/nodes.py tests/gaia/lang/
+git commit -m "feat(runtime): add composition_warrant field to Strategy"
+```
+
+### Task 10: Refactor abduction() as Binary CompositeStrategy
+
+**Files:**
+- Modify: `gaia/lang/dsl/strategies.py` (rewrite abduction)
+- Create: `tests/gaia/lang/test_abduction_v2.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/gaia/lang/test_abduction_v2.py
+from gaia.lang import claim, support, abduction
+
+def test_abduction_binary_composite():
+    """abduction takes 2 supports + observation, returns CompositeStrategy."""
+    H = claim("New theory")
+    Alt = claim("Old theory")
+    pred_h = claim("H predicts 0.97K")
+    pred_alt = claim("Alt predicts 2K")
+    obs = claim("Measured 1.2K")
+
+    s_h = support([H], pred_h, reason="first-principles", reverse_reason="validates method")
+    s_alt = support([Alt], pred_alt, reason="empirical formula", reverse_reason="supports framework")
+
+    abd = abduction(s_h, s_alt, observation=obs, reason="same experiment")
+
+    assert abd.type == "abduction"
+    assert len(abd.sub_strategies) == 3  # 2 supports + 1 compare
+    assert abd.composition_warrant is not None
+    assert abd.composition_warrant.type == "claim"
+    # Conclusion is comparison claim from internal compare
+    assert abd.conclusion is not None
+    assert "comparison" in abd.conclusion.metadata.get("helper_kind", "")
+
+def test_abduction_first_arg_is_claimed_better():
+    """First support argument is the claimed-better theory."""
+    # ... verify ordering in comparison claim content
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+- [ ] **Step 3: Rewrite abduction()**
+
+```python
+def abduction(
+    support_h: Strategy,
+    support_alt: Strategy,
+    observation: Knowledge,
+    *,
+    background: list[Knowledge] | None = None,
+    reason: ReasonInput = "",
+) -> Strategy:
+    """Binary hypothesis comparison (IBE). First arg is claimed-better theory.
+
+    Internally creates compare(support_h.conclusion, support_alt.conclusion, observation).
+    Outputs auto-generated comparison claim (pi=0.5).
+    """
+    if not isinstance(support_h, Strategy) or support_h.type != "support":
+        raise TypeError("abduction() first arg must be a support Strategy")
+    if not isinstance(support_alt, Strategy) or support_alt.type != "support":
+        raise TypeError("abduction() second arg must be a support Strategy")
+
+    # Internal compare
+    comp = compare(support_h.conclusion, support_alt.conclusion, observation)
+
+    # Composition warrant
+    comp_warrant = Knowledge(
+        content=f"compatibility({support_h.conclusion.label or 'H'}, {support_alt.conclusion.label or 'Alt'}, {observation.label or 'Obs'})",
+        type="claim",
+        metadata={"helper_kind": "composition_validity", "generated": True},
+    )
+    if isinstance(reason, str) and reason:
+        comp_warrant.metadata["warrant"] = reason
+
+    # Gather all premises from sub-strategies
+    all_premises = list(support_h.premises) + list(support_alt.premises) + [observation]
+    seen = set()
+    unique_premises = []
+    for p in all_premises:
+        if id(p) not in seen:
+            unique_premises.append(p)
+            seen.add(id(p))
+
+    strategy = Strategy(
+        type="abduction",
+        premises=unique_premises,
+        conclusion=comp.conclusion,  # comparison claim
+        background=background or [],
+        reason=reason,
+        sub_strategies=[support_h, support_alt, comp],
+        composition_warrant=comp_warrant,
+        metadata={},
+    )
+    _attach_strategy(comp.conclusion, strategy)
+    return strategy
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `pytest tests/gaia/lang/test_abduction_v2.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/lang/dsl/strategies.py tests/gaia/lang/test_abduction_v2.py
+git commit -m "feat(dsl): rewrite abduction as binary CompositeStrategy of 2 supports + 1 compare"
+```
+
+### Task 11: Refactor induction() as Binary CompositeStrategy
+
+**Files:**
+- Modify: `gaia/lang/dsl/strategies.py` (rewrite induction)
+- Create: `tests/gaia/lang/test_induction_v2.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/gaia/lang/test_induction_v2.py
+from gaia.lang import claim, support, induction
+
+def test_induction_binary_composite():
+    """induction takes 2 supports + law, returns CompositeStrategy with law as conclusion."""
+    H = claim("Mendel's law")
+    obs1 = claim("Seed shape 2.96:1")
+    obs2 = claim("Seed color 3.01:1")
+
+    s1 = support([H], obs1, reason="H predicts 3:1", reverse_reason="2.96 matches")
+    s2 = support([H], obs2, reason="H predicts 3:1", reverse_reason="3.01 matches")
+
+    ind = induction(s1, s2, law=H, reason="seed shape and color are independent traits")
+
+    assert ind.type == "induction"
+    assert ind.conclusion is H
+    assert len(ind.sub_strategies) == 2
+    assert ind.composition_warrant is not None
+
+def test_induction_chaining():
+    """induction can chain: induction(prev_induction, new_support, law)."""
+    H = claim("Law")
+    obs1, obs2, obs3 = claim("Obs1"), claim("Obs2"), claim("Obs3")
+    s1 = support([H], obs1, reason="...", reverse_reason="...")
+    s2 = support([H], obs2, reason="...", reverse_reason="...")
+    s3 = support([H], obs3, reason="...", reverse_reason="...")
+
+    ind_12 = induction(s1, s2, law=H, reason="independent")
+    ind_123 = induction(ind_12, s3, law=H, reason="obs3 independent of 1,2")
+
+    assert ind_123.conclusion is H
+    assert len(ind_123.sub_strategies) == 2  # prev_induction + s3
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+- [ ] **Step 3: Rewrite induction()**
+
+```python
+def induction(
+    support_1: Strategy,
+    support_2: Strategy,
+    law: Knowledge,
+    *,
+    background: list[Knowledge] | None = None,
+    reason: ReasonInput = "",
+) -> Strategy:
+    """Binary evidence accumulation. Outputs law itself.
+
+    support_1: support(law, obs1) or previous induction result.
+    support_2: support(law, obs2).
+    """
+    if not isinstance(support_1, Strategy):
+        raise TypeError("induction() first arg must be a Strategy")
+    if not isinstance(support_2, Strategy):
+        raise TypeError("induction() second arg must be a Strategy")
+
+    # Composition warrant
+    comp_warrant = Knowledge(
+        content=f"independence({support_1.conclusion.label or 'S1'}, {support_2.conclusion.label or 'S2'})",
+        type="claim",
+        metadata={"helper_kind": "composition_validity", "generated": True},
+    )
+    if isinstance(reason, str) and reason:
+        comp_warrant.metadata["warrant"] = reason
+
+    all_premises = list(support_1.premises) + list(support_2.premises)
+    seen = set()
+    unique_premises = []
+    for p in all_premises:
+        if id(p) not in seen:
+            unique_premises.append(p)
+            seen.add(id(p))
+
+    strategy = Strategy(
+        type="induction",
+        premises=unique_premises,
+        conclusion=law,
+        background=background or [],
+        reason=reason,
+        sub_strategies=[support_1, support_2],
+        composition_warrant=comp_warrant,
+        metadata={},
+    )
+    _attach_strategy(law, strategy)
+    return strategy
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `pytest tests/gaia/lang/test_induction_v2.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/lang/dsl/strategies.py tests/gaia/lang/test_induction_v2.py
+git commit -m "feat(dsl): rewrite induction as binary CompositeStrategy"
+```
+
+### Task 12: Deprecate noisy_and
+
+**Files:**
+- Modify: `gaia/lang/dsl/strategies.py`
+- Test: `tests/gaia/lang/test_strategies.py`
+
+- [ ] **Step 1: Add deprecation warning to noisy_and()**
+
+```python
+import warnings
+
+def noisy_and(
+    premises: list[Knowledge],
+    conclusion: Knowledge,
+    *,
+    background: list[Knowledge] | None = None,
+    reason: ReasonInput = "",
+) -> Strategy:
+    """DEPRECATED: Use support() instead."""
+    warnings.warn(
+        "noisy_and() is deprecated. Use support() with reverse_reason='' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return support(
+        premises=premises,
+        conclusion=conclusion,
+        background=background,
+        reason=reason,
+        reverse_reason="",  # silent reverse
+    )
+```
+
+- [ ] **Step 2: Test deprecation**
+
+```python
+def test_noisy_and_deprecated():
+    with pytest.warns(DeprecationWarning, match="noisy_and.*deprecated"):
+        noisy_and([claim("A")], claim("B"))
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/gaia/lang/ -v`
+Expected: PASS (existing noisy_and tests should still work with deprecation warning)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lang/dsl/strategies.py tests/gaia/lang/
+git commit -m "deprecate(dsl): noisy_and → support with reverse_reason=''"
+```
+
+---
+
+## Chunk 4: Integration and Regression (Phase 3-4)
+
+### Task 13: End-to-End Compilation Test
+
+**Files:**
+- Create: `tests/integration/test_warrant_e2e.py`
+
+- [ ] **Step 1: Write end-to-end test: Mendel example compiles**
+
+```python
+def test_mendel_peirce_cycle_compiles():
+    """Full Peirce cycle: deduction → support → abduction → induction."""
+    from gaia.lang import claim, setting, deduction, support, compare, abduction, induction
+
+    H = claim("Discrete heritable factors")
+    alt = claim("Blending inheritance")
+    obs_3to1 = claim("F2 ratio 2.96:1")
+    pred_h = claim("H predicts 3:1")
+    pred_alt = claim("Alt predicts continuous")
+
+    # Deduction
+    deduction([H], pred_h, reason="Punnett square derivation")
+
+    # Supports
+    s_h = support([H], pred_h, reason="H implies 3:1", reverse_reason="3:1 characteristic of H")
+    s_alt = support([alt], pred_alt, reason="blending implies continuous", reverse_reason="continuous indicates blending")
+
+    # Abduction
+    abd = abduction(s_h, s_alt, observation=obs_3to1, reason="both predict F2 pattern")
+    assert abd.conclusion is not None
+
+    # Induction (multiple traits)
+    obs_color = claim("Seed color 3.01:1")
+    s_shape = support([H], obs_3to1, reason="H predicts", reverse_reason="matches")
+    s_color = support([H], obs_color, reason="H predicts", reverse_reason="matches")
+    ind = induction(s_shape, s_color, law=H, reason="traits independent")
+    assert ind.conclusion is H
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pytest tests/integration/test_warrant_e2e.py -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_warrant_e2e.py
+git commit -m "test: Mendel end-to-end Peirce cycle — deduction + support + abduction + induction"
+```
+
+### Task 14: BP Regression — Support Equivalence to SOFT_ENTAILMENT
+
+**Files:**
+- Create: `tests/gaia/bp/test_support_bp.py`
+
+- [ ] **Step 1: Write BP equivalence test**
+
+Verify that support (two IMPLIES) produces the same BP message ratios as SOFT_ENTAILMENT:
+
+```python
+def test_support_bp_ratios_match_soft_entailment():
+    """Two independent IMPLIES produce same BP ratios as SOFT_ENTAILMENT (Appendix A)."""
+    # Build factor graph with two IMPLIES
+    # Run BP
+    # Check that belief ratios match SOFT_ENTAILMENT formula:
+    #   psi(1,1)/psi(1,0) = p1/(1-p1)
+    #   psi(0,0)/psi(0,1) = p2/(1-p2)
+```
+
+- [ ] **Step 2: Implement and run**
+
+Run: `pytest tests/gaia/bp/test_support_bp.py -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/gaia/bp/test_support_bp.py
+git commit -m "test(bp): verify support BP ratios match SOFT_ENTAILMENT (Appendix A proof)"
+```
+
+### Task 15: Full Test Suite Regression
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pytest --tb=short -q`
+Expected: All existing tests pass (some may need updates from implication arity change)
+
+- [ ] **Step 2: Fix any remaining failures**
+
+- [ ] **Step 3: Run linting**
+
+Run: `ruff check . && ruff format --check .`
+Expected: Clean
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git commit -m "fix: resolve remaining test failures from implication arity change"
+```
+
+---
+
+## PR Strategy
+
+| PR | Tasks | Branch |
+|----|-------|--------|
+| **PR A** | Tasks 1-5 (implication change + warrant metadata) | `feat/implication-relation` |
+| **PR B** | Tasks 6-8 (support + compare primitives) | `feat/support-compare` |
+| **PR C** | Tasks 9-12 (abduction + induction + deprecate noisy_and) | `feat/composite-strategies` |
+| **PR D** | Tasks 13-15 (integration + regression) | `test/warrant-e2e` |
+
+Each PR depends on the previous. PR A is the riskiest (changes fundamental operator semantics); PRs B-D are incremental.

--- a/gaia/cli/_reviews.py
+++ b/gaia/cli/_reviews.py
@@ -205,6 +205,7 @@ def resolve_gaia_review(loaded_review, compiled) -> ResolvedGaiaReview:
                         knowledge_id=knowledge_id,
                         value=review.prior,
                         source_id=source.source_id,
+                        justification=review.justification,
                     )
                 )
             objects.append(
@@ -244,6 +245,7 @@ def resolve_gaia_review(loaded_review, compiled) -> ResolvedGaiaReview:
                         knowledge_id=knowledge_id,
                         value=review.prior,
                         source_id=source.source_id,
+                        justification=review.justification,
                     )
                 )
             objects.append(
@@ -300,6 +302,7 @@ def resolve_gaia_review(loaded_review, compiled) -> ResolvedGaiaReview:
                         strategy_id=strategy.strategy_id,
                         conditional_probabilities=conditional_probabilities,
                         source_id=source.source_id,
+                        justification=review.justification,
                     )
                 )
 

--- a/gaia/cli/commands/_obsidian.py
+++ b/gaia/cli/commands/_obsidian.py
@@ -1,8 +1,12 @@
 """Generate Obsidian vault from compiled IR.
 
-Produces a dict mapping vault-relative paths to markdown content,
-organized as: conclusions/, evidence/, modules/, reasoning/, meta/,
-plus _index.md, overview.md, and .obsidian/ config.
+Architecture:
+- claims/  — one page per non-helper claim, numbered by topological order
+- modules/ — numbered chapter pages (narrative organized by claim numbers)
+- meta/    — beliefs table, holes list
+- _index.md, overview.md, .obsidian/
+
+Naming: filenames use titles, wikilinks use labels, aliases bridge them.
 """
 
 from __future__ import annotations
@@ -10,12 +14,19 @@ from __future__ import annotations
 import json
 
 from gaia.cli.commands._classify import classify_ir, node_role
-from gaia.cli.commands._detailed_reasoning import render_mermaid
+from gaia.cli.commands._detailed_reasoning import render_mermaid, topo_layers
+from gaia.cli.commands._simplified_mermaid import render_simplified_mermaid
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _sanitize_filename(name: str) -> str:
+    for ch in r'<>:"/\|?*':
+        name = name.replace(ch, "")
+    return name.strip()
 
 
 def _is_helper(label: str | None) -> bool:
@@ -24,59 +35,7 @@ def _is_helper(label: str | None) -> bool:
     return label.startswith("__") or label.startswith("_anon")
 
 
-def _build_page_set(
-    conclusions: list[dict],
-    evidence: list[dict],
-    module_inlined: list[dict],
-) -> tuple[set[str], dict[str, str]]:
-    """Build (ids_with_pages, id_to_module) for wikilink resolution.
-
-    Returns:
-    - ids_with_pages: set of knowledge IDs that have their own page
-    - inlined_id_to_module: kid → module name for nodes inlined in module pages
-    """
-    ids_with_pages: set[str] = set()
-    for k in conclusions:
-        ids_with_pages.add(k["id"])
-    for k in evidence:
-        ids_with_pages.add(k["id"])
-
-    inlined_id_to_module: dict[str, str] = {}
-    for k in module_inlined:
-        inlined_id_to_module[k["id"]] = k.get("module", "Root")
-
-    return ids_with_pages, inlined_id_to_module
-
-
-def _wikilink(
-    kid: str,
-    label_for_id: dict[str, str],
-    ids_with_pages: set[str],
-    inlined_id_to_module: dict[str, str],
-) -> str:
-    """Generate a wikilink for a knowledge ID.
-
-    If the target has its own page: ``[[label]]``
-    If the target is inlined in a module page: ``[[module#label|label]]``
-    Otherwise: plain ``label`` (no link).
-    """
-    label = label_for_id.get(kid, kid.split("::")[-1])
-    if kid in ids_with_pages:
-        return f"[[{label}]]"
-    if kid in inlined_id_to_module:
-        mod = inlined_id_to_module[kid]
-        return f"[[{mod}#{label}|{label}]]"
-    return label
-
-
-def _is_complex_strategy(s: dict) -> bool:
-    """A strategy gets its own page if complex (induction/elimination/case_analysis or ≥3 premises)."""
-    complex_types = {"induction", "elimination", "case_analysis"}
-    return s.get("type") in complex_types or len(s.get("premises", [])) >= 3
-
-
 def _render_frontmatter(fields: dict) -> str:
-    """Render YAML frontmatter block."""
     lines = ["---"]
     for key, value in fields.items():
         if value is None:
@@ -100,44 +59,24 @@ def _render_frontmatter(fields: dict) -> str:
     return "\n".join(lines)
 
 
-# ---------------------------------------------------------------------------
-# Classification
-# ---------------------------------------------------------------------------
+def _assign_claim_numbers(ir: dict) -> dict[str, int]:
+    """Assign sequential numbers by topological order (0=leaves, high=conclusions)."""
+    layers = topo_layers(ir)
+    module_order = ir.get("module_order") or []
+    module_rank = {m: i for i, m in enumerate(module_order)}
 
+    claims = [k for k in ir["knowledges"] if not _is_helper(k.get("label"))]
 
-def _classify_pages(
-    ir: dict,
-) -> tuple[list[dict], list[dict], list[dict]]:
-    """Classify knowledge nodes into page categories.
-
-    Returns (conclusions, evidence, module_inlined) where:
-    - conclusions: exported claims + questions → own pages in conclusions/
-    - evidence: leaf premises (premise but not conclusion, not setting) → evidence/
-    - module_inlined: non-exported derived claims + settings → inlined in modules/
-    """
-    classification = classify_ir(ir)
-    conclusions: list[dict] = []
-    evidence: list[dict] = []
-    module_inlined: list[dict] = []
-
-    for k in ir["knowledges"]:
-        label = k.get("label", "")
-        if _is_helper(label):
-            continue
-
+    def sort_key(k):
         kid = k["id"]
-        ktype = k["type"]
+        return (
+            layers.get(kid, 0),
+            module_rank.get(k.get("module", "Root"), 999),
+            k.get("declaration_index") or 0,
+        )
 
-        if ktype == "question" or (ktype == "claim" and k.get("exported")):
-            conclusions.append(k)
-        elif ktype == "setting":
-            module_inlined.append(k)
-        elif kid in classification.strategy_conclusions:
-            module_inlined.append(k)
-        else:
-            evidence.append(k)
-
-    return conclusions, evidence, module_inlined
+    claims.sort(key=sort_key)
+    return {k["id"]: i + 1 for i, k in enumerate(claims)}
 
 
 # ---------------------------------------------------------------------------
@@ -147,35 +86,41 @@ def _classify_pages(
 
 def _generate_claim_page(
     k: dict,
+    num: int,
     beliefs: dict[str, float],
     priors: dict[str, float],
+    justifications: dict[str, str],
     strategies_by_conclusion: dict[str, list[dict]],
     strategies_by_premise: dict[str, list[dict]],
     label_for_id: dict[str, str],
-    ids_with_pages: set[str],
-    inlined_id_to_module: dict[str, str],
+    claim_numbers: dict[str, int],
 ) -> str:
-    """Generate a conclusion page (exported claim or question)."""
     kid = k["id"]
     label = k.get("label", "")
     title = k.get("title") or label.replace("_", " ")
     content = k.get("content", "")
     module = k.get("module", "Root")
-
-    def wl(target_id: str) -> str:
-        return _wikilink(target_id, label_for_id, ids_with_pages, inlined_id_to_module)
+    exported = k.get("exported", False)
+    star = " ★" if exported else ""
 
     strategy_for = strategies_by_conclusion.get(kid, [])
     strategy_type = strategy_for[0]["type"] if strategy_for else None
     premise_count = len(strategy_for[0]["premises"]) if strategy_for else 0
 
+    def cref(target_id: str) -> str:
+        lbl = label_for_id.get(target_id, target_id.split("::")[-1])
+        n = claim_numbers.get(target_id)
+        return f"[[{lbl}|#{n:02d} {lbl}]]" if n else f"[[{lbl}]]"
+
     fm = _render_frontmatter(
         {
             "type": k["type"],
             "label": label,
+            "aliases": [label],
+            "claim_number": num,
             "qid": kid,
             "module": module,
-            "exported": k.get("exported", False),
+            "exported": exported,
             "prior": priors.get(kid),
             "belief": beliefs.get(kid),
             "strategy_type": strategy_type,
@@ -184,24 +129,17 @@ def _generate_claim_page(
         }
     )
 
-    lines = [fm, "", f"# {title}", "", f"> {content}", ""]
+    lines = [fm, "", f"# #{num:02d} {title}{star}", "", f"> {content}", ""]
 
-    # Derivation
     if strategy_for:
         s = strategy_for[0]
-        stype = s["type"]
-        sid = s.get("strategy_id", "")
-        s_label = label_for_id.get(sid, sid)
         lines.append("## Derivation")
-        if _is_complex_strategy(s):
-            lines.append(f"- **Strategy**: [[{s_label}]] ({stype})")
-        else:
-            lines.append(f"- **Strategy**: {stype}")
+        lines.append(f"- **Strategy**: {s['type']}")
         premises = s.get("premises", [])
         if premises:
             lines.append("- **Premises**:")
             for p in premises:
-                lines.append(f"  - {wl(p)}")
+                lines.append(f"  - {cref(p)}")
         reason = (s.get("metadata") or {}).get("reason", "") or s.get("reason", "")
         if reason:
             lines.append("")
@@ -209,177 +147,85 @@ def _generate_claim_page(
             lines.append(f"> {reason}")
         lines.append("")
 
-    # Supports
-    if kid in strategies_by_premise:
-        lines.append("## Supports")
-        for s in strategies_by_premise[kid]:
-            conc = s.get("conclusion", "")
-            lines.append(f"- → {wl(conc)} via {s['type']}")
+    # Review
+    justification = justifications.get(kid, "")
+    prior_val = priors.get(kid)
+    belief_val = beliefs.get(kid)
+    if prior_val is not None or justification:
+        lines.append("## Review")
+        if prior_val is not None:
+            lines.append(f"**Prior**: {prior_val:.2f}")
+        if justification:
+            lines.append(f"**Justification**: {justification}")
+        if belief_val is not None:
+            lines.append(f"**Belief**: {belief_val:.2f}")
         lines.append("")
-
-    # Module link
-    lines.append("## Module")
-    lines.append(f"[[{module}]]")
-    lines.append("")
-
-    return "\n".join(lines)
-
-
-def _generate_evidence_page(
-    k: dict,
-    beliefs: dict[str, float],
-    priors: dict[str, float],
-    strategies_by_premise: dict[str, list[dict]],
-    label_for_id: dict[str, str],
-    ids_with_pages: set[str],
-    inlined_id_to_module: dict[str, str],
-) -> str:
-    """Generate an evidence page (leaf premise)."""
-    kid = k["id"]
-    label = k.get("label", "")
-    title = k.get("title") or label.replace("_", " ")
-    content = k.get("content", "")
-    module = k.get("module", "Root")
-
-    def wl(target_id: str) -> str:
-        return _wikilink(target_id, label_for_id, ids_with_pages, inlined_id_to_module)
-
-    fm = _render_frontmatter(
-        {
-            "type": "evidence",
-            "label": label,
-            "qid": kid,
-            "module": module,
-            "prior": priors.get(kid),
-            "belief": beliefs.get(kid),
-            "tags": ["evidence", module.replace("_", "-")],
-        }
-    )
-
-    lines = [fm, "", f"# {title}", "", f"> {content}", ""]
 
     if kid in strategies_by_premise:
         lines.append("## Supports")
         for s in strategies_by_premise[kid]:
             conc = s.get("conclusion", "")
-            lines.append(f"- → {wl(conc)} via {s['type']}")
+            lines.append(f"- → {cref(conc)} via {s['type']}")
         lines.append("")
 
     lines.append("## Module")
     lines.append(f"[[{module}]]")
     lines.append("")
-
     return "\n".join(lines)
 
 
-def _generate_module_page(
+def _generate_module_section_page(
     module_name: str,
+    section_num: int,
+    title: str,
+    claims: list[dict],
     ir: dict,
     beliefs: dict[str, float],
     priors: dict[str, float],
-    strategies_by_conclusion: dict[str, list[dict]],
+    claim_numbers: dict[str, int],
     label_for_id: dict[str, str],
-    ids_with_pages: set[str],
-    inlined_id_to_module: dict[str, str],
-    module_title: str | None = None,
 ) -> str:
-    """Generate a module page with inlined non-exported claims and settings."""
-    title = module_title or module_name.replace("_", " ").title()
-
-    def wl(target_id: str) -> str:
-        return _wikilink(target_id, label_for_id, ids_with_pages, inlined_id_to_module)
-
-    module_nodes = [
-        k
-        for k in ir["knowledges"]
-        if k.get("module", "Root") == module_name and not _is_helper(k.get("label", ""))
-    ]
-
-    exported_count = sum(1 for k in module_nodes if k.get("exported"))
+    """Generate a section page for a DSL module, claims ordered by topo sort."""
+    exported_count = sum(1 for k in claims if k.get("exported"))
 
     fm = _render_frontmatter(
         {
-            "type": "module",
+            "type": "section",
             "label": module_name,
+            "aliases": [module_name],
+            "section_number": section_num,
             "title": title,
-            "claim_count": len(module_nodes),
+            "claim_count": len(claims),
             "exported_count": exported_count,
-            "tags": ["module", module_name.replace("_", "-")],
+            "tags": ["section", module_name.replace("_", "-")],
         }
     )
 
-    lines = [fm, "", f"# {title}", "", "## Claims", ""]
+    lines = [fm, "", f"# {section_num:02d} - {title}", ""]
 
-    for k in module_nodes:
-        kid = k["id"]
-        label = k.get("label", "")
-        content = k.get("content", "")
-        is_exported = k.get("exported", False)
-
-        if is_exported or k["type"] == "question":
-            star = " ★" if is_exported else ""
-            prior_str = f"{priors[kid]:.2f}" if kid in priors else "—"
-            belief_str = f"{beliefs[kid]:.2f}" if kid in beliefs else "—"
-            lines.append(f"### [[{label}]]{star}")
-            lines.append(f"> {content}")
-            lines.append("")
-            lines.append(f"Prior: {prior_str} → Belief: {belief_str}")
-            lines.append("")
-        else:
-            lines.append(f"### {label}")
-            lines.append(f"> {content}")
-            lines.append("")
-            if kid in strategies_by_conclusion:
-                s = strategies_by_conclusion[kid][0]
-                premises = s.get("premises", [])
-                lines.append(f"Derived via {s['type']} from: " + ", ".join(wl(p) for p in premises))
-                lines.append("")
-
-    return "\n".join(lines)
-
-
-def _generate_strategy_page(
-    s: dict,
-    label_for_id: dict[str, str],
-    ids_with_pages: set[str],
-    inlined_id_to_module: dict[str, str],
-) -> str:
-    """Generate a reasoning page for a complex strategy."""
-    sid = s.get("strategy_id", "")
-    stype = s.get("type", "unknown")
-    s_label = sid.removeprefix("lcs_") if sid else stype
-    conc = s.get("conclusion", "")
-    conc_label = label_for_id.get(conc, conc.split("::")[-1])
-    premises = s.get("premises", [])
-
-    def wl(target_id: str) -> str:
-        return _wikilink(target_id, label_for_id, ids_with_pages, inlined_id_to_module)
-
-    fm = _render_frontmatter(
-        {
-            "type": "strategy",
-            "strategy_type": stype,
-            "label": s_label,
-            "premise_count": len(premises),
-            "conclusion": conc_label,
-            "tags": ["strategy", stype],
-        }
-    )
-
-    lines = [fm, "", f"# {stype}: {s_label}", ""]
-    lines.append(f"**Conclusion:** {wl(conc)}")
-    lines.append("")
-
-    if premises:
-        lines.append("## Premises")
-        for p in premises:
-            lines.append(f"- {wl(p)}")
+    # Per-section reasoning graph
+    sec_ids = {k["id"] for k in claims}
+    if sec_ids:
+        lines.append(render_mermaid(ir, beliefs=beliefs, node_ids=sec_ids))
         lines.append("")
 
-    reason = (s.get("metadata") or {}).get("reason", "") or s.get("reason", "")
-    if reason:
-        lines.append("## Reasoning")
-        lines.append(reason)
+    lines.append("## Claims")
+    lines.append("")
+
+    for k in claims:
+        kid = k["id"]
+        label = k.get("label", "")
+        k_title = k.get("title") or label.replace("_", " ")
+        content = k.get("content", "")
+        num = claim_numbers.get(kid, 0)
+        star = " ★" if k.get("exported") else ""
+        prior_str = f"{priors[kid]:.2f}" if kid in priors else "—"
+        belief_str = f"{beliefs[kid]:.2f}" if kid in beliefs else "—"
+
+        lines.append(f"### [[{label}|#{num:02d} {k_title}]]{star}")
+        lines.append(f"> {content}")
+        lines.append("")
+        lines.append(f"Prior: {prior_str} → Belief: {belief_str}")
         lines.append("")
 
     return "\n".join(lines)
@@ -389,66 +235,76 @@ def _generate_beliefs_page(
     ir: dict,
     beliefs: dict[str, float],
     priors: dict[str, float],
-    label_for_id: dict[str, str],
-    ids_with_pages: set[str],
-    inlined_id_to_module: dict[str, str],
+    claim_numbers: dict[str, int],
 ) -> str:
-    """Generate meta/beliefs.md with a sortable belief table."""
     classification = classify_ir(ir)
-    lines = ["---", "type: meta", "tags: [meta, beliefs]", "---", "", "# Beliefs", ""]
-    lines.append("| Label | Type | Prior | Belief | Role |")
-    lines.append("|-------|------|-------|--------|------|")
+    lines = [
+        "---",
+        "type: meta",
+        "aliases: [beliefs]",
+        "tags: [meta, beliefs]",
+        "---",
+        "",
+        "# Beliefs",
+        "",
+    ]
+    lines.append("| # | Label | Type | Prior | Belief | Role |")
+    lines.append("|---|-------|------|-------|--------|------|")
 
     knowledges = [k for k in ir["knowledges"] if not _is_helper(k.get("label", ""))]
     knowledges.sort(key=lambda k: beliefs.get(k["id"], 0.0), reverse=True)
 
     for k in knowledges:
         kid = k["id"]
+        label = k.get("label", "")
         ktype = k["type"]
         role = node_role(kid, ktype, classification)
         prior = f"{priors[kid]:.2f}" if kid in priors else "—"
         belief = f"{beliefs[kid]:.2f}" if kid in beliefs else "—"
-        link = _wikilink(kid, label_for_id, ids_with_pages, inlined_id_to_module)
-        lines.append(f"| {link} | {ktype} | {prior} | {belief} | {role} |")
+        num = claim_numbers.get(kid, 0)
+        lines.append(f"| {num:02d} | [[{label}]] | {ktype} | {prior} | {belief} | {role} |")
 
     lines.append("")
     return "\n".join(lines)
 
 
-def _generate_holes_page(evidence_nodes: list[dict]) -> str:
-    """Generate meta/holes.md listing all leaf premises."""
-    lines = ["---", "type: meta", "tags: [meta, holes]", "---", "", "# Leaf Premises (Holes)", ""]
-    lines.append("| Label | Module | Content |")
-    lines.append("|-------|--------|---------|")
-    for k in evidence_nodes:
+def _generate_holes_page(leaves: list[dict], claim_numbers: dict[str, int]) -> str:
+    lines = [
+        "---",
+        "type: meta",
+        "aliases: [holes]",
+        "tags: [meta, holes]",
+        "---",
+        "",
+        "# Leaf Premises (Holes)",
+        "",
+    ]
+    lines.append("| # | Label | Module | Content |")
+    lines.append("|---|-------|--------|---------|")
+    sorted_leaves = sorted(leaves, key=lambda k: claim_numbers.get(k["id"], 0))
+    for k in sorted_leaves:
         label = k.get("label", "")
         module = k.get("module", "Root")
+        num = claim_numbers.get(k["id"], 0)
         content = k.get("content", "")
         if len(content) > 60:
             content = content[:60] + "..."
-        lines.append(f"| [[{label}]] | [[{module}]] | {content} |")
+        lines.append(f"| {num:02d} | [[{label}]] | [[{module}]] | {content} |")
     lines.append("")
     return "\n".join(lines)
 
 
 def _generate_index(
     ir: dict,
-    conclusions: list[dict],
-    evidence: list[dict],
+    all_claims: list[dict],
+    claim_numbers: dict[str, int],
     beliefs: dict[str, float],
-    modules: dict[str, str | None],
+    section_list: list[tuple[str, str, int]],
 ) -> str:
-    """Generate _index.md — master navigation page."""
+    """Generate _index.md. section_list = [(module_name, title, claim_count)]."""
     pkg = ir.get("package_name", "Package")
     ir_hash = ir.get("ir_hash", "unknown")
-
     all_k = ir["knowledges"]
-    n_claims = sum(1 for k in all_k if k["type"] == "claim")
-    n_settings = sum(1 for k in all_k if k["type"] == "setting")
-    n_questions = sum(1 for k in all_k if k["type"] == "question")
-    n_strategies = len(ir.get("strategies", []))
-    n_operators = len(ir.get("operators", []))
-    n_exported = sum(1 for k in all_k if k.get("exported"))
 
     lines = [f"# {pkg}", ""]
     if ir_hash and ir_hash != "unknown":
@@ -459,70 +315,75 @@ def _generate_index(
     lines.append("")
     lines.append("| Metric | Count |")
     lines.append("|--------|-------|")
+    n_claims = sum(1 for k in all_k if k["type"] == "claim")
+    n_settings = sum(1 for k in all_k if k["type"] == "setting")
+    n_questions = sum(1 for k in all_k if k["type"] == "question")
     lines.append(
-        f"| Knowledge nodes | {len(all_k)}"
-        f" ({n_claims} claims, {n_settings} settings, {n_questions} questions) |"
+        f"| Knowledge nodes | {len(all_k)} ({n_claims} claims, {n_settings} settings, {n_questions} questions) |"
     )
-    lines.append(f"| Strategies | {n_strategies} |")
-    lines.append(f"| Operators | {n_operators} |")
-    lines.append(f"| Modules | {len(modules)} |")
-    lines.append(f"| Exported conclusions | {n_exported} |")
-    lines.append(f"| Leaf premises | {len(evidence)} |")
+    lines.append(f"| Strategies | {len(ir.get('strategies', []))} |")
+    lines.append(f"| Operators | {len(ir.get('operators', []))} |")
+    lines.append(f"| Sections | {len(section_list)} |")
+    lines.append(f"| Exported | {sum(1 for k in all_k if k.get('exported'))} |")
     lines.append("")
 
-    # Module navigation
-    lines.append("## Modules")
+    # Sections
+    lines.append("## Sections")
     lines.append("")
-    lines.append("| Module | Claims |")
-    lines.append("|--------|--------|")
-    for mod in modules:
-        count = sum(
-            1
-            for k in all_k
-            if k.get("module", "Root") == mod and not _is_helper(k.get("label", ""))
-        )
-        lines.append(f"| [[{mod}]] | {count} |")
+    lines.append("| # | Section | Claims |")
+    lines.append("|---|---------|--------|")
+    for i, (mod, title, count) in enumerate(section_list, 1):
+        lines.append(f"| {i:02d} | [[{mod}]] | {count} |")
     lines.append("")
 
-    # Exported conclusions
-    exported = [k for k in conclusions if k.get("exported")]
-    if exported:
-        lines.append("## Exported Conclusions")
+    # Claim index
+    lines.append("## Claim Index")
+    lines.append("")
+    lines.append("| # | Claim | Type | Section | Belief |")
+    lines.append("|---|-------|------|---------|--------|")
+    sorted_claims = sorted(all_claims, key=lambda k: claim_numbers.get(k["id"], 0))
+    for k in sorted_claims:
+        kid = k["id"]
+        label = k.get("label", "")
+        mod = k.get("module", "Root")
+        num = claim_numbers.get(kid, 0)
+        star = " ★" if k.get("exported") else ""
+        belief = f"{beliefs[kid]:.2f}" if kid in beliefs else "—"
+        lines.append(f"| {num:02d} | [[{label}]]{star} | {k['type']} | [[{mod}]] | {belief} |")
+    lines.append("")
+
+    # Reading path
+    if len(section_list) > 1:
+        lines.append("## Reading Path")
         lines.append("")
-        lines.append("| Conclusion | Belief | Module |")
-        lines.append("|------------|--------|--------|")
-        for k in exported:
-            label = k.get("label", "")
-            mod = k.get("module", "Root")
-            belief = f"{beliefs[k['id']]:.2f}" if k["id"] in beliefs else "—"
-            lines.append(f"| [[{label}]] | {belief} | [[{mod}]] |")
+        lines.append(" → ".join(f"[[{mod}]]" for mod, _, _ in section_list))
         lines.append("")
 
-    # Quick links
     lines.append("## Quick Links")
     lines.append("")
     lines.append("- [[overview]] — Reasoning graph")
     if beliefs:
-        lines.append("- [[meta/beliefs]] — Full belief table")
-    lines.append("- [[meta/holes]] — Leaf premises")
+        lines.append("- [[beliefs]] — Full belief table")
+    lines.append("- [[holes]] — Leaf premises")
     lines.append("")
-
     return "\n".join(lines)
 
 
-def _generate_overview(ir: dict) -> str:
-    """Generate overview.md with Mermaid reasoning graph."""
+def _generate_overview(ir: dict, beliefs: dict[str, float], priors: dict[str, float]) -> str:
     pkg = ir.get("package_name", "Package")
     lines = ["---", "type: overview", "tags: [overview]", "---", ""]
     lines.append(f"# {pkg} — Overview")
     lines.append("")
-    lines.append(render_mermaid(ir))
+    if beliefs:
+        exported_ids = {k["id"] for k in ir.get("knowledges", []) if k.get("exported")}
+        lines.append(render_simplified_mermaid(ir, beliefs, priors, exported_ids))
+    else:
+        lines.append(render_mermaid(ir))
     lines.append("")
     return "\n".join(lines)
 
 
 def _generate_obsidian_config() -> str:
-    """Generate .obsidian/graph.json with color groups by node type."""
     config = {
         "collapse-filter": False,
         "search": "",
@@ -534,7 +395,6 @@ def _generate_obsidian_config() -> str:
             {"query": "tag:#setting", "color": {"a": 1, "rgb": 8421504}},
             {"query": "tag:#question", "color": {"a": 1, "rgb": 16750848}},
             {"query": "tag:#module", "color": {"a": 1, "rgb": 65280}},
-            {"query": "tag:#strategy", "color": {"a": 1, "rgb": 16711680}},
             {"query": "tag:#evidence", "color": {"a": 1, "rgb": 255}},
             {"query": "tag:#meta", "color": {"a": 1, "rgb": 11184810}},
         ],
@@ -553,22 +413,20 @@ def generate_obsidian_vault(
     beliefs_data: dict | None = None,
     param_data: dict | None = None,
 ) -> dict[str, str]:
-    """Generate Obsidian vault pages as {vault_path: markdown_content}.
-
-    Returns a dict mapping vault-relative file paths to markdown content.
-    The caller writes these to ``.gaia-wiki/`` on disk.
-    """
+    """Generate Obsidian vault with numbered claims and module chapters."""
     pages: dict[str, str] = {}
 
-    # Build lookup maps
     beliefs: dict[str, float] = {}
     if beliefs_data:
         beliefs = {b["knowledge_id"]: b["belief"] for b in beliefs_data.get("beliefs", [])}
     priors: dict[str, float] = {}
+    justifications: dict[str, str] = {}
     if param_data:
-        priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
+        for p in param_data.get("priors", []):
+            priors[p["knowledge_id"]] = p["value"]
+            if p.get("justification"):
+                justifications[p["knowledge_id"]] = p["justification"]
 
-    # Strategy indexes
     strategies_by_conclusion: dict[str, list[dict]] = {}
     strategies_by_premise: dict[str, list[dict]] = {}
     for s in ir.get("strategies", []):
@@ -578,96 +436,188 @@ def generate_obsidian_vault(
         for p in s.get("premises", []):
             strategies_by_premise.setdefault(p, []).append(s)
 
-    # Label lookup: kid/strategy_id → label
     label_for_id: dict[str, str] = {}
     for k in ir["knowledges"]:
         label_for_id[k["id"]] = k.get("label", k["id"].split("::")[-1])
-    for s in ir.get("strategies", []):
-        sid = s.get("strategy_id", "")
-        if sid:
-            label_for_id[sid] = sid.removeprefix("lcs_")
 
-    # Classify nodes
-    conclusions, evidence, module_inlined = _classify_pages(ir)
+    claim_numbers = _assign_claim_numbers(ir)
+    all_claims = [k for k in ir["knowledges"] if not _is_helper(k.get("label"))]
 
-    # Build page-ownership map for wikilink resolution
-    ids_with_pages, inlined_id_to_module = _build_page_set(conclusions, evidence, module_inlined)
+    # Classify claims into roles using node_role from _classify.py
+    exported_ids = {k["id"] for k in ir["knowledges"] if k.get("exported")}
+    classification = classify_ir(ir)
 
-    # Conclusion pages
-    for k in conclusions:
+    _ROLE_TO_DIR = {
+        "independent": "holes",  # premise but not conclusion — true holes
+        "derived": "intermediate",  # conclusion of strategy, not exported
+        "setting": "context",  # background settings
+        "background": "context",  # background knowledge
+        "structural": "context",  # operator conclusions
+        "orphaned": "context",  # not referenced by any strategy
+        "question": "conclusions",  # questions are interesting
+    }
+
+    def _claim_role(k: dict) -> str:
+        kid = k["id"]
+        if kid in exported_ids:
+            return "conclusions"
+        role = node_role(kid, k["type"], classification)
+        return _ROLE_TO_DIR.get(role, "context")
+
+    # Claim pages (sorted into role subdirectories)
+    for k in all_claims:
+        kid = k["id"]
         label = k.get("label", "")
-        pages[f"conclusions/{label}.md"] = _generate_claim_page(
+        title = k.get("title") or label.replace("_", " ")
+        cn = claim_numbers.get(kid, 0)
+        role = _claim_role(k)
+        fname = _sanitize_filename(f"{cn:02d} - {title}")
+        pages[f"claims/{role}/{fname}.md"] = _generate_claim_page(
             k,
+            cn,
             beliefs,
             priors,
+            justifications,
             strategies_by_conclusion,
             strategies_by_premise,
             label_for_id,
-            ids_with_pages,
-            inlined_id_to_module,
+            claim_numbers,
         )
-
-    # Evidence pages
-    for k in evidence:
-        label = k.get("label", "")
-        pages[f"evidence/{label}.md"] = _generate_evidence_page(
-            k,
-            beliefs,
-            priors,
-            strategies_by_premise,
-            label_for_id,
-            ids_with_pages,
-            inlined_id_to_module,
-        )
-
-    # Module pages
-    modules: dict[str, str | None] = {}
-    module_titles = ir.get("module_titles") or {}
+    # Section pages from DSL modules (module_order defines narrative arc)
+    module_titles: dict[str, str] = ir.get("module_titles") or {}
+    modules: list[str] = []
+    seen: set[str] = set()
+    module_order = ir.get("module_order") or []
+    for m in module_order:
+        if m not in seen:
+            modules.append(m)
+            seen.add(m)
+    # Add any modules not in module_order
     for k in ir["knowledges"]:
         mod = k.get("module", "Root")
-        if mod not in modules:
-            modules[mod] = module_titles.get(mod)
+        if mod not in seen and not _is_helper(k.get("label", "")):
+            modules.append(mod)
+            seen.add(mod)
 
-    for mod, mod_title in modules.items():
-        pages[f"modules/{mod}.md"] = _generate_module_page(
+    sec_num = 0
+    for mod in modules:
+        mod_claims = [k for k in all_claims if k.get("module", "Root") == mod]
+        if not mod_claims:
+            continue
+        sec_num += 1
+        # Sort claims within module by topological order
+        mod_claims.sort(key=lambda k: claim_numbers.get(k["id"], 0))
+        title = module_titles.get(mod) or mod.replace("_", " ").title()
+        fname = _sanitize_filename(f"{sec_num:02d} - {title}")
+        pages[f"sections/{fname}.md"] = _generate_module_section_page(
             mod,
+            sec_num,
+            title,
+            mod_claims,
             ir,
             beliefs,
             priors,
-            strategies_by_conclusion,
+            claim_numbers,
             label_for_id,
-            ids_with_pages,
-            inlined_id_to_module,
-            mod_title,
         )
 
-    # Strategy pages (complex only)
-    for s in ir.get("strategies", []):
-        if _is_complex_strategy(s):
-            sid = s.get("strategy_id", "")
-            s_label = sid.removeprefix("lcs_") if sid else s.get("type", "strategy")
-            pages[f"reasoning/{s_label}.md"] = _generate_strategy_page(
-                s,
-                label_for_id,
-                ids_with_pages,
-                inlined_id_to_module,
-            )
-
-    # Meta pages
+    # Weak Points section — claims with lowest belief
     if beliefs:
-        pages["meta/beliefs.md"] = _generate_beliefs_page(
-            ir,
-            beliefs,
-            priors,
-            label_for_id,
-            ids_with_pages,
-            inlined_id_to_module,
-        )
-    pages["meta/holes.md"] = _generate_holes_page(evidence)
+        sec_num += 1
+        weak = sorted(
+            [k for k in all_claims if k["id"] in beliefs],
+            key=lambda k: beliefs[k["id"]],
+        )[:10]  # bottom 10
+        weak_lines = [
+            "---",
+            "type: section",
+            "aliases: [weak-points]",
+            "section_number: " + str(sec_num),
+            "title: Weak Points",
+            "tags: [section, weak-points]",
+            "---",
+            "",
+            f"# {sec_num:02d} - Weak Points",
+            "",
+            "Claims with the lowest posterior belief — potential weak links in the reasoning.",
+            "",
+            "| # | Claim | Prior | Belief | Justification |",
+            "|---|-------|-------|--------|---------------|",
+        ]
+        for k in weak:
+            kid = k["id"]
+            label = k.get("label", "")
+            num = claim_numbers.get(kid, 0)
+            prior = f"{priors[kid]:.2f}" if kid in priors else "—"
+            belief = f"{beliefs[kid]:.2f}"
+            just = justifications.get(kid, "")
+            weak_lines.append(f"| {num:02d} | [[{label}]] | {prior} | {belief} | {just} |")
+        weak_lines.append("")
+        pages[f"sections/{sec_num:02d} - Weak Points.md"] = "\n".join(weak_lines)
 
-    # Index and overview
-    pages["_index.md"] = _generate_index(ir, conclusions, evidence, beliefs, modules)
-    pages["overview.md"] = _generate_overview(ir)
+    # Open Questions section — leaf premises (holes) + questions
+    sec_num += 1
+    conclusion_ids = {s.get("conclusion") for s in ir.get("strategies", []) if s.get("conclusion")}
+    leaves = [k for k in all_claims if k["id"] not in conclusion_ids and k["type"] != "setting"]
+    questions = [k for k in all_claims if k["type"] == "question"]
+    oq_lines = [
+        "---",
+        "type: section",
+        "aliases: [open-questions]",
+        "section_number: " + str(sec_num),
+        "title: Open Questions",
+        "tags: [section, open-questions]",
+        "---",
+        "",
+        f"# {sec_num:02d} - Open Questions",
+        "",
+        "Leaf premises that could be strengthened and open questions for future work.",
+        "",
+    ]
+    if questions:
+        oq_lines.append("## Questions")
+        oq_lines.append("")
+        for k in questions:
+            label = k.get("label", "")
+            num = claim_numbers.get(k["id"], 0)
+            content = k.get("content", "")
+            oq_lines.append(f"- [[{label}|#{num:02d} {label}]]: {content}")
+        oq_lines.append("")
+    oq_lines.append("## Leaf Premises (Holes)")
+    oq_lines.append("")
+    oq_lines.append("| # | Claim | Module | Content |")
+    oq_lines.append("|---|-------|--------|---------|")
+    sorted_leaves = sorted(leaves, key=lambda k: claim_numbers.get(k["id"], 0))
+    for k in sorted_leaves:
+        label = k.get("label", "")
+        mod = k.get("module", "Root")
+        num = claim_numbers.get(k["id"], 0)
+        content = k.get("content", "")
+        if len(content) > 60:
+            content = content[:60] + "..."
+        oq_lines.append(f"| {num:02d} | [[{label}]] | [[{mod}]] | {content} |")
+    oq_lines.append("")
+    pages[f"sections/{sec_num:02d} - Open Questions.md"] = "\n".join(oq_lines)
+
+    # Meta
+    if beliefs:
+        pages["meta/beliefs.md"] = _generate_beliefs_page(ir, beliefs, priors, claim_numbers)
+    pages["meta/holes.md"] = _generate_holes_page(leaves, claim_numbers)
+
+    # Build section list for index
+    section_list: list[tuple[str, str, int]] = []
+    for mod in modules:
+        mod_count = sum(1 for k in all_claims if k.get("module", "Root") == mod)
+        if mod_count > 0:
+            t = module_titles.get(mod) or mod.replace("_", " ").title()
+            section_list.append((mod, t, mod_count))
+    if beliefs:
+        section_list.append(("weak-points", "Weak Points", len(weak)))
+    section_list.append(("open-questions", "Open Questions", len(leaves) + len(questions)))
+
+    # Index + overview + config
+    pages["_index.md"] = _generate_index(ir, all_claims, claim_numbers, beliefs, section_list)
+    pages["overview.md"] = _generate_overview(ir, beliefs, priors)
     pages[".obsidian/graph.json"] = _generate_obsidian_config()
 
     return pages

--- a/gaia/cli/commands/render.py
+++ b/gaia/cli/commands/render.py
@@ -274,8 +274,12 @@ def render_command(
         obsidian_pages = generate_obsidian_vault(
             ir, beliefs_data=beliefs_data, param_data=param_data
         )
+        import shutil
+
         wiki_dir = loaded.pkg_path / "gaia-wiki"
-        wiki_dir.mkdir(exist_ok=True)
+        if wiki_dir.exists():
+            shutil.rmtree(wiki_dir)
+        wiki_dir.mkdir()
         for rel_path, page_content in obsidian_pages.items():
             out = wiki_dir / rel_path
             out.parent.mkdir(parents=True, exist_ok=True)

--- a/gaia/ir/parameterization.py
+++ b/gaia/ir/parameterization.py
@@ -28,6 +28,7 @@ class PriorRecord(BaseModel):
     knowledge_id: str
     value: float
     source_id: str
+    justification: str = ""
     created_at: datetime = None  # type: ignore[assignment]
 
     def model_post_init(self, __context: Any) -> None:
@@ -52,6 +53,7 @@ class StrategyParamRecord(BaseModel):
     strategy_id: str  # lcs_ prefix
     conditional_probabilities: list[float]
     source_id: str
+    justification: str = ""
     created_at: datetime = None  # type: ignore[assignment]
 
     def model_post_init(self, __context: Any) -> None:

--- a/skills/render-obsidian/SKILL.md
+++ b/skills/render-obsidian/SKILL.md
@@ -1,194 +1,291 @@
 ---
 name: render-obsidian
-description: "Use when user wants a browsable Obsidian wiki from a Gaia knowledge package — generates skeleton, rewrites all pages as rich knowledge documents from IR and original sources, audits cross-references."
+description: "Use when user wants a browsable Obsidian wiki from a Gaia knowledge package — generates skeleton, rewrites all pages as rich knowledge documents, audits cross-references."
 ---
 
 # Render Obsidian Wiki
 
-Generate a rich, browsable Obsidian vault (`gaia-wiki/`) from a Gaia knowledge package. The agent drives the full pipeline: skeleton generation, full rewrite into human-readable knowledge documents, and cross-reference audit.
+Generate a rich Obsidian vault (`gaia-wiki/`) from a Gaia knowledge package.
 
 ## Vault Architecture
 
 ```
 gaia-wiki/
-├── claims/                 One page per claim, numbered by topological order
-│   ├── 01 - BCS Theory.md              (layer 0, leaf premise)
-│   ├── ...
-│   └── 59 - Tc Prediction.md ★         (highest layer, exported conclusion)
-├── modules/                Chapter-level narrative, numbered by paper order
+├── claims/
+│   ├── holes/              Leaf premises — reasoning chain endpoints
+│   ├── intermediate/       Derived but not exported
+│   ├── conclusions/        Exported claims ★ + questions
+│   └── context/            Settings, background, structural
+├── sections/               Narrative chapters (DSL module order)
 │   ├── 01 - Introduction.md
-│   └── ...06 - Results.md
+│   ├── ...
+│   ├── 07 - Weak Points.md
+│   └── 08 - Open Questions.md
 ├── meta/                   beliefs table, holes list
-├── _index.md               Master index with numbered claim table
-├── overview.md             Simplified Mermaid reasoning graph
-└── .obsidian/              Graph view config
+├── _index.md               Claim Index + Sections + Reading Path
+├── overview.md             Simplified Mermaid
+└── .obsidian/
 ```
 
-**Claims** are the atomic content units. Each has a topological order number — small numbers are leaf premises (evidence), large numbers are final conclusions. Reasoning/derivation is embedded in the claim page.
+- **Claims** = atomic content units, numbered by topological order. Each carries full derivation + review justification.
+- **Sections** = narrative chapters following the paper's arc. Agent rewrites titles. Last two sections are Weak Points and Open Questions.
+- **Wikilinks** use labels, filenames use titles, `aliases` bridges them.
 
-**Modules** are reading chapters. They provide human-readable narrative organized by claim numbers, with per-module Mermaid graphs. Modules link to claim pages — they don't duplicate full derivations.
-
-**Wikilinks** use stable labels (`[[tc_al_predicted]]`). Filenames use titles (`Tc(Al) Ab Initio Prediction.md`). Obsidian `aliases` in frontmatter bridge labels to filenames.
-
-## Full Pipeline
+## Pipeline
 
 ```
-/gaia:render-obsidian
-  ↓
-Step 1: gaia compile + gaia infer (if review exists)
-Step 2: gaia render --target obsidian → gaia-wiki/ skeleton
-Step 3: Read inputs (IR, beliefs, artifacts/, DSL source, review sidecar)
-Step 4: Rewrite every page as a complete knowledge document
+Step 1: gaia compile + gaia infer
+Step 2: gaia render --target obsidian → skeleton
+Step 3: Read inputs (IR, beliefs, parameterization, DSL, review sidecar, artifacts/)
+Step 4: Rewrite every page
 Step 5: Cross-reference audit
-Step 6: Report
 ```
-
-## Step 1: Ensure Compile + Infer
-
-```bash
-gaia compile .
-ls reviews/ && gaia infer .
-```
-
-## Step 2: Generate Skeleton
-
-```bash
-gaia render . --target obsidian
-```
-
-Produces numbered claim pages + module pages with frontmatter, wikilinks, and Mermaid graphs. The skeleton provides **structure only**.
 
 ## Step 3: Read Inputs
 
 ```bash
-cat .gaia/ir.json                          # Full IR
-cat .gaia/reviews/*/beliefs.json           # BP results
-cat .gaia/reviews/*/parameterization.json  # Priors + strategy params
-cat src/<package>/*.py                     # DSL source (claims, reasons, strategies)
-cat src/<package>/reviews/*.py             # Review sidecars (justifications!)
-ls artifacts/                              # Original paper, figures, data
+cat .gaia/ir.json
+cat .gaia/reviews/*/beliefs.json
+cat .gaia/reviews/*/parameterization.json  # includes justification per prior
+cat src/<package>/*.py
+cat src/<package>/reviews/*.py             # review sidecar source
+ls artifacts/
 ```
 
-Read `artifacts/` cover-to-cover. Read the review sidecar for `justification` fields.
+Read `artifacts/` cover-to-cover before writing any page.
 
 ## Step 4: Rewrite Every Page
 
-**Core principle:** The skeleton is scaffolding. The agent rewrites every page so the reader understands the topic **without needing the original source**.
+**Core principle:** Faithful reproduction. Each page replaces reading the paper for its topic.
 
-**Language:** Follow the user's language. Frontmatter keys, wikilinks `[[label]]`, and Mermaid stay in English (structural identifiers).
+**Language:** Follow user's preference. Frontmatter/wikilinks/Mermaid stay English.
 
-### Claim pages (`claims/*.md`)
+---
 
-Each claim page is a self-contained article. The claim number in the title shows its position in the reasoning chain.
+### Claim pages (`claims/{holes,intermediate,conclusions,context}/*.md`)
 
-**Completeness standard:** Faithful reproduction of the paper's treatment, not a summary. If the paper devotes 3 pages to a derivation, reproduce them in readable form.
+Each claim is a self-contained article. `#XX` number = position in reasoning chain.
 
 **Section ordering:**
 
-1. **Title**: Write descriptive title in user's language. Keep the `#XX` number prefix. Filename stays unchanged (wikilinks not affected).
-2. **Content**: Expand the blockquote into a full explanation with all numbers, equations, conditions.
-3. **Background**: Complete scientific context. What problem? What's known? What gap? Embed relevant figures with `![[filename]]` + italic caption.
-4. **Derivation** (核心): Reproduce the paper's full argument:
-   - All key equations with step-by-step explanation
+1. **Title** — Descriptive in user's language. Keep `#XX` prefix.
+2. **Content** — Full explanation, all numbers/equations/conditions.
+3. **Background** — Scientific context from `artifacts/`. What problem? Prior work? Gap? Embed figures with `![[file]]` + italic caption.
+4. **Derivation** — Reproduce the paper's FULL argument:
+   - All equations with step-by-step explanation
    - Physical reasoning behind each step
-   - Approximations and why they're justified
-   - Numerical validations
+   - Why each approximation is justified
+   - Numerical validations from the paper
    - Appendix material
-   - Keep wikilinks (with claim numbers: `[[label|#XX label]]`)
-5. **Review**: Prior value + justification from review sidecar. Posterior belief from BP.
-   - Format: `**Prior**: 0.95 — "Migdal theorem validated for ωD/EF ~ 0.005"`
-6. **Supports**: Downstream claims that depend on this one.
-7. **Significance**: Why this matters. What breaks if wrong?
-8. **Caveats**: Limitations, alternatives, uncertainties.
+   - Use `[[label|#XX label]]` for cross-references
+5. **Review** — From `parameterization.json`:
+   - `**Prior**: 0.95`
+   - `**Justification**: omega_D/E_F ~ 0.005; Migdal theorem validated.`
+   - `**Belief**: 0.71`
+6. **Supports** — Downstream claims.
+7. **Significance** — Why it matters. What breaks if wrong?
+8. **Caveats** — Limitations, alternative explanations, uncertainties.
 
-### Module pages (`modules/*.md`)
+**Depth by claim type:**
 
-Modules are **narrative chapters** organized by claim numbers. They tell the paper's story.
+| Type | Depth |
+|------|-------|
+| **Conclusions** (★) | Most detailed — full derivation chain, multiple paragraphs per section |
+| **Holes** | Focus on source provenance — where does this evidence come from? Method, precision, limitations |
+| **Intermediate** | Full derivation of this step in the chain |
+| **Context** | Brief — what it establishes and why it's assumed |
 
-1. **Overview**: 2-3 paragraphs — scientific question, approach, key results. Write as a review paper section.
-2. **Transition**: How this module connects to previous/next modules.
-3. **Per-module Mermaid**: Keep as-is.
-4. **Claims list**: For each claim in this module, provide a brief summary (2-3 sentences with key numbers) linking to the full claim page via `[[label|#XX title]]`. Don't duplicate full derivations here.
+---
 
-### Overview page
+### Section pages (`sections/*.md`)
 
-1. **Citation**: Bibliographic reference.
-2. **Abstract**: Comprehensive summary (central question, methodology, results, limitations).
-3. **Mermaid**: Keep simplified graph as-is.
+Sections are **narrative chapters** that tell the paper's story. Claims within each section are sorted by topological order (evidence → derivation → conclusion).
 
-### `_index.md`
+**Goal:** A reader who reads sections 01 through 06 in order should understand the paper's complete argument without ever opening the original paper. Each section is a self-contained chapter of a "textbook rewrite" of the paper.
 
-Add package description. Keep statistics, Claim Index table, module table, and Reading Path.
+**Page structure (from top to bottom):**
 
-### Meta pages
+1. **Title** — Descriptive narrative title in user's language. Keep number prefix.
 
-- `beliefs.md`: Chinese introduction + belief table.
-- `holes.md`: Chinese introduction + leaf premises table.
+2. **Overview** (10%) — 2-3 paragraphs setting up the section's question, approach, and key result.
 
-### Quality bar
+3. **Per-section Mermaid** — Keep as-is.
 
-**Faithful reproduction, not summarization.** Rewrite the paper into a wiki, don't summarize it.
+4. **Claims narrative** (70% of the page — THIS IS THE MAIN BODY) — For EVERY claim in topo order, write a `###` heading + 1-3 paragraphs. This is NOT optional. Every claim listed in the skeleton MUST appear with its narrative.
 
-Every page must include:
-- ALL relevant numerical values (with units, error bars)
-- ALL key equations with explanation
-- ALL derivation steps (including appendix material)
-- Figure embeds with italic captions
-- Cross-references with claim numbers
+   **CRITICAL: This section is the bulk of the page. Do NOT skip it.** The skeleton has `### [[label|#XX title]]` entries — the agent must expand EACH ONE into a full narrative paragraph.
 
-### Figure embeds
+   For each claim:
+   - `### [[label|#XX title]]` heading (keep the wikilink)
+   - What this claim says in plain language, with key numbers and equations
+   - Why this result matters for the section's argument
+   - How it connects to the previous and next claims (logical flow)
+   - If exported (★): **highlight as a key conclusion** with a callout block
+   - Belief analysis: what does the prior→belief change reveal?
 
-Every `![[filename]]` MUST have an italic caption:
+   **Exported conclusions should be highlighted:**
+   ```
+   ### [[downfolded_bse|#43 下折叠 BSE]] ★
+
+   > [!IMPORTANT] 核心结论
+   > 完整的动量-频率 BSE 可以严格化简为仅依赖频率的一维积分方程，
+   > 误差仅 0.2%。
+
+   这是本章最重要的结果...
+   ```
+
+5. **Chapter summary** (10%) — 本章建立了什么，为下一章准备了什么。
+
+**Full section page example (showing the required structure):**
 
 ```markdown
+# 03 - 从微观推导下折叠 Bethe-Salpeter 方程
+
+## 概述
+
+(2-3 paragraphs: question, approach, key result)
+
+(Mermaid graph)
+
+## 推理链
+
+### [[pair_propagator_decomposition|#18 配对传播子分解]]
+
+配对传播子 $GG$ 可以精确分解为低能相干部分 $\Pi_{\mathrm{BCS}}$
+和高能非相干余项 $\phi$。这不是一个近似——而是一个数学恒等式。
+相干部分携带 Cooper 对数 $\ln(\omega_c/T)$，定义了低能配对通道。
+
+论文选择在双电子通道（而非传统的粒子-空穴通道）引入能量尺度
+分离，这是一个关键创新——传统方案会导致低能区域库仑相互作用
+失去屏蔽。这一选择为下面的交叉项压制论证奠定了基础。
+
+### [[cross_term_suppressed|#19 交叉项压制]]
+
+有了配对传播子分解，关键问题是：库仑和声子通道的交叉项是否
+会破坏可分离性？论文利用等离子体极子模型给出了严格的上界估计：
+交叉项被压制在 $O(\omega_c^2/\omega_p^2) \leq 1\%$。
+
+这是整条推理链中最脆弱的一环——belief 仅 0.50，反映了 1% 这个
+边界条件的不确定性。如果交叉项实际上更大，整个下折叠理论的
+精度保证就会失效。
+
+### [[downfolded_bse|#43 下折叠 BSE]] ★
+
+> [!IMPORTANT] 核心结论
+> 频率-only 下折叠 BSE：$\Lambda_\omega = \eta_\omega + \pi T
+> \sum (\lambda - \mu_{\omega_c}) z^{ph}_{\omega'}/|\omega'| \Lambda_{\omega'}$
+
+结合配对传播子分解和交叉项压制，完整 BSE 化简为仅含频率的
+一维积分方程。$\mu^*$ 和 $\lambda$ 获得了精确的微观定义...
+
+(... more claims ...)
+
+## 本章小结
+
+本章从微观出发严格推导了下折叠 BSE，为 $\mu^*$ 和 $\lambda$
+提供了精确定义。这为第四章通过 vDiagMC 计算 $\mu^*$ 和第五章
+验证 DFPT $\lambda$ 的可靠性奠定了理论基础。
+```
+
+**DO NOT** write a section page with only the overview and Mermaid — the claims narrative is the main content that readers come here to read.
+
+#### Weak Points section
+
+**Goal:** A reader should understand WHERE the argument is weakest, WHY it's weak, and WHAT could fix it. This is a critical assessment, not a data dump.
+
+The skeleton provides a table of the 10 lowest-belief claims. Agent should rewrite into a structured analysis:
+
+1. **Executive summary** (1 paragraph) — The single most important takeaway. What is the weakest link in the entire reasoning chain? If you had to bet on which claim will fail, which one and why?
+
+2. **Structural analysis** — Group weak points by their position in the reasoning graph:
+   - **Foundation weaknesses** — Are any leaf premises (holes) controversial? If a widely-accepted fact turns out to be wrong, what collapses?
+   - **Bottleneck weaknesses** — Are there single claims that many conclusions depend on? A low-belief bottleneck is more dangerous than a low-belief leaf.
+   - **Propagation effects** — Does the reasoning graph amplify uncertainty? (e.g., "the downfolded BSE has belief 0.33 not because it's intrinsically unreliable, but because it depends on cross-term suppression which has belief 0.50, and the uncertainty propagates through 3 derivation steps")
+
+3. **For each major weak point** (top 3-5), write a full paragraph:
+   - What the claim says and where it sits in the reasoning chain
+   - WHY the belief is low — trace the reasoning graph backwards to find the root cause
+   - What the reviewer's justification says about the uncertainty
+   - What competing explanation or alternative approach exists
+   - What specific evidence or experiment would resolve the uncertainty
+   - What downstream conclusions would be affected if this claim fails
+
+4. **Comparison with the paper's own assessment** — Does the paper acknowledge these weaknesses? Does the reasoning graph reveal weaknesses the paper doesn't discuss?
+
+#### Open Questions section
+
+**Goal:** A reader should know exactly what work remains to be done, prioritized by impact. This is a research roadmap derived from the reasoning graph.
+
+The skeleton lists holes and questions. Agent should rewrite into:
+
+1. **Overview** (1-2 paragraphs) — The big picture: what would make this knowledge package "complete"? What's the most impactful single improvement?
+
+2. **Open questions from the paper** — If the IR has `type: question` nodes, explain each:
+   - What the question asks
+   - Why it matters for the overall argument
+   - What the paper suggests (if anything) as an approach
+   - What the reasoning graph says about its impact (which conclusions depend on it?)
+
+3. **Evidence gaps** (grouped by theme):
+
+   **Experimental gaps:**
+   - What measurements are missing or imprecise?
+   - Which claims rely on the weakest experimental evidence?
+   - What experiments would most reduce uncertainty?
+
+   **Computational gaps:**
+   - What calculations are approximate that could be made exact?
+   - What parameters have the largest error bars?
+   - What computational advances would help?
+
+   **Theoretical gaps:**
+   - What derivations rely on uncontrolled approximations?
+   - Where does the theory break down (validity limits)?
+   - What extensions would broaden applicability?
+
+4. **Impact analysis** — For each gap, trace forward through the reasoning graph:
+   - If this hole were filled with higher confidence, which conclusions would improve?
+   - Rank the holes by "information value": how much would filling this hole reduce overall uncertainty?
+
+5. **Suggested next steps** — Prioritized list of 3-5 actionable research directions, each with:
+   - What to do
+   - Why it's high-impact (which conclusions it would strengthen)
+   - Estimated difficulty/feasibility
+
+---
+
+### Overview, _index, meta
+
+- **Overview** — Citation + abstract + simplified Mermaid graph.
+- **_index** — Package description + statistics + Claim Index table (with numbers) + Sections table + Reading Path.
+- **Meta** — `beliefs.md`: intro + full belief table. `holes.md`: intro + leaf premises table.
+
+---
+
+### Quality standard
+
+**Faithful reproduction, not summarization.** If the paper devotes 3 pages to a derivation, reproduce them in readable form. Include appendix material.
+
+**Every page must include:**
+- All relevant numerical values (units, error bars)
+- Key equations with step-by-step explanation
+- Derivation steps from the paper (including appendix)
+- Figure embeds with italic captions
+- Cross-references with claim numbers `[[label|#XX label]]`
+- Review justification where available
+
+**Figure embeds** — every `![[file]]` must have italic caption:
+```
 ![[8_0.jpg]]
-*图 4：vDiagMC 计算的 μ_{E_F}(r_s)，与 RPA 的对比。改编自 Cai et al.*
+*图 4：vDiagMC 计算的 μ_EF(r_s)。改编自 Cai et al.*
 ```
 
 ### DO NOT
 
-- Leave any page with only skeleton English content
+- Leave skeleton English content
 - Write thin summaries
-- Use Gaia jargon (noisy_and, abduction, factor graph, BP, NAND)
-- Describe graph structure ("derived from two premises via...")
+- Use Gaia jargon (noisy_and, abduction, factor graph, BP)
 - Modify frontmatter or wikilink targets
 - Embed images without captions
-- Duplicate full derivations in module pages (link to claim pages instead)
-
-### Handling missing information
-
-| Missing | Action | Annotation |
-|---------|--------|------------|
-| Terse claim | Expand from `artifacts/` | `> [!NOTE] 内容根据原文扩展` |
-| No strategy reason | Reconstruct from source | `> [!NOTE] 推理根据原文重构` |
-| No beliefs | Write structural description | `> [!WARNING] 未运行推断` |
-| No artifacts | Write from IR only | `> [!WARNING] 原始文献不可用` |
-
-## Step 5: Cross-Reference Audit
-
-Wikilinks use labels, resolved via aliases. Check:
-
-```bash
-# Collect all aliases and filenames
-all_aliases=$(grep -rh "^aliases:" gaia-wiki/ --include="*.md" | sed 's/aliases: \[//;s/\]//')
-all_files=$(find gaia-wiki -name "*.md" -exec basename {} .md \;)
-# Check each wikilink resolves
-grep -roh '\[\[[^]!]*\]\]' gaia-wiki/ --include="*.md" | grep -v '.jpg' | \
-  sed 's/\[\[//;s/\]\]//' | sed 's/#.*//' | sed 's/|.*//' | sort -u | \
-  while read name; do
-    echo "$all_aliases $all_files" | grep -qw "$name" || echo "BROKEN: [[$name]]"
-  done
-```
-
-## Step 6: Report
-
-```
-Obsidian wiki: gaia-wiki/
-- X claim pages (numbered 01-XX)
-- Y module pages (numbered 01-YY)
-- All pages rewritten in [language]
-- Figures embedded: M
-- Broken wikilinks: 0
-
-Open in Obsidian: File → Open Vault → select gaia-wiki/
-```
+- Duplicate full derivations in section pages
+- List weak points without explaining WHY they're weak

--- a/tests/cli/test_obsidian.py
+++ b/tests/cli/test_obsidian.py
@@ -6,7 +6,6 @@ from gaia.cli.commands._obsidian import generate_obsidian_vault
 
 
 def _make_ir(knowledges=None, strategies=None, operators=None):
-    """Build minimal IR dict for testing."""
     return {
         "package_name": "test_pkg",
         "namespace": "github",
@@ -16,108 +15,70 @@ def _make_ir(knowledges=None, strategies=None, operators=None):
     }
 
 
+def _find_page(pages, prefix, substring):
+    """Find a page path starting with prefix and containing substring."""
+    for p in pages:
+        if p.startswith(prefix) and substring in p:
+            return p
+    return None
+
+
 # ---------------------------------------------------------------------------
-# Page routing
+# Page routing — all claims go to claims/
 # ---------------------------------------------------------------------------
 
 
 class TestPageRouting:
-    def test_exported_claim_gets_conclusion_page(self):
+    def test_exported_claim_in_claims_dir(self):
         ir = _make_ir(
             knowledges=[
                 {
-                    "id": "github:test_pkg::main_claim",
-                    "label": "main_claim",
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
                     "type": "claim",
-                    "content": "Main finding.",
-                    "module": "results",
+                    "content": "C.",
+                    "module": "m",
                     "exported": True,
                 },
             ]
         )
         pages = generate_obsidian_vault(ir)
-        assert "conclusions/main_claim.md" in pages
+        path = _find_page(pages, "claims/", "c1")
+        assert path is not None
 
-    def test_question_gets_conclusion_page(self):
+    def test_non_exported_claim_also_in_claims_dir(self):
         ir = _make_ir(
             knowledges=[
                 {
-                    "id": "github:test_pkg::q1",
-                    "label": "q1",
-                    "type": "question",
-                    "content": "Is X true?",
-                    "module": "intro",
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        assert "conclusions/q1.md" in pages
-
-    def test_leaf_premise_gets_evidence_page(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::evidence_a",
-                    "label": "evidence_a",
-                    "type": "claim",
-                    "content": "Observed data.",
-                    "module": "results",
-                },
-                {
-                    "id": "github:test_pkg::derived",
-                    "label": "derived",
-                    "type": "claim",
-                    "content": "Conclusion.",
-                    "module": "results",
-                    "exported": True,
-                },
-            ],
-            strategies=[
-                {
-                    "strategy_id": "lcs_s1",
-                    "type": "noisy_and",
-                    "premises": ["github:test_pkg::evidence_a"],
-                    "conclusion": "github:test_pkg::derived",
-                },
-            ],
-        )
-        pages = generate_obsidian_vault(ir)
-        assert "evidence/evidence_a.md" in pages
-
-    def test_non_exported_derived_claim_inlined_in_module(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::premise_a",
-                    "label": "premise_a",
+                    "id": "github:test_pkg::p1",
+                    "label": "p1",
                     "type": "claim",
                     "content": "P.",
-                    "module": "analysis",
+                    "module": "m",
                 },
                 {
-                    "id": "github:test_pkg::intermediate",
-                    "label": "intermediate",
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
                     "type": "claim",
-                    "content": "I.",
-                    "module": "analysis",
-                    "exported": False,
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
                 },
             ],
             strategies=[
                 {
                     "strategy_id": "lcs_s1",
                     "type": "noisy_and",
-                    "premises": ["github:test_pkg::premise_a"],
-                    "conclusion": "github:test_pkg::intermediate",
+                    "premises": ["github:test_pkg::p1"],
+                    "conclusion": "github:test_pkg::c1",
                 },
             ],
         )
         pages = generate_obsidian_vault(ir)
-        assert "conclusions/intermediate.md" not in pages
-        assert "modules/analysis.md" in pages
-        assert "intermediate" in pages["modules/analysis.md"]
+        # Non-exported derived claim also gets its own page
+        assert _find_page(pages, "claims/", "p1") is not None
 
-    def test_setting_inlined_in_module(self):
+    def test_setting_in_claims_dir(self):
         ir = _make_ir(
             knowledges=[
                 {
@@ -125,14 +86,12 @@ class TestPageRouting:
                     "label": "bg",
                     "type": "setting",
                     "content": "Background.",
-                    "module": "intro",
+                    "module": "m",
                 },
             ]
         )
         pages = generate_obsidian_vault(ir)
-        assert "conclusions/bg.md" not in pages
-        assert "evidence/bg.md" not in pages
-        assert "modules/intro.md" in pages
+        assert _find_page(pages, "claims/", "bg") is not None
 
     def test_helper_nodes_excluded(self):
         ir = _make_ir(
@@ -155,18 +114,91 @@ class TestPageRouting:
             ]
         )
         pages = generate_obsidian_vault(ir)
-        for path in pages:
-            assert "__helper" not in path
-        assert "__helper" not in pages.get("modules/m.md", "")
+        assert _find_page(pages, "claims/", "__helper") is None
+
+    def test_no_conclusions_evidence_reasoning_dirs(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::p1",
+                    "label": "p1",
+                    "type": "claim",
+                    "content": "P.",
+                    "module": "m",
+                },
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ],
+            strategies=[
+                {
+                    "strategy_id": "lcs_s1",
+                    "type": "induction",
+                    "premises": [
+                        "github:test_pkg::p1",
+                        "github:test_pkg::p1",
+                        "github:test_pkg::p1",
+                    ],
+                    "conclusion": "github:test_pkg::c1",
+                },
+            ],
+        )
+        pages = generate_obsidian_vault(ir)
+        assert not any(p.startswith("conclusions/") for p in pages)
+        assert not any(p.startswith("evidence/") for p in pages)
+        assert not any(p.startswith("reasoning/") for p in pages)
 
 
 # ---------------------------------------------------------------------------
-# Frontmatter
+# Numbering
 # ---------------------------------------------------------------------------
 
 
-class TestFrontmatter:
-    def test_frontmatter_has_yaml_delimiters(self):
+class TestNumbering:
+    def test_claims_numbered_by_topo_order(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::leaf",
+                    "label": "leaf",
+                    "type": "claim",
+                    "content": "L.",
+                    "module": "m",
+                },
+                {
+                    "id": "github:test_pkg::derived",
+                    "label": "derived",
+                    "type": "claim",
+                    "content": "D.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ],
+            strategies=[
+                {
+                    "strategy_id": "lcs_s1",
+                    "type": "noisy_and",
+                    "premises": ["github:test_pkg::leaf"],
+                    "conclusion": "github:test_pkg::derived",
+                },
+            ],
+        )
+        pages = generate_obsidian_vault(ir)
+        leaf_path = _find_page(pages, "claims/", "leaf")
+        derived_path = _find_page(pages, "claims/", "derived")
+        # Leaf (premise) has lower number than derived (conclusion)
+        assert "01 -" in leaf_path
+        assert "02 -" in derived_path
+        # Leaf in holes/, derived in conclusions/
+        assert "holes/" in leaf_path
+        assert "conclusions/" in derived_path
+
+    def test_claim_page_title_has_number(self):
         ir = _make_ir(
             knowledges=[
                 {
@@ -180,76 +212,11 @@ class TestFrontmatter:
             ]
         )
         pages = generate_obsidian_vault(ir)
-        page = pages["conclusions/c1.md"]
-        assert page.startswith("---\n")
-        assert "\n---\n" in page[4:]
+        path = _find_page(pages, "claims/", "c1")
+        page = pages[path]
+        assert "# #01" in page
 
-    def test_beliefs_in_frontmatter(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        beliefs = {
-            "beliefs": [{"knowledge_id": "github:test_pkg::c1", "belief": 0.85, "label": "c1"}]
-        }
-        params = {"priors": [{"knowledge_id": "github:test_pkg::c1", "value": 0.7}]}
-        pages = generate_obsidian_vault(ir, beliefs_data=beliefs, param_data=params)
-        page = pages["conclusions/c1.md"]
-        assert "prior: 0.7" in page
-        assert "belief: 0.85" in page
-
-    def test_null_beliefs_without_inference(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        page = pages["conclusions/c1.md"]
-        assert "prior: null" in page
-        assert "belief: null" in page
-
-    def test_module_frontmatter(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "results",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        mod_page = pages["modules/results.md"]
-        assert "type: module" in mod_page
-        assert "label: results" in mod_page
-
-
-# ---------------------------------------------------------------------------
-# Wikilinks
-# ---------------------------------------------------------------------------
-
-
-class TestWikilinks:
-    def test_wikilinks_in_derivation(self):
+    def test_section_page_has_number(self):
         ir = _make_ir(
             knowledges=[
                 {
@@ -278,8 +245,148 @@ class TestWikilinks:
             ],
         )
         pages = generate_obsidian_vault(ir)
-        page = pages["conclusions/c1.md"]
-        assert "[[p1]]" in page
+        sec_pages = [p for p in pages if p.startswith("sections/")]
+        assert len(sec_pages) > 0
+        page = pages[sec_pages[0]]
+        assert "# 01 -" in page
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatter:
+    def test_frontmatter_has_aliases(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        pages = generate_obsidian_vault(ir)
+        path = _find_page(pages, "claims/", "c1")
+        page = pages[path]
+        assert "aliases: [c1]" in page
+
+    def test_frontmatter_has_claim_number(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        pages = generate_obsidian_vault(ir)
+        path = _find_page(pages, "claims/", "c1")
+        page = pages[path]
+        assert "claim_number: 1" in page
+
+    def test_beliefs_in_frontmatter(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        beliefs = {"beliefs": [{"knowledge_id": "github:test_pkg::c1", "belief": 0.85}]}
+        params = {"priors": [{"knowledge_id": "github:test_pkg::c1", "value": 0.7}]}
+        pages = generate_obsidian_vault(ir, beliefs_data=beliefs, param_data=params)
+        path = _find_page(pages, "claims/", "c1")
+        page = pages[path]
+        assert "prior: 0.7" in page
+        assert "belief: 0.85" in page
+
+    def test_section_frontmatter(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::p1",
+                    "label": "p1",
+                    "type": "claim",
+                    "content": "P.",
+                    "module": "m",
+                },
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ],
+            strategies=[
+                {
+                    "strategy_id": "lcs_s1",
+                    "type": "noisy_and",
+                    "premises": ["github:test_pkg::p1"],
+                    "conclusion": "github:test_pkg::c1",
+                },
+            ],
+        )
+        pages = generate_obsidian_vault(ir)
+        sec_pages = [p for p in pages if p.startswith("sections/")]
+        assert len(sec_pages) > 0
+        page = pages[sec_pages[0]]
+        assert "type: section" in page
+
+
+# ---------------------------------------------------------------------------
+# Wikilinks
+# ---------------------------------------------------------------------------
+
+
+class TestWikilinks:
+    def test_wikilinks_use_labels(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::p1",
+                    "label": "p1",
+                    "type": "claim",
+                    "content": "P.",
+                    "module": "m",
+                },
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ],
+            strategies=[
+                {
+                    "strategy_id": "lcs_s1",
+                    "type": "noisy_and",
+                    "premises": ["github:test_pkg::p1"],
+                    "conclusion": "github:test_pkg::c1",
+                },
+            ],
+        )
+        pages = generate_obsidian_vault(ir)
+        path = _find_page(pages, "claims/", "c1")
+        page = pages[path]
+        assert "[[p1|" in page  # wikilink with numbered display
 
     def test_module_link_in_claim_page(self):
         ir = _make_ir(
@@ -295,69 +402,10 @@ class TestWikilinks:
             ]
         )
         pages = generate_obsidian_vault(ir)
-        assert "[[results]]" in pages["conclusions/c1.md"]
+        path = _find_page(pages, "claims/", "c1")
+        assert "[[results]]" in pages[path]
 
-
-# ---------------------------------------------------------------------------
-# Strategy pages
-# ---------------------------------------------------------------------------
-
-
-class TestStrategyPages:
-    def test_complex_strategy_gets_own_page(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::p1",
-                    "label": "p1",
-                    "type": "claim",
-                    "content": "P1.",
-                    "module": "m",
-                },
-                {
-                    "id": "github:test_pkg::p2",
-                    "label": "p2",
-                    "type": "claim",
-                    "content": "P2.",
-                    "module": "m",
-                },
-                {
-                    "id": "github:test_pkg::p3",
-                    "label": "p3",
-                    "type": "claim",
-                    "content": "P3.",
-                    "module": "m",
-                },
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ],
-            strategies=[
-                {
-                    "strategy_id": "lcs_induction_s1",
-                    "type": "induction",
-                    "premises": [
-                        "github:test_pkg::p1",
-                        "github:test_pkg::p2",
-                        "github:test_pkg::p3",
-                    ],
-                    "conclusion": "github:test_pkg::c1",
-                    "reason": "Three independent observations...",
-                },
-            ],
-        )
-        pages = generate_obsidian_vault(ir)
-        assert any(p.startswith("reasoning/") for p in pages)
-        # Strategy page should have conclusion wikilink
-        strategy_page = [v for k, v in pages.items() if k.startswith("reasoning/")][0]
-        assert "[[c1]]" in strategy_page
-
-    def test_simple_strategy_no_own_page(self):
+    def test_claim_ref_has_number(self):
         ir = _make_ir(
             knowledges=[
                 {
@@ -386,7 +434,98 @@ class TestStrategyPages:
             ],
         )
         pages = generate_obsidian_vault(ir)
-        assert not any(p.startswith("reasoning/") for p in pages)
+        path = _find_page(pages, "claims/", "c1")
+        page = pages[path]
+        assert "[[p1|#01 p1]]" in page
+
+
+# ---------------------------------------------------------------------------
+# Index and overview
+# ---------------------------------------------------------------------------
+
+
+class TestIndexAndOverview:
+    def test_index_has_claim_index_table(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        pages = generate_obsidian_vault(ir)
+        index = pages["_index.md"]
+        assert "## Claim Index" in index
+        assert "[[c1]]" in index
+
+    def test_index_has_sections_table(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        pages = generate_obsidian_vault(ir)
+        assert "## Sections" in pages["_index.md"]
+
+    def test_overview_has_mermaid(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        pages = generate_obsidian_vault(ir)
+        assert "```mermaid" in pages["overview.md"]
+
+    def test_obsidian_config(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        pages = generate_obsidian_vault(ir)
+        assert ".obsidian/graph.json" in pages
+
+    def test_no_beliefs_link_when_no_infer(self):
+        ir = _make_ir(
+            knowledges=[
+                {
+                    "id": "github:test_pkg::c1",
+                    "label": "c1",
+                    "type": "claim",
+                    "content": "C.",
+                    "module": "m",
+                    "exported": True,
+                },
+            ]
+        )
+        pages = generate_obsidian_vault(ir)
+        assert "[[beliefs]]" not in pages["_index.md"]
 
 
 # ---------------------------------------------------------------------------
@@ -408,32 +547,13 @@ class TestMetaPages:
                 },
             ]
         )
-        beliefs = {
-            "beliefs": [{"knowledge_id": "github:test_pkg::c1", "belief": 0.85, "label": "c1"}]
-        }
+        beliefs = {"beliefs": [{"knowledge_id": "github:test_pkg::c1", "belief": 0.85}]}
         params = {"priors": [{"knowledge_id": "github:test_pkg::c1", "value": 0.7}]}
         pages = generate_obsidian_vault(ir, beliefs_data=beliefs, param_data=params)
         assert "meta/beliefs.md" in pages
         assert "0.85" in pages["meta/beliefs.md"]
-        assert "[[c1]]" in pages["meta/beliefs.md"]
 
-    def test_no_beliefs_page_without_data(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        assert "meta/beliefs.md" not in pages
-
-    def test_holes_page(self):
+    def test_holes_page_lists_leaves(self):
         ir = _make_ir(
             knowledges=[
                 {
@@ -462,96 +582,11 @@ class TestMetaPages:
             ],
         )
         pages = generate_obsidian_vault(ir)
-        assert "meta/holes.md" in pages
         assert "[[hole]]" in pages["meta/holes.md"]
 
 
 # ---------------------------------------------------------------------------
-# Index and overview
-# ---------------------------------------------------------------------------
-
-
-class TestIndexAndOverview:
-    def test_index_has_statistics(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-                {
-                    "id": "github:test_pkg::s1",
-                    "label": "s1",
-                    "type": "setting",
-                    "content": "S.",
-                    "module": "m",
-                },
-            ],
-        )
-        pages = generate_obsidian_vault(ir)
-        index = pages["_index.md"]
-        assert "## Statistics" in index
-        assert "1 claims" in index
-        assert "1 settings" in index
-
-    def test_index_has_exported_conclusions(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        assert "[[c1]]" in pages["_index.md"]
-
-    def test_overview_has_mermaid(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        assert "overview.md" in pages
-        assert "```mermaid" in pages["overview.md"]
-
-    def test_obsidian_config(self):
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        assert ".obsidian/graph.json" in pages
-        config = pages[".obsidian/graph.json"]
-        assert "colorGroups" in config
-
-
-# ---------------------------------------------------------------------------
-# Structural guarantees
+# Structural
 # ---------------------------------------------------------------------------
 
 
@@ -586,9 +621,8 @@ class TestStructural:
         )
         pages = generate_obsidian_vault(ir)
         for path, content in pages.items():
-            assert isinstance(path, str), f"Path {path} is not a string"
-            assert isinstance(content, str), f"Content for {path} is not a string"
-            assert len(content) > 0, f"Page {path} is empty"
+            assert isinstance(content, str), f"{path} not string"
+            assert len(content) > 0, f"{path} empty"
 
     def test_empty_ir_produces_minimal_vault(self):
         ir = _make_ir()
@@ -597,68 +631,7 @@ class TestStructural:
         assert "overview.md" in pages
         assert ".obsidian/graph.json" in pages
 
-
-# ---------------------------------------------------------------------------
-# Regression tests (Codex review findings)
-# ---------------------------------------------------------------------------
-
-
-class TestCodexRegressions:
-    def test_overview_no_double_mermaid_fence(self):
-        """P2: render_mermaid already returns fenced block — don't wrap again."""
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
-                    "type": "claim",
-                    "content": "C.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        overview = pages["overview.md"]
-        # Should have exactly one opening fence
-        assert overview.count("```mermaid") == 1
-
-    def test_unlabeled_nodes_treated_as_helpers(self):
-        """P2: Nodes with None/empty label should not create pages."""
-        ir = _make_ir(
-            knowledges=[
-                {
-                    "id": "github:test_pkg::_anon_op_1",
-                    "label": None,
-                    "type": "claim",
-                    "content": "Helper.",
-                    "module": "m",
-                },
-                {
-                    "id": "github:test_pkg::_anon_op_2",
-                    "type": "claim",
-                    "content": "Another helper.",
-                    "module": "m",
-                },
-                {
-                    "id": "github:test_pkg::real",
-                    "label": "real",
-                    "type": "claim",
-                    "content": "Real.",
-                    "module": "m",
-                    "exported": True,
-                },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        # No page with empty path segment
-        for path in pages:
-            assert "/." not in path
-            assert path != "evidence/.md"
-            assert path != "conclusions/.md"
-
     def test_reason_from_metadata(self):
-        """P2: Strategy reason lives in metadata.reason, not top-level reason."""
         ir = _make_ir(
             knowledges=[
                 {
@@ -688,40 +661,29 @@ class TestCodexRegressions:
             ],
         )
         pages = generate_obsidian_vault(ir)
-        page = pages["conclusions/c1.md"]
-        assert "Because X implies Y." in page
+        path = _find_page(pages, "claims/", "c1")
+        assert "Because X implies Y." in pages[path]
 
-    def test_root_module_count_correct(self):
-        """P3: Nodes without module field should count under Root."""
+    def test_unlabeled_nodes_treated_as_helpers(self):
         ir = _make_ir(
             knowledges=[
                 {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
+                    "id": "github:test_pkg::_anon_1",
+                    "label": None,
                     "type": "claim",
-                    "content": "C.",
-                    "exported": True,
+                    "content": "H.",
+                    "module": "m",
                 },
-            ]
-        )
-        pages = generate_obsidian_vault(ir)
-        index = pages["_index.md"]
-        assert "| [[Root]] | 1 |" in index
-
-    def test_no_beliefs_link_when_no_infer(self):
-        """P3: _index.md should not link to meta/beliefs when beliefs are absent."""
-        ir = _make_ir(
-            knowledges=[
                 {
-                    "id": "github:test_pkg::c1",
-                    "label": "c1",
+                    "id": "github:test_pkg::real",
+                    "label": "real",
                     "type": "claim",
-                    "content": "C.",
+                    "content": "R.",
                     "module": "m",
                     "exported": True,
                 },
             ]
         )
         pages = generate_obsidian_vault(ir)
-        index = pages["_index.md"]
-        assert "[[meta/beliefs]]" not in index
+        for path in pages:
+            assert "_anon" not in path


### PR DESCRIPTION
## Summary

Clean rebase of PR #411 (which had merge conflicts). Same changes, single commit on main.

### Vault structure
```
gaia-wiki/
├── claims/{holes,intermediate,conclusions,context}/  — 59 claims by role
├── sections/ 01-06 (narrative) + 07 Weak Points + 08 Open Questions
├── meta/ + _index.md + overview.md + .obsidian/
```

### Key changes
- Topological numbering, role-based directories (`node_role()`)
- `justification` in `PriorRecord`/`StrategyParamRecord` → `parameterization.json`
- Review section in claim pages (prior + justification + belief)
- Sections from DSL modules, topo-sorted claims, per-section Mermaid
- Weak Points + Open Questions auto-generated sections
- Title filenames + label aliases, shutil.rmtree, simplified overview

### Skill
- Section claims narrative = 70% mandatory main body
- Exported conclusions `> [!IMPORTANT]`
- Weak Points structural analysis, Open Questions research roadmap

## Test plan
- [x] 51 tests pass, ruff clean
- [x] E2E: 71 pages, 4050 lines Chinese, 0 broken wikilinks

Supersedes #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)