### PR TITLE
feat(bp): lower v6 likelihood log-lr scores

### DIFF
--- a/gaia/bp/contraction.py
+++ b/gaia/bp/contraction.py
@@ -444,6 +444,7 @@ def strategy_cpt(
         claim_ids=claim_ids,
         namespace=namespace,
         package_name=package_name,
+        likelihood_scores={},
     )
 
     tensors = [factor_to_tensor(f) for f in mini.factors]

--- a/gaia/bp/factor_graph.py
+++ b/gaia/bp/factor_graph.py
@@ -7,6 +7,7 @@ IR: docs/foundations/gaia-ir/02-gaia-ir.md (Operator variables + conclusion)
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Sequence
@@ -21,6 +22,14 @@ def _cromwell_clamp(value: float, label: str = "") -> float:
     if clamped != value and label:
         logger.debug("Cromwell clamp: %s %.6g -> %.6g", label, value, clamped)
     return clamped
+
+
+def _probability_from_log_odds(log_odds: float) -> float:
+    if log_odds >= 0.0:
+        z = math.exp(-log_odds)
+        return 1.0 / (1.0 + z)
+    z = math.exp(log_odds)
+    return z / (1.0 + z)
 
 
 class FactorType(Enum):
@@ -92,6 +101,19 @@ class FactorGraph:
         odds = pi / (1.0 - pi) * likelihood_ratio
         new_pi = odds / (1.0 + odds)
         self.variables[var_id] = _cromwell_clamp(new_pi, label=f"likelihood '{var_id}'")
