### PR TITLE
feat(github): expose v6 likelihood methods in graph view

### DIFF
--- a/gaia/cli/commands/_graph_json.py
+++ b/gaia/cli/commands/_graph_json.py
@@ -9,6 +9,60 @@ from __future__ import annotations
 
 import json
 from collections import Counter
+from typing import Any
+
+from gaia.cli.commands._v6_methods import likelihood_score_by_id
+
+
+def _score_payload(score: dict | None) -> dict[str, Any] | None:
+    if not score:
+        return None
+    return {
+        "score_id": score.get("score_id"),
+        "module_ref": score.get("module_ref"),
+        "target": score.get("target"),
+        "score_type": score.get("score_type"),
+        "value": score.get("value"),
+        "query": score.get("query"),
+        "rationale": score.get("rationale"),
+    }
+
+
+def _method_payload(strategy: dict, scores_by_id: dict[str, dict]) -> dict[str, Any] | None:
+    method = strategy.get("method") or {}
+    kind = method.get("kind")
+    if not kind:
+        return None
+
+    payload: dict[str, Any] = {"kind": kind}
+    for key in (
+        "module_ref",
+        "function_ref",
+        "parameter_ref",
+        "input_bindings",
+        "output_bindings",
+        "premise_bindings",
+        "output_binding",
+        "code_hash",
+    ):
+        if method.get(key):
+            payload[key] = method[key]
+
+    score_ref = None
+    if kind == "module_use":
+        score_ref = (method.get("output_bindings") or {}).get("score")
+    elif kind == "compute":
+        score_ref = method.get("output")
+        if score_ref:
+            payload["output_ref"] = score_ref
+
+    score = _score_payload(scores_by_id.get(score_ref)) if score_ref else None
+    if score:
+        payload["score"] = score
+    elif score_ref:
+        payload["score_ref"] = score_ref
+
+    return payload
 
 
 def generate_graph_json(
@@ -25,6 +79,7 @@ def generate_graph_json(
     if param_data:
         priors = {p["knowledge_id"]: p["value"] for p in param_data.get("priors", [])}
     exported = exported_ids or set()
+    scores_by_id = likelihood_score_by_id(ir)
 
     kid_module: dict[str, str] = {}
     for k in ir.get("knowledges", []):
@@ -65,15 +120,17 @@ def generate_graph_json(
         conc_mod = kid_module.get(conc, "")
         strat_id = f"strat_{i}"
 
-        nodes.append(
-            {
-                "id": strat_id,
-                "type": "strategy",
-                "strategy_type": s.get("type", ""),
-                "module": conc_mod,
-                "reason": s.get("reason", ""),
-            }
-        )
+        strategy_node = {
+            "id": strat_id,
+            "type": "strategy",
+            "strategy_type": s.get("type", ""),
+            "module": conc_mod,
+            "reason": s.get("reason", ""),
+        }
+        method = _method_payload(s, scores_by_id)
+        if method:
+            strategy_node["method"] = method
+        nodes.append(strategy_node)
         strategy_counts[conc_mod] += 1
 
         for p in s.get("premises", []):

--- a/gaia/cli/templates/pages/src/__tests__/DetailPanel.test.tsx
+++ b/gaia/cli/templates/pages/src/__tests__/DetailPanel.test.tsx
@@ -55,4 +55,40 @@ describe('DetailPanel', () => {
     expect(screen.getByText('Plain unstructured body text.')).toBeInTheDocument()
     expect(screen.queryByText('QID')).not.toBeInTheDocument()
   })
+
+  it('renders v6 strategy method score details', () => {
+    const strategyNode: GraphNode = {
+      id: 'strat-1',
+      type: 'strategy',
+      strategy_type: 'likelihood',
+      module: 'm1',
+      reason: 'Use an AB-test likelihood score.',
+      method: {
+        kind: 'module_use',
+        module_ref: 'gaia.std.likelihood.two_binomial_ab_test@v1',
+        score: {
+          score_id: 'score:ab',
+          score_type: 'log_lr',
+          value: 1.25689,
+          query: 'theta_B > theta_A',
+          rationale: 'signed log-likelihood gain',
+        },
+      },
+    }
+
+    render(
+      <DetailPanel
+        node={strategyNode}
+        edges={[]}
+        nodesById={{ 'strat-1': strategyNode }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('likelihood')).toBeInTheDocument()
+    expect(screen.getByText('gaia.std.likelihood.two_binomial_ab_test@v1')).toBeInTheDocument()
+    expect(screen.getByText('log_lr=1.25689')).toBeInTheDocument()
+    expect(screen.getByText('theta_B > theta_A')).toBeInTheDocument()
+    expect(screen.getByText('signed log-likelihood gain')).toBeInTheDocument()
+  })
 })

--- a/gaia/cli/templates/pages/src/components/DetailPanel.module.css
+++ b/gaia/cli/templates/pages/src/components/DetailPanel.module.css
@@ -60,6 +60,7 @@
 .content {
   margin-bottom: 16px;
   line-height: 1.6;
+}
 
 .contentBody {
   margin: 0 0 8px;
@@ -94,7 +95,40 @@
   margin: 0;
   color: #9ca3af;
 }
+
+.method {
   margin-bottom: 16px;
+  padding: 12px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+}
+
+.method h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  color: #374151;
+}
+
+.methodGrid {
+  display: grid;
+  grid-template-columns: minmax(72px, max-content) minmax(0, 1fr);
+  gap: 6px 10px;
+  margin: 0;
+  font-size: 12px;
+}
+
+.methodGrid dt {
+  color: #6b7280;
+  font-weight: 600;
+}
+
+.methodGrid dd {
+  min-width: 0;
+  margin: 0;
+  color: #111827;
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
 .reasoning h3 {

--- a/gaia/cli/templates/pages/src/components/DetailPanel.tsx
+++ b/gaia/cli/templates/pages/src/components/DetailPanel.tsx
@@ -18,6 +18,26 @@ function formatProb(v: number | null | undefined): string {
   return v != null ? v.toFixed(2) : '\u2014'
 }
 
+function formatValue(value: unknown): string {
+  if (value == null) return '\u2014'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return String(value)
+    if (Number.isInteger(value)) return String(value)
+    return Number(value.toPrecision(6)).toString()
+  }
+  if (typeof value === 'string') return value
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return JSON.stringify(value)
+}
+
+function scoreSummary(node: GraphNode): string | null {
+  if (!isStrategyNode(node)) return null
+  const score = node.method?.score
+  if (!score) return null
+  const value = formatValue(score.value)
+  return score.score_type ? `${score.score_type}=${value}` : value
+}
+
 function parseStructuredKnowledgeContent(content: string): ParsedKnowledgeContent | null {
   const lines = content
     .split('\n')
@@ -117,6 +137,52 @@ export default function DetailPanel({ node, edges, nodesById, onClose }: Props) 
             <div className={styles.content}>
               <p><strong>Strategy:</strong> {node.strategy_type}</p>
               {node.reason && <p>{node.reason}</p>}
+            </div>
+          )}
+
+          {isStrategyNode(node) && node.method && (
+            <div className={styles.method}>
+              <h3>Method</h3>
+              <dl className={styles.methodGrid}>
+                <dt>kind</dt>
+                <dd>{node.method.kind}</dd>
+                {node.method.module_ref && (
+                  <>
+                    <dt>module</dt>
+                    <dd>{node.method.module_ref}</dd>
+                  </>
+                )}
+                {node.method.function_ref && (
+                  <>
+                    <dt>function</dt>
+                    <dd>{node.method.function_ref}</dd>
+                  </>
+                )}
+                {scoreSummary(node) && (
+                  <>
+                    <dt>score</dt>
+                    <dd>{scoreSummary(node)}</dd>
+                  </>
+                )}
+                {node.method.score?.query != null && (
+                  <>
+                    <dt>query</dt>
+                    <dd>{formatValue(node.method.score.query)}</dd>
+                  </>
+                )}
+                {node.method.score?.rationale && (
+                  <>
+                    <dt>rationale</dt>
+                    <dd>{node.method.score.rationale}</dd>
+                  </>
+                )}
+                {!node.method.score && node.method.score_ref && (
+                  <>
+                    <dt>score ref</dt>
+                    <dd>{node.method.score_ref}</dd>
+                  </>
+                )}
+              </dl>
             </div>
           )}
 

--- a/gaia/cli/templates/pages/src/types.ts
+++ b/gaia/cli/templates/pages/src/types.ts
@@ -13,12 +13,38 @@ export interface KnowledgeNode {
   metadata: Record<string, unknown>
 }
 
+export interface LikelihoodScoreDetail {
+  score_id?: string | null
+  module_ref?: string | null
+  target?: string | null
+  score_type?: string | null
+  value?: unknown
+  query?: unknown
+  rationale?: string | null
+}
+
+export interface StrategyMethodDetails {
+  kind: string
+  module_ref?: string
+  function_ref?: string
+  parameter_ref?: string
+  input_bindings?: Record<string, string>
+  output_bindings?: Record<string, string>
+  premise_bindings?: Record<string, string>
+  output_binding?: Record<string, string>
+  output_ref?: string
+  score_ref?: string
+  score?: LikelihoodScoreDetail
+  code_hash?: string
+}
+
 export interface StrategyNode {
   id: string
   type: 'strategy'
   strategy_type: string
   module?: string
   reason?: string
+  method?: StrategyMethodDetails
 }
 
 export interface OperatorNode {

--- a/tests/cli/test_graph_json.py
+++ b/tests/cli/test_graph_json.py
@@ -12,6 +12,7 @@ def _make_ir(
     strategies: list[dict] | None = None,
     operators: list[dict] | None = None,
     module_order: list[str] | None = None,
+    likelihood_scores: list[dict] | None = None,
 ) -> dict:
     return {
         "package_name": "test_pkg",
@@ -20,6 +21,7 @@ def _make_ir(
         "strategies": strategies or [],
         "operators": operators or [],
         "module_order": module_order or [],
+        "likelihood_scores": likelihood_scores or [],
     }
 
 
@@ -97,6 +99,66 @@ def test_strategy_becomes_node_with_role_edges():
     assert len(concl_edges) == 1
     assert concl_edges[0]["source"] == sn["id"]
     assert concl_edges[0]["target"] == "github:test_pkg::b"
+
+
+def test_strategy_node_includes_v6_likelihood_method_details():
+    score_id = "score:ab"
+    target_id = "github:test_pkg::b"
+    ir = _make_ir(
+        knowledges=[
+            {
+                "id": "github:test_pkg::a",
+                "label": "a",
+                "type": "claim",
+                "content": "A.",
+                "module": "m1",
+            },
+            {
+                "id": target_id,
+                "label": "b",
+                "type": "claim",
+                "content": "B.",
+                "module": "m1",
+            },
+        ],
+        strategies=[
+            {
+                "type": "likelihood",
+                "premises": ["github:test_pkg::a"],
+                "background": [],
+                "conclusion": target_id,
+                "reason": "Use an AB-test likelihood score.",
+                "method": {
+                    "kind": "module_use",
+                    "module_ref": "gaia.std.likelihood.two_binomial_ab_test@v1",
+                    "input_bindings": {"target": target_id, "data": "github:test_pkg::a"},
+                    "output_bindings": {"score": score_id},
+                    "premise_bindings": {"data_0": "github:test_pkg::a"},
+                },
+            },
+        ],
+        likelihood_scores=[
+            {
+                "score_id": score_id,
+                "module_ref": "gaia.std.likelihood.two_binomial_ab_test@v1",
+                "target": target_id,
+                "score_type": "log_lr",
+                "value": 1.25689,
+                "query": "theta_B > theta_A",
+                "rationale": "signed log-likelihood gain",
+            }
+        ],
+        module_order=["m1"],
+    )
+
+    data = json.loads(generate_graph_json(ir))
+    strategy = next(n for n in data["nodes"] if n["type"] == "strategy")
+
+    assert strategy["method"]["kind"] == "module_use"
+    assert strategy["method"]["module_ref"] == "gaia.std.likelihood.two_binomial_ab_test@v1"
+    assert strategy["method"]["score"]["score_type"] == "log_lr"
+    assert strategy["method"]["score"]["value"] == 1.25689
+    assert strategy["method"]["score"]["query"] == "theta_B > theta_A"
 
 
 def test_background_edges_have_background_role():


### PR DESCRIPTION
## Summary
- include structured v6 strategy method payloads in graph.json strategy nodes
- attach likelihood score records to module_use and compute methods for published graph consumers
- render method kind, module/function, score, query, and rationale in the React DetailPanel

## Validation
- python -m pytest tests/cli/test_graph_json.py tests/cli/test_v6_likelihood_rendering.py tests/cli/test_github_integration.py
- python -m pytest
- npm run build
- npm test -- --run
- git diff --check HEAD~1 HEAD