### PR TITLE
feat(ir): add v6 strategy method scaffold

### DIFF
--- a/gaia/ir/__init__.py
+++ b/gaia/ir/__init__.py
@@ -18,12 +18,19 @@ from gaia.ir.knowledge import (
 from gaia.ir.operator import Operator, OperatorType
 from gaia.ir.strategy import (
     CompositeStrategy,
+    ComputeMethod,
+    DeductionMethod,
     FormalExpr,
     FormalStrategy,
+    LikelihoodModuleSpec,
+    LikelihoodScoreRecord,
+    ModuleUseMethod,
+    OpaqueConditionalMethod,
     Step,
     Strategy,
     StrategyType,
 )
+from gaia.ir.review import ReviewManifest, ReviewNote, Warrant, WarrantStatus
 from gaia.ir.graphs import LocalCanonicalGraph
 from gaia.ir.formalize import FormalizationResult, formalize_named_strategy
 from gaia.ir.parameterization import (
@@ -46,11 +53,22 @@ __all__ = [
     "OperatorType",
     # Strategy
     "CompositeStrategy",
+    "ComputeMethod",
+    "DeductionMethod",
     "FormalExpr",
     "FormalStrategy",
+    "LikelihoodModuleSpec",
+    "LikelihoodScoreRecord",
+    "ModuleUseMethod",
+    "OpaqueConditionalMethod",
     "Step",
     "Strategy",
     "StrategyType",
+    # Review
+    "ReviewManifest",
+    "ReviewNote",
+    "Warrant",
+    "WarrantStatus",
     # Graphs
     "LocalCanonicalGraph",
     # Formalization

--- a/gaia/ir/graphs.py
+++ b/gaia/ir/graphs.py
@@ -25,6 +25,11 @@ def _canonicalize_knowledge_dump(data: dict[str, Any]) -> dict[str, Any]:
     canonical["parameters"] = sorted(canonical.get("parameters", []), key=_json_sort_key)
     if canonical.get("provenance") is not None:
         canonical["provenance"] = sorted(canonical["provenance"], key=_json_sort_key)
+    if canonical.get("content_template") is not None:
+        # v6 treats rendered content as presentation. When a canonical template
+        # is present, legacy/rendered content must not affect graph identity.
+        canonical.pop("content", None)
+    canonical.pop("rendered_content", None)
     # Exclude narrative/presentational fields from content hash
     canonical.pop("title", None)
     canonical.pop("module", None)
@@ -49,6 +54,8 @@ def _canonicalize_strategy_dump(data: dict[str, Any]) -> dict[str, Any]:
     canonical["premises"] = sorted(canonical.get("premises", []))
     if canonical.get("background") is not None:
         canonical["background"] = sorted(canonical["background"])
+    if canonical.get("assertions") is not None:
+        canonical["assertions"] = sorted(canonical["assertions"])
     if canonical.get("sub_strategies") is not None:
         # sub_strategies are now string IDs, not embedded dicts
         canonical["sub_strategies"] = sorted(canonical["sub_strategies"])

--- a/gaia/ir/knowledge.py
+++ b/gaia/ir/knowledge.py
@@ -6,6 +6,7 @@ Implements docs/foundations/gaia-ir/gaia-ir.md §1.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from enum import StrEnum
 from typing import Any
@@ -31,6 +32,7 @@ class KnowledgeType(StrEnum):
     CLAIM = "claim"
     SETTING = "setting"
     QUESTION = "question"
+    CONTEXT = "context"
 
 
 class Parameter(BaseModel):
@@ -38,6 +40,7 @@ class Parameter(BaseModel):
 
     name: str
     type: str
+    value: Any | None = None
 
 
 class PackageRef(BaseModel):
@@ -51,14 +54,32 @@ def _sha256_hex(data: str, length: int = 16) -> str:
     return hashlib.sha256(data.encode()).hexdigest()[:length]
 
 
+def _canonical_param_dump(parameter: Parameter) -> dict[str, Any]:
+    return parameter.model_dump(mode="json", exclude_none=False)
+
+
 def _compute_content_hash(type_: str, content: str, parameters: list[Parameter]) -> str:
     """Content fingerprint: SHA-256(type + content + sorted(parameters)), no package_id.
 
     Same content in different packages produces the same content_hash.
     Used for canonicalization fast-path (exact match) and curation dedup.
     """
-    sorted_params = sorted((p.name, p.type) for p in parameters)
-    payload = f"{type_}|{content}|{sorted_params}"
+    if all(p.value is None for p in parameters):
+        # Preserve legacy hashes for unbound parameter declarations.
+        sorted_params = sorted((p.name, p.type) for p in parameters)
+        payload = f"{type_}|{content}|{sorted_params}"
+        return _sha256_hex(payload, length=64)
+
+    sorted_params = sorted(
+        [_canonical_param_dump(p) for p in parameters],
+        key=lambda p: json.dumps(p, sort_keys=True, ensure_ascii=False),
+    )
+    payload = json.dumps(
+        {"type": str(type_), "content": content, "parameters": sorted_params},
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
     return _sha256_hex(payload, length=64)
 
 
@@ -73,6 +94,8 @@ class Knowledge(BaseModel):
     title: str | None = None
     type: KnowledgeType
     content: str | None = None
+    content_template: str | None = None
+    rendered_content: str | None = None
     content_hash: str | None = None
     parameters: list[Parameter] = []
     metadata: dict[str, Any] | None = None
@@ -92,9 +115,13 @@ class Knowledge(BaseModel):
             raise ValueError("Knowledge requires at least one of `id` or `label`.")
 
         # Content_hash is a derived fingerprint and must stay consistent
-        # with the node's actual content.
-        if self.content is not None:
-            expected_content_hash = _compute_content_hash(self.type, self.content, self.parameters)
+        # with the node's canonical content. v6 parameterized claims use
+        # content_template for identity and rendered_content for display.
+        canonical_content = self.content_template if self.content_template is not None else self.content
+        if canonical_content is not None:
+            expected_content_hash = _compute_content_hash(
+                self.type, canonical_content, self.parameters
+            )
             if self.content_hash is not None and self.content_hash != expected_content_hash:
                 raise ValueError("content_hash must match the derived content fingerprint")
             self.content_hash = expected_content_hash

--- a/gaia/ir/review.py
+++ b/gaia/ir/review.py
@@ -1,0 +1,63 @@
+"""v6 review manifest models.
+
+These models are IR-adjacent review state. They do not enter BP and do not
+carry epistemic probability.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, model_validator
+
+
+class WarrantStatus(StrEnum):
+    """Review status for a v6 Strategy warrant."""
+
+    UNREVIEWED = "unreviewed"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    NEEDS_INPUTS = "needs_inputs"
+    SUPERSEDED = "superseded"
+
+
+class ReviewNote(BaseModel):
+    """Human or agent note attached to a Warrant."""
+
+    author: str | None = None
+    note: str
+    metadata: dict[str, Any] | None = None
+
+
+class Warrant(BaseModel):
+    """Review block attached to a Strategy.
+
+    A Warrant controls whether a Strategy is included by review policy. It is
+    not Knowledge, not a Claim, and not a probability parameter.
+    """
+
+    id: str
+    subject_strategy_id: str
+    subject_hash: str
+    status: WarrantStatus
+    blocking: bool = True
+    review_question: str | None = None
+    required_inputs: list[str] = []
+    reviewer_notes: list[ReviewNote] = []
+    resolution: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_status_payload(self) -> Warrant:
+        if self.status == WarrantStatus.NEEDS_INPUTS and not self.required_inputs:
+            raise ValueError("needs_inputs warrant must list required_inputs")
+        if self.status in {WarrantStatus.REJECTED, WarrantStatus.SUPERSEDED} and not self.resolution:
+            raise ValueError(f"{self.status.value} warrant should include resolution")
+        return self
+
+
+class ReviewManifest(BaseModel):
+    """Package-level v6 review layer."""
+
+    warrants: list[Warrant] = []
+

--- a/gaia/ir/strategy.py
+++ b/gaia/ir/strategy.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import hashlib
 import json
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from gaia.ir.operator import Operator, OperatorType
 
@@ -46,6 +46,11 @@ class StrategyType(StrEnum):
     # Composite strategies — non-atomic
     INDUCTION = "induction"  # CompositeStrategy wrapping shared-conclusion abductions
 
+    # v6 Strategy methods — carriers only in the first implementation phase.
+    LIKELIHOOD = "likelihood"
+    COMPUTE = "compute"
+    OPAQUE_CONDITIONAL = "opaque_conditional"
+
 
 class Step(BaseModel):
     """A single reasoning step (local layer only)."""
@@ -63,6 +68,73 @@ class FormalExpr(BaseModel):
     """
 
     operators: list[Operator]
+
+
+class DeductionMethod(BaseModel):
+    """v6 deduction method marker."""
+
+    kind: Literal["deduction"] = "deduction"
+
+
+class ModuleUseMethod(BaseModel):
+    """v6 module instantiation payload, used by likelihood strategies."""
+
+    kind: Literal["module_use"] = "module_use"
+    module_ref: str
+    input_bindings: dict[str, str]
+    output_bindings: dict[str, str]
+    premise_bindings: dict[str, str] = {}
+
+
+class ComputeMethod(BaseModel):
+    """v6 deterministic computation payload."""
+
+    kind: Literal["compute"] = "compute"
+    function_ref: str
+    input_bindings: dict[str, str]
+    output: str
+    output_binding: dict[str, str] | None = None
+    code_hash: str | None = None
+
+
+class OpaqueConditionalMethod(BaseModel):
+    """Legacy escape hatch for opaque conditional probability tables."""
+
+    kind: Literal["opaque_conditional"] = "opaque_conditional"
+    parameter_ref: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+StrategyMethod = Annotated[
+    DeductionMethod | ModuleUseMethod | ComputeMethod | OpaqueConditionalMethod,
+    Field(discriminator="kind"),
+]
+
+
+class LikelihoodModuleSpec(BaseModel):
+    """Machine-readable specification for a standard likelihood module."""
+
+    module_ref: str
+    input_schema: dict[str, str]
+    output_schema: dict[str, str]
+    premise_schema: dict[str, str]
+    target_role: str
+    score_role: str
+    score_value_path: str = "value"
+    score_type: Literal["log_lr", "bayes_factor", "likelihood_table", "custom"]
+    effect: Literal["add_log_odds", "multiply_odds", "likelihood_table_update"]
+
+
+class LikelihoodScoreRecord(BaseModel):
+    """Model/data-derived likelihood strength consumed by a likelihood Strategy."""
+
+    score_id: str
+    module_ref: str
+    target: str
+    score_type: Literal["log_lr", "bayes_factor", "likelihood_table", "custom"]
+    value: Any
+    query: str | dict[str, Any] | None = None
+    rationale: str | None = None
 
 
 def _sha256_hex(data: str, length: int = 16) -> str:
@@ -130,6 +202,33 @@ def _canonical_formal_expr(formal_expr: FormalExpr) -> str:
     return json.dumps(ops, sort_keys=True, separators=(",", ":"))
 
 
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def _v6_strategy_payload_hash(
+    method: StrategyMethod | None,
+    assertions: list[str],
+) -> str:
+    payload: dict[str, Any] = {}
+    if method is not None:
+        payload["method"] = method.model_dump(mode="json", exclude_none=True)
+    if assertions:
+        payload["assertions"] = sorted(assertions)
+    if not payload:
+        return ""
+    return _sha256_hex(_canonical_json(payload))
+
+
+def _combine_structure_hashes(*parts: str) -> str:
+    non_empty = [p for p in parts if p]
+    if not non_empty:
+        return ""
+    if len(non_empty) == 1:
+        return non_empty[0]
+    return _sha256_hex(_canonical_json(non_empty))
+
+
 class Strategy(BaseModel):
     """Base strategy — leaf reasoning (single ↝).
 
@@ -144,6 +243,9 @@ class Strategy(BaseModel):
     premises: list[str]  # claim Knowledge IDs
     conclusion: str | None = None  # single output Knowledge (must be claim)
     background: list[str] | None = None  # context Knowledge IDs (any type, not in BP)
+    method: StrategyMethod | None = None
+    reason: str | None = None
+    assertions: list[str] = []
 
     # local layer
     steps: list[Step] | None = None  # reasoning process (local only, None at global)
@@ -154,9 +256,9 @@ class Strategy(BaseModel):
     def _structure_hash(self) -> str:
         """Compute the structure hash component for strategy ID.
 
-        Leaf strategies have empty structure hash.
+        Leaf strategies have empty structure hash unless they use v6 method or assertions.
         """
-        return ""
+        return _v6_strategy_payload_hash(self.method, self.assertions)
 
     def formalize(
         self, *, namespace: str | None = None, package_name: str | None = None
@@ -222,7 +324,10 @@ class CompositeStrategy(Strategy):
     def _structure_hash(self) -> str:
         """SHA-256 of sorted sub_strategy IDs."""
         payload = str(sorted(self.sub_strategies))
-        return _sha256_hex(payload)
+        return _combine_structure_hashes(
+            _sha256_hex(payload),
+            _v6_strategy_payload_hash(self.method, self.assertions),
+        )
 
     @model_validator(mode="after")
     def _validate_sub_strategies(self) -> CompositeStrategy:
@@ -243,7 +348,10 @@ class FormalStrategy(Strategy):
 
     def _structure_hash(self) -> str:
         """SHA-256 of canonical formal expression."""
-        return _sha256_hex(_canonical_formal_expr(self.formal_expr))
+        return _combine_structure_hashes(
+            _sha256_hex(_canonical_formal_expr(self.formal_expr)),
+            _v6_strategy_payload_hash(self.method, self.assertions),
+        )
 
     @model_validator(mode="after")
     def _validate_formal_expr(self) -> FormalStrategy:

--- a/gaia/ir/validator.py
+++ b/gaia/ir/validator.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from gaia.ir.knowledge import Knowledge, KnowledgeType, is_qid
 from gaia.ir.operator import Operator, OperatorType
 from gaia.ir.strategy import Strategy, CompositeStrategy, FormalStrategy, StrategyType
+from gaia.ir.strategy import ComputeMethod, ModuleUseMethod
 from gaia.ir.graphs import LocalCanonicalGraph, _canonical_json
 from gaia.ir.parameterization import (
     CROMWELL_EPS,
@@ -117,7 +118,7 @@ def _validate_knowledges(
 
         # local-layer shape rules
         if scope == "local":
-            if k.content is None:
+            if k.content is None and k.content_template is None:
                 result.error(f"Knowledge '{k.id}': local layer requires content")
 
     # label uniqueness check for local scope
@@ -239,6 +240,18 @@ def _validate_strategy(
             if bid not in knowledge_lookup:
                 result.warn(f"Strategy '{sid}': background '{bid}' not found in graph")
 
+    # v6 assertion helpers are claim nodes licensed by review policy.
+    for aid in strategy.assertions:
+        if aid not in knowledge_lookup:
+            result.error(f"Strategy '{sid}': assertion '{aid}' not found in graph")
+        elif knowledge_lookup[aid].type != KnowledgeType.CLAIM:
+            result.error(
+                f"Strategy '{sid}': assertion '{aid}' is "
+                f"'{knowledge_lookup[aid].type}', must be claim"
+            )
+
+    _validate_strategy_method(strategy, knowledge_lookup, result)
+
     # scope/prefix checks
     if strategy.scope != scope:
         result.error(f"Strategy '{sid}': scope '{strategy.scope}' incompatible with {scope} graph")
@@ -258,6 +271,60 @@ def _validate_strategy(
             top_level=False,
         )
         _validate_formal_expr_closure(strategy, knowledge_lookup, result)
+
+
+def _validate_strategy_method(
+    strategy: Strategy,
+    knowledge_lookup: dict[str, Knowledge],
+    result: ValidationResult,
+) -> None:
+    """Validate v6 Strategy.method bindings without changing BP behavior."""
+    sid = strategy.strategy_id or "<no-id>"
+    method = strategy.method
+    if method is None:
+        return
+
+    if strategy.type == StrategyType.LIKELIHOOD and not isinstance(method, ModuleUseMethod):
+        result.error(f"Strategy '{sid}': likelihood strategy requires ModuleUseMethod")
+    if strategy.type == StrategyType.COMPUTE and not isinstance(method, ComputeMethod):
+        result.error(f"Strategy '{sid}': compute strategy requires ComputeMethod")
+
+    if isinstance(method, ModuleUseMethod):
+        for role, kid in method.input_bindings.items():
+            if kid not in knowledge_lookup:
+                result.error(
+                    f"Strategy '{sid}': method input binding '{role}' references '{kid}', "
+                    "not found in graph"
+                )
+        for role, pid in method.premise_bindings.items():
+            if pid not in knowledge_lookup:
+                result.error(
+                    f"Strategy '{sid}': method premise binding '{role}' references '{pid}', "
+                    "not found in graph"
+                )
+            elif knowledge_lookup[pid].type != KnowledgeType.CLAIM:
+                result.error(
+                    f"Strategy '{sid}': method premise binding '{role}' references "
+                    f"'{knowledge_lookup[pid].type}', must be claim"
+                )
+            if pid not in strategy.premises:
+                result.error(
+                    f"Strategy '{sid}': method premise binding '{role}' must also appear "
+                    "in Strategy.premises"
+                )
+
+    if isinstance(method, ComputeMethod):
+        for role, kid in method.input_bindings.items():
+            if kid not in knowledge_lookup:
+                result.error(
+                    f"Strategy '{sid}': compute input binding '{role}' references '{kid}', "
+                    "not found in graph"
+                )
+            elif knowledge_lookup[kid].type != KnowledgeType.CLAIM:
+                result.error(
+                    f"Strategy '{sid}': compute input binding '{role}' references "
+                    f"'{knowledge_lookup[kid].type}', must be claim"
+                )
 
 
 def _validate_composite_sub_strategies(
@@ -499,6 +566,22 @@ def _validate_scope_consistency(
             _check_id_format(
                 s.conclusion, f"Strategy '{s.strategy_id}': conclusion '{s.conclusion}'"
             )
+        for aid in s.assertions:
+            _check_id_format(aid, f"Strategy '{s.strategy_id}': assertion '{aid}'")
+        if isinstance(s.method, ModuleUseMethod):
+            for role, kid in s.method.input_bindings.items():
+                _check_id_format(
+                    kid, f"Strategy '{s.strategy_id}': method input binding '{role}'"
+                )
+            for role, pid in s.method.premise_bindings.items():
+                _check_id_format(
+                    pid, f"Strategy '{s.strategy_id}': method premise binding '{role}'"
+                )
+        if isinstance(s.method, ComputeMethod):
+            for role, kid in s.method.input_bindings.items():
+                _check_id_format(
+                    kid, f"Strategy '{s.strategy_id}': compute input binding '{role}'"
+                )
 
     def _check_operator_ids(op: Operator, context: str) -> None:
         for var_id in op.variables:

--- a/tests/ir/test_graphs.py
+++ b/tests/ir/test_graphs.py
@@ -3,6 +3,7 @@
 from gaia.ir import (
     Knowledge,
     Operator,
+    Parameter,
     Strategy,
     LocalCanonicalGraph,
 )
@@ -92,6 +93,31 @@ class TestLocalCanonicalGraph:
         )
         assert g.knowledges[0].id == "github:test::alpha"
         assert g.knowledges[1].id == "github:test::beta"
+
+    def test_rendered_content_excluded_from_graph_hash_when_template_exists(self):
+        def make(rendered: str) -> LocalCanonicalGraph:
+            return _local_graph(
+                knowledges=[
+                    Knowledge(
+                        id="github:test::counts",
+                        type="claim",
+                        content_template="[@experiment] recorded {count} conversions.",
+                        rendered_content=rendered,
+                        parameters=[
+                            Parameter(
+                                name="experiment",
+                                type="Setting",
+                                value="github:test::experiment",
+                            ),
+                            Parameter(name="count", type="int", value=10),
+                        ],
+                    )
+                ]
+            )
+
+        assert make("Experiment A recorded 10 conversions.").ir_hash == make(
+            "Rendered with a different label."
+        ).ir_hash
 
     def test_local_graph_preserves_explicit_id(self):
         """Knowledge with explicit id is not overwritten by auto-assign."""

--- a/tests/ir/test_knowledge.py
+++ b/tests/ir/test_knowledge.py
@@ -43,8 +43,8 @@ class TestIsQid:
 
 
 class TestKnowledgeType:
-    def test_three_types(self):
-        assert set(KnowledgeType) == {"claim", "setting", "question"}
+    def test_four_types(self):
+        assert set(KnowledgeType) == {"claim", "setting", "question", "context"}
 
     def test_no_template(self):
         with pytest.raises(ValueError):
@@ -128,6 +128,59 @@ class TestKnowledgeParameters:
             parameters=[Parameter(name="x", type="T")],
         )
         assert k1.content_hash != k2.content_hash
+
+    def test_unbound_param_value_preserves_hash(self):
+        k1 = Knowledge(
+            id="github:pkg::a",
+            type="claim",
+            content="P({x})",
+            parameters=[Parameter(name="x", type="T")],
+        )
+        k2 = Knowledge(
+            id="github:pkg::b",
+            type="claim",
+            content="P({x})",
+            parameters=[Parameter(name="x", type="T", value=None)],
+        )
+        assert k1.content_hash == k2.content_hash
+
+    def test_param_values_affect_content_hash(self):
+        k1 = Knowledge(
+            id="github:pkg::a",
+            type="claim",
+            content_template="P({x})",
+            parameters=[Parameter(name="x", type="int", value=1)],
+        )
+        k2 = Knowledge(
+            id="github:pkg::b",
+            type="claim",
+            content_template="P({x})",
+            parameters=[Parameter(name="x", type="int", value=2)],
+        )
+        assert k1.content_hash != k2.content_hash
+
+    def test_rendered_content_does_not_affect_content_hash(self):
+        k1 = Knowledge(
+            id="github:pkg::a",
+            type="claim",
+            content_template="[@experiment] recorded {count} conversions.",
+            rendered_content="Experiment A recorded 10 conversions.",
+            parameters=[
+                Parameter(name="experiment", type="Setting", value="github:pkg::exp"),
+                Parameter(name="count", type="int", value=10),
+            ],
+        )
+        k2 = Knowledge(
+            id="github:pkg::b",
+            type="claim",
+            content_template="[@experiment] recorded {count} conversions.",
+            rendered_content="Rendered differently.",
+            parameters=[
+                Parameter(name="experiment", type="Setting", value="github:pkg::exp"),
+                Parameter(name="count", type="int", value=10),
+            ],
+        )
+        assert k1.content_hash == k2.content_hash
 
 
 class TestKnowledgeLocalGlobal:

--- a/tests/ir/test_review_manifest.py
+++ b/tests/ir/test_review_manifest.py
@@ -1,0 +1,45 @@
+"""Tests for v6 ReviewManifest/Warrant models."""
+
+import pytest
+
+from gaia.ir import ReviewManifest, ReviewNote, Warrant, WarrantStatus
+
+
+def test_review_manifest_round_trip():
+    manifest = ReviewManifest(
+        warrants=[
+            Warrant(
+                id="warrant_1",
+                subject_strategy_id="lcs_abc",
+                subject_hash="sha256:abc",
+                status="accepted",
+                review_question="Is this likelihood use acceptable?",
+                reviewer_notes=[ReviewNote(author="reviewer", note="Looks good.")],
+            )
+        ]
+    )
+
+    loaded = ReviewManifest.model_validate(manifest.model_dump(mode="json"))
+    assert loaded.warrants[0].status == WarrantStatus.ACCEPTED
+    assert loaded.warrants[0].reviewer_notes[0].note == "Looks good."
+
+
+def test_needs_inputs_requires_required_inputs():
+    with pytest.raises(ValueError, match="required_inputs"):
+        Warrant(
+            id="warrant_1",
+            subject_strategy_id="lcs_abc",
+            subject_hash="sha256:abc",
+            status="needs_inputs",
+        )
+
+
+def test_rejected_requires_resolution():
+    with pytest.raises(ValueError, match="resolution"):
+        Warrant(
+            id="warrant_1",
+            subject_strategy_id="lcs_abc",
+            subject_hash="sha256:abc",
+            status="rejected",
+        )
+

--- a/tests/ir/test_strategy.py
+++ b/tests/ir/test_strategy.py
@@ -4,8 +4,13 @@ import pytest
 from gaia.ir import (
     Strategy,
     CompositeStrategy,
+    ComputeMethod,
     FormalStrategy,
     FormalExpr,
+    LikelihoodModuleSpec,
+    LikelihoodScoreRecord,
+    ModuleUseMethod,
+    OpaqueConditionalMethod,
     StrategyType,
     Step,
     Operator,
@@ -13,8 +18,8 @@ from gaia.ir import (
 
 
 class TestStrategyType:
-    def test_thirteen_types(self):
-        assert len(StrategyType) == 13
+    def test_v6_compatible_types(self):
+        assert len(StrategyType) == 16
         expected = {
             "infer",
             "noisy_and",
@@ -29,6 +34,9 @@ class TestStrategyType:
             "induction",
             "support",
             "compare",
+            "likelihood",
+            "compute",
+            "opaque_conditional",
         }
         assert set(StrategyType) == expected
 
@@ -126,6 +134,115 @@ class TestStrategyCreation:
         """Leaf strategies have empty structure hash."""
         s = Strategy(scope="local", type="infer", premises=["a"], conclusion="b")
         assert s._structure_hash() == ""
+
+    def test_likelihood_method_affects_strategy_id(self):
+        s1 = Strategy(
+            scope="local",
+            type="likelihood",
+            premises=["github:test::counts", "github:test::score_correct"],
+            conclusion="github:test::target",
+            method=ModuleUseMethod(
+                module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+                input_bindings={
+                    "counts": "github:test::counts",
+                    "target": "github:test::target",
+                },
+                output_bindings={"score": "score:ab"},
+                premise_bindings={
+                    "data_observed": "github:test::counts",
+                    "score_correct": "github:test::score_correct",
+                },
+            ),
+            reason="Apply AB-test likelihood.",
+        )
+        s2 = Strategy(
+            scope="local",
+            type="likelihood",
+            premises=["github:test::counts", "github:test::score_correct"],
+            conclusion="github:test::target",
+            method=ModuleUseMethod(
+                module_ref="gaia.std.likelihood.binomial_test@v1",
+                input_bindings={
+                    "counts": "github:test::counts",
+                    "target": "github:test::target",
+                },
+                output_bindings={"score": "score:ab"},
+                premise_bindings={
+                    "data_observed": "github:test::counts",
+                    "score_correct": "github:test::score_correct",
+                },
+            ),
+            reason="Apply binomial likelihood.",
+        )
+        assert s1.strategy_id != s2.strategy_id
+
+    def test_assertions_affect_strategy_id(self):
+        s1 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=["github:test::a"],
+            conclusion="github:test::b",
+            assertions=["github:test::assertion_1"],
+        )
+        s2 = Strategy(
+            scope="local",
+            type="deduction",
+            premises=["github:test::a"],
+            conclusion="github:test::b",
+            assertions=["github:test::assertion_2"],
+        )
+        assert s1.strategy_id != s2.strategy_id
+
+    def test_compute_and_opaque_methods_round_trip(self):
+        compute = ComputeMethod(
+            function_ref="two_binomial_log_lr",
+            input_bindings={"counts": "github:test::counts"},
+            output="score:ab",
+            output_binding={"value": "return_value"},
+            code_hash="sha256:abc",
+        )
+        strategy = Strategy(
+            scope="local",
+            type="compute",
+            premises=["github:test::counts"],
+            conclusion="github:test::score_correct",
+            method=compute,
+        )
+        dumped = strategy.model_dump(mode="json")
+        loaded = Strategy.model_validate(dumped)
+        assert isinstance(loaded.method, ComputeMethod)
+        assert loaded.method.output == "score:ab"
+
+        opaque = Strategy(
+            scope="local",
+            type="opaque_conditional",
+            premises=["github:test::a"],
+            conclusion="github:test::b",
+            method=OpaqueConditionalMethod(parameter_ref="cond_001"),
+        )
+        assert isinstance(Strategy.model_validate(opaque.model_dump()).method, OpaqueConditionalMethod)
+
+    def test_likelihood_module_and_score_records(self):
+        spec = LikelihoodModuleSpec(
+            module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+            input_schema={"counts": "ABCounts", "target": "Claim"},
+            output_schema={"score": "LikelihoodScoreRecord"},
+            premise_schema={"score_correct": "Claim"},
+            target_role="target",
+            score_role="score",
+            score_type="log_lr",
+            effect="add_log_odds",
+        )
+        score = LikelihoodScoreRecord(
+            score_id="score:ab",
+            module_ref=spec.module_ref,
+            target="github:test::target",
+            score_type="log_lr",
+            value=1.73,
+            query="theta_B > theta_A",
+        )
+        assert score.module_ref == spec.module_ref
+        assert score.value == 1.73
 
 
 class TestCompositeStrategy:

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -1,8 +1,10 @@
 """Tests for Gaia IR validator."""
 
 from gaia.ir import (
+    ComputeMethod,
     Knowledge,
     KnowledgeType,
+    ModuleUseMethod,
     Operator,
     Strategy,
     CompositeStrategy,
@@ -70,6 +72,16 @@ class TestKnowledgeValidation:
         r = validate_local_graph(g)
         assert not r.valid
         assert any("content" in e for e in r.errors)
+
+    def test_local_knowledge_may_use_content_template(self):
+        k = Knowledge(
+            id="github:test::a",
+            type=KnowledgeType.CLAIM,
+            content_template="A({x})",
+        )
+        g = _local_graph(knowledges=[k])
+        r = validate_local_graph(g)
+        assert r.valid
 
     def test_metadata_prior_must_be_in_cromwell_bounds(self):
         g = _local_graph(
@@ -456,6 +468,85 @@ class TestStrategyValidation:
         r = validate_local_graph(g)
         assert r.valid  # warning, not error
         assert any("background" in w for w in r.warnings)
+
+    def test_valid_likelihood_module_method(self):
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::counts"),
+                _claim("github:test::randomization_valid"),
+                _claim("github:test::score_correct"),
+                _claim("github:test::target"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=[
+                        "github:test::counts",
+                        "github:test::randomization_valid",
+                        "github:test::score_correct",
+                    ],
+                    conclusion="github:test::target",
+                    method=ModuleUseMethod(
+                        module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+                        input_bindings={
+                            "counts": "github:test::counts",
+                            "target": "github:test::target",
+                        },
+                        output_bindings={"score": "score:ab"},
+                        premise_bindings={
+                            "data_observed": "github:test::counts",
+                            "random_assignment": "github:test::randomization_valid",
+                            "score_correct": "github:test::score_correct",
+                        },
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert r.valid
+
+    def test_likelihood_requires_module_use_method(self):
+        g = _local_graph(
+            knowledges=[_claim("github:test::a"), _claim("github:test::b")],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=["github:test::a"],
+                    conclusion="github:test::b",
+                    method=ComputeMethod(
+                        function_ref="f",
+                        input_bindings={"x": "github:test::a"},
+                        output="score:x",
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("likelihood strategy requires ModuleUseMethod" in e for e in r.errors)
+
+    def test_assertion_must_be_claim(self):
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::a"),
+                _claim("github:test::b"),
+                _setting("github:test::setting"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="deduction",
+                    premises=["github:test::a"],
+                    conclusion="github:test::b",
+                    assertions=["github:test::setting"],
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("assertion" in e and "must be claim" in e for e in r.errors)
 
     def test_global_scope_rejected_at_construction(self):
         """Global scope is no longer allowed — Strategy model rejects it."""


### PR DESCRIPTION
## Summary
- add v6-compatible IR carrier fields: Knowledge context/template/value parameters and Strategy method/reason/assertions
- add method models for module-based likelihood, compute, deduction, and opaque conditional strategies
- add likelihood module/score records and ReviewManifest/Warrant models
- validate v6 method/assertion references while keeping old BP behavior unchanged
- preserve legacy content hashes for unbound parameters and exclude rendered_content from graph identity

## Validation
- python -m pytest tests/ir tests/test_lowering.py tests/test_contraction.py
- python -m pytest
- git diff --check