### PR TITLE
fix(bp): proper CPT for support/deduction, eliminate fan-out penalty

### DIFF
--- a/gaia/bp/bp.py
+++ b/gaia/bp/bp.py
@@ -367,17 +367,9 @@ class BeliefPropagation:
                 )
 
             # Step 2: Compute all factor→variable messages (synchronous)
-            # For directed implication factors (deduction/support), the BN structure
-            # is A, H → B where A=variables[0] is the antecedent (parent) and
-            # B=variables[1] is the consequent (child).  Skip backward messages
-            # to A — this eliminates the fan-out penalty from unobserved
-            # children while preserving forward propagation from A to B.
             new_f2v: dict[tuple[int, str], Msg] = {}
             for fi, vid in f2v_msgs:
                 factor = graph.factors[fi]
-                if factor.directed and vid == factor.variables[0]:
-                    new_f2v[(fi, vid)] = _uniform_msg()
-                    continue
                 new_f2v[(fi, vid)] = _compute_f2v(
                     factor_idx=fi,
                     target_var=vid,

--- a/gaia/bp/contraction.py
+++ b/gaia/bp/contraction.py
@@ -437,6 +437,7 @@ def strategy_cpt(
         strat_by_id,
         var_priors,
         strat_params,
+        {},
         expand_formal=True,
         infer_degraded=False,
         ctr=ctr,

--- a/gaia/bp/factor_graph.py
+++ b/gaia/bp/factor_graph.py
@@ -43,7 +43,6 @@ class Factor:
     p1: float | None = None
     p2: float | None = None
     cpt: tuple[float, ...] | None = None
-    directed: bool = False
 
     @property
     def all_vars(self) -> list[str]:
@@ -104,7 +103,6 @@ class FactorGraph:
         p1: float | None = None,
         p2: float | None = None,
         cpt: Sequence[float] | None = None,
-        directed: bool = False,
     ) -> None:
         v_list = list(variables)
         if conclusion in v_list:
@@ -176,7 +174,6 @@ class FactorGraph:
                 p1=fp1,
                 p2=fp2,
                 cpt=fcpt,
-                directed=directed,
             )
         )
 

--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -20,12 +20,14 @@ from gaia.ir.strategy import (
     StrategyType,
 )
 
-# Deduction and support produce forward-only implication operators.  In the BN
-# interpretation these are CPT edges (A, H → B) where the antecedent A
-# should not receive backward messages from unobserved children — this
-# eliminates the fan-out penalty on the premise.  Compare produces
-# relation-type implications that remain undirected.
-_DIRECTED_IMPLICATION_TYPES = frozenset({StrategyType.DEDUCTION, StrategyType.SUPPORT})
+# Deduction and support implication operators are lowered as proper CPTs
+# (SOFT_ENTAILMENT) instead of ternary constraint factors.  The author's
+# prior on the implication warrant is marginalized into p1_eff:
+#   p1_eff = π(H) · (1-ε) + (1-π(H)) · 0.5
+# with p2 = 0.5 (MaxEnt default: "no information when premises fail").
+# This eliminates the fan-out penalty (rows sum to 1) while preserving
+# backward inference (weak syllogism / Jaynes).
+_CPT_IMPLICATION_TYPES = frozenset({StrategyType.DEDUCTION, StrategyType.SUPPORT})
 
 # Operators whose conclusion is a "relation assertion" (the operator
 # DECLARES that the relation holds) — their helper claim should be
@@ -97,6 +99,11 @@ def lower_local_graph(
     }
     if helper_ids:
         priors = {k: v for k, v in priors.items() if k not in helper_ids}
+    metadata_priors = {
+        k.id: float(k.metadata["prior"])
+        for k in canonical.knowledges
+        if k.id and k.metadata and "prior" in k.metadata
+    }
     strat_params = strategy_conditional_params or {}
     fg = FactorGraph()
     ctr = [0]
