### PR TITLE
feat(lang): add v6 compute and likelihood surface scaffold

### DIFF
--- a/gaia/lang/__init__.py
+++ b/gaia/lang/__init__.py
@@ -8,7 +8,9 @@ from gaia.lang.dsl import (
     compare,
     composite,
     complement,
+    compute,
     contradiction,
+    context,
     deduction,
     disjunction,
     elimination,
@@ -17,16 +19,19 @@ from gaia.lang.dsl import (
     fills,
     induction,
     infer,
+    likelihood_from,
     mathematical_induction,
     noisy_and,
     question,
     setting,
     support,
 )
-from gaia.lang.runtime import Knowledge, Operator, Step, Strategy
+from gaia.lang.runtime import ComputeResult, Knowledge, LikelihoodScore, Operator, Step, Strategy
 
 __all__ = [
+    "ComputeResult",
     "Knowledge",
+    "LikelihoodScore",
     "Operator",
     "Step",
     "Strategy",
@@ -37,7 +42,9 @@ __all__ = [
     "compare",
     "composite",
     "complement",
+    "compute",
     "contradiction",
+    "context",
     "deduction",
     "disjunction",
     "elimination",
@@ -46,6 +53,7 @@ __all__ = [
     "fills",
     "induction",
     "infer",
+    "likelihood_from",
     "mathematical_induction",
     "noisy_and",
     "question",

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -29,7 +29,7 @@ from gaia.lang.refs import (
     resolve,
     validate_groups,
 )
-from gaia.lang.runtime import Knowledge, Operator
+from gaia.lang.runtime import ComputeResult, Knowledge, LikelihoodScore, Operator
 from gaia.lang.runtime.package import CollectedPackage
 
 _COMPILE_TIME_FORMAL_STRATEGIES = frozenset(
@@ -62,7 +62,8 @@ class CompiledPackage:
 def _content_hash(k: Knowledge) -> str:
     """SHA-256(type + content + sorted(parameters))."""
     params_str = json.dumps(sorted(k.parameters, key=lambda p: p.get("name", "")), sort_keys=True)
-    raw = f"{k.type}|{k.content}|{params_str}"
+    content = k.content_template if k.content_template is not None else k.content
+    raw = f"{k.type}|{content}|{params_str}"
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
@@ -123,6 +124,61 @@ def _knowledge_id(
 def _knowledge_metadata(k: Knowledge) -> dict[str, Any] | None:
     metadata = dict(k.metadata)
     return metadata or None
+
+
+def _value_ref(value: Any, knowledge_map: dict[int, str]) -> str:
+    if isinstance(value, ComputeResult):
+        return _value_ref(value.output, knowledge_map)
+    if isinstance(value, LikelihoodScore):
+        if value.score_id is None:
+            raise ValueError("LikelihoodScore is missing score_id")
+        return value.score_id
+    if isinstance(value, Knowledge):
+        return knowledge_map[id(value)]
+    if isinstance(value, str):
+        return value
+    raise ValueError(f"Unsupported value reference type: {type(value)!r}")
+
+
+def _knowledge_binding_map(
+    bindings: dict[str, Knowledge],
+    knowledge_map: dict[int, str],
+) -> dict[str, str]:
+    return {role: knowledge_map[id(value)] for role, value in bindings.items()}
+
+
+def _compile_strategy_method(method: dict[str, Any] | None, knowledge_map: dict[int, str]):
+    if method is None:
+        return None
+    kind = method.get("kind")
+    if kind == "module_use":
+        return {
+            "kind": "module_use",
+            "module_ref": method["module_ref"],
+            "input_bindings": _knowledge_binding_map(method.get("input_bindings", {}), knowledge_map),
+            "output_bindings": {
+                role: _value_ref(value, knowledge_map)
+                for role, value in method.get("output_bindings", {}).items()
+            },
+            "premise_bindings": _knowledge_binding_map(
+                method.get("premise_bindings", {}), knowledge_map
+            ),
+        }
+    if kind == "compute":
+        payload = {
+            "kind": "compute",
+            "function_ref": method["function_ref"],
+            "input_bindings": _knowledge_binding_map(method.get("input_bindings", {}), knowledge_map),
+            "output": _value_ref(method["output"], knowledge_map),
+        }
+        if method.get("output_binding"):
+            payload["output_binding"] = dict(method["output_binding"])
+        if method.get("code_hash"):
+            payload["code_hash"] = method["code_hash"]
+        return payload
+    if kind in {"deduction", "opaque_conditional"}:
+        return dict(method)
+    raise ValueError(f"Unsupported strategy method kind: {kind!r}")
 
 
 def _knowledge_provenance(k: Knowledge) -> list[IrPackageRef] | None:
@@ -294,6 +350,21 @@ def compile_package_artifact(
             register_knowledge(background)
         if strategy.conclusion is not None:
             register_knowledge(strategy.conclusion)
+        for assertion in strategy.assertions:
+            register_knowledge(assertion)
+        if strategy.method:
+            for value in strategy.method.get("input_bindings", {}).values():
+                if isinstance(value, Knowledge):
+                    register_knowledge(value)
+            for value in strategy.method.get("premise_bindings", {}).values():
+                if isinstance(value, Knowledge):
+                    register_knowledge(value)
+            output = strategy.method.get("output")
+            if isinstance(output, Knowledge):
+                register_knowledge(output)
+            for value in strategy.method.get("output_bindings", {}).values():
+                if isinstance(value, Knowledge):
+                    register_knowledge(value)
         # composition_warrant is metadata-only, not a BP variable.
         # Do NOT register it as knowledge — it has no prior, no lowering,
         # no factor graph participation. Render tools will read it
@@ -337,6 +408,8 @@ def compile_package_artifact(
             title=getattr(k, "title", None),
             type=k.type,
             content=k.content,
+            content_template=k.content_template,
+            rendered_content=k.rendered_content,
             parameters=[IrParameter(**p) for p in k.parameters],
             provenance=_knowledge_provenance(k),
             metadata=_knowledge_metadata(k),
@@ -369,6 +442,9 @@ def compile_package_artifact(
             "premises": [knowledge_map[id(p)] for p in s.premises],
             "conclusion": knowledge_map[id(s.conclusion)] if s.conclusion else None,
             "background": [knowledge_map[id(b)] for b in s.background] or None,
+            "method": _compile_strategy_method(s.method, knowledge_map),
+            "reason": s.reason if isinstance(s.reason, str) and s.reason else None,
+            "assertions": [knowledge_map[id(a)] for a in s.assertions],
             "steps": steps,
             "metadata": _metadata_with_reason(s.metadata, s.reason),
         }
@@ -481,7 +557,10 @@ def compile_package_artifact(
     # imports the moment a dep adopts the new reference syntax.
     for k in knowledge_nodes:
         if _is_local(k, pkg):
-            _accumulate(k, k.content)
+            # v6 content_template may contain parameter references like
+            # [@experiment], which are not the same as Gaia's provenance
+            # reference syntax. Scan rendered/content text for provenance.
+            _accumulate(k, k.rendered_content or k.content)
 
     # Write provenance metadata onto IR knowledge nodes.
     # Belt-and-suspenders: never mutate foreign nodes' metadata even if

--- a/gaia/lang/dsl/__init__.py
+++ b/gaia/lang/dsl/__init__.py
@@ -1,4 +1,4 @@
-from gaia.lang.dsl.knowledge import claim, question, setting
+from gaia.lang.dsl.knowledge import claim, context, question, setting
 from gaia.lang.dsl.operators import complement, contradiction, disjunction, equivalence
 from gaia.lang.dsl.strategies import (
     abduction,
@@ -6,12 +6,14 @@ from gaia.lang.dsl.strategies import (
     case_analysis,
     compare,
     composite,
+    compute,
     deduction,
     elimination,
     extrapolation,
     fills,
     induction,
     infer,
+    likelihood_from,
     mathematical_induction,
     noisy_and,
     support,
@@ -25,7 +27,9 @@ __all__ = [
     "compare",
     "composite",
     "complement",
+    "compute",
     "contradiction",
+    "context",
     "deduction",
     "disjunction",
     "elimination",
@@ -34,6 +38,7 @@ __all__ = [
     "fills",
     "induction",
     "infer",
+    "likelihood_from",
     "mathematical_induction",
     "noisy_and",
     "question",

--- a/gaia/lang/dsl/knowledge.py
+++ b/gaia/lang/dsl/knowledge.py
@@ -27,6 +27,18 @@ def question(content: str, *, title: str | None = None, **metadata) -> Knowledge
     )
 
 
+def context(content: str, *, title: str | None = None, **metadata) -> Knowledge:
+    """Declare raw source material that should not enter BP directly."""
+    provenance = metadata.pop("provenance", None)
+    return Knowledge(
+        content=content.strip(),
+        type="context",
+        title=title,
+        provenance=provenance or [],
+        metadata=_flatten_metadata(metadata),
+    )
+
+
 def _flatten_metadata(metadata: dict) -> dict:
     """Unwrap nested metadata={"metadata": {...}} into a flat dict."""
     if "metadata" in metadata and isinstance(metadata["metadata"], dict) and len(metadata) == 1:
@@ -38,6 +50,8 @@ def claim(
     content: str,
     *,
     title: str | None = None,
+    content_template: str | None = None,
+    rendered_content: str | None = None,
     background: list[Knowledge] | None = None,
     parameters: list[dict] | None = None,
     provenance: list[dict[str, str]] | None = None,
@@ -48,6 +62,8 @@ def claim(
         content=content.strip(),
         type="claim",
         title=title,
+        content_template=content_template,
+        rendered_content=rendered_content,
         background=background or [],
         parameters=parameters or [],
         provenance=provenance or [],

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -6,7 +6,7 @@ import warnings
 from copy import deepcopy
 from typing import Literal
 
-from gaia.lang.runtime import Knowledge, Step, Strategy
+from gaia.lang.runtime import ComputeResult, Knowledge, LikelihoodScore, Step, Strategy
 from gaia.lang.runtime.nodes import ReasonInput
 from gaia.lang.runtime.nodes import _current_package
 from gaia.lang.dsl.operators import _validate_reason_prior
@@ -44,6 +44,36 @@ def _attach_strategy(conclusion: Knowledge | None, strategy: Strategy) -> None:
     pkg = _authoring_package()
     if pkg is None or conclusion._package is None or conclusion._package is pkg:
         conclusion.strategy = strategy
+
+
+def _dedupe_knowledge(items: list[Knowledge]) -> list[Knowledge]:
+    seen: set[int] = set()
+    deduped: list[Knowledge] = []
+    for item in items:
+        if id(item) in seen:
+            continue
+        seen.add(id(item))
+        deduped.append(item)
+    return deduped
+
+
+def _function_ref(fn) -> str:
+    if isinstance(fn, str):
+        return fn
+    module = getattr(fn, "__module__", None)
+    qualname = getattr(fn, "__qualname__", None)
+    if module and qualname:
+        return f"{module}.{qualname}"
+    name = getattr(fn, "__name__", None)
+    if name:
+        return name
+    return repr(fn)
+
+
+def _input_bindings(inputs: dict[str, Knowledge] | list[Knowledge]) -> dict[str, Knowledge]:
+    if isinstance(inputs, dict):
+        return dict(inputs)
+    return {f"input_{i}": item for i, item in enumerate(inputs)}
 
 
 def _named_strategy(
@@ -239,6 +269,116 @@ def infer(
         background=background,
         reason=reason,
     )
+
+
+def compute(
+    fn,
+    *,
+    inputs: dict[str, Knowledge] | list[Knowledge],
+    output,
+    assumptions: list[Knowledge] | None = None,
+    correctness: Knowledge | None = None,
+    output_binding: dict[str, str] | None = None,
+    code_hash: str | None = None,
+    reason: ReasonInput = "",
+) -> ComputeResult:
+    """Declare a deterministic computation that produces a value/artifact.
+
+    The computation itself does not carry probability. Its uncertainty is
+    represented by premise Claims and by the generated correctness Claim.
+    """
+    bindings = _input_bindings(inputs)
+    assumptions = list(assumptions or [])
+    if correctness is None:
+        correctness = Knowledge(
+            content=f"The output of {_function_ref(fn)} was correctly computed and bound.",
+            type="claim",
+            metadata={
+                "generated": True,
+                "helper_kind": "compute_correctness",
+                "function_ref": _function_ref(fn),
+            },
+        )
+    premises = _dedupe_knowledge([*bindings.values(), *assumptions])
+    strategy = Strategy(
+        type="compute",
+        premises=premises,
+        conclusion=correctness,
+        reason=reason,
+        metadata={"surface_construct": "compute"},
+        method={
+            "kind": "compute",
+            "function_ref": _function_ref(fn),
+            "input_bindings": bindings,
+            "output": output,
+            "output_binding": dict(output_binding or {}),
+            "code_hash": code_hash,
+        },
+    )
+    _attach_strategy(correctness, strategy)
+    return ComputeResult(output=output, correctness=correctness, strategy=strategy)
+
+
+def likelihood_from(
+    *,
+    target: Knowledge,
+    data: list[Knowledge],
+    assumptions: list[Knowledge] | None = None,
+    score=None,
+    score_correctness: Knowledge | None = None,
+    module_ref: str,
+    query: str | dict | None = None,
+    input_bindings: dict[str, Knowledge] | None = None,
+    reason: ReasonInput = "",
+) -> Strategy:
+    """Declare a module-based likelihood update for a target Claim."""
+    assumptions = list(assumptions or [])
+    if isinstance(score, ComputeResult):
+        score_correctness = score.correctness
+        score = score.output
+    if score_correctness is None:
+        raise ValueError("likelihood_from() requires score_correctness unless score is ComputeResult")
+
+    if input_bindings is None:
+        input_bindings = {"target": target}
+        if len(data) == 1:
+            input_bindings["data"] = data[0]
+        else:
+            for i, item in enumerate(data):
+                input_bindings[f"data_{i}"] = item
+    else:
+        input_bindings = dict(input_bindings)
+        input_bindings.setdefault("target", target)
+
+    premise_bindings: dict[str, Knowledge] = {
+        "score_correct": score_correctness,
+    }
+    for i, item in enumerate(data):
+        premise_bindings[f"data_{i}"] = item
+    for i, item in enumerate(assumptions):
+        premise_bindings[f"assumption_{i}"] = item
+
+    premises = _dedupe_knowledge([*data, *assumptions, score_correctness])
+    strategy = Strategy(
+        type="likelihood",
+        premises=premises,
+        conclusion=target,
+        reason=reason,
+        metadata={
+            "surface_construct": "likelihood_from",
+            "module_ref": module_ref,
+            "query": query,
+        },
+        method={
+            "kind": "module_use",
+            "module_ref": module_ref,
+            "input_bindings": input_bindings,
+            "output_bindings": {"score": score},
+            "premise_bindings": premise_bindings,
+        },
+    )
+    _attach_strategy(target, strategy)
+    return strategy
 
 
 def fills(

--- a/gaia/lang/runtime/__init__.py
+++ b/gaia/lang/runtime/__init__.py
@@ -1,3 +1,3 @@
-from gaia.lang.runtime.nodes import Knowledge, Operator, Step, Strategy
+from gaia.lang.runtime.nodes import ComputeResult, Knowledge, LikelihoodScore, Operator, Step, Strategy
 
-__all__ = ["Knowledge", "Operator", "Step", "Strategy"]
+__all__ = ["ComputeResult", "Knowledge", "LikelihoodScore", "Operator", "Step", "Strategy"]

--- a/gaia/lang/runtime/nodes.py
+++ b/gaia/lang/runtime/nodes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -19,6 +21,8 @@ class Knowledge:
     content: str
     type: str  # "claim" | "setting" | "question"
     title: str | None = None
+    content_template: str | None = None
+    rendered_content: str | None = None
     background: list[Knowledge] = field(default_factory=list)
     parameters: list[dict] = field(default_factory=list)
     provenance: list[dict[str, str]] = field(default_factory=list)
@@ -59,6 +63,32 @@ ReasonInput = str | list[str | Step]
 
 
 @dataclass
+class LikelihoodScore:
+    """Value object for a module-produced likelihood score."""
+
+    target: Knowledge
+    module_ref: str
+    score_type: str
+    value: Any
+    query: str | dict[str, Any] | None = None
+    score_id: str | None = None
+    rationale: str | None = None
+
+    def __post_init__(self):
+        if self.score_id is not None:
+            return
+        payload = {
+            "target": self.target.label or self.target.content,
+            "module_ref": self.module_ref,
+            "score_type": self.score_type,
+            "query": self.query,
+            "value": self.value,
+        }
+        raw = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+        self.score_id = f"score:{hashlib.sha256(raw.encode()).hexdigest()[:16]}"
+
+
+@dataclass
 class Strategy:
     """A reasoning declaration."""
 
@@ -72,6 +102,8 @@ class Strategy:
     formal_expr: list | None = None
     sub_strategies: list[Strategy] = field(default_factory=list)
     composition_warrant: Knowledge | None = None
+    method: dict[str, Any] | None = None
+    assertions: list[Knowledge] = field(default_factory=list)
 
     def __post_init__(self):
         pkg = _current_package.get()
@@ -81,6 +113,15 @@ class Strategy:
             pkg = infer_package_from_callstack()
         if pkg is not None:
             pkg._register_strategy(self)
+
+
+@dataclass
+class ComputeResult:
+    """Structured return value for v6 compute(...)."""
+
+    output: Any
+    correctness: Knowledge
+    strategy: Strategy
 
 
 @dataclass

--- a/tests/gaia/lang/test_core.py
+++ b/tests/gaia/lang/test_core.py
@@ -1,5 +1,5 @@
 from gaia.lang import __all__ as gaia_lang_exports
-from gaia.lang import claim, question, setting
+from gaia.lang import claim, context, question, setting
 
 
 def test_setting_creates_knowledge():
@@ -17,6 +17,12 @@ def test_claim_creates_knowledge():
 def test_question_creates_knowledge():
     q = question("An open question?")
     assert q.type == "question"
+
+
+def test_context_creates_knowledge():
+    ctx = context("Raw experiment dashboard excerpt.")
+    assert ctx.type == "context"
+    assert ctx.content == "Raw experiment dashboard excerpt."
 
 
 def test_claim_with_explicit_noisy_and():

--- a/tests/gaia/lang/test_v6_surface.py
+++ b/tests/gaia/lang/test_v6_surface.py
@@ -1,0 +1,122 @@
+"""Tests for v6 Lang surface scaffolding."""
+
+from gaia.ir import ComputeMethod, ModuleUseMethod
+from gaia.lang import (
+    LikelihoodScore,
+    claim,
+    compute,
+    context,
+    likelihood_from,
+    setting,
+)
+from gaia.lang.compiler.compile import compile_package_artifact
+from gaia.lang.runtime import ComputeResult
+from gaia.lang.runtime.package import CollectedPackage
+
+
+def test_context_compiles_to_context_knowledge():
+    pkg = CollectedPackage("v6_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        ctx = context("Control A had 10 users and 1 conversion.")
+        ctx.label = "dashboard_excerpt"
+
+    compiled = compile_package_artifact(pkg)
+    ir_ctx = compiled.graph.knowledges[0]
+    assert ir_ctx.type == "context"
+    assert ir_ctx.id == "github:v6_pkg::dashboard_excerpt"
+
+
+def test_parameterized_claim_template_and_values_compile():
+    pkg = CollectedPackage("v6_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        exp = setting("AB test exp_123.")
+        exp.label = "exp_123"
+        counts = claim(
+            "AB test exp_123 recorded 500/10000 control conversions.",
+            content_template="[@experiment] recorded {ctrl_k}/{ctrl_n} control conversions.",
+            rendered_content="AB test exp_123 recorded 500/10000 control conversions.",
+            parameters=[
+                {"name": "experiment", "type": "Setting", "value": "github:v6_pkg::exp_123"},
+                {"name": "ctrl_k", "type": "int", "value": 500},
+                {"name": "ctrl_n", "type": "int", "value": 10_000},
+            ],
+        )
+        counts.label = "counts"
+
+    compiled = compile_package_artifact(pkg)
+    ir_counts = next(k for k in compiled.graph.knowledges if k.label == "counts")
+    assert ir_counts.content_template == "[@experiment] recorded {ctrl_k}/{ctrl_n} control conversions."
+    assert ir_counts.rendered_content == "AB test exp_123 recorded 500/10000 control conversions."
+    assert {p.name: p.value for p in ir_counts.parameters}["ctrl_k"] == 500
+
+
+def test_compute_and_likelihood_from_compile_to_v6_methods():
+    pkg = CollectedPackage("v6_pkg", namespace="github", version="1.0.0")
+    module_ref = "gaia.std.likelihood.two_binomial_ab_test@v1"
+
+    with pkg:
+        counts = claim("AB counts are 500/10000 control and 550/10000 treatment.")
+        counts.label = "counts"
+        target = claim("Variant B has a higher true conversion rate than A.")
+        target.label = "b_better"
+        randomization_valid = claim("Users were randomly assigned between A and B.")
+        randomization_valid.label = "randomization_valid"
+        formula_correct = claim("The two-binomial log LR formula is correct.")
+        formula_correct.label = "formula_correct"
+        implementation_correct = claim("The reviewed code implements the formula.")
+        implementation_correct.label = "implementation_correct"
+
+        score = LikelihoodScore(
+            target=target,
+            module_ref=module_ref,
+            score_type="log_lr",
+            value=1.73,
+            query="theta_B > theta_A",
+            score_id="score:ab",
+        )
+        score_result = compute(
+            "two_binomial_log_lr",
+            inputs={"counts": counts},
+            output=score,
+            assumptions=[formula_correct, implementation_correct],
+            output_binding={"value": "return_value"},
+            reason="Compute the AB-test log likelihood ratio.",
+        )
+        assert isinstance(score_result, ComputeResult)
+
+        likelihood_from(
+            target=target,
+            data=[counts],
+            assumptions=[randomization_valid],
+            score=score_result.output,
+            score_correctness=score_result.correctness,
+            module_ref=module_ref,
+            input_bindings={"counts": counts, "target": target},
+            query="theta_B > theta_A",
+            reason="Apply the AB-test likelihood score.",
+        )
+
+    compiled = compile_package_artifact(pkg)
+    strategies = {s.type: s for s in compiled.graph.strategies}
+
+    compute_ir = strategies["compute"]
+    assert isinstance(compute_ir.method, ComputeMethod)
+    assert compute_ir.method.function_ref == "two_binomial_log_lr"
+    assert compute_ir.method.input_bindings == {"counts": "github:v6_pkg::counts"}
+    assert compute_ir.method.output == "score:ab"
+    assert compute_ir.method.output_binding == {"value": "return_value"}
+
+    correctness_id = compiled.knowledge_ids_by_object[id(score_result.correctness)]
+    assert compute_ir.conclusion == correctness_id
+
+    likelihood_ir = strategies["likelihood"]
+    assert isinstance(likelihood_ir.method, ModuleUseMethod)
+    assert likelihood_ir.conclusion == "github:v6_pkg::b_better"
+    assert likelihood_ir.method.module_ref == module_ref
+    assert likelihood_ir.method.input_bindings == {
+        "counts": "github:v6_pkg::counts",
+        "target": "github:v6_pkg::b_better",
+    }
+    assert likelihood_ir.method.output_bindings == {"score": "score:ab"}
+    assert likelihood_ir.method.premise_bindings["score_correct"] == correctness_id
+    assert correctness_id in likelihood_ir.premises


### PR DESCRIPTION
## Summary
- add v6 Lang surface for context(), LikelihoodScore, compute(), and likelihood_from()
- compile runtime compute/likelihood method payloads into v6 IR ComputeMethod/ModuleUseMethod
- preserve the v6 template/reference boundary by scanning rendered/content text for provenance, not content_template
- export the new v6 surface from gaia.lang and gaia.lang.dsl

## Validation
- python -m pytest tests/gaia/lang/test_core.py tests/gaia/lang/test_compiler.py tests/gaia/lang/test_v6_surface.py tests/ir
- python -m pytest
- git diff --check