### PR TITLE
test(examples): add v6 likelihood end-to-end examples

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable Gaia examples."""

--- a/examples/v6_likelihood/README.md
+++ b/examples/v6_likelihood/README.md
@@ -1,0 +1,16 @@
+# v6 likelihood examples
+
+These examples exercise the v6 statistical-model path:
+
+1. represent observed data as parameterized Claims,
+2. compute a `LikelihoodScore`,
+3. attach the score to a `compute()` correctness Claim,
+4. feed it through `likelihood_from()`,
+5. compile to IR and lower `log_lr` into BP.
+
+Run them from the repository root:
+
+```bash
+python -m examples.v6_likelihood.mendel
+python -m examples.v6_likelihood.ab_test
+```

--- a/examples/v6_likelihood/__init__.py
+++ b/examples/v6_likelihood/__init__.py
@@ -1,0 +1,3 @@
+"""Runnable v6 likelihood examples."""
+
+__all__: list[str] = []

--- a/examples/v6_likelihood/ab_test.py
+++ b/examples/v6_likelihood/ab_test.py
@@ -1,0 +1,101 @@
+"""Two-binomial AB test as a v6 likelihood example."""
+
+from __future__ import annotations
+
+from gaia.lang import claim, compute, context, likelihood_from
+from gaia.lang.runtime.package import CollectedPackage
+from gaia.std.likelihood import TWO_BINOMIAL_AB_TEST_REF, two_binomial_ab_test_score
+
+from examples.v6_likelihood.common import ExampleResult, compile_and_infer
+
+
+def build_ab_test_package() -> CollectedPackage:
+    """Build a Gaia package for 500/10000 vs 550/10000 conversions."""
+    package = CollectedPackage("v6_ab_test_likelihood", namespace="github", version="1.0.0")
+    with package:
+        source = context(
+            "AB dashboard excerpt: control A had 500 conversions out of 10000 users; "
+            "treatment B had 550 conversions out of 10000 users."
+        )
+        source.label = "ab_dashboard"
+
+        counts = claim(
+            "AB test counts are 500/10000 for control A and 550/10000 for treatment B.",
+            content_template=(
+                "[@experiment] recorded {control_successes}/{control_trials} for "
+                "control and {treatment_successes}/{treatment_trials} for treatment."
+            ),
+            rendered_content=(
+                "AB test exp_001 recorded 500/10000 for control and "
+                "550/10000 for treatment."
+            ),
+            parameters=[
+                {
+                    "name": "experiment",
+                    "type": "Context",
+                    "value": "github:v6_ab_test_likelihood::ab_dashboard",
+                },
+                {"name": "control_successes", "type": "int", "value": 500},
+                {"name": "control_trials", "type": "int", "value": 10_000},
+                {"name": "treatment_successes", "type": "int", "value": 550},
+                {"name": "treatment_trials", "type": "int", "value": 10_000},
+            ],
+            prior=0.999,
+        )
+        counts.label = "ab_counts"
+
+        randomization_valid = claim(
+            "Users were randomly assigned between control A and treatment B.",
+            prior=0.999,
+        )
+        randomization_valid.label = "randomization_valid"
+
+        target = claim("Treatment B has a higher true conversion rate than control A.", prior=0.5)
+        target.label = "treatment_b_better"
+
+        score_correct = claim(
+            "The two-binomial AB-test log-likelihood score was computed correctly.",
+            prior=0.999,
+        )
+        score_correct.label = "ab_score_correct"
+
+        score = two_binomial_ab_test_score(
+            target=target,
+            control_successes=500,
+            control_trials=10_000,
+            treatment_successes=550,
+            treatment_trials=10_000,
+            query="theta_B > theta_A",
+        )
+        score_result = compute(
+            "gaia.std.likelihood.two_binomial_ab_test_score",
+            inputs={"counts": counts, "target": target},
+            assumptions=[randomization_valid],
+            output=score,
+            correctness=score_correct,
+            reason="Compute the signed two-binomial log likelihood ratio.",
+        )
+
+        likelihood_from(
+            target=target,
+            data=[counts],
+            assumptions=[randomization_valid],
+            score=score_result,
+            reason="Use the AB-test score as a likelihood update.",
+        )
+
+    return package
+
+
+def infer_ab_test() -> ExampleResult:
+    return compile_and_infer(build_ab_test_package())
+
+
+if __name__ == "__main__":
+    result = infer_ab_test()
+    score = result.compiled.graph.likelihood_scores[0]
+    target_id = "github:v6_ab_test_likelihood::treatment_b_better"
+    print(f"module_ref={TWO_BINOMIAL_AB_TEST_REF}")
+    print(f"score_id={score.score_id}")
+    print(f"log_lr={score.value:.6f}")
+    print(f"belief={result.beliefs[target_id]:.6f}")

--- a/examples/v6_likelihood/common.py
+++ b/examples/v6_likelihood/common.py
@@ -1,0 +1,24 @@
+"""Shared helpers for v6 likelihood examples."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gaia.bp import lower_local_graph
+from gaia.bp.exact import exact_inference
+from gaia.lang.compiler.compile import CompiledPackage, compile_package_artifact
+from gaia.lang.runtime.package import CollectedPackage
+
+
+@dataclass(frozen=True)
+class ExampleResult:
+    package: CollectedPackage
+    compiled: CompiledPackage
+    beliefs: dict[str, float]
+
+
+def compile_and_infer(package: CollectedPackage) -> ExampleResult:
+    compiled = compile_package_artifact(package)
+    factor_graph = lower_local_graph(compiled.graph)
+    beliefs, _ = exact_inference(factor_graph)
+    return ExampleResult(package=package, compiled=compiled, beliefs=beliefs)

