### PR TITLE
feat(ir): validate v6 likelihood module contracts

### DIFF
--- a/docs/specs/2026-04-20-gaia-v6-likelihood-minimal-design.md
+++ b/docs/specs/2026-04-20-gaia-v6-likelihood-minimal-design.md
@@ -1,0 +1,303 @@
+# Gaia v6 Likelihood Minimal Design
+
+> Status: implementation note
+> Date: 2026-04-20
+> Scope: current Python implementation of v6 `compute()` and `likelihood_from()`
+> Related PR stack: v6 strategy methods, standard likelihood modules, BP lowering, CLI/rendering surfaces
+
+---
+
+## 1. First principles
+
+Gaia v6 keeps one probability-bearing object:
+
+```text
+Claim
+```
+
+Everything else explains how claims are connected, computed, reviewed, or rendered.
+
+The likelihood design follows from this rule:
+
+1. A statistical model does not become a probabilistic edge.
+2. A computed score is not itself a Claim.
+3. Uncertain assumptions about the model, data, or code must be represented as Claims.
+4. A likelihood Strategy consumes a score value and applies it to one target Claim.
+
+So the minimal shape is:
+
+```text
+data/model/code assumptions  ->  compute correctness Claim
+LikelihoodScore value        ->  likelihood update on target Claim
+```
+
+The score is a value object. The correctness of computing or using the score is a Claim.
+
+---
+
+## 2. Objects
+
+### `LikelihoodScore`
+
+`LikelihoodScore` is a runtime value object produced by a module function.
+
+It contains:
+
+```python
+target: Claim
+module_ref: str
+score_type: "log_lr" | "bayes_factor" | "likelihood_table" | "custom"
+value: Any
+query: str | dict | None
+rationale: str | None
+score_id: str
+```
+
+It is not a Claim and does not get a prior or posterior.
+
+Example:
+
+```python
+score = two_binomial_ab_test_score(
+    target=b_better,
+    control_successes=500,
+    control_trials=10_000,
+    treatment_successes=550,
+    treatment_trials=10_000,
+    query="theta_B > theta_A",
+)
+```
+
+This says: under the registered AB-test likelihood module, compute a score for the query
+`theta_B > theta_A` against the target Claim `b_better`.
+
+### `compute()`
+
+`compute()` records a deterministic computation and returns:
+
+```python
+ComputeResult(output, correctness, strategy)
+```
+
+Current semantics:
+
+- `output` is the value/artifact produced by the function, often a `LikelihoodScore`.
+- `correctness` is a Claim saying the computation output was correctly produced.
+- `strategy` is `Strategy(type="compute")` with `method=ComputeMethod(...)`.
+
+`compute()` does not itself add probability. If the computation might be wrong, that uncertainty
+lives in the `correctness` Claim and in any assumption Claims passed to `compute()`.
+
+Example:
+
+```python
+score_result = compute(
+    "gaia.std.likelihood.two_binomial_ab_test_score",
+    inputs={"counts": counts, "target": b_better},
+    assumptions=[randomization_valid],
+    output=score,
+    correctness=score_correct,
+)
+```
+
+This connects:
+
+```text
+counts, b_better, randomization_valid -> score_correct
+output = score
+```
+
+### `likelihood_from()`
+
+`likelihood_from()` records a likelihood update and returns a `Strategy(type="likelihood")`.
+
+It consumes either:
+
+```python
+score=LikelihoodScore(...)
+score_correctness=Claim(...)
+```
+
+or the preferred bundled form:
+
+```python
+score=ComputeResult(...)
+```
+
+When passed a `ComputeResult`, it automatically extracts:
+
+```text
+score.output       -> score value
+score.correctness  -> score_correct premise
+```
+
+Example:
+
+```python
+likelihood_from(
+    target=b_better,
+    data=[counts],
+    assumptions=[randomization_valid],
+    score=score_result,
+)
+```
+
+This lowers to a `Strategy(type="likelihood")` whose method is:
+
+```python
+ModuleUseMethod(
+    module_ref="gaia.std.likelihood.two_binomial_ab_test@v1",
+    input_bindings={"target": b_better, ...},
+    output_bindings={"score": score.score_id},
+    premise_bindings={"score_correct": score_correct, ...},
+)
+```
+
+---
+
+## 3. What `query` means
+
+`query` is the statistical proposition answered by the module score. It is not display text only.
+
+Examples:
+
+```text
+theta_B > theta_A
+p = 0.75
+```
+
+For AB tests, `query="theta_B > theta_A"` means the signed likelihood score should update the
+Claim that treatment B has a higher true rate than control A.
+
+For Mendel-style counts, `query="p = 0.75"` means the score measures how well the observed count
+fits a binomial model with success probability 0.75 relative to the saturated MLE model.
+
+The current standard modules require non-empty `query` in validated IR because otherwise a score
+has no machine-readable statement of what was actually evaluated.
+
+---
+
+## 4. Standard module registry
+
+The first implementation has a small static registry:
+
+```python
+gaia.std.likelihood.binomial_model@v1
+gaia.std.likelihood.two_binomial_ab_test@v1
+```
+
+Each `LikelihoodModuleSpec` declares:
+
+```python
+module_ref
+input_schema
+output_schema
+premise_schema
+target_role
+score_role
+score_type
+effect
+```
+
+Current lowering supports:
+
+```text
+score_type = "log_lr"
+effect     = "add_log_odds"
+```
+
+Future modules may add Bayes factors or likelihood tables, but they must enter through a registered
+spec before the validator accepts them.
+
+---
+
+## 5. Validator contract
+
+The IR validator checks the executable contract rather than only checking shapes.
+
+For every registered likelihood score:
+
+- `score.module_ref` must be known.
+- `score.score_type` must match the registered module spec.
+- `score.target` must exist and be a Claim.
+- `score.query` must be non-empty.
+- `log_lr` values must be finite numbers.
+
+For every `Strategy(type="likelihood")`:
+
+- `method` must be `ModuleUseMethod`.
+- `method.module_ref` must be known.
+- `method.output_bindings[spec.score_role]` must reference an existing score record.
+- the score module must match the method module.
+- the score type must match the module spec.
+- `method.input_bindings[spec.target_role]` must point to the Strategy conclusion.
+- `score.target` must match the Strategy conclusion and target binding.
+
+This prevents the common failure mode where a likelihood Strategy points at one target while the
+score was computed for another target, or where a score value from one statistical module is used
+as if it came from another module.
+
+---
+
+## 6. BP lowering
+
+For the current `log_lr` modules, lowering applies a gated likelihood update:
+
+```text
+posterior odds(target) = prior odds(target) * exp(log_lr)
+```
+
+The gate is the score correctness Claim. If the correctness Claim is false, the likelihood update
+is neutral. If it is true, the log-likelihood ratio shifts the target Claim's log-odds.
+
+This is why `compute()` creates or accepts a correctness Claim. The system never treats a numeric
+score as automatically trustworthy.
+
+---
+
+## 7. Minimal worked example
+
+```python
+from gaia.lang import claim, compute, likelihood_from
+from gaia.std.likelihood import two_binomial_ab_test_score
+
+counts = claim("A: 500/10000 conversions; B: 550/10000 conversions.", prior=0.999)
+randomization = claim("Users were randomly assigned.", prior=0.999)
+score_correct = claim("The AB log-likelihood score was computed correctly.", prior=0.999)
+target = claim("Treatment B has a higher true conversion rate than control A.", prior=0.5)
+
+score = two_binomial_ab_test_score(
+    target=target,
+    control_successes=500,
+    control_trials=10_000,
+    treatment_successes=550,
+    treatment_trials=10_000,
+    query="theta_B > theta_A",
+)
+
+score_result = compute(
+    "gaia.std.likelihood.two_binomial_ab_test_score",
+    inputs={"counts": counts, "target": target},
+    assumptions=[randomization],
+    output=score,
+    correctness=score_correct,
+)
+
+likelihood_from(
+    target=target,
+    data=[counts],
+    assumptions=[randomization],
+    score=score_result,
+)
+```
+
+Conceptually:
+
+```text
+score = statistical model(data, query, target)
+score_correct = claim that the score computation is correct
+target belief is updated by score only through a likelihood Strategy gated by score_correct
+```
+
+This is the smallest working contract. It deliberately avoids a general compute replay engine.
+Replay validation for standard modules can be added later without changing the IR shape.

