### PR TITLE
fix(compiler): formalize support/compare at compile time (v0.4.3)

### DIFF
--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -41,6 +41,8 @@ _COMPILE_TIME_FORMAL_STRATEGIES = frozenset(
         "abduction",
         "analogy",
         "extrapolation",
+        "support",
+        "compare",
     }
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaia-lang"
-version = "0.4.2"
+version = "0.4.3"
 description = "Gaia Lang — Python DSL for knowledge authoring, compilation, and inference"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Add `support` and `compare` to `_COMPILE_TIME_FORMAL_STRATEGIES` so they get formalized into `FormalStrategy` with proper operator expansions at compile time
- Without this, support/compare stayed as bare `Strategy` and were lowered as ternary IMPLICATION factors, blocking backward message propagation through helper claims
- Bumps version to 0.4.3

## Context

Discovered while investigating hypothesis differentiation failure in the luria-delbruck-fluctuation-gaia package. The abduction structure uses `support([H], obs)` with asymmetric priors (0.9 vs 0.1) to distinguish competing hypotheses. Without compile-time formalization, the ternary IMPLICATION helper claims absorbed the backward messages, causing both hypotheses to stay at ~0.33 regardless of evidence strength. With this fix, the lowering layer correctly converts to binary SOFT_ENTAILMENT CPTs, and hypothesis beliefs separate to 0.47 vs 0.28.

## Test plan

- [x] Full test suite: 826 passed, 0 failures
- [x] `ruff check` + `ruff format --check` clean
- [x] Verified on luria-delbruck package: hypothesis_mutation 0.33→0.47, hypothesis_acquired_immunity 0.34→0.28, resistance_is_heritable_mutation 0.78→0.94

🤖 Generated with [Claude Code](https://claude.com/claude-code)