### PR TITLE
feat(cli): gaia check --hole + prior annotations; fix induction self-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ gaia init → gaia add → /gaia:formalization → gaia compile → gaia infer �
 | `gaia check [path]` | Validate package structure and IR consistency (used by registry CI) |
 | `gaia check --brief [path]` | Show per-module warrant structure overview (claims, strategies, priors) |
 | `gaia check --show <name> [path]` | Expand a module or claim label with full warrant trees |
+| `gaia check --hole [path]` | Detailed prior review report for all independent claims (holes + covered) |
 | `gaia infer [path]` | Run belief propagation with metadata priors (from `priors.py` + DSL `reason`/`prior`) |
 | `gaia infer --depth 1 [path]` | Joint cross-package inference merging dependency factor graphs |
 | `gaia render --target github [path]` | Generate GitHub presentation skeleton (`.github-output/`): wiki, README, React Pages, graph.json |

--- a/docs/for-users/cli-commands.md
+++ b/docs/for-users/cli-commands.md
@@ -57,6 +57,7 @@ gaia check [path]
 gaia check --brief [path]
 gaia check --show <module|label> [path]
 gaia check --brief --show <module|label> [path]
+gaia check --hole [path]
 ```
 
 Arguments:
@@ -71,6 +72,7 @@ Options:
 |--------|-------------|
 | `--brief`, `-b` | Show per-module warrant structure overview after validation |
 | `--show`, `-s` | Expand a specific module or claim/strategy label with full warrant trees |
+| `--hole` | Show detailed prior review report for all independent claims (holes without priors + covered with priors) |
 
 What it checks:
 
@@ -97,11 +99,21 @@ When given a **claim or strategy label**, shows that node's full content and all
 
 When `--brief` and `--show` are combined, both the overview and the expanded detail are shown.
 
+### `--hole` output
+
+Detailed report for prior review. Splits all independent claims into two groups:
+
+- **Holes**: claims without priors — shows QID, content preview, and `NOT SET (defaults to 0.5)` status
+- **Covered**: claims with priors — shows prior value and justification reason
+
+The default `gaia check` output also annotates each independent premise with `prior=X` or `⚠ no prior`, and shows a "Holes (no prior set): N" count in the summary when any holes remain.
+
 Example:
 
 ```bash
 gaia compile .
-gaia check .                          # validate only
+gaia check .                          # validate + prior annotations on independent claims
+gaia check --hole .                   # validate + detailed hole/covered report
 gaia check --brief .                  # validate + overview
 gaia check --show motivation .        # validate + expand module
 gaia check --show hypothesis .        # validate + expand claim

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -85,11 +85,20 @@ Validate package structure and artifact consistency.
 
 ```
 gaia check [PATH]
+gaia check --brief [PATH]
+gaia check --show <module|label> [PATH]
+gaia check --hole [PATH]
 ```
 
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `PATH`   | `.`     | Path to knowledge package directory |
+
+| Option | Description |
+|--------|-------------|
+| `--brief`, `-b` | Show per-module warrant structure overview |
+| `--show`, `-s` | Expand a specific module or claim/strategy label |
+| `--hole` | Show detailed prior review report for all independent claims |
 
 **What it does:**
 
@@ -102,7 +111,9 @@ gaia check [PATH]
 Exits with code 1 on any error. Warnings (e.g., missing compiled artifacts) are
 printed but do not fail the check.
 
-**Key output:** none (validation only, prints pass/fail summary).
+**Default output:** Prints pass/fail summary with knowledge diagnostics. Each independent premise is annotated with `prior=X` or `⚠ no prior (defaults to 0.5)`. Shows a "Holes (no prior set): N" count when any independent claims lack priors.
+
+**`--hole` output:** Detailed report splitting all independent claims into holes (missing prior, with content and QID) and covered (with prior value and justification). Use during prior review to identify what still needs `priors.py` entries.
 
 Reference: [Compilation](compilation.md) for validation details.
 

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -14,6 +14,12 @@ from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
 
 
+def _get_prior(k: dict) -> float | None:
+    """Extract prior from a knowledge node's metadata, or None if absent."""
+    meta = k.get("metadata") or {}
+    return meta.get("prior")
+
+
 def _knowledge_diagnostics(ir: dict) -> list[str]:
     """Analyze the knowledge graph and return diagnostic lines."""
     lines: list[str] = []
