### PR TITLE
fix: preserve owner priors in dependency graph merge

### DIFF
--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -419,7 +419,7 @@ def lower_operator(graph: FactorGraph, op: Operator, factor_id: str) -> None:
 
 def merge_factor_graphs(
     local_fg: FactorGraph,
-    dep_graphs: list[tuple[str, FactorGraph]],
+    dep_graphs: list[tuple[str, FactorGraph, str]],
     *,
     local_prefix: str,
 ) -> FactorGraph:
@@ -430,7 +430,9 @@ def merge_factor_graphs(
     local_fg:
         The local package's factor graph.
     dep_graphs:
-        List of ``(dep_import_name, dep_factor_graph)`` pairs.
+        List of ``(dep_import_name, dep_factor_graph, dep_qid_prefix)``
+        triples. ``dep_qid_prefix`` identifies variables owned by that
+        dependency, e.g. ``"github:dep_pkg::"``.
     local_prefix:
         QID prefix for the local package, e.g. ``"github:my_pkg::"``.
         Variables starting with this prefix are owned by the local package.
@@ -443,10 +445,12 @@ def merge_factor_graphs(
     """
     merged = FactorGraph()
 
-    # 1. Add dep variables first — dep priors are authoritative for dep-owned nodes
-    for dep_name, dep_fg in dep_graphs:
+    # 1. Add dep variables first. A dep graph is authoritative only for
+    # variables it owns; foreign references may carry neutral placeholder priors.
+    for dep_name, dep_fg, dep_prefix in dep_graphs:
         for var_id, prior in dep_fg.variables.items():
-            merged.add_variable(var_id, prior)
+            if var_id.startswith(dep_prefix) or var_id not in merged.variables:
+                merged.add_variable(var_id, prior)
 
     # 2. Add local variables — overwrite only for locally-owned nodes
     for var_id, prior in local_fg.variables.items():
@@ -459,7 +463,7 @@ def merge_factor_graphs(
         # else: dep owns it, dep prior already set — skip
 
     # 3. Copy dep factors with prefixed IDs
-    for dep_name, dep_fg in dep_graphs:
+    for dep_name, dep_fg, _dep_prefix in dep_graphs:
         for factor in dep_fg.factors:
             prefixed = replace(factor, factor_id=f"dep_{dep_name}_{factor.factor_id}")
             merged.factors.append(prefixed)

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -89,10 +89,11 @@ def infer_command(
         if not dep_compiled:
             typer.echo("No -gaia dependencies found; running local inference only")
 
-        dep_factor_graphs: list[tuple[str, FactorGraph]] = []
+        dep_factor_graphs: list[tuple[str, FactorGraph, str]] = []
         for dep in dep_compiled:
             dep_fg = lower_local_graph(dep.graph)
-            dep_factor_graphs.append((dep.import_name, dep_fg))
+            dep_prefix = f"{dep.graph.namespace}:{dep.graph.package_name}::"
+            dep_factor_graphs.append((dep.import_name, dep_fg, dep_prefix))
             typer.echo(
                 f"Loaded dep '{dep.import_name}': "
                 f"{len(dep.graph.knowledges)} knowledge, "

--- a/tests/test_lowering.py
+++ b/tests/test_lowering.py
@@ -1120,7 +1120,9 @@ def test_merge_factor_graphs_basic():
         "op_f1", FactorType.SOFT_ENTAILMENT, ["github:dep::b"], "github:local::c", p1=0.8, p2=0.999
     )
 
-    merged = merge_factor_graphs(local_fg, [("dep", dep_fg)], local_prefix="github:local::")
+    merged = merge_factor_graphs(
+        local_fg, [("dep", dep_fg, "github:dep::")], local_prefix="github:local::"
+    )
 
     # Shared variable gets dep prior (0.7), not local default (0.5)
     assert merged.variables["github:dep::b"] == pytest.approx(0.7, abs=0.01)
@@ -1153,7 +1155,9 @@ def test_merge_factor_graphs_factor_id_no_collision():
         p2=0.999,
     )
 
-    merged = merge_factor_graphs(local_fg, [("dep", dep_fg)], local_prefix="github:local::")
+    merged = merge_factor_graphs(
+        local_fg, [("dep", dep_fg, "github:dep::")], local_prefix="github:local::"
+    )
 
     factor_ids = [f.factor_id for f in merged.factors]
     assert "dep_dep_op_f1" in factor_ids
@@ -1169,7 +1173,9 @@ def test_merge_factor_graphs_local_owned_preserved():
     local_fg = FactorGraph()
     local_fg.add_variable("github:local::shared", 0.9)
 
-    merged = merge_factor_graphs(local_fg, [("dep", dep_fg)], local_prefix="github:local::")
+    merged = merge_factor_graphs(
+        local_fg, [("dep", dep_fg, "github:dep::")], local_prefix="github:local::"
+    )
 
     # Local-owned node keeps local prior, not dep's
     assert merged.variables["github:local::shared"] == pytest.approx(0.9, abs=0.01)
@@ -1191,7 +1197,9 @@ def test_merge_factor_graphs_validates():
         "op_f1", FactorType.SOFT_ENTAILMENT, ["github:dep::b"], "github:local::c", p1=0.8, p2=0.999
     )
 
-    merged = merge_factor_graphs(local_fg, [("dep", dep_fg)], local_prefix="github:local::")
+    merged = merge_factor_graphs(
+        local_fg, [("dep", dep_fg, "github:dep::")], local_prefix="github:local::"
+    )
     errors = merged.validate()
     assert errors == []
 
@@ -1216,8 +1224,34 @@ def test_merge_factor_graphs_multiple_deps():
     local_fg.add_variable("github:local::c", 0.6)
 
     merged = merge_factor_graphs(
-        local_fg, [("dep1", dep1_fg), ("dep2", dep2_fg)], local_prefix="github:local::"
+        local_fg,
+        [("dep1", dep1_fg, "github:dep1::"), ("dep2", dep2_fg, "github:dep2::")],
+        local_prefix="github:local::",
     )
     assert "github:dep1::a" in merged.variables
     assert "github:dep2::b" in merged.variables
     assert "github:local::c" in merged.variables
+
+
+def test_merge_factor_graphs_dep_owner_prior_survives_foreign_reference():
+    """A non-owner dep must not overwrite a shared QID's owner prior."""
+    referencing_dep = FactorGraph()
+    referencing_dep.add_variable("github:dep::owned", 0.5)
+
+    owner_dep = FactorGraph()
+    owner_dep.add_variable("github:dep::owned", 0.9)
+
+    later_referencing_dep = FactorGraph()
+    later_referencing_dep.add_variable("github:dep::owned", 0.3)
+
+    merged = merge_factor_graphs(
+        FactorGraph(),
+        [
+            ("ref_a", referencing_dep, "github:ref_a::"),
+            ("dep", owner_dep, "github:dep::"),
+            ("ref_c", later_referencing_dep, "github:ref_c::"),
+        ],
+        local_prefix="github:local::",
+    )
+
+    assert merged.variables["github:dep::owned"] == pytest.approx(0.9)


### PR DESCRIPTION
## Summary

- pass each dependency graph owner QID prefix into merge_factor_graphs
- prevent non-owner dependency graphs from overwriting authoritative owner priors for shared QIDs
- add a regression test covering a later foreign-reference dependency attempting to overwrite the owner prior

## Verification

- uv run --project /tmp/gaia_pr431_review ruff check gaia/bp/lowering.py gaia/cli/commands/infer.py tests/test_lowering.py
- uv run --project /tmp/gaia_pr431_review ruff format --check gaia/bp/lowering.py gaia/cli/commands/infer.py tests/test_lowering.py
- uv run --project /tmp/gaia_pr431_review pytest tests/test_lowering.py -k merge_factor_graphs
- uv run --project /tmp/gaia_pr431_review pytest tests/cli/test_infer.py -k depth