### PR TITLE
fix: validate abduction support structure

### DIFF
--- a/docs/foundations/gaia-ir/06-parameterization.md
+++ b/docs/foundations/gaia-ir/06-parameterization.md
@@ -4,7 +4,7 @@
 >
 > **⚠️ Protected Contract Layer** — 本目录定义 CLI↔LKM 结构契约。变更需要独立 PR 并经负责人审查批准。
 
-Parameterization 是 Gaia IR 上的概率参数层。它由一组**原子记录**构成——每条记录是一个 Knowledge 的先验概率，或一个**需要外部概率参数的 Strategy** 的条件概率。不同 review 来源（不同模型、不同策略）产出不同的记录，推理运行前按 resolution policy 组装成完整参数集。
+Parameterization 是 Gaia IR 上的概率参数层。它由一组**原子记录**构成——每条记录是一个 Knowledge 的先验概率，或一个**需要外部概率参数的 Strategy** 的条件概率。不同 ParameterizationSource（不同模型、不同策略、不同人工/自动来源）产出不同的记录，推理运行前按 resolution policy 组装成完整参数集。
 
 Gaia IR 结构定义见 [02-gaia-ir.md](02-gaia-ir.md)。推理输出见 [../bp/belief-state.md](../bp/belief-state.md)。三者的关系见 [01-overview.md](01-overview.md)。
 
@@ -49,7 +49,7 @@ ParameterizationSource:
 
 **三层语义：**
 
-1. **持久化输入层**：这里只存 review 明确给出的外部参数，即 `StrategyParamRecord`
+1. **持久化输入层**：这里只存 parameterization source 明确给出的外部参数，即 `PriorRecord` 与 `StrategyParamRecord`
 2. **结构推导层**：直接 FormalStrategy 的行为由 `FormalExpr` + 相关显式 claim prior 决定；结构型 helper claim 由 Operator 确定
 3. **运行时 assembled / compiled 层**：系统可以为任意 Strategy 生成一份等效的 `conditional_probabilities` 视图，但这份视图不是新的持久化 source of truth
 
@@ -120,7 +120,8 @@ P(C=1 | A₁, A₂) = Σ_m P(C=1 | M=m) × P(M=m | A₁, A₂)
 
 - 图中每个承载外生不确定性的 `type=claim` Knowledge 都必须有对应的 PriorRecord
 - 每个参数化 Strategy 都必须有 StrategyParamRecord