--- a/gaia/ir/__init__.py
+++ b/gaia/ir/__init__.py
@@ -33,6 +33,14 @@ from gaia.ir.strategy import (
 from gaia.ir.review import ReviewManifest, ReviewNote, Warrant, WarrantStatus
 from gaia.ir.graphs import LocalCanonicalGraph
 from gaia.ir.formalize import FormalizationResult, formalize_named_strategy
+from gaia.ir.likelihood_registry import (
+    BINOMIAL_MODEL_REF,
+    BINOMIAL_MODEL_SPEC,
+    STANDARD_LIKELIHOOD_MODULES,
+    TWO_BINOMIAL_AB_TEST_REF,
+    TWO_BINOMIAL_AB_TEST_SPEC,
+    get_likelihood_module_spec,
+)
 from gaia.ir.parameterization import (
     CROMWELL_EPS,
     ParameterizationSource,
@@ -71,6 +79,13 @@ __all__ = [
     "WarrantStatus",
     # Graphs
     "LocalCanonicalGraph",
+    # Standard likelihood module registry
+    "BINOMIAL_MODEL_REF",
+    "BINOMIAL_MODEL_SPEC",
+    "STANDARD_LIKELIHOOD_MODULES",
+    "TWO_BINOMIAL_AB_TEST_REF",
+    "TWO_BINOMIAL_AB_TEST_SPEC",
+    "get_likelihood_module_spec",
     # Formalization
     "FormalizationResult",
     "formalize_named_strategy",

--- a/gaia/ir/likelihood_registry.py
+++ b/gaia/ir/likelihood_registry.py
@@ -1,0 +1,40 @@
+"""Registry for standard likelihood modules known to the IR validator."""
+
+from __future__ import annotations
+
+from gaia.ir.strategy import LikelihoodModuleSpec
+
+BINOMIAL_MODEL_REF = "gaia.std.likelihood.binomial_model@v1"
+TWO_BINOMIAL_AB_TEST_REF = "gaia.std.likelihood.two_binomial_ab_test@v1"
+
+BINOMIAL_MODEL_SPEC = LikelihoodModuleSpec(
+    module_ref=BINOMIAL_MODEL_REF,
+    input_schema={"counts": "BinomialCounts", "target": "Claim"},
+    output_schema={"score": "LikelihoodScoreRecord"},
+    premise_schema={"score_correct": "Claim"},
+    target_role="target",
+    score_role="score",
+    score_type="log_lr",
+    effect="add_log_odds",
+)
+
+TWO_BINOMIAL_AB_TEST_SPEC = LikelihoodModuleSpec(
+    module_ref=TWO_BINOMIAL_AB_TEST_REF,
+    input_schema={"counts": "TwoBinomialCounts", "target": "Claim"},
+    output_schema={"score": "LikelihoodScoreRecord"},
+    premise_schema={"score_correct": "Claim"},
+    target_role="target",
+    score_role="score",
+    score_type="log_lr",
+    effect="add_log_odds",
+)
+
+STANDARD_LIKELIHOOD_MODULES: dict[str, LikelihoodModuleSpec] = {
+    BINOMIAL_MODEL_REF: BINOMIAL_MODEL_SPEC,
+    TWO_BINOMIAL_AB_TEST_REF: TWO_BINOMIAL_AB_TEST_SPEC,
+}
+
+
+def get_likelihood_module_spec(module_ref: str) -> LikelihoodModuleSpec | None:
+    """Return the registered likelihood module spec for ``module_ref``."""
+    return STANDARD_LIKELIHOOD_MODULES.get(module_ref)

--- a/gaia/ir/validator.py
+++ b/gaia/ir/validator.py
@@ -14,6 +14,7 @@ from gaia.ir.operator import Operator, OperatorType
 from gaia.ir.strategy import Strategy, CompositeStrategy, FormalStrategy, StrategyType
 from gaia.ir.strategy import ComputeMethod, LikelihoodScoreRecord, ModuleUseMethod
 from gaia.ir.graphs import LocalCanonicalGraph, _canonical_json
+from gaia.ir.likelihood_registry import get_likelihood_module_spec
 from gaia.ir.parameterization import (
     CROMWELL_EPS,
     PriorRecord,
@@ -334,9 +335,20 @@ def _validate_likelihood_scores(
 ) -> dict[str, LikelihoodScoreRecord]:
     lookup: dict[str, LikelihoodScoreRecord] = {}
     for score in scores:
+        spec = get_likelihood_module_spec(score.module_ref)
         if score.score_id in lookup:
             result.error(f"LikelihoodScore '{score.score_id}': duplicate score_id")
         lookup[score.score_id] = score
+        if spec is None:
+            result.error(
+                f"LikelihoodScore '{score.score_id}': unknown likelihood module_ref "
+                f"'{score.module_ref}'"
+            )
+        elif score.score_type != spec.score_type:
+            result.error(
+                f"LikelihoodScore '{score.score_id}': score_type '{score.score_type}' "
+                f"does not match module '{score.module_ref}' score_type '{spec.score_type}'"
+            )
         if score.target not in knowledge_lookup:
             result.error(
                 f"LikelihoodScore '{score.score_id}': target '{score.target}' not found in graph"
@@ -352,6 +364,15 @@ def _validate_likelihood_scores(
                 )
             elif not math.isfinite(float(score.value)):
                 result.error(f"LikelihoodScore '{score.score_id}': log_lr value must be finite")
+        if spec is not None and (
+            score.query is None
+            or (isinstance(score.query, str) and not score.query.strip())
+            or (isinstance(score.query, dict) and not score.query)
+        ):
+            result.error(
+                f"LikelihoodScore '{score.score_id}': registered module "
+                f"'{score.module_ref}' requires a non-empty query"
+            )
     return lookup
 
 
@@ -366,9 +387,20 @@ def _validate_likelihood_strategy_scores(
         ):
             continue
         sid = strategy.strategy_id or "<no-id>"
-        score_ref = strategy.method.output_bindings.get("score")
+        spec = get_likelihood_module_spec(strategy.method.module_ref)
+        if spec is None:
+            result.error(
+                f"Strategy '{sid}': unknown likelihood module_ref "
+                f"'{strategy.method.module_ref}'"
+            )
+            continue
+
+        score_ref = strategy.method.output_bindings.get(spec.score_role)
         if not score_ref:
-            result.error(f"Strategy '{sid}': likelihood method missing output binding 'score'")
+            result.error(
+                f"Strategy '{sid}': likelihood method missing output binding "
+                f"'{spec.score_role}'"
+            )
             continue
         score = score_lookup.get(score_ref)
         if score is None:
@@ -380,10 +412,32 @@ def _validate_likelihood_strategy_scores(
                 f"'{score.module_ref}' does not match method module_ref "
                 f"'{strategy.method.module_ref}'"
             )
+        if score.score_type != spec.score_type:
+            result.error(
+                f"Strategy '{sid}': likelihood score '{score_ref}' score_type "
+                f"'{score.score_type}' does not match module score_type '{spec.score_type}'"
+            )
+        target_binding = strategy.method.input_bindings.get(spec.target_role)
+        if target_binding is None:
+            result.error(
+                f"Strategy '{sid}': likelihood method missing target binding "
+                f"'{spec.target_role}'"
+            )
+        elif strategy.conclusion and target_binding != strategy.conclusion:
+            result.error(
+                f"Strategy '{sid}': likelihood target binding '{spec.target_role}' "
+                f"references '{target_binding}', expected strategy conclusion "
+                f"'{strategy.conclusion}'"
+            )
         if strategy.conclusion and score.target != strategy.conclusion:
             result.error(
                 f"Strategy '{sid}': likelihood score '{score_ref}' target "
                 f"'{score.target}' does not match strategy conclusion '{strategy.conclusion}'"
+            )
+        elif target_binding is not None and score.target != target_binding:
+            result.error(
+                f"Strategy '{sid}': likelihood score '{score_ref}' target "
+                f"'{score.target}' does not match target binding '{target_binding}'"
             )
 
 

--- a/gaia/std/likelihood.py
+++ b/gaia/std/likelihood.py
@@ -4,33 +4,13 @@ from __future__ import annotations
 
 import math
 
-from gaia.ir import LikelihoodModuleSpec
+from gaia.ir.likelihood_registry import (
+    BINOMIAL_MODEL_REF,
+    BINOMIAL_MODEL_SPEC,
+    TWO_BINOMIAL_AB_TEST_REF,
+    TWO_BINOMIAL_AB_TEST_SPEC,
+)
 from gaia.lang.runtime import Knowledge, LikelihoodScore
-
-BINOMIAL_MODEL_REF = "gaia.std.likelihood.binomial_model@v1"
-TWO_BINOMIAL_AB_TEST_REF = "gaia.std.likelihood.two_binomial_ab_test@v1"
-
-BINOMIAL_MODEL_SPEC = LikelihoodModuleSpec(
-    module_ref=BINOMIAL_MODEL_REF,
-    input_schema={"counts": "BinomialCounts", "target": "Claim"},
-    output_schema={"score": "LikelihoodScoreRecord"},
-    premise_schema={"score_correct": "Claim"},
-    target_role="target",
-    score_role="score",
-    score_type="log_lr",
-    effect="add_log_odds",
-)
-
-TWO_BINOMIAL_AB_TEST_SPEC = LikelihoodModuleSpec(
-    module_ref=TWO_BINOMIAL_AB_TEST_REF,
-    input_schema={"counts": "TwoBinomialCounts", "target": "Claim"},
-    output_schema={"score": "LikelihoodScoreRecord"},
-    premise_schema={"score_correct": "Claim"},
-    target_role="target",
-    score_role="score",
-    score_type="log_lr",
-    effect="add_log_odds",
-)
 
 
 def _validate_count(name: str, value: int) -> None:

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -511,11 +511,192 @@ class TestStrategyValidation:
                     target="github:test::target",
                     score_type="log_lr",
                     value=1.73,
+                    query="theta_B > theta_A",
                 )
             ],
         )
         r = validate_local_graph(g)
         assert r.valid
+
+    def test_likelihood_method_requires_known_module(self):
+        module_ref = "gaia.std.likelihood.unknown@v1"
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::score_correct"),
+                _claim("github:test::target"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=["github:test::score_correct"],
+                    conclusion="github:test::target",
+                    method=ModuleUseMethod(
+                        module_ref=module_ref,
+                        input_bindings={"target": "github:test::target"},
+                        output_bindings={"score": "score:unknown"},
+                        premise_bindings={"score_correct": "github:test::score_correct"},
+                    ),
+                )
+            ],
+            likelihood_scores=[
+                LikelihoodScoreRecord(
+                    score_id="score:unknown",
+                    module_ref=module_ref,
+                    target="github:test::target",
+                    score_type="log_lr",
+                    value=1.0,
+                    query="theta > 0",
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("unknown likelihood module_ref" in e for e in r.errors)
+
+    def test_likelihood_score_type_must_match_module_spec(self):
+        module_ref = "gaia.std.likelihood.two_binomial_ab_test@v1"
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::score_correct"),
+                _claim("github:test::target"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=["github:test::score_correct"],
+                    conclusion="github:test::target",
+                    method=ModuleUseMethod(
+                        module_ref=module_ref,
+                        input_bindings={"target": "github:test::target"},
+                        output_bindings={"score": "score:bad_type"},
+                        premise_bindings={"score_correct": "github:test::score_correct"},
+                    ),
+                )
+            ],
+            likelihood_scores=[
+                LikelihoodScoreRecord(
+                    score_id="score:bad_type",
+                    module_ref=module_ref,
+                    target="github:test::target",
+                    score_type="bayes_factor",
+                    value=2.0,
+                    query="theta_B > theta_A",
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("score_type 'bayes_factor'" in e for e in r.errors)
+
+    def test_likelihood_score_requires_query_for_registered_module(self):
+        module_ref = "gaia.std.likelihood.two_binomial_ab_test@v1"
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::score_correct"),
+                _claim("github:test::target"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=["github:test::score_correct"],
+                    conclusion="github:test::target",
+                    method=ModuleUseMethod(
+                        module_ref=module_ref,
+                        input_bindings={"target": "github:test::target"},
+                        output_bindings={"score": "score:no_query"},
+                        premise_bindings={"score_correct": "github:test::score_correct"},
+                    ),
+                )
+            ],
+            likelihood_scores=[
+                LikelihoodScoreRecord(
+                    score_id="score:no_query",
+                    module_ref=module_ref,
+                    target="github:test::target",
+                    score_type="log_lr",
+                    value=1.0,
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("requires a non-empty query" in e for e in r.errors)
+
+    def test_likelihood_method_requires_registered_score_role(self):
+        module_ref = "gaia.std.likelihood.two_binomial_ab_test@v1"
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::score_correct"),
+                _claim("github:test::target"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=["github:test::score_correct"],
+                    conclusion="github:test::target",
+                    method=ModuleUseMethod(
+                        module_ref=module_ref,
+                        input_bindings={"target": "github:test::target"},
+                        output_bindings={"not_score": "score:ab"},
+                        premise_bindings={"score_correct": "github:test::score_correct"},
+                    ),
+                )
+            ],
+            likelihood_scores=[
+                LikelihoodScoreRecord(
+                    score_id="score:ab",
+                    module_ref=module_ref,
+                    target="github:test::target",
+                    score_type="log_lr",
+                    value=1.0,
+                    query="theta_B > theta_A",
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("missing output binding 'score'" in e for e in r.errors)
+
+    def test_likelihood_target_binding_must_match_strategy_conclusion(self):
+        module_ref = "gaia.std.likelihood.two_binomial_ab_test@v1"
+        g = _local_graph(
+            knowledges=[
+                _claim("github:test::score_correct"),
+                _claim("github:test::target"),
+                _claim("github:test::other_target"),
+            ],
+            strategies=[
+                Strategy(
+                    scope="local",
+                    type="likelihood",
+                    premises=["github:test::score_correct"],
+                    conclusion="github:test::target",
+                    method=ModuleUseMethod(
+                        module_ref=module_ref,
+                        input_bindings={"target": "github:test::other_target"},
+                        output_bindings={"score": "score:ab"},
+                        premise_bindings={"score_correct": "github:test::score_correct"},
+                    ),
+                )
+            ],
+            likelihood_scores=[
+                LikelihoodScoreRecord(
+                    score_id="score:ab",
+                    module_ref=module_ref,
+                    target="github:test::target",
+                    score_type="log_lr",
+                    value=1.0,
+                    query="theta_B > theta_A",
+                )
+            ],
+        )
+        r = validate_local_graph(g)
+        assert not r.valid
+        assert any("target binding 'target'" in e for e in r.errors)
 
     def test_likelihood_method_requires_registered_score(self):
         g = _local_graph(


### PR DESCRIPTION
## Summary
- add a minimal implementation note for the v6 likelihood design
- introduce a standard likelihood module registry in IR
- validate registered likelihood score/module contracts: known module_ref, score_type, query, score role, and target binding alignment
- keep std likelihood specs sourced from the registry

## Validation
- python -m pytest tests/ir/test_validator.py tests/gaia/std/test_likelihood.py tests/gaia/lang/test_v6_surface.py tests/cli/test_v6_likelihood_cli.py tests/gaia/examples/test_v6_likelihood_examples.py tests/test_lowering.py
- python -m pytest
- git diff --check HEAD~1 HEAD