### PR TITLE
style: ruff format register.py import line

### DIFF
--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -10,7 +10,12 @@ from uuid import UUID
 
 import typer
 
-from gaia.cli._packages import GaiaCliError, apply_package_priors, build_package_manifests, load_gaia_package
+from gaia.cli._packages import (
+    GaiaCliError,
+    apply_package_priors,
+    build_package_manifests,
+    load_gaia_package,
+)
 from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.cli._packages import render_manifest_json
 from gaia.ir import LocalCanonicalGraph


### PR DESCRIPTION
## Summary
- Split long import line in `register.py` to comply with ruff line-length (100 chars)
- Follow-up to 5c53896 which added `apply_package_priors` to the import list

## Context
The `apply_package_priors` import was added in the register command bugfix (5c53896) but the combined import line exceeded ruff's line limit. This formats it properly.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>