### PR TITLE
docs: clarify v6 likelihood module contract

### DIFF
--- a/docs/specs/2026-04-20-gaia-ir-v6-strategy-warrant-redesign.md
+++ b/docs/specs/2026-04-20-gaia-ir-v6-strategy-warrant-redesign.md
@@ -176,7 +176,7 @@ This is important for generated helper claims and statistical score claims such 
 ```text
 Equivalent[A, B]
 Implies[G, C]
-LikelihoodScore[target=H, model=two_binomial, query=theta_B>theta_A, log_lr=1.73]
+LikelihoodScoreRecord[target=H, module_ref=gaia.std.likelihood.two_binomial_ab_test@v1, score_type=log_lr, value=1.73]
 ```
 
 ### Knowledge references in parameters
@@ -204,7 +204,8 @@ At IR level:
 Knowledge(
     knowledge_id="github:my_package::counts",
     type="claim",
-    content="[@github:my_package::exp] recorded 500/10000 control conversions.",
+    content_template="[@experiment] recorded {ctrl_k}/{ctrl_n} control conversions.",
+    rendered_content="[@github:my_package::exp] recorded 500/10000 control conversions.",  # derived/display only
     parameters=[
         Parameter(name="experiment", type="Setting", value="github:my_package::exp"),  # QID reference
         Parameter(name="ctrl_n", type="int", value=10000),
@@ -215,7 +216,17 @@ Knowledge(
 )
 ```
 
-The `[@...]` syntax in `content` is resolved at compile time to the referenced node's label or QID. This allows:
+The `[@...]` syntax in `content_template` is resolved at compile time for rendering, not for canonical identity. Canonical hashing should use:
+
+```text
+Knowledge.type
+content_template
+sorted Parameter(name, type, value)
+```
+
+`rendered_content` is derived presentation data and must not participate in the canonical hash. This keeps display labels, package names, and link rendering from changing Claim identity. It also avoids storing the same reference twice as both an embedded rendered QID and a `Parameter.value`.
+
+This allows:
 
 1. **Stable hashing**: Parameter values (including QID references) participate in content hash
 2. **Cross-package matching**: Two packages can reference the same Setting and match on it
@@ -391,6 +402,8 @@ class Strategy:
     conclusion: ClaimID | None = None
     background: list[KnowledgeID] | None = None
 
+    method: StrategyMethod | None = None  # v6: machine-readable lowering payload
+
     reason: str                         # v6: first-class, not metadata
     assertions: list[ClaimID] = []        # v6: generated helper claims to assert
 
@@ -401,6 +414,27 @@ class Strategy:
 `reason` is required for reviewable v6 Strategies.
 
 `assertions` is explicit. It replaces the implicit old assumption that a generated “warrant helper” and its prior determine support strength.
+
+`method` is a first-class, machine-readable payload. It must not be hidden in `metadata`, because review, hashing, validation, and BP lowering must all see the same object.
+
+```python
+StrategyMethod = (
+    DeductionMethod
+    | ModuleUseMethod
+    | ComputeMethod
+    | OpaqueConditionalMethod
+)
+
+class ModuleUseMethod:
+    module_ref: str
+    input_bindings: dict[str, KnowledgeID]
+    output_bindings: dict[str, ValueRef]
+    premise_bindings: dict[str, ClaimID] = {}
+
+ValueRef = KnowledgeID | ArtifactRef | ScoreID  # ScoreID references a LikelihoodScoreRecord
+```
+
+`method` must participate in both the Strategy structure hash and the Warrant `subject_hash`.
 
 ## 6.3 FormalStrategy remains useful
 
@@ -604,7 +638,8 @@ This should be allowed only for:
 Recommended lint:
 
 ```text
-Warn on author-facing deduction with empty premises unless marked as definition/axiom/internal.
+Strict mode: error on author-facing deduction with empty premises unless marked as definition/axiom/internal/reviewed_declaration.
+Draft mode: warn on author-facing deduction with empty premises unless marked as definition/axiom/internal/reviewed_declaration.
 ```
 
 ---
@@ -637,18 +672,47 @@ ImplementationCorrect(formula_name: str)
 
 Standard helpers like `ab_test(counts, target)` auto-generate these assumption Claims with default priors, so users don't manually declare them unless overriding.
 
-At IR level, these appear as ordinary `Knowledge(type="claim")` nodes with bound parameters. The IR doesn't distinguish "standard library Claims" from user Claims — they're all just parameterized Claims with priors.
-
-## 9.3 Schema extension
-
-A likelihood Strategy should have a method payload:
+Auto-generated assumption Claims must still be materialized in the graph and surfaced in review/rendering. They should carry provenance such as:
 
 ```python
-class LikelihoodMethod:
-    score: ClaimID | ArtifactRef
+metadata={
+    "generated_by": "gaia.std.likelihood.two_binomial_ab_test@v1",
+    "role": "standard_assumption",
+}
+```
+
+The helper may save authoring effort, but it must not hide priors or assumptions.
+
+At IR level, these appear as ordinary `Knowledge(type="claim")` nodes with bound parameters. The IR doesn't distinguish "standard library Claims" from user Claims — they're all just parameterized Claims with priors.
+
+## 9.3 Module-based schema extension
+
+At the Lang layer, users normally call standard helpers such as `ab_test(...)` or `binomial_test(...)`. At the IR layer, those helpers lower to a module use, not to free-form strings.
+
+A likelihood module defines the statistical model, required bindings, score shape, and BP effect:
+
+```python
+class LikelihoodModuleSpec:
+    module_ref: str
+    input_schema: dict[str, type]
+    output_schema: dict[str, type]
+    premise_schema: dict[str, type]
+
+    target_role: str
+    score_role: str
+    score_value_path: str = "value"
     score_type: Literal["log_lr", "bayes_factor", "likelihood_table", "custom"]
-    model: str | dict
-    query: str | dict
+    effect: Literal["add_log_odds", "multiply_odds", "likelihood_table_update"]
+```
+
+A likelihood Strategy instantiates such a module:
+
+```python
+class ModuleUseMethod:
+    module_ref: str
+    input_bindings: dict[str, KnowledgeID]
+    output_bindings: dict[str, ValueRef]
+    premise_bindings: dict[str, ClaimID] = {}
 ```
 
 Example:
@@ -668,23 +732,40 @@ Strategy(
         "Given valid experiment assumptions and a correctly computed likelihood "
         "score, the AB-test likelihood ratio updates belief in whether B improves conversion."
     ),
-    method=LikelihoodMethod(
-        score=ab_log_lr_score,
-        score_type="log_lr",
-        model="two_binomial",
-        query="theta_B > theta_A",
+    method=ModuleUseMethod(
+        module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+        input_bindings={
+            "counts": ab_counts_true,
+            "target": B_better,
+        },
+        output_bindings={
+            "score": ab_log_lr_score,
+        },
+        premise_bindings={
+            "data_observed": ab_counts_true,
+            "random_assignment": randomization_valid,
+            "consistent_logging": logging_valid,
+            "stopping_rule_accounted_for": stopping_rule_accounted_for,
+            "score_correct": ab_log_lr_score_correct,
+        },
     ),
     assertions=[],
 )
 ```
 
-## 9.3 Semantics
+The module spec, not the author, defines that this is a two-binomial AB-test likelihood, that the score is a log likelihood ratio, and that the BP effect is to add the score value to the target's log-odds.
+
+## 9.4 Semantics
 
 If the Strategy is included by review policy:
 
 ```text
-if all premises are true:
-    apply likelihood score to conclusion/target
+look up method.module_ref in the module registry
+validate input/output/premise bindings against the module spec
+extract the score from method.output_bindings[spec.score_role]
+
+if all Strategy.premises are true:
+    apply the module-defined effect to the target
 else:
     neutral
 ```
@@ -699,6 +780,15 @@ else:
 ```
 
 The Strategy itself has no probability. The score is model/data-derived evidence strength; the premises carry epistemic reliability.
+
+The score value and the score correctness Claim are distinct:
+
+```text
+ab_log_lr_score          = value record or artifact containing log_lr = 1.73
+ab_log_lr_score_correct  = Claim that the value was correctly computed/bound
+```
+
+The likelihood Strategy consumes both: the value through `method.output_bindings`, and the correctness gate through `premises`/`premise_bindings`.
 
 ---
 
@@ -721,7 +811,7 @@ Example use cases:
 class ComputeMethod:
     function_ref: str
     input_bindings: dict[str, ClaimID]
-    output: ClaimID | ArtifactRef
+    output: ValueRef
     output_binding: dict[str, str] | None = None
     code_hash: str | None = None
 ```
@@ -741,6 +831,16 @@ Strategy(
         output_binding={"log_lr": "return_value"},
     ),
 )
+```
+
+The `output` is the produced value or artifact. The `conclusion` is a Claim about the correctness of that produced value. They should not be the same object.
+
+```text
+output:
+  ab_log_lr_score, a value record containing log_lr = 1.73
+
+conclusion:
+  ab_log_lr_score_correct, a Claim that this value was correctly computed
 ```
 
 A compute Strategy can itself be reviewed. If computation validity is uncertain, add explicit premise Claims such as:
@@ -902,23 +1002,28 @@ If something is uncertain, it should become a premise Claim.
 
 ## 13.3 Likelihood scores
 
-Likelihood Strategy needs scores. These scores may live in:
+Likelihood Strategy needs score values. A score value is not itself a Strategy prior and should not be confused with the Claim that the score was correctly computed.
 
-1. a parameterized Claim, such as `LikelihoodScore(log_lr=1.73)`, or
-2. a parameterization record, such as `LikelihoodScoreRecord`.
+Scores may live in:
+
+1. a value record, such as `LikelihoodScoreRecord(value=1.73)`;
+2. an artifact referenced by `ArtifactRef`; or
+3. a future value-carrying Knowledge object, provided its truth/correctness gate is modeled separately.
 
 Recommended first-class parameterization:
 
 ```python
 class LikelihoodScoreRecord:
     score_id: str
-    strategy_id: StrategyID
+    module_ref: str
+    target: ClaimID
     score_type: Literal["log_lr", "bayes_factor", "likelihood_table", "custom"]
     value: JsonValue | ArtifactRef
+    query: str | dict | None = None
     rationale: str | None = None
 ```
 
-This is not a Strategy prior. It is model/data evidence strength.
+This is model/data evidence strength. It is consumed by a module-based likelihood Strategy. The uncertainty that this score was computed from the correct inputs, formula, code, or binding is represented by ordinary premise Claims such as `ab_log_lr_score_correct`.
 
 ---
 
@@ -973,10 +1078,20 @@ Implementation may use an epsilon relaxation for numerical stability, but this i
 For an included likelihood Strategy:
 
 ```text
+module_spec = registry[Strategy.method.module_ref]
+score = resolve(Strategy.method.output_bindings[module_spec.score_role])
+target = resolve(Strategy.method.input_bindings[module_spec.target_role])
+
 if premises all true:
-    apply likelihood score to target/conclusion
+    apply module_spec.effect(score, target)
 else:
     neutral
+```
+
+For `effect="add_log_odds"` and score type `log_lr`, this means:
+
+```text
+log_odds(target) += score.value
 ```
 
 BP can implement this as a gated likelihood factor or equivalent lowering. This is a backend detail and does not introduce `Factor` to Gaia IR.
@@ -1013,10 +1128,12 @@ Add:
 
 - `Knowledge(type="context")`
 - `Parameter.value`
+- `Strategy.method`
 - `Strategy.reason`
 - `Strategy.assertions`
 - `Strategy(type="likelihood")`
 - `Strategy(type="compute")`
+- `ModuleUseMethod` and module specs for standard likelihood updates
 - `ReviewManifest`
 - `Warrant`
 - likelihood score parameterization
@@ -1129,7 +1246,8 @@ ab_counts_true                    — ABCounts(experiment=exp, ctrl_n=10000, ctr
 randomization_valid               — RandomAssignment(experiment=exp)
 logging_valid                     — ConsistentLogging(experiment=exp)
 stopping_rule_accounted_for       — NoEarlyStopping(experiment=exp)
-ab_log_lr_score_correct           — LikelihoodScore(target=B_better, model="two_binomial", query="theta_B > theta_A", log_lr=1.73)
+ab_log_lr_score                   — LikelihoodScoreRecord(target=B_better, module_ref="gaia.std.likelihood.two_binomial_ab_test@v1", score_type="log_lr", value=1.73)
+ab_log_lr_score_correct           — Claim that ab_log_lr_score was correctly computed and bound
 formula_correct                   — FormulaCorrect(formula_name="two_binomial_log_lr")
 implementation_correct            — ImplementationCorrect(formula_name="two_binomial_log_lr")
 ```
@@ -1147,8 +1265,8 @@ Strategy(
     method=ComputeMethod(
         function_ref="two_binomial_log_lr",
         input_bindings={"counts": ab_counts_true},
-        output=ab_log_lr_score_correct,
-        output_binding={"log_lr": "return_value"},
+        output=ab_log_lr_score,
+        output_binding={"value": "return_value"},
     ),
 )
 ```
@@ -1167,11 +1285,22 @@ Strategy(
     ],
     conclusion=B_better,
     reason="Apply the computed AB likelihood score to B_better under valid experiment assumptions.",
-    method=LikelihoodMethod(
-        score=ab_log_lr_score,
-        score_type="log_lr",
-        model="two_binomial",
-        query="theta_B > theta_A",
+    method=ModuleUseMethod(
+        module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+        input_bindings={
+            "counts": ab_counts_true,
+            "target": B_better,
+        },
+        output_bindings={
+            "score": ab_log_lr_score,
+        },
+        premise_bindings={
+            "data_observed": ab_counts_true,
+            "random_assignment": randomization_valid,
+            "consistent_logging": logging_valid,
+            "stopping_rule_accounted_for": stopping_rule_accounted_for,
+            "score_correct": ab_log_lr_score_correct,
+        },
     ),
 )
 ```

--- a/docs/specs/2026-04-20-gaia-lang-v6-strategy-warrant-spec.md
+++ b/docs/specs/2026-04-20-gaia-lang-v6-strategy-warrant-spec.md
@@ -176,14 +176,16 @@ ab_counts = ABCounts(
         source_refs=[ctx],
     ),
 )
