### PR TITLE
fix(lang): enforce generative direction in induction()

### DIFF
--- a/gaia/ir/coarsen.py
+++ b/gaia/ir/coarsen.py
@@ -34,11 +34,32 @@ def coarsen_ir(ir: dict, exported_ids: set[str]) -> dict:
     leaf_ids: set[str] = set()
     for k in ir["knowledges"]:
         kid = k["id"]
-        label = k.get("label", "")
+        label = k.get("label") or ""
         if label.startswith("__") or label.startswith("_anon"):
             continue
         if kid not in all_concluded and k["type"] == "claim":
             leaf_ids.add(kid)
+
+    # Induction intentionally forms a fine-grained confirmation cycle:
+    # law -> observations via support, and observations -> law via the
+    # induction composite.  The observations are therefore concluded nodes,
+    # but they are still the coarse evidence interface for the law.  Seed them
+    # as surrogate leaves so coarse BFS exposes obs -> law instead of guessing
+    # a cycle-breaking leaf later.
+    helper_labels = {k["id"]: k.get("label") or "" for k in ir["knowledges"]}
+    for s in ir["strategies"]:
+        if s.get("type") != "induction":
+            continue
+        conc = s.get("conclusion")
+        if not conc:
+            continue
+        for premise in s.get("premises", []):
+            if premise == conc:
+                continue
+            label = helper_labels.get(premise, "")
+            if label.startswith("__") or label.startswith("_anon"):
+                continue
+            leaf_ids.add(premise)
 
     # 3. Build forward adjacency: for each node, which conclusions does it
     #    support (as a premise of a strategy or variable of an operator)?
@@ -115,7 +136,7 @@ def coarsen_ir(ir: dict, exported_ids: set[str]) -> dict:
 
         # For each orphaned export, reverse-BFS to find claims with no further
         # non-helper predecessors — these are "cycle-breaking" leaves.
-        kid_labels = {k["id"]: k.get("label", "") for k in ir["knowledges"]}
+        kid_labels = {k["id"]: k.get("label") or "" for k in ir["knowledges"]}
         kid_types = {k["id"]: k.get("type", "") for k in ir["knowledges"]}
         surrogate_leaves: set[str] = set()
 
@@ -191,6 +212,8 @@ def coarsen_ir(ir: dict, exported_ids: set[str]) -> dict:
     coarse_strategies = []
     by_conclusion: dict[str, list[str]] = {}
     for src, dst in unique_edges:
+        if src == dst:
+            continue
         by_conclusion.setdefault(dst, []).append(src)
 
     for conc, premises in by_conclusion.items():