-- 每个直接 FormalStrategy 所依赖的相关 interface claim 都必须有 PriorRecord；这包括 formalization 自动补齐的 public interface claim（如 abduction 的 `AlternativeExplanationForObs`）
+- 非 CompositeStrategy 的 conclusion 不需要 PriorRecord，因为 lowering 会为该 strategy 产生真实 BP factor；CompositeStrategy 的 conclusion 不因此免 PriorRecord，因为 CompositeStrategy 只是结构分组，本身不 lower 成 factor
+- 每个直接 FormalStrategy 所依赖的相关 interface claim，如果不是非 composite strategy 的 conclusion，就必须有 PriorRecord；这包括 formalization 自动补齐的 public interface claim
 
 结构型 helper claim **禁止**携带独立 PriorRecord——它们的分布完全由 Operator 确定性约束决定，没有自由度（详细解释见 [04-helper-claims.md §6](04-helper-claims.md#6-与-parameterization-的关系)）。
 
@@ -132,14 +133,14 @@ P(C=1 | A₁, A₂) = Σ_m P(C=1 | M=m) × P(M=m | A₁, A₂)
 
 ## Prior 来源
 
-每个 claim Knowledge 的 prior 由 review 赋值。
+每个独立 claim Knowledge 的 prior 由 selected ParameterizationSource 赋值。若没有外部判断，可以显式使用 MaxEnt prior 0.5，但应作为该 source 的参数记录，而不是给 derived/helper claim 补默认 prior。
 
 ## Strategy 条件概率来源
 
 | type | 条件概率来源 |
 |------|-------------|
-| `infer` | Review 赋值。完整 CPT（2^k 参数），默认 MaxEnt 0.5 |
-| `noisy_and` | Review 赋值。单参数 p，反映推理本身的可信度 |
+| `infer` | ParameterizationSource 赋值。完整 CPT（2^k 参数），默认 MaxEnt 0.5 |
+| `noisy_and` | ParameterizationSource 赋值。单参数 p，反映推理本身的可信度 |
 | 直接 FormalStrategy（`deduction` 至 `case_analysis`） | 不单独赋持久化 strategy 参数；其有效条件行为由 FormalExpr + 相关 interface claim 的 PriorRecord 导出。纯结构型 helper claim 作为 Operator 结果，不默认引入独立 prior；若 formalization 自动补齐了 public interface claim，则它与其他 premise/conclusion claim 一样需要参数化 |
 | `toolcall` / `proof`（deferred） | 未引入 |
 

--- a/docs/foundations/gaia-ir/06-parameterization.md
+++ b/docs/foundations/gaia-ir/06-parameterization.md
@@ -120,7 +120,7 @@ P(C=1 | A₁, A₂) = Σ_m P(C=1 | M=m) × P(M=m | A₁, A₂)
 
 - 图中每个承载外生不确定性的 `type=claim` Knowledge 都必须有对应的 PriorRecord
 - 每个参数化 Strategy 都必须有 StrategyParamRecord
-- 非 CompositeStrategy 的 conclusion 不需要 PriorRecord，因为 lowering 会为该 strategy 产生真实 BP factor；CompositeStrategy 的 conclusion 不因此免 PriorRecord，因为 CompositeStrategy 只是结构分组，本身不 lower 成 factor
+- 非 CompositeStrategy 的 conclusion 禁止携带 PriorRecord，因为 lowering 会为该 strategy 产生真实 BP factor；再给独立 unary prior 会把外生证据和推理来源 double count。CompositeStrategy 的 conclusion 不因此免 PriorRecord，因为 CompositeStrategy 只是结构分组，本身不 lower 成 factor
 - 每个直接 FormalStrategy 所依赖的相关 interface claim，如果不是非 composite strategy 的 conclusion，就必须有 PriorRecord；这包括 formalization 自动补齐的 public interface claim
 
 结构型 helper claim **禁止**携带独立 PriorRecord——它们的分布完全由 Operator 确定性约束决定，没有自由度（详细解释见 [04-helper-claims.md §6](04-helper-claims.md#6-与-parameterization-的关系)）。
@@ -133,7 +133,7 @@ P(C=1 | A₁, A₂) = Σ_m P(C=1 | M=m) × P(M=m | A₁, A₂)
 
 ## Prior 来源
 
-每个独立 claim Knowledge 的 prior 由 selected ParameterizationSource 赋值。若没有外部判断，可以显式使用 MaxEnt prior 0.5，但应作为该 source 的参数记录，而不是给 derived/helper claim 补默认 prior。
+每个独立 claim Knowledge 的 prior 由 selected ParameterizationSource 赋值。若没有外部判断，可以显式使用 MaxEnt prior 0.5，但应作为该 source 的参数记录，而不是给 derived/helper claim 补默认 prior。非 composite strategy conclusion 是 derived claim，禁止携带 PriorRecord。
 
 ## Strategy 条件概率来源
 
@@ -141,7 +141,7 @@ P(C=1 | A₁, A₂) = Σ_m P(C=1 | M=m) × P(M=m | A₁, A₂)
 |------|-------------|
 | `infer` | ParameterizationSource 赋值。完整 CPT（2^k 参数），默认 MaxEnt 0.5 |
 | `noisy_and` | ParameterizationSource 赋值。单参数 p，反映推理本身的可信度 |
-| 直接 FormalStrategy（`deduction` 至 `case_analysis`） | 不单独赋持久化 strategy 参数；其有效条件行为由 FormalExpr + 相关 interface claim 的 PriorRecord 导出。纯结构型 helper claim 作为 Operator 结果，不默认引入独立 prior；若 formalization 自动补齐了 public interface claim，则它与其他 premise/conclusion claim 一样需要参数化 |
+| 直接 FormalStrategy（`deduction` 至 `case_analysis`） | 不单独赋持久化 strategy 参数；其有效条件行为由 FormalExpr + 相关 interface claim 的 PriorRecord 导出。纯结构型 helper claim 作为 Operator 结果，不默认引入独立 prior；若 formalization 自动补齐了 public interface claim，则只有其中的外生输入 claim 需要 PriorRecord，strategy conclusion 仍禁止 PriorRecord |
 | `toolcall` / `proof`（deferred） | 未引入 |
 
 ## 源代码

--- a/gaia/ir/validator.py
+++ b/gaia/ir/validator.py
@@ -229,9 +229,9 @@ def _validate_strategy(
                 f"'{knowledge_lookup[strategy.conclusion].type}', must be claim"
             )
 
-    # no self-loop for BP-participating strategies. CompositeStrategy is reviewer
-    # structure only; induction legitimately uses the law as both conclusion and
-    # shared premise of its child supports.
+    # no self-loop for BP-participating strategies. CompositeStrategy is a
+    # structural grouping only; induction legitimately uses the law as both
+    # conclusion and shared premise of its child supports.
     if (
         not isinstance(strategy, CompositeStrategy)
         and strategy.conclusion is not None
@@ -661,20 +661,22 @@ def validate_parameterization(
     priors: list[PriorRecord],
     strategy_params: list[StrategyParamRecord],
 ) -> ValidationResult:
-    """Validate parameterization completeness before BP run.
+    """Validate LocalParameterization overlay completeness before BP run.
 
-    Checks that every independent claim Knowledge has at least one PriorRecord
-    and every parameterized Strategy (infer/noisy_and) has a StrategyParamRecord.
-    FormalStrategy types derive behavior from FormalExpr — no params needed.
+    ``PriorRecord`` applies only to independent claim variables: claims whose
+    initial belief is an exogenous parameter of the graph. ``StrategyParamRecord``
+    applies only to parameterized Strategy types (infer/noisy_and).
 
-    Three categories of claims are excluded from PriorRecord requirements:
+    Claims are classified as follows:
 
-    1. **Strategy conclusions** — claims that appear as the conclusion of any
-       Strategy. Their belief is derived from premises via BP; they do not need
-       independent priors (but may optionally have them).
+    1. **Non-composite Strategy conclusions** — their belief is derived from
+       premises through factors produced by lowering, so they do not need an
+       independent PriorRecord. A CompositeStrategy conclusion is not included
+       here because CompositeStrategy is structural grouping only and does not
+       itself lower to a BP factor.
     2. **Top-level structural helper claims** — conclusions of top-level Operators
        with structural types (conjunction/disjunction/equivalence/contradiction/
-       complement). Their truth value is fully determined by the Operator.
+       complement/implication). Their truth value is determined by the Operator.
        These are PROHIBITED from having independent PriorRecords.
     3. **FormalExpr private nodes** — ANY operator conclusion inside a FormalExpr
        that is NOT in the owning FormalStrategy's premises/conclusion interface.
@@ -682,9 +684,9 @@ def validate_parameterization(
        independent PriorRecord regardless of the operator type.
        These are PROHIBITED from having independent PriorRecords.
 
-    Generated public interface claims (e.g. abduction's AlternativeExplanationForObs)
-    are part of the strategy interface, so they remain ordinary claim inputs and
-    still require PriorRecord.
+    Public interface claims created during formalization remain ordinary claim
+    variables unless they are concluded by a non-composite Strategy; if they are
+    exogenous inputs, they still require PriorRecord.
     """
     result = ValidationResult()
 

--- a/gaia/ir/validator.py
+++ b/gaia/ir/validator.py
@@ -229,8 +229,14 @@ def _validate_strategy(
                 f"'{knowledge_lookup[strategy.conclusion].type}', must be claim"
             )
 
-    # no self-loop
-    if strategy.conclusion is not None and strategy.conclusion in strategy.premises:
+    # no self-loop for BP-participating strategies. CompositeStrategy is reviewer
+    # structure only; induction legitimately uses the law as both conclusion and
+    # shared premise of its child supports.
+    if (
+        not isinstance(strategy, CompositeStrategy)
+        and strategy.conclusion is not None
+        and strategy.conclusion in strategy.premises
+    ):
         result.error(f"Strategy '{sid}': conclusion in premises (self-loop)")
 
     # background reference (any type OK, just must exist)
@@ -265,15 +271,106 @@ def _validate_composite_sub_strategies(
     strategy_lookup: dict[str, Strategy] | None,
     result: ValidationResult,
 ) -> None:
-    """Validate CompositeStrategy sub_strategy references exist."""
+    """Validate CompositeStrategy sub_strategy references and named composite shape."""
     sid = strategy.strategy_id or "<no-id>"
     if strategy_lookup is None:
         return
+    sub_strategies: list[Strategy] = []
     for sub_id in strategy.sub_strategies:
         if sub_id not in strategy_lookup:
             result.error(
                 f"CompositeStrategy '{sid}': sub_strategy '{sub_id}' not found as top-level strategy"
             )
+            continue
+        sub_strategies.append(strategy_lookup[sub_id])
+
+    if strategy.type == StrategyType.ABDUCTION:
+        _validate_abduction_composite(strategy, sub_strategies, result)
+    elif strategy.type == StrategyType.INDUCTION:
+        _validate_induction_composite(strategy, sub_strategies, result)
+
+
+def _validate_abduction_composite(
+    strategy: CompositeStrategy,
+    sub_strategies: list[Strategy],
+    result: ValidationResult,
+) -> None:
+    """Validate abduction = support, support, compare over one observation."""
+    sid = strategy.strategy_id or "<no-id>"
+    if len(sub_strategies) != 3:
+        result.error(f"CompositeStrategy '{sid}': abduction requires 3 sub_strategies")
+        return
+
+    support_h, support_alt, comparison = sub_strategies
+    if support_h.type != StrategyType.SUPPORT:
+        result.error(f"CompositeStrategy '{sid}': abduction first sub_strategy must be support")
+    if support_alt.type != StrategyType.SUPPORT:
+        result.error(f"CompositeStrategy '{sid}': abduction second sub_strategy must be support")
+    if comparison.type != StrategyType.COMPARE:
+        result.error(f"CompositeStrategy '{sid}': abduction third sub_strategy must be compare")
+        return
+
+    if len(comparison.premises) != 3:
+        result.error(
+            f"CompositeStrategy '{sid}': compare sub_strategy must have "
+            "[pred_h, pred_alt, observation] premises"
+        )
+        return
+    if comparison.conclusion is None:
+        result.error(f"CompositeStrategy '{sid}': compare sub_strategy must have a conclusion")
+        return
+    if strategy.conclusion != comparison.conclusion:
+        result.error(
+            f"CompositeStrategy '{sid}': abduction conclusion must match compare conclusion"
+        )
+
+    observation = comparison.premises[2]
+    if support_h.conclusion != observation:
+        result.error(
+            f"CompositeStrategy '{sid}': abduction first support must conclude "
+            "the compared observation"
+        )
+    if support_alt.conclusion != observation:
+        result.error(
+            f"CompositeStrategy '{sid}': abduction second support must conclude "
+            "the compared observation"
+        )
+
+
+def _validate_induction_composite(
+    strategy: CompositeStrategy,
+    sub_strategies: list[Strategy],
+    result: ValidationResult,
+) -> None:
+    """Validate induction = (support | previous induction), support over one law premise."""
+    sid = strategy.strategy_id or "<no-id>"
+    if len(sub_strategies) != 2:
+        result.error(f"CompositeStrategy '{sid}': induction requires 2 sub_strategies")
+        return
+    if strategy.conclusion is None:
+        result.error(f"CompositeStrategy '{sid}': induction requires a law conclusion")
+        return
+
+    support_1, support_2 = sub_strategies
+    law = strategy.conclusion
+    if support_1.type not in {StrategyType.SUPPORT, StrategyType.INDUCTION}:
+        result.error(
+            f"CompositeStrategy '{sid}': induction first sub_strategy must be support "
+            "or previous induction"
+        )
+    elif support_1.type == StrategyType.SUPPORT and law not in support_1.premises:
+        result.error(
+            f"CompositeStrategy '{sid}': induction first support must include the law as a premise"
+        )
+    elif support_1.type == StrategyType.INDUCTION and support_1.conclusion != law:
+        result.error(f"CompositeStrategy '{sid}': previous induction must conclude the same law")
+
+    if support_2.type != StrategyType.SUPPORT:
+        result.error(f"CompositeStrategy '{sid}': induction second sub_strategy must be support")
+    elif law not in support_2.premises:
+        result.error(
+            f"CompositeStrategy '{sid}': induction second support must include the law as a premise"
+        )
 
 
 def _validate_composite_dag(
@@ -619,7 +716,7 @@ def validate_parameterization(
     # Strategy conclusions — their belief derives from premises via BP
     strategy_conclusions: set[str] = set()
     for s in graph.strategies:
-        if s.conclusion is not None:
+        if s.conclusion is not None and not isinstance(s, CompositeStrategy):
             strategy_conclusions.add(s.conclusion)
 
     # Combined: all claims exempt from the "must have prior" check

--- a/gaia/ir/validator.py
+++ b/gaia/ir/validator.py
@@ -670,10 +670,10 @@ def validate_parameterization(
     Claims are classified as follows:
 
     1. **Non-composite Strategy conclusions** — their belief is derived from
-       premises through factors produced by lowering, so they do not need an
-       independent PriorRecord. A CompositeStrategy conclusion is not included
-       here because CompositeStrategy is structural grouping only and does not
-       itself lower to a BP factor.
+       premises through factors produced by lowering, so they must not receive
+       an independent PriorRecord. A CompositeStrategy conclusion is not
+       included here because CompositeStrategy is structural grouping only and
+       does not itself lower to a BP factor.
     2. **Top-level structural helper claims** — conclusions of top-level Operators
        with structural types (conjunction/disjunction/equivalence/contradiction/
        complement/implication). Their truth value is determined by the Operator.
@@ -714,8 +714,8 @@ def validate_parameterization(
                 if op.conclusion not in own_interface:
                     no_prior_allowed.add(op.conclusion)
 
-    # (b) Claims that don't NEED PriorRecords but may optionally have them
-    # Strategy conclusions — their belief derives from premises via BP
+    # Non-composite Strategy conclusions — their belief derives from premises
+    # via BP, so they must not receive independent PriorRecords.
     strategy_conclusions: set[str] = set()
     for s in graph.strategies:
         if s.conclusion is not None and not isinstance(s, CompositeStrategy):
@@ -743,11 +743,18 @@ def validate_parameterization(
         if cid not in prior_knowledge_ids:
             result.error(f"Claim '{cid}': missing PriorRecord")
 
-    # prohibited claims must NOT have PriorRecords (spec §4 of 04-helper-claims.md)
+    # Prohibited claims must NOT have PriorRecords (spec §4 of
+    # 04-helper-claims.md). This includes derived strategy conclusions to avoid
+    # double-counting independent unary evidence and incoming strategy factors.
     for r_prior in priors:
         if r_prior.knowledge_id in no_prior_allowed:
             result.error(
                 f"PriorRecord '{r_prior.knowledge_id}': private or structural helper claim "
+                f"must not have independent PriorRecord"
+            )
+        elif r_prior.knowledge_id in strategy_conclusions:
+            result.error(
+                f"PriorRecord '{r_prior.knowledge_id}': non-composite strategy conclusion "
                 f"must not have independent PriorRecord"
             )
 

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -350,6 +350,21 @@ def abduction(
         raise TypeError("abduction() second arg must be a Strategy")
     if not isinstance(comparison, Strategy):
         raise TypeError("abduction() third arg must be a Strategy")
+    if support_h.type != "support":
+        raise TypeError("abduction() first arg must be a support strategy")
+    if support_alt.type != "support":
+        raise TypeError("abduction() second arg must be a support strategy")
+    if comparison.type != "compare":
+        raise TypeError("abduction() third arg must be a compare strategy")
+    if len(comparison.premises) != 3:
+        raise ValueError("abduction() compare strategy must have [pred_h, pred_alt, observation]")
+    observation = comparison.premises[2]
+    if support_h.conclusion is not observation:
+        raise ValueError("abduction() support_h must conclude the compared observation")
+    if support_alt.conclusion is not observation:
+        raise ValueError("abduction() support_alt must conclude the compared observation")
+    if comparison.conclusion is None:
+        raise ValueError("abduction() compare strategy must have a conclusion")
 
     # Composition warrant
     comp_warrant = Knowledge(

--- a/tests/gaia/lang/test_abduction_v2.py
+++ b/tests/gaia/lang/test_abduction_v2.py
@@ -82,6 +82,51 @@ def test_abduction_requires_strategy_inputs():
         abduction(sup, sup, k)  # type: ignore[arg-type]
 
 
+def test_abduction_requires_support_support_compare():
+    """Abduction only accepts support, support, compare sub-strategies."""
+    sup_h, sup_alt, comp, theory_h, *_ = _make_abduction_triple()
+    not_support = Strategy(type="deduction", premises=[theory_h], conclusion=sup_h.conclusion)
+    not_compare = Strategy(type="support", premises=list(comp.premises), conclusion=comp.conclusion)
+
+    with pytest.raises(TypeError, match="first arg must be a support strategy"):
+        abduction(not_support, sup_alt, comp)
+
+    with pytest.raises(TypeError, match="second arg must be a support strategy"):
+        abduction(sup_h, not_support, comp)
+
+    with pytest.raises(TypeError, match="third arg must be a compare strategy"):
+        abduction(sup_h, sup_alt, not_compare)
+
+
+def test_abduction_requires_supports_to_conclude_compared_observation():
+    """Both explanation supports must target compare()'s observation."""
+    sup_h, sup_alt, comp, theory_h, theory_alt, _obs, *_ = _make_abduction_triple()
+    other_obs = claim("Different observation.")
+
+    bad_h = support(premises=[theory_h], conclusion=other_obs)
+    with pytest.raises(ValueError, match="support_h must conclude the compared observation"):
+        abduction(bad_h, sup_alt, comp)
+
+    bad_alt = support(premises=[theory_alt], conclusion=other_obs)
+    with pytest.raises(ValueError, match="support_alt must conclude the compared observation"):
+        abduction(sup_h, bad_alt, comp)
+
+
+def test_abduction_requires_well_formed_compare():
+    """The comparison sub-strategy must expose pred_h, pred_alt, observation and conclusion."""
+    sup_h, sup_alt, comp, *_ = _make_abduction_triple()
+    malformed_premises = Strategy(
+        type="compare", premises=comp.premises[:2], conclusion=comp.conclusion
+    )
+    missing_conclusion = Strategy(type="compare", premises=list(comp.premises), conclusion=None)
+
+    with pytest.raises(ValueError, match=r"must have \[pred_h, pred_alt, observation\]"):
+        abduction(sup_h, sup_alt, malformed_premises)
+
+    with pytest.raises(ValueError, match="compare strategy must have a conclusion"):
+        abduction(sup_h, sup_alt, missing_conclusion)
+
+
 def test_abduction_premises_are_deduplicated():
     """Premises from all sub-strategies are merged without duplicates."""
     theory = claim("Theory.")

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -1246,7 +1246,6 @@ class TestParameterizationValidation:
             g,
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::b", value=0.7, source_id="s"),
             ],
             strategy_params=[
                 StrategyParamRecord(
@@ -1257,7 +1256,7 @@ class TestParameterizationValidation:
         assert r.valid
 
     def test_strategy_conclusion_does_not_require_prior(self):
-        """Strategy conclusions are exempt from PriorRecord requirement."""
+        """Strategy conclusions are derived claims and do not need PriorRecord."""
         from gaia.ir import PriorRecord, StrategyParamRecord
 
         g = self._graph()
@@ -1299,14 +1298,34 @@ class TestParameterizationValidation:
         g = self._graph()
         r = validate_parameterization(
             g,
-            priors=[
-                PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::b", value=0.7, source_id="s"),
-            ],
+            priors=[PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s")],
             strategy_params=[],
         )
         assert not r.valid
         assert any("missing StrategyParamRecord" in e for e in r.errors)
+
+    def test_strategy_conclusion_prior_prohibited(self):
+        """Strategy conclusions must not receive independent unary priors."""
+        from gaia.ir import PriorRecord, StrategyParamRecord
+
+        g = self._graph()
+        sid = g.strategies[0].strategy_id
+        r = validate_parameterization(
+            g,
+            priors=[
+                PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
+                PriorRecord(knowledge_id="github:test::b", value=0.7, source_id="s"),
+            ],
+            strategy_params=[
+                StrategyParamRecord(
+                    strategy_id=sid, conditional_probabilities=[0.85], source_id="s"
+                ),
+            ],
+        )
+        assert not r.valid
+        assert any(
+            "github:test::b" in e and "non-composite strategy conclusion" in e for e in r.errors
+        )
 
     def test_formal_strategy_without_params_passes(self):
         """FormalStrategy types do not need StrategyParamRecord."""
@@ -1342,7 +1361,6 @@ class TestParameterizationValidation:
             g,
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::b", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::m", value=0.5, source_id="s"),
             ],
             strategy_params=[],  # no params needed for deduction
@@ -1391,7 +1409,6 @@ class TestParameterizationValidation:
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::b", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::c", value=0.5, source_id="s"),
                 # no prior for reg:test::m
             ],
             strategy_params=[],
@@ -1438,7 +1455,6 @@ class TestParameterizationValidation:
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::b", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::c", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::m", value=0.5, source_id="s"),  # prohibited!
             ],
             strategy_params=[],
@@ -1488,7 +1504,6 @@ class TestParameterizationValidation:
             g,
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::c", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::final", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::mid", value=0.5, source_id="s"),
                 PriorRecord(
@@ -1539,7 +1554,6 @@ class TestParameterizationValidation:
             g,
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::c", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::mid", value=0.5, source_id="s"),
                 # github:test::h1 and h2 are private -- no prior needed
             ],
