### PR TITLE
fix: make support implications forward-only

### DIFF
--- a/gaia/bp/bp.py
+++ b/gaia/bp/bp.py
@@ -367,7 +367,7 @@ class BeliefPropagation:
                 )
 
             # Step 2: Compute all factor→variable messages (synchronous)
-            # For directed implication factors (deduction), the BN structure
+            # For directed implication factors (deduction/support), the BN structure
             # is A, H → B where A=variables[0] is the antecedent (parent) and
             # B=variables[1] is the consequent (child).  Skip backward messages
             # to A — this eliminates the fan-out penalty from unobserved

--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -20,13 +20,12 @@ from gaia.ir.strategy import (
     StrategyType,
 )
 
-# Deduction and support produce forward-only implication operators.
-# In the BN interpretation these are CPT edges (A, H → B) where the
-# antecedent A should not receive backward messages from unobserved
-# children — this eliminates the fan-out penalty on the premise.
-# Support is a soft (probabilistic) version of deduction with the same
-# directed semantics: premises imply conclusion, not the reverse.
-_DIRECTED_DEDUCTION_TYPES = frozenset({StrategyType.DEDUCTION, StrategyType.SUPPORT})
+# Deduction and support produce forward-only implication operators.  In the BN
+# interpretation these are CPT edges (A, H → B) where the antecedent A
+# should not receive backward messages from unobserved children — this
+# eliminates the fan-out penalty on the premise.  Compare produces
+# relation-type implications that remain undirected.
+_DIRECTED_IMPLICATION_TYPES = frozenset({StrategyType.DEDUCTION, StrategyType.SUPPORT})
 
 # Operators whose conclusion is a "relation assertion" (the operator
 # DECLARES that the relation holds) — their helper claim should be