@@ -142,6 +149,7 @@ def lower_local_graph(
             strat_by_id,
             priors,
             strat_params,
+            metadata_priors,
             expand_formal,
             infer_use_degraded_noisy_and,
             ctr,
@@ -205,6 +213,7 @@ def _lower_strategy(
     strat_by_id: dict[str, Strategy],
     priors: dict[str, float],
     strat_params: dict[str, list[float]],
+    metadata_priors: dict[str, float] | None,
     expand_formal: bool,
     infer_degraded: bool,
     ctr: list[int],
@@ -223,6 +232,7 @@ def _lower_strategy(
         if s.strategy_id in seen_strategies:
             return
         seen_strategies.add(s.strategy_id)
+    metadata_priors = metadata_priors or {}
 
     if isinstance(s, CompositeStrategy):
         for sid in s.sub_strategies:
@@ -235,6 +245,7 @@ def _lower_strategy(
                 strat_by_id,
                 priors,
                 strat_params,
+                metadata_priors,
                 expand_formal,
                 infer_degraded,
                 ctr,
@@ -254,10 +265,34 @@ def _lower_strategy(
         for i, op in enumerate(s.formal_expr.operators):
             fid = _next_fid(f"fs_{s.strategy_id}_{i}", ctr)
             ft = _OPERATOR_MAP[op.operator]
-            is_directed = (
-                s.type in _DIRECTED_IMPLICATION_TYPES and op.operator == OperatorType.IMPLICATION
-            )
-            fg.add_factor(fid, ft, op.variables, op.conclusion, directed=is_directed)
+
+            # Support/deduction implication operators → SOFT_ENTAILMENT CPT.
+            # The ternary implication factor (antecedent, conclusion, helper)
+            # is replaced by a binary CPT (antecedent → conclusion) with the
+            # helper's prior marginalized into p1_eff.
+            if s.type in _CPT_IMPLICATION_TYPES and op.operator == OperatorType.IMPLICATION:
+                # Helper claim prior: use author-set prior if available,
+                # otherwise the relation assertion default (1-ε) since the
+                # implication helper is a relation operator conclusion.
+                helper_prior = priors.get(
+                    op.conclusion,
+                    metadata_priors.get(op.conclusion, 1.0 - CROMWELL_EPS),
+                )
+                p1_eff = helper_prior * (1.0 - CROMWELL_EPS) + (1.0 - helper_prior) * 0.5
+                # op.variables = [antecedent, actual_conclusion]
+                antecedent = op.variables[0]
+                consequent = op.variables[1]
+                _ensure_claim_var(fg, antecedent, priors, claim_ids)
+                _ensure_claim_var(fg, consequent, priors, claim_ids)
+                fg.add_factor(
+                    fid, FactorType.SOFT_ENTAILMENT, [antecedent], consequent, p1=p1_eff, p2=0.5
+                )
+                # Helper claim variable is marginalized into p1_eff, so it
+                # should not remain as an orphan in the factor graph.
+                fg.variables.pop(op.conclusion, None)
+                continue
+
+            fg.add_factor(fid, ft, op.variables, op.conclusion)
             for vid in op.variables:
                 _ensure_claim_var(fg, vid, priors, claim_ids)
             concl = op.conclusion
@@ -394,6 +429,7 @@ def _lower_strategy(
             strat_by_id,
             priors,
             strat_params,
+            metadata_priors,
             expand_formal,
             infer_degraded,
             ctr,

--- a/gaia/bp/potentials.py
+++ b/gaia/bp/potentials.py
@@ -104,36 +104,12 @@ def conditional_potential(
     return p if assignment[conclusion] == 1 else (1.0 - p)
 
 
-def directed_implication_potential(
-    assignment: Assignment, antecedent: str, consequent: str, helper: str
-) -> float:
-    """Directed implication CPT: P(B | A, H).
-
-    Used for deduction/support — the antecedent A is a parent (not influenced
-    by B), the consequent B is a child (no independent prior needed).
-
-    When H=1 and A=1: B must be 1 (deduction succeeds).
-    When H=1 and A=0: B is uniform (premise false, no constraint).
-    When H=0: B is uniform (warrant doesn't hold).
-
-    Each row sums to 1 over B, so marginalizing over B gives a constant
-    for each (A, H) — the factor does not constrain A or H.
-    """
-    a, b, h = assignment[antecedent], assignment[consequent], assignment[helper]
-    if h == 1 and a == 1:
-        return (1.0 - CROMWELL_EPS) if b == 1 else CROMWELL_EPS
-    # A=0 or H=0: uniform over B
-    return 0.5
-
-
 def evaluate_potential(factor: Factor, assignment: Assignment) -> float:
     ft = factor.factor_type
     v = factor.variables
     c = factor.conclusion
 
     if ft == FactorType.IMPLICATION:
-        if factor.directed:
-            return directed_implication_potential(assignment, v[0], v[1], c)
         return implication_potential(assignment, v[0], v[1], c)
 
     if ft == FactorType.CONJUNCTION:

--- a/tests/gaia/bp/test_factor_graph.py
+++ b/tests/gaia/bp/test_factor_graph.py
@@ -159,24 +159,4 @@ def test_factor_all_vars_dedup():
     assert f.all_vars.count("A") == 1
 
 
-# ── Directed factors ──
-
-
-def test_add_directed_factor():
-    """directed=True is stored on the Factor."""
-    fg = FactorGraph()
-    fg.add_variable("A", 0.5)
-    fg.add_variable("B", 0.5)
-    fg.add_variable("H", 1.0 - CROMWELL_EPS)
-    fg.add_factor("f1", FactorType.IMPLICATION, ["A", "B"], "H", directed=True)
-    assert fg.factors[0].directed is True
-
-
-def test_factor_default_undirected():
-    """Factors are undirected by default."""
-    fg = FactorGraph()
-    fg.add_variable("A", 0.5)
-    fg.add_variable("B", 0.5)
-    fg.add_variable("H", 1.0 - CROMWELL_EPS)
-    fg.add_factor("f1", FactorType.IMPLICATION, ["A", "B"], "H")
-    assert fg.factors[0].directed is False
+# ── (Directed factors removed — fan-out now solved by SOFT_ENTAILMENT CPT) ──

--- a/tests/gaia/bp/test_inference.py
+++ b/tests/gaia/bp/test_inference.py
@@ -512,61 +512,33 @@ class TestGBPRegionDecomposition:
         )
 
 
-# ── Directed factors: fan-out elimination ──
+# ── SOFT_ENTAILMENT CPT: fan-out elimination via proper CPTs ──
 
 
-def _deduction_fanout_graph(*, directed: bool) -> FactorGraph:
-    """A with 4 deduction children via implication. Each child has prior 0.5."""
+def _soft_entailment_fanout_graph() -> FactorGraph:
+    """A with 4 SOFT_ENTAILMENT children (proper CPT, p2=0.5 MaxEnt)."""
     fg = FactorGraph()
     fg.add_variable("A", 0.5)
     for i in range(4):
         fg.add_variable(f"B{i}", 0.5)
-        fg.add_variable(f"H{i}", 1.0 - CROMWELL_EPS)
         fg.add_factor(
             f"f{i}",
-            FactorType.IMPLICATION,
-            ["A", f"B{i}"],
-            f"H{i}",
-            directed=directed,
+            FactorType.SOFT_ENTAILMENT,
+            ["A"],
+            f"B{i}",
+            p1=1.0 - CROMWELL_EPS,
+            p2=0.5,
         )
     return fg
 
 
-class TestDirectedFactorFanout:
-    """Directed implication factors should not penalize the antecedent via modus tollens."""
+class TestSoftEntailmentFanout:
+    """SOFT_ENTAILMENT with p2=0.5 eliminates fan-out while preserving backward inference."""
 
-    def test_undirected_has_fanout(self):
-        """Baseline: undirected implication with 4 children drags A far below 0.5."""
-        fg = _deduction_fanout_graph(directed=False)
-        result = BeliefPropagation().run(fg)
-        assert result.beliefs["A"] < 0.15  # severe fan-out
-
-    def test_directed_eliminates_fanout(self):
-        """Directed implication with 4 children: A stays at its prior."""
-        fg = _deduction_fanout_graph(directed=True)
-        result = BeliefPropagation().run(fg)
-        assert result.beliefs["A"] == pytest.approx(0.5, abs=0.01)
-
-    def test_directed_still_propagates_forward(self):
-        """Directed implication still sends messages from A to B (forward)."""
+    def test_constraint_implication_has_fanout(self):
+        """Baseline: constraint implication with 4 children drags A far below 0.5."""
         fg = FactorGraph()
-        fg.add_variable("A", 0.9)
-        fg.add_variable("B", 0.5)
-        fg.add_variable("H", 1.0 - CROMWELL_EPS)
-        fg.add_factor("f1", FactorType.IMPLICATION, ["A", "B"], "H", directed=True)
-        result = BeliefPropagation().run(fg)
-        # B should be pulled up by A's high belief (forward propagation works)
-        assert result.beliefs["B"] > 0.6
-        # A should stay near its prior (no backward pull from B)
-        assert result.beliefs["A"] == pytest.approx(0.9, abs=0.02)
-
-    def test_directed_chain_no_cascade_penalty(self):
-        """Chain P → A → B1...B4: directed deductions don't cascade fan-out."""
-        fg = FactorGraph()
-        fg.add_variable("P", 0.2)
         fg.add_variable("A", 0.5)
-        fg.add_variable("H_up", 1.0 - CROMWELL_EPS)
-        fg.add_factor("f_up", FactorType.IMPLICATION, ["P", "A"], "H_up", directed=True)
         for i in range(4):
             fg.add_variable(f"B{i}", 0.5)
             fg.add_variable(f"H{i}", 1.0 - CROMWELL_EPS)
@@ -575,21 +547,57 @@ class TestDirectedFactorFanout:
                 FactorType.IMPLICATION,
                 ["A", f"B{i}"],
                 f"H{i}",
-                directed=True,
             )
         result = BeliefPropagation().run(fg)
-        # P should stay near its prior (no cascade from downstream)
-        assert result.beliefs["P"] == pytest.approx(0.2, abs=0.02)
+        assert result.beliefs["A"] < 0.15  # severe fan-out penalty
 
-    def test_directed_support_does_not_backpropagate_to_premise(self):
-        """Support is forward-only: conclusion evidence must not pull the premise."""
+    def test_soft_entailment_eliminates_fanout(self):
+        """SOFT_ENTAILMENT with p2=0.5: A stays at its prior (neutral children)."""
+        fg = _soft_entailment_fanout_graph()
+        result = BeliefPropagation().run(fg)
+        assert result.beliefs["A"] == pytest.approx(0.5, abs=0.02)
+
+    def test_soft_entailment_forward_propagation(self):
+        """SOFT_ENTAILMENT propagates from premise to conclusion (forward)."""
         fg = FactorGraph()
         fg.add_variable("A", 0.9)
         fg.add_variable("B", 0.5)
-        fg.add_variable("H_fwd", 1.0 - CROMWELL_EPS)
-        fg.add_factor("f_fwd", FactorType.IMPLICATION, ["A", "B"], "H_fwd", directed=True)
+        fg.add_factor("f1", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=1.0 - CROMWELL_EPS, p2=0.5)
         result = BeliefPropagation().run(fg)
-        # B pulled up by A (forward)
+        # B should be pulled up by A's high belief
         assert result.beliefs["B"] > 0.6
-        # A stays at its prior because support no longer has reverse reason/warrant.
-        assert result.beliefs["A"] == pytest.approx(0.9, abs=0.01)
+
+    def test_soft_entailment_backward_inference(self):
+        """SOFT_ENTAILMENT preserves backward inference (weak syllogism).
+
+        When B is observed true, A should be pulled above its prior.
+        This is Jaynes' backward inference: P(H|E) > P(H) when E follows from H.
+        """
+        fg = FactorGraph()
+        fg.add_variable("A", 0.5)
+        fg.add_variable("B", 0.5)
+        fg.add_factor("f1", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=0.95, p2=0.5)
+        fg.observe("B", 1)
+        result = BeliefPropagation().run(fg)
+        # A should be pulled above 0.5 (backward inference works)
+        assert result.beliefs["A"] > 0.6
+
+    def test_soft_entailment_chain_no_cascade(self):
+        """Chain P → A → B1...B4: SOFT_ENTAILMENT doesn't cascade fan-out."""
+        fg = FactorGraph()
+        fg.add_variable("P", 0.2)
+        fg.add_variable("A", 0.5)
+        fg.add_factor("f_up", FactorType.SOFT_ENTAILMENT, ["P"], "A", p1=1.0 - CROMWELL_EPS, p2=0.5)
+        for i in range(4):
+            fg.add_variable(f"B{i}", 0.5)
+            fg.add_factor(
+                f"f{i}",
+                FactorType.SOFT_ENTAILMENT,
+                ["A"],
+                f"B{i}",
+                p1=1.0 - CROMWELL_EPS,
+                p2=0.5,
+            )
+        result = BeliefPropagation().run(fg)
+        # P should stay near its prior (no cascade from downstream)
+        assert result.beliefs["P"] == pytest.approx(0.2, abs=0.03)

--- a/tests/test_lowering.py
+++ b/tests/test_lowering.py
@@ -176,7 +176,8 @@ def test_formal_strategy_expand_implication():
         strategies=[fs],
     )
     fg = lower_local_graph(g, expand_formal=True)
-    assert any(f.factor_type == FactorType.IMPLICATION for f in fg.factors)
+    # Deduction implication is now lowered as SOFT_ENTAILMENT (proper CPT)
+    assert any(f.factor_type == FactorType.SOFT_ENTAILMENT for f in fg.factors)
 
 
 def test_formal_fold_not_implemented():
@@ -215,7 +216,7 @@ def test_formal_fold_not_implemented():
 
 
 def test_deduction_leaf_strategy_auto_formalizes():
-    """Plain Strategy(type=deduction) is auto-formalized to CONJUNCTION + IMPLICATION."""
+    """Plain Strategy(type=deduction) is auto-formalized to CONJUNCTION + SOFT_ENTAILMENT."""
     s = Strategy(
         scope="local",
         type="deduction",
@@ -234,7 +235,8 @@ def test_deduction_leaf_strategy_auto_formalizes():
     assert not fg.validate()
     ftypes = {f.factor_type for f in fg.factors}
     assert FactorType.CONJUNCTION in ftypes
-    assert FactorType.IMPLICATION in ftypes
+    # Deduction implication is now lowered as SOFT_ENTAILMENT (proper CPT)
+    assert FactorType.SOFT_ENTAILMENT in ftypes
 
 
 def test_analogy_leaf_strategy_auto_formalizes():
@@ -632,7 +634,7 @@ def test_e2e_deduction_binary_implication_full_pipeline():
         strategies=[s],
     )
 
-    # Step 1: lower (auto-formalizes deduction → CONJUNCTION + IMPLICATION with helper)
+    # Step 1: lower (auto-formalizes deduction → CONJUNCTION + SOFT_ENTAILMENT)
     fg = lower_local_graph(
         g,
         node_priors={
@@ -646,18 +648,15 @@ def test_e2e_deduction_binary_implication_full_pipeline():
     # The factor graph should contain both factor types
     ftypes = {f.factor_type for f in fg.factors}
     assert FactorType.CONJUNCTION in ftypes
-    assert FactorType.IMPLICATION in ftypes
+    # Deduction implication is now lowered as SOFT_ENTAILMENT (proper CPT)
+    assert FactorType.SOFT_ENTAILMENT in ftypes
 
-    # IMPLICATION factor should have 2 variables (not 1)
-    impl_factors = [f for f in fg.factors if f.factor_type == FactorType.IMPLICATION]
-    assert len(impl_factors) == 1
-    assert len(impl_factors[0].variables) == 2
-
-    # Helper claim (implication conclusion) should be at assertion prior ~1-eps
-    from gaia.bp.factor_graph import CROMWELL_EPS
-
-    impl_concl = impl_factors[0].conclusion
-    assert fg.variables[impl_concl] == pytest.approx(1.0 - CROMWELL_EPS)
+    # SOFT_ENTAILMENT factor has 1 variable (premise/conjunction node) + conclusion
+    se_factors = [f for f in fg.factors if f.factor_type == FactorType.SOFT_ENTAILMENT]
+    assert len(se_factors) == 1
+    assert len(se_factors[0].variables) == 1
+    assert se_factors[0].p1 is not None
+    assert se_factors[0].p2 == pytest.approx(0.5)
 
     # Step 2: run exact inference — must not error
     beliefs, _ = exact_inference(fg)
@@ -667,7 +666,7 @@ def test_e2e_deduction_binary_implication_full_pipeline():
 
 
 def test_e2e_single_premise_deduction_binary_implication():
-    """E2E: single-premise deduction uses binary implication (no conjunction)."""
+    """E2E: single-premise deduction uses SOFT_ENTAILMENT (no conjunction)."""
     s = Strategy(
         scope="local",
         type="deduction",
@@ -691,14 +690,14 @@ def test_e2e_single_premise_deduction_binary_implication():
     )
     assert not fg.validate()
 
-    # Only IMPLICATION factor (no CONJUNCTION for single premise)
+    # Only SOFT_ENTAILMENT factor (no CONJUNCTION for single premise)
     ftypes = [f.factor_type for f in fg.factors]
-    assert FactorType.IMPLICATION in ftypes
+    assert FactorType.SOFT_ENTAILMENT in ftypes
     assert FactorType.CONJUNCTION not in ftypes
 
-    # IMPLICATION has 2 variables
-    impl_f = [f for f in fg.factors if f.factor_type == FactorType.IMPLICATION][0]
-    assert len(impl_f.variables) == 2
+    # SOFT_ENTAILMENT has 1 variable (premise) + conclusion
+    se_f = [f for f in fg.factors if f.factor_type == FactorType.SOFT_ENTAILMENT][0]
+    assert len(se_f.variables) == 1
 
     # Run inference
     beliefs, _ = exact_inference(fg)
@@ -707,53 +706,64 @@ def test_e2e_single_premise_deduction_binary_implication():
 
 
 def test_relation_helper_defaults_to_assertion_prior():
-    """Relation operator helper claims default to 1-ε when absent from node_priors.
-
-    Callers that generate node_priors should set relation helpers to 1-ε
-    (not 0.5). When the helper is absent from node_priors, lowering falls
-    back to the structural default 1-ε.
+    """For deduction/support, the helper claim's prior (1-ε) is marginalized into
+    SOFT_ENTAILMENT p1_eff. For standalone operators (equivalence, etc.),
+    relation helper claims still get the 1-ε default variable prior.
     """
+    from gaia.ir.operator import Operator as IROp
+
+    # Case: standalone equivalence operator — helper claim gets 1-ε default
+    g = _lg(
+        knowledges=[
+            Knowledge(id="github:lowertest::x", type="claim", content="X"),
+            Knowledge(id="github:lowertest::y", type="claim", content="Y"),
+            Knowledge(id="github:lowertest::h_eq", type="claim", content="H_eq"),
+        ],
+        operators=[
+            IROp(
+                operator="equivalence",
+                variables=["github:lowertest::x", "github:lowertest::y"],
+                conclusion="github:lowertest::h_eq",
+            ),
+        ],
+    )
+
+    from gaia.bp.factor_graph import CROMWELL_EPS
+
+    fg = lower_local_graph(g)
+    # Equivalence helper should be at assertion prior 1-ε
+    assert fg.variables["github:lowertest::h_eq"] == pytest.approx(1.0 - CROMWELL_EPS)
+
+    # Case: deduction — SOFT_ENTAILMENT p1_eff encodes the helper prior
     s = Strategy(
         scope="local",
         type="deduction",
         premises=["github:lowertest::a"],
         conclusion="github:lowertest::b",
     )
-    g = _lg(
+    g2 = _lg(
         knowledges=[
             Knowledge(id="github:lowertest::a", type="claim", content="A"),
             Knowledge(id="github:lowertest::b", type="claim", content="B"),
         ],
         strategies=[s],
     )
-
-    from gaia.bp.factor_graph import CROMWELL_EPS
-
-    # Case 1: helper NOT in node_priors → lowering uses 1-ε default
-    fg = lower_local_graph(
-        g,
-        node_priors={
-            "github:lowertest::a": 0.8,
-            "github:lowertest::b": 0.5,
-        },
-    )
-    impl_f = [f for f in fg.factors if f.factor_type == FactorType.IMPLICATION][0]
-    helper_id = impl_f.conclusion
-    assert fg.variables[helper_id] == pytest.approx(1.0 - CROMWELL_EPS)
-
-    # Case 2: helper in node_priors at 1-ε (correct generation) → lowering uses it
     fg2 = lower_local_graph(
-        g,
+        g2,
         node_priors={
             "github:lowertest::a": 0.8,
             "github:lowertest::b": 0.5,
-            helper_id: 1.0 - CROMWELL_EPS,
         },
     )
-    assert fg2.variables[helper_id] == pytest.approx(1.0 - CROMWELL_EPS)
+    se_factors = [f for f in fg2.factors if f.factor_type == FactorType.SOFT_ENTAILMENT]
+    assert len(se_factors) == 1
+    # p1_eff = π(H) * (1-ε) + (1-π(H)) * 0.5; with helper prior ~1-ε:
+    # p1_eff ≈ 0.999 * 0.999 + 0.001 * 0.5 ≈ 0.9985
+    assert se_factors[0].p1 > 0.99
+    assert se_factors[0].p2 == pytest.approx(0.5)
 
-    # Both cases: BP propagates correctly
-    beliefs, _ = exact_inference(fg)
+    # BP propagates correctly
+    beliefs, _ = exact_inference(fg2)
     assert beliefs["github:lowertest::b"] > 0.5
 
 
@@ -763,7 +773,7 @@ def test_relation_helper_defaults_to_assertion_prior():
 
 
 def test_e2e_support_compiles_and_runs_bp():
-    """E2E: support([A], B) -> formalize (1 IMPLIES) -> lower -> BP."""
+    """E2E: support([A], B) -> formalize (1 SOFT_ENTAILMENT) -> lower -> BP."""
     s = Strategy(
         scope="local",
         type="support",
@@ -787,10 +797,9 @@ def test_e2e_support_compiles_and_runs_bp():
     )
     assert not fg.validate()
 
-    # Support produces 1 IMPLICATION factor (forward only)
-    impl_factors = [f for f in fg.factors if f.factor_type == FactorType.IMPLICATION]
-    assert len(impl_factors) == 1
-    assert impl_factors[0].directed is True
+    # Support now produces SOFT_ENTAILMENT (proper CPT)
+    se_factors = [f for f in fg.factors if f.factor_type == FactorType.SOFT_ENTAILMENT]
+    assert len(se_factors) == 1
 
     # Run inference
     beliefs, _ = exact_inference(fg)
@@ -1033,7 +1042,14 @@ def test_e2e_mendel_peirce_cycle():
 
 
 def test_lowering_uses_author_prior_for_relation_helper():
-    """If helper claim has metadata['prior'], lowering uses it instead of 1-eps."""
+    """If helper claim has metadata['prior'], the author prior is encoded into p1_eff.
+
+    With proper CPT lowering, the implication helper is marginalized into
+    SOFT_ENTAILMENT p1_eff = π(H) * (1-ε) + (1-π(H)) * 0.5.  When the
+    author sets prior=0.85, p1_eff ≈ 0.85 * 0.999 + 0.15 * 0.5 ≈ 0.924.
+    """
+    from gaia.bp.factor_graph import CROMWELL_EPS
+
     s = Strategy(
         scope="local",
         type="deduction",
@@ -1049,18 +1065,59 @@ def test_lowering_uses_author_prior_for_relation_helper():
         strategies=[s],
     )
     fg = lower_local_graph(g)
-    # Find the implication helper variable (auto-generated, label starts with __)
     helper_vars = [
         vid for vid in fg.variables if vid.startswith("github:lowertest::__implication_result")
     ]
-    assert len(helper_vars) == 1
-    assert fg.variables[helper_vars[0]] == pytest.approx(0.85)
+    assert helper_vars == []
+    # SOFT_ENTAILMENT factor encodes the author prior via p1_eff
+    se_factors = [f for f in fg.factors if f.factor_type == FactorType.SOFT_ENTAILMENT]
+    assert len(se_factors) == 1
+    expected_p1 = 0.85 * (1.0 - CROMWELL_EPS) + 0.15 * 0.5
+    assert se_factors[0].p1 == pytest.approx(expected_p1, abs=1e-6)
+    assert se_factors[0].p2 == pytest.approx(0.5)
+
+
+def test_compiled_formal_deduction_metadata_prior_used_for_p1_eff():
+    """Compiled FormalStrategy helper metadata prior is encoded into p1_eff."""
+    from gaia.bp.factor_graph import CROMWELL_EPS
+    from gaia.ir.formalize import formalize_named_strategy
+
+    formalized = formalize_named_strategy(
+        scope="local",
+        type_="deduction",
+        premises=["github:lowertest::a"],
+        conclusion="github:lowertest::b",
+        namespace="github",
+        package_name="lowertest",
+        metadata={"prior": 0.85},
+    )
+    g = _lg(
+        knowledges=[
+            Knowledge(id="github:lowertest::a", type="claim", content="A"),
+            Knowledge(id="github:lowertest::b", type="claim", content="B"),
+            *formalized.knowledges,
+        ],
+        strategies=[formalized.strategy],
+    )
+
+    fg = lower_local_graph(g)
+
+    helper_ids = {k.id for k in formalized.knowledges if "implication_result" in (k.id or "")}
+    assert helper_ids
+    assert helper_ids.isdisjoint(fg.variables)
+    se_factors = [f for f in fg.factors if f.factor_type == FactorType.SOFT_ENTAILMENT]
+    assert len(se_factors) == 1
+    expected_p1 = 0.85 * (1.0 - CROMWELL_EPS) + 0.15 * 0.5
+    assert se_factors[0].p1 == pytest.approx(expected_p1, abs=1e-6)
+    assert se_factors[0].p2 == pytest.approx(0.5)
 
 
 def test_lowering_default_prior_for_relation_helper_without_author():
-    """Without author prior, relation helper gets 1-eps as before."""
-    from gaia.bp.factor_graph import CROMWELL_EPS
+    """Without author prior, relation helper is marginalized into SOFT_ENTAILMENT p1_eff.
 
+    The helper claim itself is no longer in the factor graph as a variable —
+    its prior (1-ε by default for relation operators) is captured by p1_eff.
+    """
     s = Strategy(
         scope="local",
         type="deduction",
@@ -1078,8 +1135,14 @@ def test_lowering_default_prior_for_relation_helper_without_author():
     helper_vars = [
         vid for vid in fg.variables if vid.startswith("github:lowertest::__implication_result")
     ]
-    assert len(helper_vars) == 1
-    assert fg.variables[helper_vars[0]] == pytest.approx(1.0 - CROMWELL_EPS)
+    assert helper_vars == []
+
+    # SOFT_ENTAILMENT factor captures the helper's role
+    se_factors = [f for f in fg.factors if f.factor_type == FactorType.SOFT_ENTAILMENT]
+    assert len(se_factors) == 1
+    # p1_eff = (1-ε) * (1-ε) + ε * 0.5 ≈ 0.998
+    assert se_factors[0].p1 > 0.99
+    assert se_factors[0].p2 == pytest.approx(0.5)
 
 
 def test_claim_metadata_prior_used_in_lowering():

--- a/tests/test_science_examples.py
+++ b/tests/test_science_examples.py
@@ -306,7 +306,10 @@ class TestNewtonCoarse:
         )
         beliefs, _ = exact_inference(fg)
         isq = beliefs[_qid("newton", "inverse_square_force")]
-        assert isq < 0.6, f"inverse_square should be lower with weak Kepler: {isq:.4f}"
+        # With proper CPTs (p2=0.5 MaxEnt default), the drop is less extreme
+        # than with constraint-based implication (fan-out penalty eliminated).
+        # Kepler=0.3 still pulls inverse_square below the high-confidence case (~0.85).
+        assert isq < 0.7, f"inverse_square should be lower with weak Kepler: {isq:.4f}"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Replace ternary IMPLICATION factors with binary SOFT_ENTAILMENT CPTs (p1_eff, p2=0.5) for support/deduction strategies in lowering.py
- Marginalize the implication helper claim into p1_eff = π(H)·(1-ε) + (1-π(H))·0.5, eliminating the fan-out penalty while preserving backward inference (Jaynes' weak syllogism)
- Remove `directed` field from Factor dataclass and `directed_implication_potential` from potentials.py — no longer needed with proper CPTs

## Test plan
- [x] All 1042 tests pass (11 skipped)
- [x] New tests verify: fan-out elimination, forward propagation, backward inference (weak syllogism), chain no-cascade
- [x] Science examples (Newton, Einstein, Mendel) updated for correct belief thresholds under proper CPTs
- [x] Ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)