@@ -1573,10 +1587,7 @@ class TestParameterizationValidation:
         )
         r = validate_parameterization(
             g,
-            priors=[
-                PriorRecord(knowledge_id="github:test::obs", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::h", value=0.5, source_id="s"),
-            ],
+            priors=[PriorRecord(knowledge_id="github:test::obs", value=0.5, source_id="s")],
             strategy_params=[],
         )
         assert not r.valid
@@ -1610,7 +1621,6 @@ class TestParameterizationValidation:
             g,
             priors=[
                 PriorRecord(knowledge_id="github:test::obs", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::h", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id=alternative_explanation.id, value=0.5, source_id="s"),
             ],
             strategy_params=[],
@@ -1654,7 +1664,6 @@ class TestParameterizationValidation:
                 PriorRecord(knowledge_id="github:test::e1", value=0.9, source_id="s"),
                 PriorRecord(knowledge_id="github:test::h2", value=0.2, source_id="s"),
                 PriorRecord(knowledge_id="github:test::e2", value=0.9, source_id="s"),
-                PriorRecord(knowledge_id="github:test::h3", value=0.2, source_id="s"),
             ],
             strategy_params=[],
         )
@@ -1755,10 +1764,7 @@ class TestParameterizationValidation:
         sid = g.strategies[0].strategy_id
         r = validate_parameterization(
             g,
-            priors=[
-                PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::b", value=0.5, source_id="s"),
-            ],
+            priors=[PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s")],
             strategy_params=[
                 StrategyParamRecord(
                     strategy_id=sid, conditional_probabilities=[0.5], source_id="s"
@@ -1778,7 +1784,6 @@ class TestParameterizationValidation:
             g,
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::b", value=0.7, source_id="s"),
             ],
             strategy_params=[
                 StrategyParamRecord(
@@ -1845,10 +1850,7 @@ class TestParameterizationValidation:
         sid = g.strategies[0].strategy_id
         r = validate_parameterization(
             g,
-            priors=[
-                PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::b", value=0.7, source_id="s"),
-            ],
+            priors=[PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s")],
             strategy_params=[
                 StrategyParamRecord(
                     strategy_id=sid,
@@ -1884,7 +1886,6 @@ class TestParameterizationValidation:
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::b", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::c", value=0.5, source_id="s"),
             ],
             strategy_params=[
                 StrategyParamRecord(
@@ -1921,7 +1922,6 @@ class TestParameterizationValidation:
             priors=[
                 PriorRecord(knowledge_id="github:test::a", value=0.5, source_id="s"),
                 PriorRecord(knowledge_id="github:test::b", value=0.5, source_id="s"),
-                PriorRecord(knowledge_id="github:test::c", value=0.5, source_id="s"),
             ],
             strategy_params=[
                 StrategyParamRecord(

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -502,7 +502,7 @@ class TestCompositeStrategyValidation:
                 sub,
                 CompositeStrategy(
                     scope="local",
-                    type="abduction",
+                    type="infer",
                     premises=["github:test::a"],
                     conclusion="github:test::c",
                     sub_strategies=[sub.strategy_id],
@@ -519,7 +519,7 @@ class TestCompositeStrategyValidation:
             strategies=[
                 CompositeStrategy(
                     scope="local",
-                    type="abduction",
+                    type="infer",
                     premises=["github:test::a"],
                     conclusion="github:test::c",
                     sub_strategies=["lcs_nonexistent"],
@@ -545,7 +545,7 @@ class TestCompositeStrategyValidation:
         comp_a = CompositeStrategy(
             strategy_id="lcs_comp_a",
             scope="local",
-            type="abduction",
+            type="infer",
             premises=["github:test::a"],
             conclusion="github:test::b",
             sub_strategies=["lcs_comp_b"],
@@ -553,7 +553,7 @@ class TestCompositeStrategyValidation:
         comp_b = CompositeStrategy(
             strategy_id="lcs_comp_b",
             scope="local",
-            type="abduction",
+            type="infer",
             premises=["github:test::a"],
             conclusion="github:test::b",
             sub_strategies=["lcs_comp_a"],
@@ -576,7 +576,7 @@ class TestCompositeStrategyValidation:
         )
         comp = CompositeStrategy(
             scope="local",
-            type="abduction",
+            type="infer",
             premises=["github:test::a"],
             conclusion="github:test::b",
             sub_strategies=[leaf.strategy_id],
@@ -587,6 +587,159 @@ class TestCompositeStrategyValidation:
         )
         r = validate_local_graph(g)
         assert r.valid
+
+    def test_valid_abduction_composite_shape(self):
+        """Abduction composite must be support, support, compare over one observation."""
+        sup_h = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::h"],
+            conclusion="github:test::obs",
+        )
+        sup_alt = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::alt"],
+            conclusion="github:test::obs",
+        )
+        cmp = Strategy(
+            scope="local",
+            type="compare",
+            premises=["github:test::pred_h", "github:test::pred_alt", "github:test::obs"],
+            conclusion="github:test::cmp",
+        )
+        comp = CompositeStrategy(
+            scope="local",
+            type="abduction",
+            premises=["github:test::h", "github:test::alt", "github:test::pred_h"],
+            conclusion="github:test::cmp",
+            sub_strategies=[sup_h.strategy_id, sup_alt.strategy_id, cmp.strategy_id],
+        )
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::h"),
+                _claim("github:test::alt"),
+                _claim("github:test::obs"),
+                _claim("github:test::pred_h"),
+                _claim("github:test::pred_alt"),
+                _claim("github:test::cmp"),
+            ],
+            strategies=[sup_h, sup_alt, cmp, comp],
+        )
+        r = validate_local_graph(g)
+        assert r.valid, r.errors
+
+    def test_abduction_composite_rejects_wrong_child_shape(self):
+        """Malformed abduction composites are rejected at IR validation."""
+        not_support = Strategy(
+            scope="local",
+            type="noisy_and",
+            premises=["github:test::h"],
+            conclusion="github:test::obs",
+        )
+        sup_alt = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::alt"],
+            conclusion="github:test::other_obs",
+        )
+        cmp = Strategy(
+            scope="local",
+            type="compare",
+            premises=["github:test::pred_h", "github:test::pred_alt", "github:test::obs"],
+            conclusion="github:test::cmp",
+        )
+        comp = CompositeStrategy(
+            scope="local",
+            type="abduction",
+            premises=["github:test::h", "github:test::alt", "github:test::pred_h"],
+            conclusion="github:test::wrong_cmp",
+            sub_strategies=[not_support.strategy_id, sup_alt.strategy_id, cmp.strategy_id],
+        )
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::h"),
+                _claim("github:test::alt"),
+                _claim("github:test::obs"),
+                _claim("github:test::other_obs"),
+                _claim("github:test::pred_h"),
+                _claim("github:test::pred_alt"),
+                _claim("github:test::cmp"),
+                _claim("github:test::wrong_cmp"),
+            ],
+            strategies=[not_support, sup_alt, cmp, comp],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("abduction first sub_strategy must be support" in e for e in r.errors)
+        assert any("abduction conclusion must match compare conclusion" in e for e in r.errors)
+        assert any("second support must conclude the compared observation" in e for e in r.errors)
+
+    def test_valid_induction_composite_shape(self):
+        """Induction composite children must share the same law premise."""
+        sup1 = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::law"],
+            conclusion="github:test::obs1",
+        )
+        sup2 = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::law"],
+            conclusion="github:test::obs2",
+        )
+        comp = CompositeStrategy(
+            scope="local",
+            type="induction",
+            premises=["github:test::law"],
+            conclusion="github:test::law",
+            sub_strategies=[sup1.strategy_id, sup2.strategy_id],
+        )
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::law"),
+                _claim("github:test::obs1"),
+                _claim("github:test::obs2"),
+            ],
+            strategies=[sup1, sup2, comp],
+        )
+        r = validate_local_graph(g)
+        assert r.valid, r.errors
+
+    def test_induction_composite_rejects_children_without_law_premise(self):
+        """Induction children must include the composite conclusion law as a premise."""
+        sup1 = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::other"],
+            conclusion="github:test::obs1",
+        )
+        sup2 = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::law"],
+            conclusion="github:test::obs2",
+        )
+        comp = CompositeStrategy(
+            scope="local",
+            type="induction",
+            premises=["github:test::law"],
+            conclusion="github:test::law",
+            sub_strategies=[sup1.strategy_id, sup2.strategy_id],
+        )
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::law"),
+                _claim("github:test::other"),
+                _claim("github:test::obs1"),
+                _claim("github:test::obs2"),
+            ],
+            strategies=[sup1, sup2, comp],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("induction first support must include the law" in e for e in r.errors)
 
 
 class TestFormalStrategyValidation:
@@ -1819,3 +1972,52 @@ class TestParameterizationValidation:
             ],
         )
         assert r.valid, r.errors
