### PR TITLE
feat(cli): render v6 likelihood method details

### DIFF
--- a/gaia/cli/commands/_brief.py
+++ b/gaia/cli/commands/_brief.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from collections import defaultdict
 
 from gaia.cli.commands._classify import classify_ir, node_role
+from gaia.cli.commands._v6_methods import (
+    format_method_lines,
+    format_method_oneline,
+    likelihood_score_by_id,
+)
 
 
 def _truncate(text: str, max_len: int = 80) -> str:
@@ -82,6 +87,7 @@ def _module_of(kid: str, knowledge_by_id: dict[str, dict]) -> str | None:
 def generate_brief_overview(ir: dict) -> list[str]:
     """Per-module compact overview of all non-helper nodes and strategies."""
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    scores_by_id = likelihood_score_by_id(ir)
     c = classify_ir(ir)
     module_order = ir.get("module_order") or []
 
@@ -186,7 +192,7 @@ def generate_brief_overview(ir: dict) -> list[str]:
         if strats:
             lines.append("  Strategies:")
             for s in strats:
-                lines.append(_format_strategy_oneline(s, knowledge_by_id))
+                lines.append(_format_strategy_oneline(s, knowledge_by_id, scores_by_id))
 
         ops = op_by_module.get(mod, [])
         if ops:
@@ -197,8 +203,13 @@ def generate_brief_overview(ir: dict) -> list[str]:
     return lines
 
 
-def _format_strategy_oneline(s: dict, knowledge_by_id: dict[str, dict]) -> str:
+def _format_strategy_oneline(
+    s: dict,
+    knowledge_by_id: dict[str, dict],
+    scores_by_id: dict[str, dict] | None = None,
+) -> str:
     stype = s.get("type", "?")