--- a/examples/v6_likelihood/mendel.py
+++ b/examples/v6_likelihood/mendel.py
@@ -1,0 +1,100 @@
+"""Mendel 2.95:1 vs 3:1 as a v6 likelihood example."""
+
+from __future__ import annotations
+
+from gaia.lang import claim, compute, context, likelihood_from
+from gaia.lang.runtime.package import CollectedPackage
+from gaia.std.likelihood import BINOMIAL_MODEL_REF, binomial_model_score
+
+from examples.v6_likelihood.common import ExampleResult, compile_and_infer
+
+
+def build_mendel_package() -> CollectedPackage:
+    """Build a Gaia package for an observed 295:100 ratio under a 3:1 model."""
+    package = CollectedPackage("v6_mendel_likelihood", namespace="github", version="1.0.0")
+    with package:
+        source = context(
+            "Mendel-style dominant/recessive count: 295 dominant and 100 recessive plants."
+        )
+        source.label = "mendel_table"
+
+        counts = claim(
+            "The experiment observed 295 dominant plants out of 395 total plants.",
+            content_template=(
+                "[@experiment] observed {dominant_count} dominant plants out of "
+                "{total_count} total plants."
+            ),
+            rendered_content=(
+                "The Mendel-style experiment observed 295 dominant plants out of "
+                "395 total plants."
+            ),
+            parameters=[
+                {
+                    "name": "experiment",
+                    "type": "Context",
+                    "value": "github:v6_mendel_likelihood::mendel_table",
+                },
+                {"name": "dominant_count", "type": "int", "value": 295},
+                {"name": "total_count", "type": "int", "value": 395},
+            ],
+            prior=0.999,
+        )
+        counts.label = "mendel_counts"
+
+        target = claim(
+            "The 3:1 binomial model is not strongly disconfirmed by the observed count.",
+            prior=0.5,
+        )
+        target.label = "three_to_one_not_disconfirmed"
+
+        statistical_model_valid = claim(
+            "A binomial count model is appropriate for this segregating-trait count.",
+            prior=0.999,
+        )
+        statistical_model_valid.label = "binomial_model_valid"
+
+        score_correct = claim(
+            "The binomial log-likelihood score was computed correctly.",
+            prior=0.999,
+        )
+        score_correct.label = "mendel_score_correct"
+
+        score = binomial_model_score(
+            target=target,
+            successes=295,
+            trials=395,
+            probability=0.75,
+            query="p = 0.75",
+        )
+        score_result = compute(
+            "gaia.std.likelihood.binomial_model_score",
+            inputs={"counts": counts, "target": target},
+            assumptions=[statistical_model_valid],
+            output=score,
+            correctness=score_correct,
+            reason="Compute log L(p=0.75) - log L(p_hat) for the observed count.",
+        )
+
+        likelihood_from(
+            target=target,
+            data=[counts],
+            assumptions=[statistical_model_valid],
+            score=score_result,
+            reason="Use the binomial-model score as a likelihood update.",
+        )
+
+    return package
+
+
+def infer_mendel() -> ExampleResult:
+    return compile_and_infer(build_mendel_package())
+
+
+if __name__ == "__main__":
+    result = infer_mendel()
+    score = result.compiled.graph.likelihood_scores[0]
+    target_id = "github:v6_mendel_likelihood::three_to_one_not_disconfirmed"
+    print(f"module_ref={BINOMIAL_MODEL_REF}")
+    print(f"score_id={score.score_id}")
+    print(f"log_lr={score.value:.6f}")
+    print(f"belief={result.beliefs[target_id]:.6f}")