+
+    def test_composite_conclusion_does_not_exempt_prior_by_itself(self):
+        """CompositeStrategy is review structure only; its conclusion still needs support/prior."""
+        from gaia.ir import PriorRecord
+
+        sup1 = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::law"],
+            conclusion="github:test::obs1",
+        )
+        sup2 = Strategy(
+            scope="local",
+            type="support",
+            premises=["github:test::law"],
+            conclusion="github:test::obs2",
+        )
+        comp = CompositeStrategy(
+            scope="local",
+            type="induction",
+            premises=["github:test::law"],
+            conclusion="github:test::law",
+            sub_strategies=[sup1.strategy_id, sup2.strategy_id],
+        )
+        g = _local_graph(
+            knowledges=[
+                Knowledge(id="github:test::law", content="Law", type="claim", label="law"),
+                Knowledge(id="github:test::obs1", content="Obs 1", type="claim", label="obs1"),
+                Knowledge(id="github:test::obs2", content="Obs 2", type="claim", label="obs2"),
+            ],
+            strategies=[sup1, sup2, comp],
+        )
+        r = validate_parameterization(
+            g,
+            priors=[
+                # obs1/obs2 are exempt because they are non-composite support conclusions.
+                # law is only the composite conclusion, so it must still require a prior.
+            ],
+            strategy_params=[],
+        )
+        assert not r.valid
+        assert any("github:test::law" in e and "missing PriorRecord" in e for e in r.errors)
+
+        r_with_law_prior = validate_parameterization(
+            g,
+            priors=[PriorRecord(knowledge_id="github:test::law", value=0.5, source_id="s")],
+            strategy_params=[],
+        )
+        assert r_with_law_prior.valid, r_with_law_prior.errors

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -1974,7 +1974,7 @@ class TestParameterizationValidation:
         assert r.valid, r.errors
 
     def test_composite_conclusion_does_not_exempt_prior_by_itself(self):
-        """CompositeStrategy is review structure only; its conclusion still needs support/prior."""
+        """CompositeStrategy is structural only; its conclusion still needs support/prior."""
         from gaia.ir import PriorRecord
 
         sup1 = Strategy(


### PR DESCRIPTION
## Summary

- validate abduction arguments are support, support, compare
- require both explanation supports to conclude the observation used by compare(pred_h, pred_alt, observation)
- require compare to expose pred_h, pred_alt, observation and a comparison conclusion
- add negative tests for malformed abduction structures

## Verification

- uv run --project /tmp/gaia_pr431_review pytest tests/gaia/lang/test_abduction_v2.py tests/gaia/lang/test_compiler.py -k abduction tests/test_lowering.py -k abduction
- uv run --project /tmp/gaia_pr431_review ruff check gaia/lang/dsl/strategies.py tests/gaia/lang/test_abduction_v2.py
- uv run --project /tmp/gaia_pr431_review ruff format --check gaia/lang/dsl/strategies.py tests/gaia/lang/test_abduction_v2.py