### PR TITLE
fix(cli): harden metadata priors

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
+import math
 import sys
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -19,6 +20,7 @@ from gaia.lang.runtime import Knowledge, Strategy
 from gaia.lang.runtime.package import CollectedPackage
 from gaia.lang.runtime.package import pyproject_for_module
 from gaia.lang.runtime.package import get_inferred_package, reset_inferred_package
+from gaia.ir.parameterization import CROMWELL_EPS
 from packaging.requirements import InvalidRequirement, Requirement
 
 try:
@@ -192,6 +194,27 @@ def compile_loaded_package_artifact(loaded: LoadedGaiaPackage):
         raise GaiaCliError(str(e)) from e
 
 
+def _knowledge_display_name(knowledge: Knowledge) -> str:
+    return knowledge.label or knowledge.content or repr(knowledge)
+
+
+def _validate_prior_value(value: Any, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise GaiaCliError(
+            f"Error: PRIORS[{label!r}] prior must be a number, "
+            f"got {type(value).__name__}."
+        )
+    prior = float(value)
+    if not math.isfinite(prior):
+        raise GaiaCliError(f"Error: PRIORS[{label!r}] prior must be finite, got {prior!r}.")
+    if prior < CROMWELL_EPS or prior > 1 - CROMWELL_EPS:
+        raise GaiaCliError(
+            f"Error: PRIORS[{label!r}] prior {prior} outside Cromwell bounds "
+            f"[{CROMWELL_EPS}, {1 - CROMWELL_EPS}]."
+        )
+    return prior
+
+
 def apply_package_priors(loaded: LoadedGaiaPackage) -> None:
     """Discover priors.py and inject prior+justification into Knowledge metadata.
 
@@ -208,10 +231,22 @@ def apply_package_priors(loaded: LoadedGaiaPackage) -> None:
     if not priors_path.exists():
         return
 
+    existing_knowledge_ids = {id(k) for k in loaded.package.knowledge}
+
     try:
         module = _import_fresh(priors_module_name)
     except Exception as exc:
         raise GaiaCliError(f"Error importing priors.py: {exc}") from exc
+
+    new_knowledge = [k for k in loaded.package.knowledge if id(k) not in existing_knowledge_ids]
+    if new_knowledge:
+        names = ", ".join(_knowledge_display_name(k) for k in new_knowledge[:5])
+        suffix = " ..." if len(new_knowledge) > 5 else ""
+        raise GaiaCliError(
+            "Error: priors.py must not declare new Knowledge objects; it may only "
+            "reference claims/settings/questions already declared by the package. "
+            f"New declarations: {names}{suffix}."
+        )
 
     priors_dict = getattr(module, "PRIORS", None)
     if priors_dict is None:
@@ -227,23 +262,24 @@ def apply_package_priors(loaded: LoadedGaiaPackage) -> None:
                 f"Error: PRIORS key {key!r} is not a Knowledge object. "
                 "Keys must be claim/setting/question objects from the package."
             )
+        if id(key) not in existing_knowledge_ids:
+            raise GaiaCliError(
+                f"Error: PRIORS key {_knowledge_display_name(key)!r} is not an "
+                "already-declared Knowledge object from this package."
+            )
         if not isinstance(value, tuple) or len(value) != 2:
             raise GaiaCliError(
                 f"Error: PRIORS[{key.label or key.content!r}] must be a (prior, justification) tuple, "
                 f"got {type(value).__name__}."
             )
         prior_val, justification = value
-        if not isinstance(prior_val, (int, float)):
-            raise GaiaCliError(
-                f"Error: PRIORS[{key.label or key.content!r}] prior must be a number, "
-                f"got {type(prior_val).__name__}."
-            )
+        prior = _validate_prior_value(prior_val, label=_knowledge_display_name(key))
         if not isinstance(justification, str):
             raise GaiaCliError(
                 f"Error: PRIORS[{key.label or key.content!r}] justification must be a string, "
                 f"got {type(justification).__name__}."
             )
-        key.metadata["prior"] = float(prior_val)
+        key.metadata["prior"] = prior
         key.metadata["prior_justification"] = justification
 
 

--- a/gaia/cli/commands/_render_priors.py
+++ b/gaia/cli/commands/_render_priors.py
@@ -1,0 +1,23 @@
+"""Helpers for rendering prior metadata in legacy parameterization-shaped outputs."""
+
+from __future__ import annotations
+
+
+def param_data_from_ir_metadata(ir: dict) -> dict | None:
+    """Return parameterization-shaped prior data extracted from Knowledge metadata."""
+    priors: list[dict] = []
+    for knowledge in ir.get("knowledges", []):
+        metadata = knowledge.get("metadata") or {}
+        if "prior" not in metadata:
+            continue
+        record = {
+            "knowledge_id": knowledge["id"],
+            "value": float(metadata["prior"]),
+        }
+        justification = metadata.get("prior_justification")
+        if isinstance(justification, str) and justification:
+            record["justification"] = justification
+        priors.append(record)
+    if not priors:
+        return None
+    return {"priors": priors, "strategy_params": []}

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -7,6 +7,7 @@ import json
 import typer
 
 from gaia.cli._packages import GaiaCliError, load_gaia_package, validate_fills_relations
+from gaia.cli._packages import apply_package_priors
 from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.cli.commands._classify import classify_ir, node_role
 from gaia.ir import LocalCanonicalGraph
@@ -91,6 +92,7 @@ def check_command(
     """Validate structure and artifact consistency for a Gaia knowledge package."""
     try:
         loaded = load_gaia_package(path)
+        apply_package_priors(loaded)
         compiled = compile_loaded_package_artifact(loaded)
         ir = compiled.to_json()
         validate_fills_relations(loaded, compiled)

--- a/gaia/cli/commands/render.py
+++ b/gaia/cli/commands/render.py
@@ -15,6 +15,7 @@ from gaia.cli._packages import (
 )
 from gaia.cli.commands._detailed_reasoning import generate_detailed_reasoning
 from gaia.cli.commands._github import generate_github_output
+from gaia.cli.commands._render_priors import param_data_from_ir_metadata
 from gaia.ir.validator import validate_local_graph
 
 
@@ -90,7 +91,7 @@ def render_command(
     # If present it MUST be fresh (ir_hash matches compiled graph).
     # --target github requires beliefs; --target docs degrades gracefully.
     beliefs_data: dict | None = None
-    param_data: dict | None = None
+    param_data = param_data_from_ir_metadata(ir)
 
     beliefs_path = gaia_dir / "beliefs.json"
     if beliefs_path.exists():

--- a/gaia/ir/validator.py
+++ b/gaia/ir/validator.py
@@ -6,6 +6,7 @@ invariants as defined in docs/foundations/gaia-ir/gaia-ir.md.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 
 from gaia.ir.knowledge import Knowledge, KnowledgeType, is_qid
@@ -95,6 +96,24 @@ def _validate_knowledges(
         # type
         if k.type not in set(KnowledgeType):
             result.error(f"Knowledge '{k.id}': invalid type '{k.type}'")
+
+        metadata = k.metadata or {}
+        if "prior" in metadata:
+            prior = metadata["prior"]
+            if isinstance(prior, bool) or not isinstance(prior, (int, float)):
+                result.error(
+                    f"Knowledge '{k.id}': metadata prior must be a number, "
+                    f"got {type(prior).__name__}"
+                )
+            else:
+                prior_value = float(prior)
+                if not math.isfinite(prior_value):
+                    result.error(f"Knowledge '{k.id}': metadata prior must be finite")
+                elif prior_value < CROMWELL_EPS or prior_value > 1 - CROMWELL_EPS:
+                    result.error(
+                        f"Knowledge '{k.id}': metadata prior {prior_value} outside Cromwell bounds "
+                        f"[{CROMWELL_EPS}, {1 - CROMWELL_EPS}]"
+                    )
 
         # local-layer shape rules
         if scope == "local":

--- a/gaia/lang/dsl/operators.py
+++ b/gaia/lang/dsl/operators.py
@@ -2,9 +2,25 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
+from gaia.ir.parameterization import CROMWELL_EPS
 from gaia.lang.runtime import Knowledge, Operator
+
+
+def _validate_prior_range(prior: float | None) -> None:
+    if prior is None:
+        return
+    if isinstance(prior, bool) or not isinstance(prior, (int, float)):
+        raise ValueError(f"prior must be a number, got {type(prior).__name__}.")
+    prior_value = float(prior)
+    if not math.isfinite(prior_value):
+        raise ValueError(f"prior must be finite, got {prior_value!r}.")
+    if prior_value < CROMWELL_EPS or prior_value > 1 - CROMWELL_EPS:
+        raise ValueError(
+            f"prior {prior_value} outside Cromwell bounds [{CROMWELL_EPS}, {1 - CROMWELL_EPS}]"
+        )
 
 
 def _validate_reason_prior(reason: str | Any, prior: float | None) -> None:
@@ -16,6 +32,7 @@ def _validate_reason_prior(reason: str | Any, prior: float | None) -> None:
             "reason and prior must be paired: provide both or neither. "
             f"Got reason={'yes' if has_reason else 'no'}, prior={'yes' if has_prior else 'no'}."
         )
+    _validate_prior_range(prior)
 
 
 def _helper_metadata(helper_kind: str, prior: float | None) -> dict:

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -36,6 +36,22 @@ def test_check_passes_with_fresh_artifacts(tmp_path):
     assert "Check passed" in result.output
 
 
+def test_check_applies_priors_py_before_stale_check(tmp_path):
+    pkg_dir = tmp_path / "check_demo"
+    _write_package(pkg_dir)
+    (pkg_dir / "check_demo" / "priors.py").write_text(
+        "from . import main_claim\n\n"
+        'PRIORS = {main_claim: (0.8, "Reviewed premise.")}\n'
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Check passed" in result.output
+
+
 def test_check_fails_when_compiled_artifacts_are_stale(tmp_path):
     pkg_dir = tmp_path / "check_demo"
     _write_package(pkg_dir, content="Original claim.")

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -1154,6 +1154,52 @@ def test_compile_priors_py_invalid_key_raises(tmp_path):
     assert "Knowledge" in result.output or "PRIORS" in result.output
 
 
+def test_compile_priors_py_new_knowledge_raises(tmp_path):
+    """priors.py may only annotate Knowledge objects already declared by the package."""
+    pkg_dir = tmp_path / "prior_ghost_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "prior-ghost-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "prior_ghost_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        'from gaia.lang import claim\n\nmain_claim = claim("Main claim.")\n__all__ = ["main_claim"]\n'
+    )
+    (pkg_src / "priors.py").write_text(
+        "from gaia.lang import claim\n\n"
+        'ghost = claim("Ghost prior-only claim.")\n'
+        'PRIORS = {ghost: (0.9, "Accidental new claim.")}\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "must not declare new Knowledge" in result.output
+
+
+def test_compile_priors_py_out_of_range_prior_raises(tmp_path):
+    pkg_dir = tmp_path / "bad_prior_value_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "bad-prior-value-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "bad_prior_value_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        'from gaia.lang import claim\n\nmain_claim = claim("Main claim.")\n__all__ = ["main_claim"]\n'
+    )
+    (pkg_src / "priors.py").write_text(
+        "from . import main_claim\n\n"
+        'PRIORS = {main_claim: (2.5, "Invalid probability.")}\n'
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code != 0
+    assert "Cromwell bounds" in result.output
+
+
 def test_compile_priors_py_reason_prior_pairing(tmp_path):
     """PRIORS values must be (float, str) tuples."""
     pkg_dir = tmp_path / "malformed_priors_pkg"

--- a/tests/cli/test_render.py
+++ b/tests/cli/test_render.py
@@ -77,6 +77,17 @@ def test_render_target_all_writes_docs_and_github(tmp_path):
     assert (github_dir / "README.md").exists()
 
 
+def test_render_uses_metadata_priors_from_priors_py(tmp_path):
+    pkg_dir = _prepare_inferred_package(tmp_path, name="metadata_prior_render")
+
+    result = runner.invoke(app, ["render", str(pkg_dir), "--target", "docs"])
+    assert result.exit_code == 0, result.output
+
+    content = (pkg_dir / "docs" / "detailed-reasoning.md").read_text()
+    assert "Prior: 0.90" in content
+    assert "| [evidence_b](#evidence_b) | claim | 0.80 |" in content
+
+
 def test_render_fails_when_ir_artifacts_missing(tmp_path):
     """render before compile → error about missing compiled artifacts."""
     pkg_dir = tmp_path / "no_compile"

--- a/tests/gaia/lang/test_operators.py
+++ b/tests/gaia/lang/test_operators.py
@@ -95,6 +95,15 @@ def test_operator_prior_without_reason_raises():
         contradiction(a, b, prior=0.9)  # no reason!
 
 
+def test_operator_prior_outside_cromwell_bounds_raises():
+    import pytest
+
+    a = claim("A.")
+    b = claim("B.")
+    with pytest.raises(ValueError, match="Cromwell bounds"):
+        contradiction(a, b, reason="invalid probability", prior=1.5)
+
+
 def test_operator_no_reason_no_prior_ok():
     """Neither reason nor prior is fine — uses defaults."""
     a = claim("A.")

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -71,6 +71,21 @@ class TestKnowledgeValidation:
         assert not r.valid
         assert any("content" in e for e in r.errors)
 
+    def test_metadata_prior_must_be_in_cromwell_bounds(self):
+        g = _local_graph(
+            knowledges=[
+                Knowledge(
+                    id="github:test::a",
+                    type=KnowledgeType.CLAIM,
+                    content="A.",
+                    metadata={"prior": 1.5},
+                )
+            ]
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("metadata prior" in e and "Cromwell bounds" in e for e in r.errors)
+
     def test_duplicate_label_rejected(self):
         g = _local_graph(
             knowledges=[


### PR DESCRIPTION
## Summary

Fixes the metadata-prior regressions found during PR #421 review:

- apply `priors.py` before `gaia check` recompiles for stale-artifact comparison
- render prior values from IR metadata after the review sidecar removal
- reject `priors.py` files that declare new `Knowledge` objects or reference non-package Knowledge keys
- validate metadata prior values against Cromwell bounds instead of silently clamping invalid probabilities

## Tests

- `python -m pytest tests/cli/test_check.py tests/cli/test_compile.py::test_compile_priors_py_injects_metadata_prior tests/cli/test_compile.py::test_compile_priors_py_invalid_key_raises tests/cli/test_compile.py::test_compile_priors_py_new_knowledge_raises tests/cli/test_compile.py::test_compile_priors_py_out_of_range_prior_raises tests/cli/test_compile.py::test_compile_priors_py_reason_prior_pairing tests/cli/test_render.py::test_render_uses_metadata_priors_from_priors_py tests/gaia/lang/test_operators.py::test_operator_prior_outside_cromwell_bounds_raises tests/ir/test_validator.py::TestKnowledgeValidation::test_metadata_prior_must_be_in_cromwell_bounds -q`
- `python -m pytest -q`

Full suite result: `986 passed, 11 skipped, 11 warnings in 32.60s`.