@@ -383,6 +406,11 @@ def compute_coarse_cpts(
         coarse_premises = list(s["premises"])
         coarse_conclusion = s["conclusion"]
         free = [*coarse_premises, coarse_conclusion]
+        if len(free) != len(set(free)):
+            raise ValueError(
+                f"coarse strategy {i}: conclusion {coarse_conclusion!r} must not also "
+                "appear in premises"
+            )
         free_set = set(free)
 
         # Unary priors for every variable that:

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -89,6 +89,11 @@ def _is_local(k: Knowledge, pkg: CollectedPackage) -> bool:
     return k in pkg.knowledge
 
 
+def _is_composition_warrant(k: Knowledge) -> bool:
+    """Composition warrants are strategy metadata, not IR knowledge nodes."""
+    return k.metadata.get("helper_kind") == "composition_validity"
+
+
 def _knowledge_id(
     k: Knowledge,
     pkg: CollectedPackage,
@@ -302,6 +307,8 @@ def compile_package_artifact(
             register_strategy_knowledge(sub_strategy)
 
     for k in pkg.knowledge:
+        if _is_composition_warrant(k):
+            continue
         register_knowledge(k)
     for s in pkg.strategies:
         register_strategy_knowledge(s)

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -543,18 +543,26 @@ def induction(
     if support_2.type != "support":
         raise TypeError("induction() support_2 must be a support strategy")
 
-    # Validate law participation: each support must reference the law as
-    # either a premise (law predicts obs) or a conclusion (obs supports law).
+    # Validate law participation: each support must have law as a *premise*
+    # (generative direction: law predicts observation).  Putting law as the
+    # conclusion (obs → law) is the wrong direction for induction — the
+    # observation is the evidence, not the conclusion of the sub-strategy.
     # A chained induction must have law as its conclusion.
-    def _support_references_law(s: Strategy) -> bool:
-        return any(p is law for p in s.premises) or s.conclusion is law
+    def _support_has_law_as_premise(s: Strategy) -> bool:
+        return any(p is law for p in s.premises)
 
-    if support_1.type == "support" and not _support_references_law(support_1):
-        raise ValueError("induction() support_1 must reference the law as a premise or conclusion")
+    if support_1.type == "support" and not _support_has_law_as_premise(support_1):
+        raise ValueError(
+            "induction() support_1 must have the law as a premise "
+            "(generative direction: support([law, ...], obs))"
+        )
     if support_1.type == "induction" and support_1.conclusion is not law:
         raise ValueError("induction() support_1 (previous induction) must conclude the same law")
-    if not _support_references_law(support_2):
-        raise ValueError("induction() support_2 must reference the law as a premise or conclusion")
+    if not _support_has_law_as_premise(support_2):
+        raise ValueError(
+            "induction() support_2 must have the law as a premise "
+            "(generative direction: support([law, ...], obs))"
+        )
 
     # Auto-create composition warrant
     warrant_metadata: dict = {"helper_kind": "composition_validity", "generated": True}
@@ -566,8 +574,10 @@ def induction(
         metadata=warrant_metadata,
     )
 
-    # Collect all premises from sub-strategies, excluding the law itself
-    # (law is the conclusion; including it would create a self-loop)
+    # Collect all variables from sub-strategies (excluding law) as composite
+    # premises.  In the generative model (law → obs), observations are the
+    # sub-strategy *conclusions*, not premises.  We must gather both to
+    # correctly expose all evidence nodes at the composite level.
     all_premises: list[Knowledge] = []
     seen: set[int] = set()
     for s in [support_1, support_2]:
@@ -575,6 +585,10 @@ def induction(
             if id(p) not in seen and p is not law:
                 all_premises.append(p)
                 seen.add(id(p))
+        # Sub-strategy conclusions (observations in generative mode)
+        if s.conclusion is not None and s.conclusion is not law and id(s.conclusion) not in seen:
+            all_premises.append(s.conclusion)
+            seen.add(id(s.conclusion))
 
     strategy = Strategy(
         type="induction",

--- a/tests/cli/test_brief.py
+++ b/tests/cli/test_brief.py
@@ -61,9 +61,9 @@ def _write_induction_package(pkg_dir):
         'obs1 = claim("Sample 1 confirms law.")\n'
         'obs2 = claim("Sample 2 confirms law.")\n'
         'obs3 = claim("Sample 3 confirms law.")\n'
-        "s1 = support([obs1], law, reason='obs1 supports law', prior=0.9)\n"
-        "s2 = support([obs2], law, reason='obs2 supports law', prior=0.9)\n"
-        "s3 = support([obs3], law, reason='obs3 supports law', prior=0.85)\n"
+        "s1 = support([law], obs1, reason='law predicts obs1', prior=0.9)\n"
+        "s2 = support([law], obs2, reason='law predicts obs2', prior=0.9)\n"
+        "s3 = support([law], obs3, reason='law predicts obs3', prior=0.85)\n"
         "ind_12 = induction(s1, s2, law=law, reason='independent samples')\n"
         "ind_123 = induction(ind_12, s3, law=law, reason='third sample')\n"
     )

--- a/tests/gaia/lang/compiler/test_refs_integration.py
+++ b/tests/gaia/lang/compiler/test_refs_integration.py
@@ -130,8 +130,8 @@ def test_compile_scans_sub_strategy_reasons(tmp_path: Path) -> None:
             'obs2 = claim("Second observation.")\n'
             'law = claim("A general law.")\n'
             # Create sub-strategies manually to test recursion
-            "sub1 = support(premises=[obs1], conclusion=law)\n"
-            "sub2 = support(premises=[obs2], conclusion=law, reason='Justification [@missing_key]', prior=0.9)\n"
+            "sub1 = support(premises=[law], conclusion=obs1)\n"
+            "sub2 = support(premises=[law], conclusion=obs2, reason='Justification [@missing_key]', prior=0.9)\n"
             "induction(sub1, sub2, law)\n"
             '__all__ = ["law", "obs1", "obs2"]\n'
         ),

--- a/tests/gaia/lang/test_induction_v2.py
+++ b/tests/gaia/lang/test_induction_v2.py
@@ -134,19 +134,74 @@ def test_induction_requires_support_for_second_input():
         induction(previous, not_support, law)
 
 
-def test_induction_requires_sub_strategies_to_include_law():
-    """Reject supports that don't reference the law as premise or conclusion."""
+def test_induction_requires_law_as_premise_of_support():
+    """Reject supports that don't have the law as a premise (wrong direction)."""
     obs1 = claim("Obs 1.")
     obs2 = claim("Obs 2.")
     law = claim("Law.")
-    missing_law = support(premises=[obs1], conclusion=obs2)
+    # Mode B (wrong direction): obs → law
+    wrong_direction = support(premises=[obs1], conclusion=law)
     valid_support = support(premises=[law], conclusion=obs2)
 
-    with pytest.raises(ValueError, match="support_1 must reference the law"):
-        induction(missing_law, valid_support, law)
+    with pytest.raises(ValueError, match="support_1 must have the law as a premise"):
+        induction(wrong_direction, valid_support, law)
 
-    with pytest.raises(ValueError, match="support_2 must reference the law"):
-        induction(valid_support, missing_law, law)
+    with pytest.raises(ValueError, match="support_2 must have the law as a premise"):
+        induction(valid_support, wrong_direction, law)
+
+
+def test_induction_rejects_support_without_law():
+    """Reject supports that don't reference the law at all."""
+    obs1 = claim("Obs 1.")
+    obs2 = claim("Obs 2.")
+    law = claim("Law.")
+    no_law = support(premises=[obs1], conclusion=obs2)
+    valid_support = support(premises=[law], conclusion=obs2)
+
+    with pytest.raises(ValueError, match="support_1 must have the law as a premise"):
+        induction(no_law, valid_support, law)
+
+    with pytest.raises(ValueError, match="support_2 must have the law as a premise"):
+        induction(valid_support, no_law, law)
+
+
+def test_induction_premises_include_observations():
+    """Composite premises include observations (sub-strategy conclusions)."""
+    obs1 = claim("Obs 1.")
+    obs2 = claim("Obs 2.")
+    law = claim("Law.")
+
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
+
+    s = induction(sup1, sup2, law)
+
+    assert obs1 in s.premises
+    assert obs2 in s.premises
+    assert law not in s.premises
+    assert len(s.premises) == 2
+
+
+def test_induction_chained_premises_accumulate():
+    """Chained induction collects observations from all supports."""
+    obs1 = claim("Obs 1.")
+    obs2 = claim("Obs 2.")
+    obs3 = claim("Obs 3.")
+    law = claim("Law.")
+
+    sup1 = support(premises=[law], conclusion=obs1)
+    sup2 = support(premises=[law], conclusion=obs2)
+    sup3 = support(premises=[law], conclusion=obs3)
+
+    ind1 = induction(sup1, sup2, law)
+    ind2 = induction(ind1, sup3, law)
+
+    # ind2 should have all three observations as premises
+    assert obs1 in ind2.premises
+    assert obs2 in ind2.premises
+    assert obs3 in ind2.premises
+    assert law not in ind2.premises
+    assert len(ind2.premises) == 3
 
 
 def test_induction_premises_are_deduplicated():

--- a/tests/test_contraction.py
+++ b/tests/test_contraction.py
@@ -1038,7 +1038,7 @@ def test_coarsen_ir_induction_cycle_promotes_surrogate_leaves():
                 "reason": "",
             },
             {
-                "type": "infer",
+                "type": "induction",
                 "premises": ["ns::obs1", "ns::obs2"],
                 "conclusion": "ns::law",
                 "reason": "",
@@ -1055,15 +1055,61 @@ def test_coarsen_ir_induction_cycle_promotes_surrogate_leaves():
     coarse_ids = {k["id"] for k in coarse["knowledges"]}
     assert "ns::law" in coarse_ids
 
-    # At least one surrogate leaf should connect to law
+    # The surrogate leaves should be the observations, not law itself.
     assert len(coarse["strategies"]) >= 1
     for s in coarse["strategies"]:
         if s["conclusion"] == "ns::law":
             # Premises should be the cycle-broken observations
-            assert len(s["premises"]) > 0
+            assert set(s["premises"]) == {"ns::obs1", "ns::obs2"}
             break
     else:
         pytest.fail("No coarse strategy concluding to ns::law found")
+
+
+def test_compiled_induction_coarsens_to_observations_and_cpt():
+    """Compiled DSL induction should expose observations, not law -> law."""
+    from gaia.ir.coarsen import coarsen_ir, compute_coarse_cpts
+    from gaia.lang import claim, support
+    from gaia.lang.compiler.compile import compile_package_artifact
+    from gaia.lang.dsl.strategies import induction
+    from gaia.lang.runtime.package import CollectedPackage
+
+    pkg = CollectedPackage("induction_demo", namespace="github", version="1.0.0")
+    with pkg:
+        law = claim("Law.", prior=0.5)
+        law.label = "law"
+        obs1 = claim("Observation 1.", prior=0.9)
+        obs1.label = "obs1"
+        obs2 = claim("Observation 2.", prior=0.9)
+        obs2.label = "obs2"
+        sup1 = support([law], obs1, reason="law predicts obs1", prior=0.9)
+        sup2 = support([law], obs2, reason="law predicts obs2", prior=0.9)
+        induction(sup1, sup2, law=law, reason="independent observations")
+
+    compiled = compile_package_artifact(pkg)
+    ir = compiled.to_json()
+
+    assert all(
+        (k.get("metadata") or {}).get("helper_kind") != "composition_validity"
+        for k in ir["knowledges"]
+    )
+
+    law_id = "github:induction_demo::law"
+    obs_ids = {"github:induction_demo::obs1", "github:induction_demo::obs2"}
+    coarse = coarsen_ir(ir, {law_id})
+    law_strategies = [s for s in coarse["strategies"] if s["conclusion"] == law_id]
+
+    assert len(law_strategies) == 1
+    assert set(law_strategies[0]["premises"]) == obs_ids
+
+    node_priors = {
+        k["id"]: (k.get("metadata") or {}).get("prior", 0.5) for k in ir["knowledges"]
+    }
+    cpts = compute_coarse_cpts(ir, coarse, node_priors=node_priors)
+    strategy_index = coarse["strategies"].index(law_strategies[0])
+
+    assert len(cpts[strategy_index]) == 4
+    assert cpts[strategy_index][3] > cpts[strategy_index][0]
 
 
 def test_coarsen_ir_induction_to_downstream_export():
@@ -1085,7 +1131,7 @@ def test_coarsen_ir_induction_to_downstream_export():
             {"type": "support", "premises": ["ns::law"], "conclusion": "ns::obs1", "reason": ""},
             {"type": "support", "premises": ["ns::law"], "conclusion": "ns::obs2", "reason": ""},
             {
-                "type": "infer",
+                "type": "induction",
                 "premises": ["ns::obs1", "ns::obs2"],
                 "conclusion": "ns::law",
                 "reason": "",
@@ -1124,7 +1170,7 @@ def test_coarsen_ir_mixed_leaf_and_cycle():
             {"type": "support", "premises": ["ns::leaf"], "conclusion": "ns::core", "reason": ""},
             # Induction cycle: law ↔ obs
             {"type": "support", "premises": ["ns::law"], "conclusion": "ns::obs", "reason": ""},
-            {"type": "infer", "premises": ["ns::obs"], "conclusion": "ns::law", "reason": ""},
+            {"type": "induction", "premises": ["ns::obs"], "conclusion": "ns::law", "reason": ""},
             # law also feeds into derived (exported)
             {"type": "support", "premises": ["ns::law"], "conclusion": "ns::derived", "reason": ""},
         ],

--- a/tests/test_contraction.py
+++ b/tests/test_contraction.py
@@ -1102,9 +1102,7 @@ def test_compiled_induction_coarsens_to_observations_and_cpt():
     assert len(law_strategies) == 1
     assert set(law_strategies[0]["premises"]) == obs_ids
 
-    node_priors = {
-        k["id"]: (k.get("metadata") or {}).get("prior", 0.5) for k in ir["knowledges"]
-    }
+    node_priors = {k["id"]: (k.get("metadata") or {}).get("prior", 0.5) for k in ir["knowledges"]}
     cpts = compute_coarse_cpts(ir, coarse, node_priors=node_priors)
     strategy_index = coarse["strategies"].index(law_strategies[0])
 


### PR DESCRIPTION
## Summary

- **Enforce generative direction**: `induction()` now requires law to be a *premise* of each support sub-strategy (`support([law], obs)`), rejecting the reverse direction (`support([obs], law)`)
- **Fix premise collection**: Composite premises now include sub-strategy conclusions (observations), not just sub-strategy premises. Previously `composite.premises = []` in the correct generative mode because observations are sub-strategy conclusions, not premises
- **Update test fixtures**: Two test fixtures (`test_brief.py`, `test_refs_integration.py`) that used the wrong direction are corrected

## Context

In the generative model of induction: `law → obs1`, `law → obs2`. Observations with high priors send backward BP messages through SOFT_ENTAILMENT factors to boost the law's belief. The old code allowed the reverse direction and failed to collect observations into composite premises, breaking tensor contraction (obs treated as bridge variables) and forcing coarsening to use orphan recovery heuristics.

## Test plan

- [x] 15 induction unit tests pass (including 4 new tests for direction enforcement and premise collection)
- [x] Full test suite: 1048 passed, 11 skipped, 0 failures
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)