+
+    def add_log_likelihood(self, var_id: str, log_likelihood_ratio: float) -> None:
+        """Soft evidence: add a log likelihood ratio to a variable's log odds."""
+        if var_id not in self.variables:
+            raise KeyError(f"Variable '{var_id}' not registered.")
+        if not math.isfinite(log_likelihood_ratio):
+            raise ValueError(
+                f"log_likelihood_ratio must be finite, got {log_likelihood_ratio}."
+            )
+        pi = self.variables[var_id]
+        log_odds = math.log(pi) - math.log1p(-pi) + log_likelihood_ratio
+        new_pi = _probability_from_log_odds(log_odds)
+        self.variables[var_id] = _cromwell_clamp(new_pi, label=f"log likelihood '{var_id}'")
 
     def add_factor(
         self,

--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -5,6 +5,7 @@ Spec: docs/foundations/gaia-ir/07-lowering.md
 
 from __future__ import annotations
 
+import math
 from dataclasses import replace
 
 from gaia.bp.factor_graph import CROMWELL_EPS, FactorGraph, FactorType
@@ -16,6 +17,8 @@ from gaia.ir.strategy import (
     _FORMAL_STRATEGY_TYPES,
     CompositeStrategy,
     FormalStrategy,
+    LikelihoodScoreRecord,
+    ModuleUseMethod,
     Strategy,
     StrategyType,
 )
@@ -57,6 +60,14 @@ _OPERATOR_MAP: dict[OperatorType, FactorType] = {
 def _next_fid(prefix: str, i: list[int]) -> str:
     i[0] += 1
     return f"{prefix}_f{i[0]}"
+
+
+def _probability_from_log_odds(log_odds: float) -> float:
+    if log_odds >= 0.0:
+        z = math.exp(-log_odds)
+        return 1.0 / (1.0 + z)
+    z = math.exp(log_odds)
+    return z / (1.0 + z)
 
 
 def lower_local_graph(
@@ -105,6 +116,7 @@ def lower_local_graph(
         if k.id and k.metadata and "prior" in k.metadata
     }
     strat_params = strategy_conditional_params or {}
+    likelihood_scores = {score.score_id: score for score in canonical.likelihood_scores}
     fg = FactorGraph()
     ctr = [0]
 
@@ -156,6 +168,7 @@ def lower_local_graph(
             claim_ids,
             canonical.namespace,
             canonical.package_name,
+            likelihood_scores,
             seen_strategies=seen_strategies,
         )
 
@@ -220,6 +233,7 @@ def _lower_strategy(
     claim_ids: set[str],
     namespace: str,
     package_name: str,
+    likelihood_scores: dict[str, LikelihoodScoreRecord],
     seen_strategies: set[str] | None = None,
 ) -> None:
     # Dedup: when ``seen_strategies`` is provided (lower_local_graph
@@ -252,6 +266,7 @@ def _lower_strategy(
                 claim_ids,
                 namespace,
                 package_name,
+                likelihood_scores,
                 seen_strategies=seen_strategies,
             )
         return
@@ -392,6 +407,13 @@ def _lower_strategy(
             )
         return
 
+    if s.type == StrategyType.COMPUTE:
+        return
+
+    if s.type == StrategyType.LIKELIHOOD:
+        _lower_likelihood_strategy(fg, s, likelihood_scores, ctr)
+        return
+
     # Named leaf strategy (not yet formalized into FormalStrategy) — auto-formalize.
     # Supported: deduction, elimination, mathematical_induction, case_analysis,
     #            abduction, analogy, extrapolation  (all entries in _FORMAL_STRATEGY_TYPES).
@@ -437,6 +459,7 @@ def _lower_strategy(
             claim_ids,
             namespace,
             package_name,
+            likelihood_scores,
             seen_strategies=seen_strategies,
         )
         return
@@ -445,6 +468,70 @@ def _lower_strategy(
         f"Leaf strategy type {s.type!r} is deferred in Gaia IR core "
         "(docs/foundations/gaia-ir/02-gaia-ir.md §3.3). "
         "Supply a pre-formalized FormalStrategy, or use infer/noisy_and."
+    )
+
+
+def _lower_likelihood_strategy(
+    fg: FactorGraph,
+    strategy: Strategy,
+    likelihood_scores: dict[str, LikelihoodScoreRecord],
+    ctr: list[int],
+) -> None:
+    method = strategy.method
+    if not isinstance(method, ModuleUseMethod):
+        raise ValueError(f"likelihood strategy {strategy.strategy_id}: requires ModuleUseMethod")
+    score_ref = method.output_bindings.get("score")
+    if not score_ref:
+        raise ValueError(
+            f"likelihood strategy {strategy.strategy_id}: missing output binding 'score'"
+        )
+    score = likelihood_scores.get(score_ref)
+    if score is None:
+        raise ValueError(
+            f"likelihood strategy {strategy.strategy_id}: score '{score_ref}' not found"
+        )
+    if score.score_type != "log_lr":
+        raise NotImplementedError(
+            f"likelihood strategy {strategy.strategy_id}: only log_lr scores lower to BP"
+        )
+    if score.target != strategy.conclusion:
+        raise ValueError(
+            f"likelihood strategy {strategy.strategy_id}: score target '{score.target}' "
+            f"does not match conclusion '{strategy.conclusion}'"
+        )
+
+    log_lr = float(score.value)
+    if not math.isfinite(log_lr):
+        raise ValueError(
+            f"likelihood strategy {strategy.strategy_id}: log_lr score must be finite"
+        )
+
+    if not strategy.premises:
+        fg.add_log_likelihood(strategy.conclusion, log_lr)
+        return
+
+    if len(strategy.premises) == 1:
+        gate = strategy.premises[0]
+    else:
+        gate = f"_m_likelihood_{strategy.strategy_id}"
+        fg.add_variable(gate, 0.5)
+        fg.add_factor(
+            _next_fid("like_gate", ctr),
+            FactorType.CONJUNCTION,
+            strategy.premises,
+            gate,
+        )
+
+    # Conditional row 0 is neutral when the warrant/data gate is false.
+    # Row 1 has odds exp(log_lr), so when the gate is true the factor adds
+    # exactly log_lr to the target's log-odds.
+    p_when_gate_true = _probability_from_log_odds(log_lr)
+    fg.add_factor(
+        _next_fid("like_loglr", ctr),
+        FactorType.CONDITIONAL,
+        [gate],
+        strategy.conclusion,
+        cpt=[0.5, p_when_gate_true],
     )
 
 

--- a/gaia/ir/graphs.py
+++ b/gaia/ir/graphs.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, model_validator
 
 from gaia.ir.knowledge import Knowledge, make_qid
 from gaia.ir.operator import Operator
-from gaia.ir.strategy import CompositeStrategy, FormalStrategy, Strategy
+from gaia.ir.strategy import CompositeStrategy, FormalStrategy, LikelihoodScoreRecord, Strategy
 
 
 def _json_sort_key(value: Any) -> str:
@@ -73,6 +73,7 @@ def _canonical_json(
     knowledges: list[Knowledge],
     operators: list[Operator],
     strategies: list[Strategy],
+    likelihood_scores: list[LikelihoodScoreRecord] | None = None,
 ) -> str:
     """Produce canonical JSON for hashing — independent of insertion order."""
     data = {
@@ -86,6 +87,13 @@ def _canonical_json(
         ),
         "strategies": sorted(
             [_canonicalize_strategy_dump(s.model_dump(mode="json")) for s in strategies],
+            key=_json_sort_key,
+        ),
+        "likelihood_scores": sorted(
+            [
+                score.model_dump(mode="json", exclude_none=True)
+                for score in (likelihood_scores or [])
+            ],
             key=_json_sort_key,
         ),
     }
@@ -106,6 +114,7 @@ class LocalCanonicalGraph(BaseModel):
     knowledges: list[Knowledge]
     operators: list[Operator] = []
     strategies: list[CompositeStrategy | FormalStrategy | Strategy] = []
+    likelihood_scores: list[LikelihoodScoreRecord] = []
     module_order: list[str] | None = None
     module_titles: dict[str, str] | None = None
 
@@ -117,7 +126,12 @@ class LocalCanonicalGraph(BaseModel):
                 k.id = make_qid(self.namespace, self.package_name, k.label)
 
         if self.ir_hash is None:
-            canonical = _canonical_json(self.knowledges, self.operators, self.strategies)
+            canonical = _canonical_json(
+                self.knowledges,
+                self.operators,
+                self.strategies,
+                self.likelihood_scores,
+            )
             digest = hashlib.sha256(canonical.encode()).hexdigest()
             self.ir_hash = f"sha256:{digest}"
         return self

--- a/gaia/ir/validator.py
+++ b/gaia/ir/validator.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from gaia.ir.knowledge import Knowledge, KnowledgeType, is_qid
 from gaia.ir.operator import Operator, OperatorType
 from gaia.ir.strategy import Strategy, CompositeStrategy, FormalStrategy, StrategyType
-from gaia.ir.strategy import ComputeMethod, ModuleUseMethod
+from gaia.ir.strategy import ComputeMethod, LikelihoodScoreRecord, ModuleUseMethod
 from gaia.ir.graphs import LocalCanonicalGraph, _canonical_json
 from gaia.ir.parameterization import (
     CROMWELL_EPS,
@@ -327,6 +327,66 @@ def _validate_strategy_method(
                 )
 
 
+def _validate_likelihood_scores(
+    scores: list[LikelihoodScoreRecord],
+    knowledge_lookup: dict[str, Knowledge],
+    result: ValidationResult,
+) -> dict[str, LikelihoodScoreRecord]:
+    lookup: dict[str, LikelihoodScoreRecord] = {}
+    for score in scores:
+        if score.score_id in lookup:
+            result.error(f"LikelihoodScore '{score.score_id}': duplicate score_id")
+        lookup[score.score_id] = score
+        if score.target not in knowledge_lookup:
+            result.error(
+                f"LikelihoodScore '{score.score_id}': target '{score.target}' not found in graph"
+            )
+        elif knowledge_lookup[score.target].type != KnowledgeType.CLAIM:
+            result.error(
+                f"LikelihoodScore '{score.score_id}': target '{score.target}' must be claim"
+            )
+        if score.score_type == "log_lr":
+            if isinstance(score.value, bool) or not isinstance(score.value, (int, float)):
+                result.error(
+                    f"LikelihoodScore '{score.score_id}': log_lr value must be numeric"
+                )
+            elif not math.isfinite(float(score.value)):
+                result.error(f"LikelihoodScore '{score.score_id}': log_lr value must be finite")
+    return lookup
+
+
+def _validate_likelihood_strategy_scores(
+    strategies: list[Strategy],
+    score_lookup: dict[str, LikelihoodScoreRecord],
+    result: ValidationResult,
+) -> None:
+    for strategy in strategies:
+        if strategy.type != StrategyType.LIKELIHOOD or not isinstance(
+            strategy.method, ModuleUseMethod
+        ):
+            continue
+        sid = strategy.strategy_id or "<no-id>"
+        score_ref = strategy.method.output_bindings.get("score")
+        if not score_ref:
+            result.error(f"Strategy '{sid}': likelihood method missing output binding 'score'")
+            continue
+        score = score_lookup.get(score_ref)
+        if score is None:
+            result.error(f"Strategy '{sid}': likelihood score '{score_ref}' not found")
+            continue
+        if score.module_ref != strategy.method.module_ref:
+            result.error(
+                f"Strategy '{sid}': likelihood score '{score_ref}' module_ref "
+                f"'{score.module_ref}' does not match method module_ref "
+                f"'{strategy.method.module_ref}'"
+            )
+        if strategy.conclusion and score.target != strategy.conclusion:
+            result.error(
+                f"Strategy '{sid}': likelihood score '{score_ref}' target "
+                f"'{score.target}' does not match strategy conclusion '{strategy.conclusion}'"
+            )
+
+
 def _validate_composite_sub_strategies(
     strategy: CompositeStrategy,
     strategy_lookup: dict[str, Strategy] | None,
@@ -617,15 +677,22 @@ def validate_local_graph(graph: LocalCanonicalGraph) -> ValidationResult:
         graph_namespace=graph.namespace,
         graph_package_name=graph.package_name,
     )
+    score_lookup = _validate_likelihood_scores(graph.likelihood_scores, knowledge_lookup, result)
     _validate_operators(graph.operators, knowledge_lookup, "local", result, top_level=True)
     _validate_strategies(graph.strategies, graph.operators, knowledge_lookup, "local", result)
+    _validate_likelihood_strategy_scores(graph.strategies, score_lookup, result)
     _validate_scope_consistency(
         knowledge_lookup, graph.operators, graph.strategies, "local", result
     )
 
     # hash consistency
     if graph.ir_hash is not None:
-        recomputed = _canonical_json(graph.knowledges, graph.operators, graph.strategies)
+        recomputed = _canonical_json(
+            graph.knowledges,
+            graph.operators,
+            graph.strategies,
+            graph.likelihood_scores,
+        )
         import hashlib
 
         expected = f"sha256:{hashlib.sha256(recomputed.encode()).hexdigest()}"

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -13,6 +13,7 @@ from gaia.ir import (
     FormalExpr as IrFormalExpr,
     FormalStrategy as IrFormalStrategy,
     Knowledge as IrKnowledge,
+    LikelihoodScoreRecord as IrLikelihoodScoreRecord,
     LocalCanonicalGraph,
     Operator as IrOperator,
     Parameter as IrParameter,
@@ -138,6 +139,37 @@ def _value_ref(value: Any, knowledge_map: dict[int, str]) -> str:
     if isinstance(value, str):
         return value
     raise ValueError(f"Unsupported value reference type: {type(value)!r}")
+
+
+def _value_knowledge_items(value: Any) -> list[Knowledge]:
+    if isinstance(value, ComputeResult):
+        return _value_knowledge_items(value.output)
+    if isinstance(value, LikelihoodScore):
+        return [value.target]
+    if isinstance(value, Knowledge):
+        return [value]
+    return []
+
+
+def _likelihood_score_record(
+    value: Any,
+    knowledge_map: dict[int, str],
+) -> IrLikelihoodScoreRecord | None:
+    if isinstance(value, ComputeResult):
+        return _likelihood_score_record(value.output, knowledge_map)
+    if not isinstance(value, LikelihoodScore):
+        return None
+    if value.score_id is None:
+        raise ValueError("LikelihoodScore is missing score_id")
+    return IrLikelihoodScoreRecord(
+        score_id=value.score_id,
+        module_ref=value.module_ref,
+        target=knowledge_map[id(value.target)],
+        score_type=value.score_type,
+        value=value.value,
+        query=value.query,
+        rationale=value.rationale,
+    )
 
 
 def _knowledge_binding_map(
@@ -354,17 +386,17 @@ def compile_package_artifact(
             register_knowledge(assertion)
         if strategy.method:
             for value in strategy.method.get("input_bindings", {}).values():
-                if isinstance(value, Knowledge):
-                    register_knowledge(value)
+                for item in _value_knowledge_items(value):
+                    register_knowledge(item)
             for value in strategy.method.get("premise_bindings", {}).values():
-                if isinstance(value, Knowledge):
-                    register_knowledge(value)
+                for item in _value_knowledge_items(value):
+                    register_knowledge(item)
             output = strategy.method.get("output")
-            if isinstance(output, Knowledge):
-                register_knowledge(output)
+            for item in _value_knowledge_items(output):
+                register_knowledge(item)
             for value in strategy.method.get("output_bindings", {}).values():
-                if isinstance(value, Knowledge):
-                    register_knowledge(value)
+                for item in _value_knowledge_items(value):
+                    register_knowledge(item)
         # composition_warrant is metadata-only, not a BP variable.
         # Do NOT register it as knowledge — it has no prior, no lowering,
         # no factor graph participation. Render tools will read it
@@ -488,6 +520,25 @@ def compile_package_artifact(
         ir_strategies.append(compile_strategy(s))
         emitted_strategies.add(strategy_key)
 
+    likelihood_scores: list[IrLikelihoodScoreRecord] = []
+    seen_score_ids: set[str] = set()
+
+    def collect_likelihood_scores(s) -> None:
+        if s.method:
+            values = [s.method.get("output")]
+            values.extend(s.method.get("output_bindings", {}).values())
+            for value in values:
+                record = _likelihood_score_record(value, knowledge_map)
+                if record is None or record.score_id in seen_score_ids:
+                    continue
+                likelihood_scores.append(record)
+                seen_score_ids.add(record.score_id)
+        for sub_strategy in s.sub_strategies:
+            collect_likelihood_scores(sub_strategy)
+
+    for s in pkg.strategies:
+        collect_likelihood_scores(s)
+
     # Build label-to-QID table from the full knowledge closure (local + imported foreign nodes).
     label_to_id: dict[str, str] = {}
     for k in knowledge_nodes:
@@ -599,6 +650,7 @@ def compile_package_artifact(
         knowledges=[*ir_knowledges, *generated_knowledges],
         operators=ir_operators,
         strategies=ir_strategies,
+        likelihood_scores=likelihood_scores,
         module_order=module_order,
         module_titles=module_titles if module_titles else None,
     )

--- a/tests/gaia/bp/test_factor_graph.py
+++ b/tests/gaia/bp/test_factor_graph.py
@@ -1,5 +1,7 @@
 """Unit tests for gaia.bp.factor_graph — graph construction and validation."""
 
+import math
+
 import pytest
 
 from gaia.bp.factor_graph import CROMWELL_EPS, Factor, FactorGraph, FactorType
@@ -44,6 +46,13 @@ def test_add_likelihood():
     original = fg.variables["A"]
     fg.add_likelihood("A", 3.0)
     assert fg.variables["A"] > original
+
+
+def test_add_log_likelihood():
+    fg = FactorGraph()
+    fg.add_variable("A", 0.5)
+    fg.add_log_likelihood("A", math.log(3.0))
+    assert fg.variables["A"] == pytest.approx(0.75)
 
 
 # ── Factor construction ──

--- a/tests/gaia/std/test_likelihood.py
+++ b/tests/gaia/std/test_likelihood.py
@@ -75,6 +75,10 @@ def test_standard_score_flows_through_compute_and_likelihood_surface():
         )
 
     compiled = compile_package_artifact(pkg)
+    assert len(compiled.graph.likelihood_scores) == 1
+    assert compiled.graph.likelihood_scores[0].score_id == score.score_id
+    assert compiled.graph.likelihood_scores[0].value == score.value
+
     strategies = {s.type: s for s in compiled.graph.strategies}
     assert strategies["compute"].method.output == score.score_id
     assert strategies["likelihood"].method.module_ref == TWO_BINOMIAL_AB_TEST_REF

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -10,6 +10,7 @@ from gaia.ir import (
     CompositeStrategy,
     FormalStrategy,
     FormalExpr,
+    LikelihoodScoreRecord,
     LocalCanonicalGraph,
 )
 from gaia.ir.validator import (
@@ -470,6 +471,7 @@ class TestStrategyValidation:
         assert any("background" in w for w in r.warnings)
 
     def test_valid_likelihood_module_method(self):
+        module_ref = "gaia.std.likelihood.two_binomial_ab_test@v1"
         g = _local_graph(
             knowledges=[
                 _claim("github:test::counts"),
@@ -488,7 +490,7 @@ class TestStrategyValidation:
                     ],
                     conclusion="github:test::target",
                     method=ModuleUseMethod(
-                        module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+                        module_ref=module_ref,
                         input_bindings={
                             "counts": "github:test::counts",
                             "target": "github:test::target",
@@ -502,9 +504,43 @@ class TestStrategyValidation:
                     ),
                 )
             ],
+            likelihood_scores=[
+                LikelihoodScoreRecord(
+                    score_id="score:ab",
+                    module_ref=module_ref,
+                    target="github:test::target",
+                    score_type="log_lr",
+                    value=1.73,
+                )
+            ],
         )
         r = validate_local_graph(g)
         assert r.valid
+
+    def test_likelihood_method_requires_registered_score(self):
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::score_correct"),
+                _claim("github:test::target"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=["github:test::score_correct"],
+                    conclusion="github:test::target",
+                    method=ModuleUseMethod(
+                        module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+                        input_bindings={"target": "github:test::target"},
+                        output_bindings={"score": "score:missing"},
+                        premise_bindings={"score_correct": "github:test::score_correct"},
+                    ),
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("likelihood score 'score:missing' not found" in e for e in r.errors)
 
     def test_likelihood_requires_module_use_method(self):
         g = _local_graph(

--- a/tests/test_lowering.py
+++ b/tests/test_lowering.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 import pytest
 
 from gaia.bp import FactorType, lower_local_graph, lower_operator
-from gaia.bp.factor_graph import FactorGraph
+from gaia.bp.factor_graph import CROMWELL_EPS, FactorGraph
 from gaia.bp.exact import exact_inference
 from gaia.bp.lowering import fold_composite_to_cpt, merge_factor_graphs
-from gaia.ir import Knowledge, Operator, Strategy, CompositeStrategy, LocalCanonicalGraph
+from gaia.ir import (
+    CompositeStrategy,
+    Knowledge,
+    LikelihoodScoreRecord,
+    LocalCanonicalGraph,
+    ModuleUseMethod,
+    Operator,
+    Strategy,
+)
 
 NS, PKG = "github", "lowertest"
 
@@ -126,6 +134,123 @@ def test_noisy_and_strategy_lowering():
     fts = [f.factor_type for f in fg.factors]
     assert FactorType.CONJUNCTION in fts
     assert FactorType.SOFT_ENTAILMENT in fts
+
+
+def test_likelihood_log_lr_lowers_to_gated_conditional():
+    target = "github:lowertest::target"
+    gate = "github:lowertest::score_correct"
+    strategy = Strategy(
+        scope="local",
+        type="likelihood",
+        premises=[gate],
+        conclusion=target,
+        method=ModuleUseMethod(
+            module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+            input_bindings={"target": target},
+            output_bindings={"score": "score:positive"},
+            premise_bindings={"score_correct": gate},
+        ),
+    )
+    graph = _lg(
+        knowledges=[
+            Knowledge(id=gate, type="claim", content="Score was computed correctly."),
+            Knowledge(id=target, type="claim", content="Treatment B is better."),
+        ],
+        strategies=[strategy],
+        likelihood_scores=[
+            LikelihoodScoreRecord(
+                score_id="score:positive",
+                module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+                target=target,
+                score_type="log_lr",
+                value=1.0,
+            )
+        ],
+    )
+
+    fg = lower_local_graph(graph, node_priors={gate: 1.0 - CROMWELL_EPS, target: 0.5})
+    like_factor = next(f for f in fg.factors if f.factor_id.startswith("like_loglr"))
+    assert like_factor.factor_type == FactorType.CONDITIONAL
+    assert like_factor.cpt[0] == pytest.approx(0.5)
+    assert like_factor.cpt[1] > 0.73
+
+    beliefs, _ = exact_inference(fg)
+    assert beliefs[target] > 0.73
+
+
+def test_likelihood_log_lr_is_neutral_when_gate_is_false():
+    target = "github:lowertest::target"
+    gate = "github:lowertest::score_correct"
+    strategy = Strategy(
+        scope="local",
+        type="likelihood",
+        premises=[gate],
+        conclusion=target,
+        method=ModuleUseMethod(
+            module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+            input_bindings={"target": target},
+            output_bindings={"score": "score:positive"},
+            premise_bindings={"score_correct": gate},
+        ),
+    )
+    graph = _lg(
+        knowledges=[
+            Knowledge(id=gate, type="claim", content="Score was computed correctly."),
+            Knowledge(id=target, type="claim", content="Treatment B is better."),
+        ],
+        strategies=[strategy],
+        likelihood_scores=[
+            LikelihoodScoreRecord(
+                score_id="score:positive",
+                module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+                target=target,
+                score_type="log_lr",
+                value=1.0,
+            )
+        ],
+    )
+
+    fg = lower_local_graph(graph, node_priors={gate: CROMWELL_EPS, target: 0.5})
+    beliefs, _ = exact_inference(fg)
+    assert beliefs[target] == pytest.approx(0.5, abs=2e-3)
+
+
+def test_negative_likelihood_log_lr_lowers_without_soft_entailment_constraint():
+    target = "github:lowertest::target"
+    gate = "github:lowertest::score_correct"
+    strategy = Strategy(
+        scope="local",
+        type="likelihood",
+        premises=[gate],
+        conclusion=target,
+        method=ModuleUseMethod(
+            module_ref="gaia.std.likelihood.binomial_model@v1",
+            input_bindings={"target": target},
+            output_bindings={"score": "score:negative"},
+            premise_bindings={"score_correct": gate},
+        ),
+    )
+    graph = _lg(
+        knowledges=[
+            Knowledge(id=gate, type="claim", content="Score was computed correctly."),
+            Knowledge(id=target, type="claim", content="The 3:1 model fits."),
+        ],
+        strategies=[strategy],
+        likelihood_scores=[
+            LikelihoodScoreRecord(
+                score_id="score:negative",
+                module_ref="gaia.std.likelihood.binomial_model@v1",
+                target=target,
+                score_type="log_lr",
+                value=-1.0,
+            )
+        ],
+    )
+
+    fg = lower_local_graph(graph, node_priors={gate: 1.0 - CROMWELL_EPS, target: 0.5})
+    like_factor = next(f for f in fg.factors if f.factor_id.startswith("like_loglr"))
+    assert like_factor.factor_type == FactorType.CONDITIONAL
+    assert like_factor.cpt[1] < 0.27
 
 
 def test_infer_conditional_lowering():


### PR DESCRIPTION
## Summary
- persist v6 LikelihoodScoreRecord values on LocalCanonicalGraph so score refs can be reviewed and lowered
- compile Lang LikelihoodScore/ComputeResult outputs into graph-level likelihood score records
- lower log_lr likelihood strategies as gated conditional factors: gate false is neutral, gate true adds log_lr to target log-odds
- add validation for score records and strategy score bindings
- add FactorGraph.add_log_likelihood plus lowering tests for positive, neutral-gated, and negative log_lr cases

## Validation
- python -m pytest tests/gaia/std/test_likelihood.py tests/gaia/lang/test_v6_surface.py tests/ir/test_graphs.py tests/ir/test_validator.py tests/test_lowering.py tests/gaia/bp/test_factor_graph.py
- python -m pytest
- git diff --check