-# ab_counts.content = "[@exp_123] recorded 500/10000 control and 550/10000 treatment conversions."
+# ab_counts.content_template = "[@experiment] recorded {ctrl_k}/{ctrl_n} control and {treat_k}/{treat_n} treatment conversions."
+# ab_counts.rendered_content = "[@exp_123] recorded 500/10000 control and 550/10000 treatment conversions."
 ```
 
 Template rendering order:
 
-1. Compiler extracts `[@...]` references from docstring, resolves Knowledge-typed parameters to their labels/QIDs.
-2. Compiler applies `str.format()` for value-typed parameters.
-3. Final `content` contains resolved `[@label]` references and substituted values.
+1. Compiler stores the docstring as canonical `content_template`.
+2. Compiler records Knowledge-typed parameter references in `Parameter.value` as QIDs.
+3. Compiler applies `str.format()` and reference rendering only to produce derived `rendered_content`.
+4. `rendered_content` is display-only and does not participate in canonical hashing.
 
 Lowering:
 
@@ -191,6 +193,7 @@ Lowering:
 Knowledge(type="claim")
 Parameter.value stores bound values.
 Knowledge-typed parameters store the referenced node's QID.
+Stable hash uses type + content_template + sorted Parameter(name, type, value).
 ```
 
 The bound parameter values must be preserved in IR and included in stable hashes.