+    scores_by_id = scores_by_id or {}
     premise_labels = [
         _label_of(p, knowledge_by_id)
         for p in s.get("premises", [])
@@ -213,6 +224,9 @@ def _format_strategy_oneline(s: dict, knowledge_by_id: dict[str, dict]) -> str:
     line = f"    {stype}([{', '.join(premise_labels)}] \u2192 {conc_label}{prior_s})"
     if reason:
         line += f'\n      reason: "{_truncate(reason, 70)}"'
+    method = format_method_oneline(s, scores_by_id)
+    if method:
+        line += f"\n      {method}"
     return line
 
 
@@ -241,6 +255,7 @@ def _format_operator_oneline(o: dict, knowledge_by_id: dict[str, dict]) -> str:
 def generate_brief_module(ir: dict, module_name: str) -> list[str]:
     """Expand a module showing full content and recursive warrant trees."""
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    scores_by_id = likelihood_score_by_id(ir)
     c = classify_ir(ir)
     sid_map = _strategy_by_id(ir)
     conc_map = _strategies_for_conclusion(ir)
@@ -296,7 +311,13 @@ def generate_brief_module(ir: dict, module_name: str) -> list[str]:
             # If derived, show strategy tree
             strat = conc_map.get(kid)
             if strat:
-                tree_lines = _format_warrant_tree(strat, knowledge_by_id, sid_map, indent=6)
+                tree_lines = _format_warrant_tree(
+                    strat,
+                    knowledge_by_id,
+                    sid_map,
+                    scores_by_id=scores_by_id,
+                    indent=6,
+                )
                 lines.extend(tree_lines)
         lines.append("")
 
@@ -338,6 +359,7 @@ def _format_operator_expanded(o: dict, knowledge_by_id: dict[str, dict], indent:
 def generate_brief_detail(ir: dict, label: str) -> list[str]:
     """Expand the warrant tree for a specific claim or strategy label."""
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    scores_by_id = likelihood_score_by_id(ir)
     c = classify_ir(ir)
     sid_map = _strategy_by_id(ir)
     conc_map = _strategies_for_conclusion(ir)
@@ -365,7 +387,13 @@ def generate_brief_detail(ir: dict, label: str) -> list[str]:
     strat = conc_map.get(kid)
     if strat:
         lines.append("")
-        tree_lines = _format_warrant_tree(strat, knowledge_by_id, sid_map, indent=4)
+        tree_lines = _format_warrant_tree(
+            strat,
+            knowledge_by_id,
+            sid_map,
+            scores_by_id=scores_by_id,
+            indent=4,
+        )
         lines.extend(tree_lines)
 
         # For composite strategies (abduction/induction), add review notes
@@ -405,11 +433,13 @@ def _format_warrant_tree(
     strategy: dict,
     knowledge_by_id: dict[str, dict],
     sid_map: dict[str, dict],
+    scores_by_id: dict[str, dict] | None = None,
     indent: int = 4,
 ) -> list[str]:
     """Recursively format a strategy's warrant tree."""
     pad = " " * indent
     lines: list[str] = []
+    scores_by_id = scores_by_id or {}
 
     stype = strategy.get("type", "?")
     meta = strategy.get("metadata") or {}
@@ -483,6 +513,7 @@ def _format_warrant_tree(
         )
         if reason:
             lines.append(f'{pad}  reason: "{_truncate(reason, 70)}"')
+        lines.extend(format_method_lines(strategy, scores_by_id, indent=indent + 2))
 
         for op in formal_expr.get("operators", []):
             op_type = op.get("operator", "?")
@@ -505,6 +536,7 @@ def _format_warrant_tree(
         )
         if reason:
             lines.append(f'{pad}  reason: "{_truncate(reason, 70)}"')
+        lines.extend(format_method_lines(strategy, scores_by_id, indent=indent + 2))
         if stype == "infer":
             n_premises = len(strategy.get("premises", []))
             lines.append(

--- a/gaia/cli/commands/_detailed_reasoning.py
+++ b/gaia/cli/commands/_detailed_reasoning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 from gaia.cli.commands._classify import classify_ir, node_role
+from gaia.cli.commands._v6_methods import format_method_lines, likelihood_score_by_id
 
 
 def topo_layers(ir: dict) -> dict[str, int]:
@@ -329,6 +330,7 @@ def _render_node(
     knowledge_by_id: dict[str, dict],
     beliefs: dict[str, float],
     priors: dict[str, float],
+    scores_by_id: dict[str, dict] | None = None,
     *,
     emit_anchor: bool = True,
 ) -> list[str]:
@@ -387,6 +389,16 @@ def _render_node(
             lines.append("<details><summary>Reasoning</summary>")
             lines.append("")
             lines.append(reason)
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
+        method_lines = format_method_lines(s, scores_by_id or {})
+        if method_lines:
+            lines.append("<details><summary>Method</summary>")
+            lines.append("")
+            for line in method_lines:
+                lines.append(f"- {line}")
             lines.append("")
             lines.append("</details>")
             lines.append("")
@@ -490,6 +502,7 @@ def _render_introduction(
         return []
 
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    scores_by_id = likelihood_score_by_id(ir)
     strategy_for: dict[str, dict] = {}
     for s in ir.get("strategies", []):
         if s.get("conclusion"):
@@ -510,6 +523,7 @@ def _render_introduction(
                 knowledge_by_id,
                 beliefs,
                 priors,
+                scores_by_id,
                 emit_anchor=False,
             )
         )
@@ -523,6 +537,7 @@ def render_knowledge_nodes(
 ) -> str:
     """Render knowledge nodes grouped by module with per-module Mermaid diagrams."""
     knowledge_by_id = {k["id"]: k for k in ir["knowledges"]}
+    scores_by_id = likelihood_score_by_id(ir)
     beliefs = beliefs or {}
     priors = priors or {}
 
@@ -564,7 +579,9 @@ def render_knowledge_nodes(
                 sections.append("")
 
             for k in nodes:
-                sections.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+                sections.extend(
+                    _render_node(k, strategy_for, knowledge_by_id, beliefs, priors, scores_by_id)
+                )
     else:
         # Single-file/legacy: one global diagram + type-based grouping
         ordered = _narrative_order(ir)
@@ -582,7 +599,9 @@ def render_knowledge_nodes(
                 current_type = ktype
                 sections.append(f"### {ktype.title()}s")
                 sections.append("")
-            sections.extend(_render_node(k, strategy_for, knowledge_by_id, beliefs, priors))
+            sections.extend(
+                _render_node(k, strategy_for, knowledge_by_id, beliefs, priors, scores_by_id)
+            )
 
     return "\n".join(sections)
 

--- a/gaia/cli/commands/_v6_methods.py
+++ b/gaia/cli/commands/_v6_methods.py
@@ -1,0 +1,117 @@
+"""Formatting helpers for v6 strategy method payloads."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def likelihood_score_by_id(ir: dict) -> dict[str, dict]:
+    """Return likelihood score records keyed by score_id."""
+    return {
+        score["score_id"]: score
+        for score in ir.get("likelihood_scores", [])
+        if isinstance(score, dict) and score.get("score_id")
+    }
+
+
+def _format_scalar(value: Any) -> str:
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+
+
+def _format_query(query: Any) -> str | None:
+    if query is None:
+        return None
+    if isinstance(query, str):
+        return query
+    return json.dumps(query, sort_keys=True, ensure_ascii=False, default=str)
+
+
+def _score_summary(score: dict | None) -> str | None:
+    if not score:
+        return None
+    score_type = score.get("score_type")
+    if not score_type or "value" not in score:
+        return None
+    return f"{score_type}={_format_scalar(score['value'])}"
+
+
+def _score_for_ref(score_ref: str | None, scores_by_id: dict[str, dict]) -> dict | None:
+    if not score_ref:
+        return None
+    return scores_by_id.get(score_ref)
+
+
+def format_method_lines(
+    strategy: dict,
+    scores_by_id: dict[str, dict],
+    *,
+    indent: int = 0,
+    include_rationale: bool = True,
+) -> list[str]:
+    """Format a v6 strategy method as plain, indented diagnostic lines."""
+    method = strategy.get("method") or {}
+    if not method:
+        return []
+
+    pad = " " * indent
+    kind = method.get("kind")
+    lines: list[str] = []
+
+    if kind == "module_use":
+        module_ref = method.get("module_ref")
+        if module_ref:
+            lines.append(f"{pad}method: {module_ref}")
+
+        score_ref = (method.get("output_bindings") or {}).get("score")
+        score = _score_for_ref(score_ref, scores_by_id)
+        summary = _score_summary(score)
+        if summary:
+            lines.append(f"{pad}score: {summary}")
+            query = _format_query(score.get("query"))
+            if query:
+                lines.append(f"{pad}query: {query}")
+            if include_rationale and score.get("rationale"):
+                lines.append(f"{pad}rationale: {score['rationale']}")
+        elif score_ref:
+            lines.append(f"{pad}score: {score_ref}")
+
+    elif kind == "compute":
+        function_ref = method.get("function_ref")
+        if function_ref:
+            lines.append(f"{pad}function: {function_ref}")
+
+        output_ref = method.get("output")
+        score = _score_for_ref(output_ref, scores_by_id)
+        summary = _score_summary(score)
+        if summary:
+            lines.append(f"{pad}output: {summary}")
+            query = _format_query(score.get("query"))
+            if query:
+                lines.append(f"{pad}query: {query}")
+            if include_rationale and score.get("rationale"):
+                lines.append(f"{pad}rationale: {score['rationale']}")
+        elif output_ref:
+            lines.append(f"{pad}output: {output_ref}")
+
+    elif kind:
+        lines.append(f"{pad}method: {kind}")
+
+    return lines
+
+
+def format_method_oneline(strategy: dict, scores_by_id: dict[str, dict]) -> str:
+    """Format method details compactly for one-line strategy summaries."""
+    lines = format_method_lines(
+        strategy,
+        scores_by_id,
+        indent=0,
+        include_rationale=False,
+    )
+    return "; ".join(lines)

--- a/tests/cli/test_v6_likelihood_rendering.py
+++ b/tests/cli/test_v6_likelihood_rendering.py
@@ -1,0 +1,94 @@
+"""CLI rendering coverage for v6 likelihood method details."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_base_package(pkg_dir, *, name: str, version: str = "1.0.0") -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "{version}"\n'
+        'description = "v6 likelihood rendering test package."\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    (pkg_dir / name).mkdir()
+
+
+def _write_ab_test_package(pkg_dir) -> None:
+    name = "v6_render_ab"
+    _write_base_package(pkg_dir, name=name)
+    (pkg_dir / name / "__init__.py").write_text(
+        "from gaia.lang import claim, compute, context, likelihood_from\n"
+        "from gaia.std.likelihood import two_binomial_ab_test_score\n\n"
+        'source = context("A: 500/10000 conversions; B: 550/10000 conversions.")\n'
+        'counts = claim("AB counts are 500/10000 for A and 550/10000 for B.", prior=0.999)\n'
+        'randomization = claim("Users were randomly assigned.", prior=0.999)\n'
+        'score_correct = claim("The AB log-likelihood score was computed correctly.", prior=0.999)\n'
+        'target = claim("Treatment B has a higher true conversion rate than control A.", prior=0.5)\n'
+        "score = two_binomial_ab_test_score(\n"
+        "    target=target,\n"
+        "    control_successes=500,\n"
+        "    control_trials=10000,\n"
+        "    treatment_successes=550,\n"
+        "    treatment_trials=10000,\n"
+        '    query="theta_B > theta_A",\n'
+        ")\n"
+        "score_result = compute(\n"
+        '    "gaia.std.likelihood.two_binomial_ab_test_score",\n'
+        '    inputs={"counts": counts, "target": target},\n'
+        "    assumptions=[randomization],\n"
+        "    output=score,\n"
+        "    correctness=score_correct,\n"
+        ")\n"
+        "likelihood_from(\n"
+        "    target=target,\n"
+        "    data=[counts],\n"
+        "    assumptions=[randomization],\n"
+        "    score=score_result,\n"
+        ")\n"
+        '__all__ = ["target", "score_correct"]\n'
+    )
+
+
+def test_check_show_renders_likelihood_method_details(tmp_path):
+    pkg_dir = tmp_path / "v6_render_ab"
+    _write_ab_test_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    target_result = runner.invoke(app, ["check", "--show", "target", str(pkg_dir)])
+    assert target_result.exit_code == 0, target_result.output
+    assert "method: gaia.std.likelihood.two_binomial_ab_test@v1" in target_result.output
+    assert "score: log_lr=1.25689" in target_result.output
+    assert "query: theta_B > theta_A" in target_result.output
+
+    compute_result = runner.invoke(app, ["check", "--show", "score_correct", str(pkg_dir)])
+    assert compute_result.exit_code == 0, compute_result.output
+    assert "function: gaia.std.likelihood.two_binomial_ab_test_score" in compute_result.output
+    assert "output: log_lr=1.25689" in compute_result.output
+    assert "query: theta_B > theta_A" in compute_result.output
+
+
+def test_render_docs_include_v6_method_details(tmp_path):
+    pkg_dir = tmp_path / "v6_render_ab"
+    _write_ab_test_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+    infer_result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert infer_result.exit_code == 0, infer_result.output
+
+    render_result = runner.invoke(app, ["render", "--target", "docs", str(pkg_dir)])
+    assert render_result.exit_code == 0, render_result.output
+
+    content = (pkg_dir / "docs" / "detailed-reasoning.md").read_text()
+    assert "<details><summary>Method</summary>" in content
+    assert "- method: gaia.std.likelihood.two_binomial_ab_test@v1" in content
+    assert "- score: log_lr=1.25689" in content
+    assert "- function: gaia.std.likelihood.two_binomial_ab_test_score" in content


### PR DESCRIPTION
## Summary
- add a shared CLI formatter for v6 strategy method payloads
- show likelihood module, score, query, and compute output details in check --brief/--show
- include v6 method details in rendered detailed-reasoning docs

## Validation
- python -m pytest tests/cli/test_v6_likelihood_rendering.py tests/cli/test_brief.py tests/cli/test_render.py
- python -m pytest
- git diff --check HEAD~1 HEAD