@@ -256,7 +255,7 @@ def _lower_strategy(
             fid = _next_fid(f"fs_{s.strategy_id}_{i}", ctr)
             ft = _OPERATOR_MAP[op.operator]
             is_directed = (
-                s.type in _DIRECTED_DEDUCTION_TYPES and op.operator == OperatorType.IMPLICATION
+                s.type in _DIRECTED_IMPLICATION_TYPES and op.operator == OperatorType.IMPLICATION
             )
             fg.add_factor(fid, ft, op.variables, op.conclusion, directed=is_directed)
             for vid in op.variables:

--- a/gaia/bp/potentials.py
+++ b/gaia/bp/potentials.py
@@ -109,8 +109,8 @@ def directed_implication_potential(
 ) -> float:
     """Directed implication CPT: P(B | A, H).
 
-    Used for deduction — the antecedent A is a parent (not influenced by B),
-    the consequent B is a child (no independent prior needed).
+    Used for deduction/support — the antecedent A is a parent (not influenced
+    by B), the consequent B is a child (no independent prior needed).
 
     When H=1 and A=1: B must be 1 (deduction succeeds).
     When H=1 and A=0: B is uniform (premise false, no constraint).

--- a/gaia/ir/strategy.py
+++ b/gaia/ir/strategy.py
@@ -40,7 +40,7 @@ class StrategyType(StrEnum):
     ABDUCTION = "abduction"
     ANALOGY = "analogy"
     EXTRAPOLATION = "extrapolation"
-    SUPPORT = "support"  # bidirectional implication (sufficiency + necessity)
+    SUPPORT = "support"  # forward implication with a soft warrant
     COMPARE = "compare"  # prediction comparison via matching + inferential ordering
 
     # Composite strategies — non-atomic

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -523,6 +523,14 @@ def induction(
         raise TypeError(f"induction() support_1 must be a Strategy, got {type(support_1).__name__}")
     if not isinstance(support_2, Strategy):
         raise TypeError(f"induction() support_2 must be a Strategy, got {type(support_2).__name__}")
+    if support_1.type not in {"support", "induction"}:
+        raise TypeError("induction() support_1 must be a support strategy or previous induction")
+    if support_2.type != "support":
+        raise TypeError("induction() support_2 must be a support strategy")
+    if not any(p is law for p in support_1.premises):
+        raise ValueError("induction() support_1 must include the law as a premise")
+    if not any(p is law for p in support_2.premises):
+        raise ValueError("induction() support_2 must include the law as a premise")
 
     # Auto-create composition warrant
     warrant_metadata: dict = {"helper_kind": "composition_validity", "generated": True}

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -350,6 +350,21 @@ def abduction(
         raise TypeError("abduction() second arg must be a Strategy")
     if not isinstance(comparison, Strategy):
         raise TypeError("abduction() third arg must be a Strategy")
+    if support_h.type != "support":
+        raise TypeError("abduction() first arg must be a support strategy")
+    if support_alt.type != "support":
+        raise TypeError("abduction() second arg must be a support strategy")
+    if comparison.type != "compare":
+        raise TypeError("abduction() third arg must be a compare strategy")
+    if len(comparison.premises) != 3:
+        raise ValueError("abduction() compare strategy must have [pred_h, pred_alt, observation]")
+    observation = comparison.premises[2]
+    if support_h.conclusion is not observation:
+        raise ValueError("abduction() support_h must conclude the compared observation")
+    if support_alt.conclusion is not observation:
+        raise ValueError("abduction() support_alt must conclude the compared observation")
+    if comparison.conclusion is None:
+        raise ValueError("abduction() compare strategy must have a conclusion")
 
     # Composition warrant
     comp_warrant = Knowledge(

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -542,10 +542,19 @@ def induction(
         raise TypeError("induction() support_1 must be a support strategy or previous induction")
     if support_2.type != "support":
         raise TypeError("induction() support_2 must be a support strategy")
-    if not any(p is law for p in support_1.premises):
-        raise ValueError("induction() support_1 must include the law as a premise")
-    if not any(p is law for p in support_2.premises):
-        raise ValueError("induction() support_2 must include the law as a premise")
+
+    # Validate law participation: each support must reference the law as
+    # either a premise (law predicts obs) or a conclusion (obs supports law).
+    # A chained induction must have law as its conclusion.
+    def _support_references_law(s: Strategy) -> bool:
+        return any(p is law for p in s.premises) or s.conclusion is law
+
+    if support_1.type == "support" and not _support_references_law(support_1):
+        raise ValueError("induction() support_1 must reference the law as a premise or conclusion")
+    if support_1.type == "induction" and support_1.conclusion is not law:
+        raise ValueError("induction() support_1 (previous induction) must conclude the same law")
+    if not _support_references_law(support_2):
+        raise ValueError("induction() support_2 must reference the law as a premise or conclusion")
 
     # Auto-create composition warrant
     warrant_metadata: dict = {"helper_kind": "composition_validity", "generated": True}

--- a/tests/gaia/bp/test_inference.py
+++ b/tests/gaia/bp/test_inference.py
@@ -581,18 +581,15 @@ class TestDirectedFactorFanout:
         # P should stay near its prior (no cascade from downstream)
         assert result.beliefs["P"] == pytest.approx(0.2, abs=0.02)
 
-    def test_support_undirected_still_bidirectional(self):
-        """Support (undirected) implication still propagates both ways."""
+    def test_directed_support_does_not_backpropagate_to_premise(self):
+        """Support is forward-only: conclusion evidence must not pull the premise."""
         fg = FactorGraph()
         fg.add_variable("A", 0.9)
         fg.add_variable("B", 0.5)
         fg.add_variable("H_fwd", 1.0 - CROMWELL_EPS)
-        fg.add_variable("H_rev", 1.0 - CROMWELL_EPS)
-        # Both undirected (support semantics)
-        fg.add_factor("f_fwd", FactorType.IMPLICATION, ["A", "B"], "H_fwd")
-        fg.add_factor("f_rev", FactorType.IMPLICATION, ["B", "A"], "H_rev")
+        fg.add_factor("f_fwd", FactorType.IMPLICATION, ["A", "B"], "H_fwd", directed=True)
         result = BeliefPropagation().run(fg)
         # B pulled up by A (forward)
         assert result.beliefs["B"] > 0.6
-        # A pulled toward B too (backward via undirected)
-        assert result.beliefs["A"] != pytest.approx(0.9, abs=0.01)
+        # A stays at its prior because support no longer has reverse reason/warrant.
+        assert result.beliefs["A"] == pytest.approx(0.9, abs=0.01)

--- a/tests/gaia/lang/test_abduction_v2.py
+++ b/tests/gaia/lang/test_abduction_v2.py
@@ -82,6 +82,51 @@ def test_abduction_requires_strategy_inputs():
         abduction(sup, sup, k)  # type: ignore[arg-type]
 
 
+def test_abduction_requires_support_support_compare():
+    """Abduction only accepts support, support, compare sub-strategies."""
+    sup_h, sup_alt, comp, theory_h, *_ = _make_abduction_triple()
+    not_support = Strategy(type="deduction", premises=[theory_h], conclusion=sup_h.conclusion)
+    not_compare = Strategy(type="support", premises=list(comp.premises), conclusion=comp.conclusion)
+
+    with pytest.raises(TypeError, match="first arg must be a support strategy"):
+        abduction(not_support, sup_alt, comp)
+
+    with pytest.raises(TypeError, match="second arg must be a support strategy"):
+        abduction(sup_h, not_support, comp)
+
+    with pytest.raises(TypeError, match="third arg must be a compare strategy"):
+        abduction(sup_h, sup_alt, not_compare)
+
+
+def test_abduction_requires_supports_to_conclude_compared_observation():
+    """Both explanation supports must target compare()'s observation."""
+    sup_h, sup_alt, comp, theory_h, theory_alt, _obs, *_ = _make_abduction_triple()
+    other_obs = claim("Different observation.")
+
+    bad_h = support(premises=[theory_h], conclusion=other_obs)
+    with pytest.raises(ValueError, match="support_h must conclude the compared observation"):
+        abduction(bad_h, sup_alt, comp)
+
+    bad_alt = support(premises=[theory_alt], conclusion=other_obs)
+    with pytest.raises(ValueError, match="support_alt must conclude the compared observation"):
+        abduction(sup_h, bad_alt, comp)
+
+
+def test_abduction_requires_well_formed_compare():
+    """The comparison sub-strategy must expose pred_h, pred_alt, observation and conclusion."""
+    sup_h, sup_alt, comp, *_ = _make_abduction_triple()
+    malformed_premises = Strategy(
+        type="compare", premises=comp.premises[:2], conclusion=comp.conclusion
+    )
+    missing_conclusion = Strategy(type="compare", premises=list(comp.premises), conclusion=None)
+
+    with pytest.raises(ValueError, match=r"must have \[pred_h, pred_alt, observation\]"):
+        abduction(sup_h, sup_alt, malformed_premises)
+
+    with pytest.raises(ValueError, match="compare strategy must have a conclusion"):
+        abduction(sup_h, sup_alt, missing_conclusion)
+
+
 def test_abduction_premises_are_deduplicated():
     """Premises from all sub-strategies are merged without duplicates."""
     theory = claim("Theory.")

--- a/tests/gaia/lang/test_compiler.py
+++ b/tests/gaia/lang/test_compiler.py
@@ -339,8 +339,8 @@ def test_compile_induction():
         obs2 = claim("Copper expands when heated.")
         obs2.label = "obs2"
 
-        sup1 = support(premises=[obs1], conclusion=law)
-        sup2 = support(premises=[obs2], conclusion=law)
+        sup1 = support(premises=[law], conclusion=obs1)
+        sup2 = support(premises=[law], conclusion=obs2)
         induction(sup1, sup2, law)
 
     result = compile_package_artifact(pkg)

--- a/tests/gaia/lang/test_induction_v2.py
+++ b/tests/gaia/lang/test_induction_v2.py
@@ -134,18 +134,18 @@ def test_induction_requires_support_for_second_input():
         induction(previous, not_support, law)
 
 
-def test_induction_requires_sub_strategies_to_include_law_premise():
-    """Reject supports that are not predictions from the law."""
+def test_induction_requires_sub_strategies_to_include_law():
+    """Reject supports that don't reference the law as premise or conclusion."""
     obs1 = claim("Obs 1.")
     obs2 = claim("Obs 2.")
     law = claim("Law.")
     missing_law = support(premises=[obs1], conclusion=obs2)
     valid_support = support(premises=[law], conclusion=obs2)
 
-    with pytest.raises(ValueError, match="support_1 must include the law as a premise"):
+    with pytest.raises(ValueError, match="support_1 must reference the law"):
         induction(missing_law, valid_support, law)
 
-    with pytest.raises(ValueError, match="support_2 must include the law as a premise"):
+    with pytest.raises(ValueError, match="support_2 must reference the law"):
         induction(valid_support, missing_law, law)
 
 

--- a/tests/gaia/lang/test_induction_v2.py
+++ b/tests/gaia/lang/test_induction_v2.py
@@ -12,8 +12,8 @@ def test_induction_binary_composite():
     obs2 = claim("Copper expands when heated.")
     law = claim("All metals expand when heated.")
 
-    sup1 = support(premises=[obs1], conclusion=law, reason="Iron supports the law.", prior=0.9)
-    sup2 = support(premises=[obs2], conclusion=law, reason="Copper supports the law.", prior=0.9)
+    sup1 = support(premises=[law], conclusion=obs1, reason="Law predicts iron.", prior=0.9)
+    sup2 = support(premises=[law], conclusion=obs2, reason="Law predicts copper.", prior=0.9)
 
     s = induction(sup1, sup2, law)
 
@@ -30,8 +30,8 @@ def test_induction_conclusion_is_law():
     obs2 = claim("Obs 2.")
     law = claim("Law.")
 
-    sup1 = support(premises=[obs1], conclusion=law)
-    sup2 = support(premises=[obs2], conclusion=law)
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
 
     s = induction(sup1, sup2, law)
 
@@ -45,9 +45,9 @@ def test_induction_chaining():
     obs3 = claim("Obs 3.")
     law = claim("Law.")
 
-    sup1 = support(premises=[obs1], conclusion=law)
-    sup2 = support(premises=[obs2], conclusion=law)
-    sup3 = support(premises=[obs3], conclusion=law)
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
+    sup3 = support(premises=[law], conclusion=obs3)
 
     # First induction
     ind1 = induction(sup1, sup2, law)
@@ -67,8 +67,8 @@ def test_induction_composition_warrant():
     obs2 = claim("Obs 2.")
     law = claim("Law.")
 
-    sup1 = support(premises=[obs1], conclusion=law)
-    sup2 = support(premises=[obs2], conclusion=law)
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
 
     s = induction(sup1, sup2, law, reason="Independent observations.")
 
@@ -85,8 +85,8 @@ def test_induction_composition_warrant_no_reason():
     obs2 = claim("Obs 2.")
     law = claim("Law.")
 
-    sup1 = support(premises=[obs1], conclusion=law)
-    sup2 = support(premises=[obs2], conclusion=law)
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
 
     s = induction(sup1, sup2, law)
 
@@ -98,7 +98,7 @@ def test_induction_requires_strategy_inputs():
     """Raises TypeError for non-Strategy inputs."""
     law = claim("Law.")
     k = claim("Not a strategy.")
-    sup = support(premises=[claim("Obs.")], conclusion=law)
+    sup = support(premises=[law], conclusion=claim("Obs."))
 
     with pytest.raises(TypeError, match="support_1 must be a Strategy"):
         induction(k, sup, law)  # type: ignore[arg-type]
@@ -107,13 +107,55 @@ def test_induction_requires_strategy_inputs():
         induction(sup, k, law)  # type: ignore[arg-type]
 
 
+def test_induction_requires_support_or_previous_induction_for_first_input():
+    """The first input cannot be an unrelated strategy type."""
+    obs1 = claim("Obs 1.")
+    obs2 = claim("Obs 2.")
+    law = claim("Law.")
+    unrelated = Strategy(type="compare", premises=[obs1], conclusion=law)
+    sup = support(premises=[law], conclusion=obs2)
+
+    with pytest.raises(TypeError, match="support_1 must be a support strategy"):
+        induction(unrelated, sup, law)
+
+
+def test_induction_requires_support_for_second_input():
+    """Chained induction only accepts a new support as the second input."""
+    obs1 = claim("Obs 1.")
+    obs2 = claim("Obs 2.")
+    obs3 = claim("Obs 3.")
+    law = claim("Law.")
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
+    previous = induction(sup1, sup2, law)
+    not_support = Strategy(type="compare", premises=[law], conclusion=obs3)
+
+    with pytest.raises(TypeError, match="support_2 must be a support strategy"):
+        induction(previous, not_support, law)
+
+
+def test_induction_requires_sub_strategies_to_include_law_premise():
+    """Reject supports that are not predictions from the law."""
+    obs1 = claim("Obs 1.")
+    obs2 = claim("Obs 2.")
+    law = claim("Law.")
+    missing_law = support(premises=[obs1], conclusion=obs2)
+    valid_support = support(premises=[law], conclusion=obs2)
+
+    with pytest.raises(ValueError, match="support_1 must include the law as a premise"):
+        induction(missing_law, valid_support, law)
+
+    with pytest.raises(ValueError, match="support_2 must include the law as a premise"):
+        induction(valid_support, missing_law, law)
+
+
 def test_induction_premises_are_deduplicated():
     """Premises from both sub-strategies are merged without duplicates."""
     shared_obs = claim("Shared observation.")
     law = claim("Law.")
 
-    sup1 = support(premises=[shared_obs], conclusion=law)
-    sup2 = support(premises=[shared_obs], conclusion=law)
+    sup1 = support(premises=[law, shared_obs], conclusion=claim("Obs 1."))
+    sup2 = support(premises=[law, shared_obs], conclusion=claim("Obs 2."))
 
     s = induction(sup1, sup2, law)
 
@@ -128,8 +170,8 @@ def test_induction_strategy_attached_to_law():
     obs2 = claim("Obs 2.")
     law = claim("Law.")
 
-    sup1 = support(premises=[obs1], conclusion=law)
-    sup2 = support(premises=[obs2], conclusion=law)
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
 
     s = induction(sup1, sup2, law)
 
@@ -143,8 +185,8 @@ def test_induction_with_background():
     law = claim("Law.")
     bg = claim("Background context.")
 
-    sup1 = support(premises=[obs1], conclusion=law)
-    sup2 = support(premises=[obs2], conclusion=law)
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
 
     s = induction(sup1, sup2, law, background=[bg])
 

--- a/tests/test_lowering.py
+++ b/tests/test_lowering.py
@@ -790,6 +790,7 @@ def test_e2e_support_compiles_and_runs_bp():
     # Support produces 1 IMPLICATION factor (forward only)
     impl_factors = [f for f in fg.factors if f.factor_type == FactorType.IMPLICATION]
     assert len(impl_factors) == 1
+    assert impl_factors[0].directed is True
 
     # Run inference
     beliefs, _ = exact_inference(fg)


### PR DESCRIPTION
## Summary

- lower support implication factors as directed, matching the current forward-only support formalization
- update BP/potential/IR comments that still described support as deduction-only or bidirectional
- update tests so support no longer backpropagates to the premise and lowering asserts support factors are directed

## Verification

- uv run --project /tmp/gaia_pr431_review ruff check gaia/bp/lowering.py gaia/bp/bp.py gaia/bp/potentials.py gaia/ir/strategy.py tests/test_lowering.py tests/gaia/bp/test_inference.py
- uv run --project /tmp/gaia_pr431_review ruff format --check gaia/bp/lowering.py gaia/bp/bp.py gaia/bp/potentials.py gaia/ir/strategy.py tests/test_lowering.py tests/gaia/bp/test_inference.py
- uv run --project /tmp/gaia_pr431_review pytest tests/gaia/bp/test_inference.py -k directed
- uv run --project /tmp/gaia_pr431_review pytest tests/test_lowering.py -k support