@@ -432,7 +435,7 @@ class ImplementationCorrect(Claim):
     formula_name: str
 ```
 
-### Standard data Claims
+### Standard data Claims and score values
 
 ```python
 class ABCounts(Claim):
@@ -443,17 +446,20 @@ class ABCounts(Claim):
     treat_n: int
     treat_k: int
 
-class LikelihoodScore(Claim):
-    “””Likelihood score for [@target] under {model} model: log_lr = {log_lr:.3f}.”””
+class LikelihoodScore:
+    “””Value object for a module-produced likelihood score.”””
     target: Claim
-    model: str
+    module_ref: str
+    score_type: str
     query: str
-    log_lr: float
+    value: float
 ```
+
+`LikelihoodScore` is not the same thing as the Claim that the score was correctly computed. The score is the value consumed by likelihood lowering; score correctness is an ordinary Claim used as a premise gate.
 
 ## 6.3 Standard likelihood helpers
 
-The standard library provides one-line helpers that automatically instantiate standard assumptions:
+The standard library provides one-line helpers that automatically instantiate standard assumptions. These Claims are generated for convenience, but they are still visible graph objects with priors, grounding/provenance, and review surface.
 
 ```python
 def ab_test(counts: ABCounts, target: Claim) -> Strategy:
@@ -481,14 +487,15 @@ def ab_test(counts: ABCounts, target: Claim) -> Strategy:
     impl = ImplementationCorrect(formula_name=”two_binomial_log_lr”, prior=0.97)
     
     # Compute score