@@ -24,7 +30,7 @@ def _knowledge_diagnostics(ir: dict) -> list[str]:
 
     c = classify_ir(ir)
 
-    independent = []
+    independent: list[tuple[str, str]] = []  # (label, cid)
     derived = []
     structural = []
     background_only = []
@@ -38,11 +44,13 @@ def _knowledge_diagnostics(ir: dict) -> list[str]:
         elif role == "derived":
             derived.append(label)
         elif role == "independent":
-            independent.append(label)
+            independent.append((label, cid))
         elif role == "background":
             background_only.append(label)
         else:
             orphaned.append(label)
+
+    n_holes = sum(1 for _, cid in independent if _get_prior(claims[cid]) is None)
 
     # Summary
     lines.append("")
@@ -50,6 +58,8 @@ def _knowledge_diagnostics(ir: dict) -> list[str]:
     lines.append(f"  Questions: {len(questions)}")
     lines.append(f"  Claims:    {len(claims)}")
     lines.append(f"    Independent (need prior):  {len(independent)}")
+    if n_holes:
+        lines.append(f"      Holes (no prior set):   {n_holes}")
     lines.append(f"    Derived (BP propagates):   {len(derived)}")
     lines.append(f"    Structural (deterministic): {len(structural)}")
     if background_only:
@@ -59,9 +69,13 @@ def _knowledge_diagnostics(ir: dict) -> list[str]:
 
     if independent:
         lines.append("")
-        lines.append("  Independent premises (reviewer must assign prior):")
-        for label in sorted(independent):
-            lines.append(f"    - {label}")
+        lines.append("  Independent premises:")
+        for label, cid in sorted(independent):
+            prior = _get_prior(claims[cid])
+            if prior is not None:
+                lines.append(f"    - {label}  prior={prior}")
+            else:
+                lines.append(f"    - {label}  \u26a0 no prior (defaults to 0.5)")
 
     if derived:
         lines.append("")
@@ -86,6 +100,59 @@ def _knowledge_diagnostics(ir: dict) -> list[str]:
     return lines
 
 