--- a/tests/gaia/examples/test_v6_likelihood_examples.py
+++ b/tests/gaia/examples/test_v6_likelihood_examples.py
@@ -1,0 +1,46 @@
+"""End-to-end tests for runnable v6 likelihood examples."""
+
+from gaia.bp import lower_local_graph
+from gaia.ir import ModuleUseMethod
+from gaia.ir.validator import validate_local_graph
+
+from examples.v6_likelihood.ab_test import infer_ab_test
+from examples.v6_likelihood.mendel import infer_mendel
+
+
+def test_mendel_example_compiles_and_infers():
+    result = infer_mendel()
+    graph = result.compiled.graph
+    validation = validate_local_graph(graph)
+    assert validation.valid, validation.errors
+
+    assert len(graph.likelihood_scores) == 1
+    score = graph.likelihood_scores[0]
+    assert score.module_ref == "gaia.std.likelihood.binomial_model@v1"
+    assert round(score.value, 6) == -0.010519
+
+    target_id = "github:v6_mendel_likelihood::three_to_one_not_disconfirmed"
+    assert target_id in result.beliefs
+    assert 0.49 < result.beliefs[target_id] < 0.51
+
+    factor_graph = lower_local_graph(graph)
+    assert any(f.factor_id.startswith("like_loglr") for f in factor_graph.factors)
+
+
+def test_ab_test_example_compiles_and_infers():
+    result = infer_ab_test()
+    graph = result.compiled.graph
+    validation = validate_local_graph(graph)
+    assert validation.valid, validation.errors
+
+    strategies = {strategy.type: strategy for strategy in graph.strategies}
+    likelihood = strategies["likelihood"]
+    assert isinstance(likelihood.method, ModuleUseMethod)
+    assert likelihood.method.output_bindings["score"] == graph.likelihood_scores[0].score_id
+
+    score = graph.likelihood_scores[0]
+    assert score.module_ref == "gaia.std.likelihood.two_binomial_ab_test@v1"
+    assert score.value > 1.25
+
+    target_id = "github:v6_ab_test_likelihood::treatment_b_better"
+    assert result.beliefs[target_id] > 0.75


### PR DESCRIPTION
## Summary
- add runnable v6 likelihood examples for Mendel 3:1 and a two-binomial AB test
- each example builds a Gaia Lang package, computes a LikelihoodScore, compiles IR, lowers to BP, and runs exact inference
- include a small shared example runner and README with python -m commands
- add regression tests that validate graph structure, score records, likelihood factors, and resulting beliefs

## Validation
- python -m pytest tests/gaia/examples/test_v6_likelihood_examples.py tests/gaia/std/test_likelihood.py tests/test_lowering.py
- python -m examples.v6_likelihood.mendel
- python -m examples.v6_likelihood.ab_test
- python -m pytest
- git diff --check