-    score = compute(
+    score_result = compute(
         fn=two_binomial_log_lr,
-        inputs=[counts],
+        inputs={"counts": counts},
         output=LikelihoodScore(
             target=target,
-            model=”two_binomial”,
+            module_ref=”gaia.std.likelihood.two_binomial_ab_test@v1”,
+            score_type=”log_lr”,
             query=”theta_B > theta_A”,
-            log_lr=0.0,  # placeholder, computed by fn
+            value=0.0,  # placeholder, computed by fn
         ),
         assumptions=[formula, impl],
         reason=”Compute two-binomial log likelihood ratio.”,
@@ -499,8 +506,9 @@ def ab_test(counts: ABCounts, target: Claim) -> Strategy:
         target=target,
         data=[counts],
         assumptions=[rand, log, stop],
-        score=score,
-        model=”two_binomial”,
+        score=score_result.output,
+        score_correctness=score_result.correctness,
+        module_ref=”gaia.std.likelihood.two_binomial_ab_test@v1”,
         query=”theta_B > theta_A”,
         reason=”AB test likelihood under standard experiment assumptions.”,
     )
@@ -539,7 +547,8 @@ If a user needs non-standard priors or additional assumptions:
 # Override stopping rule prior
 stop_custom = NoEarlyStopping(experiment=exp, prior=0.60)
 
-# Manual likelihood_from with custom assumptions
+# Manual likelihood_from with custom assumptions.
+# `score_result` may come from compute(...) or a reviewed imported score.
 likelihood_from(
     target=b_better,
     data=[counts],
@@ -549,8 +558,9 @@ likelihood_from(
         stop_custom,  # custom prior
         novelty_effect_accounted,  # additional assumption
     ],
-    score=score,
-    model=”two_binomial”,
+    score=score_result.output,
+    score_correctness=score_result.correctness,
+    module_ref=”gaia.std.likelihood.two_binomial_ab_test@v1”,
     query=”theta_B > theta_A”,
     reason=”AB test with custom stopping rule confidence and novelty effect check.”,
 )
@@ -565,8 +575,9 @@ likelihood_from(
     target=claim,
     data=[data_claims],
     assumptions=[assumption_claims],
-    score=likelihood_score_claim,
-    model=”...”,
+    score=likelihood_score_value,
+    score_correctness=score_correctness_claim,
+    module_ref=”...”,
     query=”...”,
     reason=”...”,
 )
@@ -583,15 +594,16 @@ with premises:
 ```text
 data claims
 assumption claims
-score correctness claim
+score_correctness claim
 ```
 
 and method payload:
 
 ```text
-score
-score_type
-model
+module_ref
+input_bindings
+output_bindings
+premise_bindings
 query
 ```
 
@@ -622,16 +634,40 @@ and include it in assumptions.
 
 `compute(...)` is used when values or parameterized Claims are produced by deterministic code/formulas.
 
+It returns a structured result, not a bare Strategy and not just the output value:
+
+```python
+class ComputeResult(Generic[T]):
+    output: T
+    correctness: Claim
+    strategy: Strategy
+```
+
+This makes the three roles explicit:
+
+```text
+output:
+  the produced value or artifact
+
+correctness:
+  the Claim that the output was correctly computed and bound
+
+strategy:
+  the reviewable compute Strategy that produced/validates the output
+```
+
 Example:
 
 ```python
-score = compute(
+score_result = compute(
     fn=two_binomial_log_lr,
-    inputs=[counts],
+    inputs={"counts": counts},
     output=LikelihoodScore(
         target=b_better,
-        model="two_binomial",
+        module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+        score_type="log_lr",
         query="theta_B > theta_A",
+        value=0.0,
     ),
     assumptions=[
         FormulaCorrect(formula_name="two_binomial_log_lr", prior=0.98),
@@ -646,6 +682,8 @@ Lowering:
 ```text
 Strategy(type="compute")
 ```
+
+The lowered compute Strategy uses `score_result.output` as `method.output` and `score_result.correctness` as `conclusion`.
 
 ## 7.2 Computation uncertainty
 
@@ -907,10 +945,16 @@ binomial_model_valid = Claim(
 formula = FormulaCorrect(formula_name="binomial_log_lr", prior=0.98)
 impl = ImplementationCorrect(formula_name="binomial_log_lr", prior=0.97)
 
-score = compute(
+score_result = compute(
     fn=binomial_log_lr_for_p,
-    inputs=[mendel_counts],
-    output=LikelihoodScore(target=p_is_075, model="binomial", query="p=0.75"),
+    inputs={"counts": mendel_counts},
+    output=LikelihoodScore(
+        target=p_is_075,
+        module_ref="gaia.std.likelihood.binomial_test@v1",
+        score_type="log_lr",
+        query="p=0.75",
+        value=0.0,
+    ),
     assumptions=[formula, impl],
     reason="Compute the likelihood score of the observed counts under p=0.75.",
 )
@@ -919,8 +963,9 @@ likelihood_from(
     target=p_is_075,
     data=[mendel_counts],
     assumptions=[binomial_model_valid],
-    score=score,
-    model="binomial",
+    score=score_result.output,
+    score_correctness=score_result.correctness,
+    module_ref="gaia.std.likelihood.binomial_test@v1",
     query="p=0.75",
     reason="Given the binomial sampling model, the observed counts update belief in p=0.75.",
 )
@@ -964,10 +1009,16 @@ novelty = Claim("The novelty effect has been accounted for.", prior=0.75)
 formula = FormulaCorrect(formula_name="two_binomial_log_lr", prior=0.98)
 impl = ImplementationCorrect(formula_name="two_binomial_log_lr", prior=0.97)
 
-score = compute(
+score_result = compute(
     fn=two_binomial_log_lr,
-    inputs=[counts],
-    output=LikelihoodScore(target=b_better, model="two_binomial", query="theta_B > theta_A"),
+    inputs={"counts": counts},
+    output=LikelihoodScore(
+        target=b_better,
+        module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+        score_type="log_lr",
+        query="theta_B > theta_A",
+        value=0.0,
+    ),
     assumptions=[formula, impl],
     reason="Compute the two-binomial log likelihood ratio.",
 )
@@ -976,8 +1027,9 @@ likelihood_from(
     target=b_better,
     data=[counts],
     assumptions=[rand, log, stop, novelty],
-    score=score,
-    model="two_binomial",
+    score=score_result.output,
+    score_correctness=score_result.correctness,
+    module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
     query="theta_B > theta_A",
     reason="AB test with custom stopping rule confidence and novelty effect check.",
 )
@@ -990,7 +1042,7 @@ likelihood_from(
 Recommended v6 lint rules:
 
 1. `supported_by(...)` must not have `prior`.
-2. `supported_by(...)` with empty inputs should warn unless marked as definition/axiom/internal.
+2. In strict mode, `supported_by(...)` with empty inputs should error unless marked as definition/axiom/internal/reviewed_declaration.
 3. Root Claims with non-default prior should have grounding.
 4. Statistical comparisons should prefer `likelihood_from(...)` over `supported_by(...)`.
 5. Opaque conditional strategies should warn.


### PR DESCRIPTION
## Summary
- replace free-form LikelihoodMethod examples with module-based ModuleUseMethod and LikelihoodModuleSpec
- split score value, score correctness Claim, and compute Strategy/ComputeResult semantics
- clarify canonical content_template/rendered_content separation for Knowledge references
- tighten empty-premise linting and make auto-generated statistical assumptions visible

## Validation
- git diff --check