+def _hole_report(ir: dict) -> list[str]:
+    """Return detailed report of all independent claims without priors (holes)."""
+    claims = {k["id"]: k for k in ir["knowledges"] if k["type"] == "claim"}
+    c = classify_ir(ir)
+    lines: list[str] = []
+    holes: list[tuple[str, dict]] = []
+    covered: list[tuple[str, dict]] = []
+
+    for cid, k in claims.items():
+        if node_role(cid, "claim", c) != "independent":
+            continue
+        prior = _get_prior(k)
+        if prior is None:
+            holes.append((cid, k))
+        else:
+            covered.append((cid, k))
+
+    lines.append("")
+    lines.append(
+        f"  Hole analysis: {len(holes)} hole(s) / {len(holes) + len(covered)} independent claims"
+    )
+
+    if holes:
+        lines.append("")
+        lines.append("  Holes (independent claims missing prior — defaults to 0.5):")
+        for cid, k in sorted(holes, key=lambda x: x[0]):
+            label = k.get("label", cid.split("::")[-1])
+            content = k.get("content", "")
+            preview = (content[:72] + "...") if len(content) > 75 else content
+            lines.append(f"    {label}")
+            lines.append(f"      id:      {cid}")
+            lines.append(f"      content: {preview}")
+            lines.append("      prior:   NOT SET (defaults to 0.5)")
+
+    if covered:
+        lines.append("")
+        lines.append("  Covered (independent claims with prior set):")
+        for cid, k in sorted(covered, key=lambda x: x[0]):
+            label = k.get("label", cid.split("::")[-1])
+            prior = _get_prior(k)
+            justification = (k.get("metadata") or {}).get("prior_justification", "")
+            lines.append(f"    {label}  prior={prior}")
+            if justification:
+                preview = (justification[:72] + "...") if len(justification) > 75 else justification
+                lines.append(f"      reason: {preview}")
+
+    if not holes:
+        lines.append("")
+        lines.append("  All independent claims have priors assigned.")
+
+    return lines
+
+
 def check_command(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
     brief: bool = typer.Option(
@@ -96,6 +163,11 @@ def check_command(
         "--show",
         "-s",
         help="Expand detail for a module name or claim/strategy label (implies --brief)",
+    ),
+    hole: bool = typer.Option(
+        False,
+        "--hole",
+        help="Show detailed prior review report for all independent claims",
     ),
 ) -> None:
     """Validate structure and artifact consistency for a Gaia knowledge package."""
@@ -170,3 +242,7 @@ def check_command(
         if show:
             for line in dispatch_show(ir, show):
                 typer.echo(line)
+
+    if hole:
+        for line in _hole_report(ir):
+            typer.echo(line)

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -534,12 +534,13 @@ def induction(
         metadata=warrant_metadata,
     )
 
-    # Collect all premises from sub-strategies
+    # Collect all premises from sub-strategies, excluding the law itself
+    # (law is the conclusion; including it would create a self-loop)
     all_premises: list[Knowledge] = []
     seen: set[int] = set()
     for s in [support_1, support_2]:
         for p in s.premises:
-            if id(p) not in seen:
+            if id(p) not in seen and p is not law:
                 all_premises.append(p)
                 seen.add(id(p))
 

--- a/skills/formalization/SKILL.md
+++ b/skills/formalization/SKILL.md
@@ -32,7 +32,7 @@ digraph formalization {
     r5 [label="gaia compile + gaia check"];
     p6 [label="Pass 6: Polish for Standalone Readability\n(self-containedness, figures, formatting)"];
     r6 [label="gaia compile + gaia check"];
-    priors [label="Write priors.py\n(metadata priors)"];
+    priors [label="gaia check --hole\n→ Write priors.py"];
     infer [label="gaia infer .\n→ .gaia/beliefs.json"];
     interpret [label="Interpret BP results"];
     analysis [label="Write ANALYSIS.md"];
@@ -706,15 +706,25 @@ Add `metadata={"figure": "...", "caption": "..."}` to every claim whose content 
 
 After completing each pass, write code, compile, and check. For DSL syntax, see the **gaia-lang** skill.
 
-### Verify with `--brief` and `--show`
+### Verify with `--brief`, `--show`, and `--hole`
 
-After compiling, use `gaia check --brief` to verify that all claims and strategies have visible names:
+After compiling, use `gaia check` to verify structure and prior coverage:
 
 ```bash
+gaia check .               # Summary with prior annotations on independent claims
+gaia check --hole .        # Detailed hole report: which claims still need priors
 gaia check --brief .       # Overview: all modules with strategy summaries
 gaia check --show s6_xxx . # Expanded view of a specific module
 gaia check --show label .  # Detail view of a specific claim's warrant tree
 ```
+
+**What to check in default output:**
+- Each independent premise shows `prior=X` if set, or `⚠ no prior` if missing
+- The summary shows "Holes (no prior set): N" when any holes remain
+
+**What to check in `--hole` output:**
+- Every hole claim has its content and QID listed — use this to write `priors.py` entries
+- Every covered claim shows its prior value and justification — verify these are reasonable
 
 **What to check in `--brief` output:**
 - Every strategy should show named labels (not `_anon_xxx`). If a strategy conclusion shows `_anon_xxx`, the strategy's result variable was not assigned to a named Python variable.
@@ -725,6 +735,8 @@ gaia check --show label .  # Detail view of a specific claim's warrant tree
 ## Write priors.py
 
 `priors.py` assigns priors to leaf claims. Strategy/operator warrant priors are set via `prior=` in the DSL.
+
+**Before writing `priors.py`, run `gaia check --hole .`** to see exactly which independent claims need priors, along with their content and current status. Use this as your checklist — address each hole, then re-run `gaia check --hole .` to confirm "All independent claims have priors assigned."
 
 For how to write `priors.py`, assign priors, and evaluate strategy parameters, see the **review** skill.
 

--- a/skills/gaia-cli/SKILL.md
+++ b/skills/gaia-cli/SKILL.md
@@ -110,6 +110,7 @@ gaia check .
 gaia check --brief .
 gaia check --show <module|label> .
 gaia check --brief --show <module|label> .
+gaia check --hole .
 ```
 
 Validates package structure and IR consistency. Used by registry CI during publishing.
@@ -117,6 +118,7 @@ Validates package structure and IR consistency. Used by registry CI during publi
 Options:
 - `--brief` / `-b` — Show per-module warrant structure overview (claims with roles, strategies with priors, operators)
 - `--show` / `-s` — Expand a specific module name or claim/strategy label with full warrant trees
+- `--hole` — Show detailed prior review report for all independent claims (holes without priors + covered with priors)
 
 Common errors:
 - Missing `[tool.gaia].type` in `pyproject.toml`
@@ -128,10 +130,23 @@ Common errors:
 
 `gaia check` also reports informational diagnostics (not errors) useful for completeness checking during formalization:
 
-- **Independent premises** — claims not concluded by any strategy that need priors
+- **Independent premises** — claims not concluded by any strategy that need priors. Each shows `prior=X` if set, or `⚠ no prior (defaults to 0.5)` if missing.
+- **Holes (no prior set)** — count of independent claims still missing priors, shown in the summary when > 0
 - **Derived conclusions** — claims whose belief comes from BP propagation (do not set priors)
 - **Orphaned claims** — claims not referenced by any strategy
 - **Background-only claims** — claims only used in strategy `background=`, not as premises
+
+### `--hole` output
+
+Detailed report for prior review. Lists all independent claims split into two groups:
+
+- **Holes**: claims without priors — shows each claim's QID, content preview, and `NOT SET (defaults to 0.5)` status
+- **Covered**: claims with priors — shows each claim's `prior=X` and justification reason
+
+Use `--hole` during prior review to:
+1. Identify which claims still need priors in `priors.py`
+2. Verify that existing prior values and justifications are reasonable
+3. Confirm "All independent claims have priors assigned" before running inference
 
 ### `--brief` output
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -12,18 +12,16 @@ A review sidecar assigns probability parameters to a knowledge package's claims 
 Before writing the review sidecar, use `gaia check` to understand the package structure and prior coverage:
 
 ```bash
-gaia check .                          # Summary: lists independent claims with prior status
-gaia check --hole .                   # Detailed hole report: which claims need priors in priors.py
-gaia check --brief .                  # Overview: all modules, claims, strategies with priors
+gaia check .                          # Summary: independent claims annotated with prior status
+gaia check --hole .                   # All independent claims: holes (no prior) + covered (with prior)
+gaia check --brief .                  # Per-module overview: claims, strategies, operators
 gaia check --show <module_name> .     # Expanded module: full claim content + warrant trees
-gaia check --show <claim_label> .     # Detail: specific claim's warrant tree with premises
+gaia check --show <claim_label> .     # Specific claim's warrant tree with premises
 ```
 
-**Start with `gaia check .`** — the default output now annotates each independent premise with its prior value (`prior=X`) or flags missing priors (`⚠ no prior (defaults to 0.5)`). The summary also shows a "Holes (no prior set): N" count.
+**`gaia check .`** annotates each independent premise with `prior=X` or `⚠ no prior (defaults to 0.5)`. Shows a "Holes (no prior set): N" count in the summary.
 
-**Then run `gaia check --hole .`** to get a detailed breakdown:
-- **Holes** section: each claim missing a prior, with its full QID, content preview, and status — these are the claims you need to address in `priors.py`
-- **Covered** section: each claim with a prior, showing the value and justification reason — review these to verify the prior is reasonable
+**`gaia check --hole .`** splits all independent claims into **Holes** (QID, content, status) and **Covered** (prior value, justification). See §4 for the review workflow built around this output.
 
 **`--brief` output shows:**
 - Per-module breakdown of settings, claims (with role: independent/derived/structural), and strategies
@@ -121,7 +119,12 @@ Use `gaia check --hole` to identify hole claims (independent premises without pr
 
 **Derived conclusions** (claims that ARE the conclusion of a strategy): do NOT set a prior. The inference engine automatically assigns uninformative priors (0.5); their beliefs are entirely determined by BP propagation. Setting an explicit prior double-counts evidence.
 
-**Workflow:** Run `gaia check --hole .` → address each hole in `priors.py` → re-run `gaia check --hole .` to confirm "All independent claims have priors assigned" → then run `gaia infer .`.
+### Review workflow
+
+1. **`gaia check --hole .`** — read the Covered section first. For each covered claim, verify that the prior value and justification are reasonable. Adjust in `priors.py` if not.
+2. **Fill holes** — for each hole claim, read its content preview. Use `gaia check --show <label> .` when you need the full warrant tree for context. Assign a prior in `priors.py` (see §5 for guidance).
+3. **`gaia check --hole .`** — confirm "All independent claims have priors assigned."
+4. **`gaia infer .`** — run BP and interpret results (see §6).
 
 ## 5. Prior Assignment Guide
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -9,13 +9,21 @@ A review sidecar assigns probability parameters to a knowledge package's claims 
 
 ### Pre-Review: Inspect the Package
 
-Before writing the review sidecar, use `gaia check --brief` to understand the package structure:
+Before writing the review sidecar, use `gaia check` to understand the package structure and prior coverage:
 
 ```bash
+gaia check .                          # Summary: lists independent claims with prior status
+gaia check --hole .                   # Detailed hole report: which claims need priors in priors.py
 gaia check --brief .                  # Overview: all modules, claims, strategies with priors
 gaia check --show <module_name> .     # Expanded module: full claim content + warrant trees
 gaia check --show <claim_label> .     # Detail: specific claim's warrant tree with premises
 ```
+
+**Start with `gaia check .`** — the default output now annotates each independent premise with its prior value (`prior=X`) or flags missing priors (`⚠ no prior (defaults to 0.5)`). The summary also shows a "Holes (no prior set): N" count.
+
+**Then run `gaia check --hole .`** to get a detailed breakdown:
+- **Holes** section: each claim missing a prior, with its full QID, content preview, and status — these are the claims you need to address in `priors.py`
+- **Covered** section: each claim with a prior, showing the value and justification reason — review these to verify the prior is reasonable
 
 **`--brief` output shows:**
 - Per-module breakdown of settings, claims (with role: independent/derived/structural), and strategies
@@ -91,7 +99,7 @@ Assign a prior to an auto-generated claim (e.g., abduction's alternative).
 
 ## 4. What Needs Review
 
-Use `gaia check --brief` to identify what needs review. The output classifies claims by role:
+Use `gaia check --hole` to identify hole claims (independent premises without priors), and `gaia check --brief` to see the full structure. The output classifies claims by role:
 
 - **Independent (need prior):** Listed under "Independent premises" — these MUST have priors in the review sidecar or `priors.py`
 - **Derived (BP propagates):** Do NOT set priors — inference assigns 0.5 automatically
@@ -112,6 +120,8 @@ Use `gaia check --brief` to identify what needs review. The output classifies cl
 | `composite` | No direct review | Review leaf sub-strategies |
 
 **Derived conclusions** (claims that ARE the conclusion of a strategy): do NOT set a prior. The inference engine automatically assigns uninformative priors (0.5); their beliefs are entirely determined by BP propagation. Setting an explicit prior double-counts evidence.
+
+**Workflow:** Run `gaia check --hole .` → address each hole in `priors.py` → re-run `gaia check --hole .` to confirm "All independent claims have priors assigned" → then run `gaia infer .`.
 
 ## 5. Prior Assignment Guide
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -121,8 +121,8 @@ Use `gaia check --hole` to identify hole claims (independent premises without pr
 
 ### Review workflow
 
-1. **`gaia check --hole .`** — shows all independent claims: holes (missing prior, with content and QID) and covered (with prior value and justification). Review covered priors for reasonableness; identify holes to fill.
-2. **`gaia check --brief .`** — review warrant priors on strategies and operators. Check that `support`/`compare` warrant priors (`prior=` in DSL) reflect reasoning strength, and that `composite` strategy warrant priors are reasonable. Verify operator semantics (contradiction vs complement, see §5).
+1. **`gaia check --brief .`** — review the package structure and warrant priors. Check that `support`/`compare` warrant priors (`prior=` in DSL) reflect reasoning strength, and that `composite` strategy warrant priors are reasonable. Verify operator semantics (contradiction vs complement, see §5).
+2. **`gaia check --hole .`** — shows all independent claims: holes (missing prior, with content and QID) and covered (with prior value and justification). Review covered priors for reasonableness; identify holes to fill.
 3. **Write `priors.py`** — for each hole, assign a prior (see §5 for guidance). Use `gaia check --show <label> .` when you need the full warrant tree for context. Adjust any covered priors or DSL warrant priors that look wrong.
 4. **`gaia check --hole .`** — confirm "All independent claims have priors assigned."
 5. **`gaia infer .`** — run BP and interpret results (see §6).

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -122,9 +122,10 @@ Use `gaia check --hole` to identify hole claims (independent premises without pr
 ### Review workflow
 
 1. **`gaia check --hole .`** — shows all independent claims: holes (missing prior, with content and QID) and covered (with prior value and justification). Review covered priors for reasonableness; identify holes to fill.
-2. **Write `priors.py`** — for each hole, assign a prior (see §5 for guidance). Use `gaia check --show <label> .` when you need the full warrant tree for context. Adjust any covered priors that look wrong.
-3. **`gaia check --hole .`** — confirm "All independent claims have priors assigned."
-4. **`gaia infer .`** — run BP and interpret results (see §6).
+2. **`gaia check --brief .`** — review warrant priors on strategies and operators. Check that `support`/`compare` warrant priors (`prior=` in DSL) reflect reasoning strength, and that `composite` strategy warrant priors are reasonable. Verify operator semantics (contradiction vs complement, see §5).
+3. **Write `priors.py`** — for each hole, assign a prior (see §5 for guidance). Use `gaia check --show <label> .` when you need the full warrant tree for context. Adjust any covered priors or DSL warrant priors that look wrong.
+4. **`gaia check --hole .`** — confirm "All independent claims have priors assigned."
+5. **`gaia infer .`** — run BP and interpret results (see §6).
 
 ## 5. Prior Assignment Guide
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -121,8 +121,8 @@ Use `gaia check --hole` to identify hole claims (independent premises without pr
 
 ### Review workflow
 
-1. **`gaia check --hole .`** — read the Covered section first. For each covered claim, verify that the prior value and justification are reasonable. Adjust in `priors.py` if not.
-2. **Fill holes** — for each hole claim, read its content preview. Use `gaia check --show <label> .` when you need the full warrant tree for context. Assign a prior in `priors.py` (see §5 for guidance).
+1. **`gaia check --hole .`** — shows all independent claims: holes (missing prior, with content and QID) and covered (with prior value and justification). Review covered priors for reasonableness; identify holes to fill.
+2. **Write `priors.py`** — for each hole, assign a prior (see §5 for guidance). Use `gaia check --show <label> .` when you need the full warrant tree for context. Adjust any covered priors that look wrong.
 3. **`gaia check --hole .`** — confirm "All independent claims have priors assigned."
 4. **`gaia infer .`** — run BP and interpret results (see §6).
 

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -109,3 +109,121 @@ def test_check_fails_on_invalid_fills_target(tmp_path, monkeypatch):
     result = runner.invoke(app, ["check", str(pkg_dir)])
     assert result.exit_code != 0
     assert "missing .gaia/manifests/premises.json" in result.output
+
+
+def _write_multi_claim_package(pkg_dir, *, with_priors: bool = False) -> None:
+    """Create a test package with two independent premises and one derived claim."""
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "check-holes-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "check_holes"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n\n"
+        'premise_a = claim("Evidence A is observed.")\n'
+        'premise_b = claim("Evidence B is observed.")\n'
+        'conclusion = claim("Therefore, hypothesis H holds.")\n'
+        "deduction(premises=[premise_a, premise_b], conclusion=conclusion)\n"
+        '__all__ = ["premise_a", "premise_b", "conclusion"]\n'
+    )
+    if with_priors:
+        (pkg_src / "priors.py").write_text(
+            "from . import premise_a\n\n"
+            'PRIORS = {premise_a: (0.85, "Strong experimental evidence.")}\n'
+        )
+
+
+def test_check_shows_prior_on_independent_claims(tmp_path):
+    """Independent claims with priors show prior=X; without show warning."""
+    pkg_dir = tmp_path / "check_holes"
+    _write_multi_claim_package(pkg_dir, with_priors=True)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "prior=0.85" in result.output
+    assert "no prior (defaults to 0.5)" in result.output
+
+
+def test_check_shows_hole_count_in_summary(tmp_path):
+    """Summary shows hole count when some independent claims lack priors."""
+    pkg_dir = tmp_path / "check_holes"
+    _write_multi_claim_package(pkg_dir, with_priors=True)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    # premise_a has prior, premise_b does not → 1 hole
+    assert "Holes (no prior set):   1" in result.output
+
+
+def test_check_no_hole_count_when_all_covered(tmp_path):
+    """Summary omits hole count when all independent claims have priors."""
+    pkg_dir = tmp_path / "check_holes"
+    _write_multi_claim_package(pkg_dir)
+
+    pkg_src = pkg_dir / "check_holes"
+    (pkg_src / "priors.py").write_text(
+        "from . import premise_a, premise_b\n\n"
+        "PRIORS = {\n"
+        '    premise_a: (0.85, "Strong evidence."),\n'
+        '    premise_b: (0.70, "Moderate evidence."),\n'
+        "}\n"
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Holes (no prior set)" not in result.output
+
+
+def test_check_hole_flag_lists_details(tmp_path):
+    """--hole flag shows detailed report with content and prior status."""
+    pkg_dir = tmp_path / "check_holes"
+    _write_multi_claim_package(pkg_dir, with_priors=True)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", "--hole", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Hole analysis:" in result.output
+    assert "NOT SET (defaults to 0.5)" in result.output
+    # premise_b is the hole
+    assert "premise_b" in result.output
+    assert "Evidence B is observed." in result.output
+    # premise_a is covered
+    assert "Covered" in result.output
+    assert "prior=0.85" in result.output
+    assert "Strong experimental evidence." in result.output
+
+
+def test_check_hole_flag_all_covered(tmp_path):
+    """--hole with all priors set shows 'all assigned' message."""
+    pkg_dir = tmp_path / "check_holes"
+    _write_multi_claim_package(pkg_dir)
+
+    pkg_src = pkg_dir / "check_holes"
+    (pkg_src / "priors.py").write_text(
+        "from . import premise_a, premise_b\n\n"
+        "PRIORS = {\n"
+        '    premise_a: (0.85, "Strong evidence."),\n'
+        '    premise_b: (0.70, "Moderate evidence."),\n'
+        "}\n"
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", "--hole", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "All independent claims have priors assigned." in result.output
+    assert "0 hole(s)" in result.output


### PR DESCRIPTION
## Summary
- `gaia check` default output now annotates each independent premise with `prior=X` or `⚠ no prior (defaults to 0.5)`, plus a hole count in the summary
- New `--hole` flag produces a detailed report of all independent claims: holes (missing prior) with content/QID, and covered claims with prior value + justification
- Fix `induction()` collecting the `law` claim into `all_premises`, which created a self-loop in the factor graph
- Skills (review, formalization, gaia-cli) updated to integrate `--hole` into the prior review workflow

## Test plan
- [x] 5 new tests in `tests/cli/test_check.py` (prior annotations, hole count, --hole detail, all-covered)
- [x] Full test suite: 1040 passed
- [x] `ruff check . && ruff format --check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)