### PR TITLE
fix(cli): hide generated helpers in check diagnostics

### DIFF
--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -20,11 +20,29 @@ def _get_prior(k: dict) -> float | None:
     return meta.get("prior")
 
 
+def _is_helper_claim(k: dict) -> bool:
+    """Return true for generated/private claims that should stay out of diagnostics."""
+    label = k.get("label") or k.get("id", "").split("::")[-1]
+    meta = k.get("metadata") or {}
+    return (
+        label.startswith("__")
+        or label.startswith("_anon")
+        or meta.get("generated") is True
+        or meta.get("generated_kind") == "helper_claim"
+    )
+
+
 def _knowledge_diagnostics(ir: dict) -> list[str]:
     """Analyze the knowledge graph and return diagnostic lines."""
     lines: list[str] = []
 
-    claims = {k["id"]: k for k in ir["knowledges"] if k["type"] == "claim"}
+    all_claims = {k["id"]: k for k in ir["knowledges"] if k["type"] == "claim"}
+    helper_claims = {
+        cid: k for cid, k in all_claims.items() if _is_helper_claim(k)
+    }
+    claims = {
+        cid: k for cid, k in all_claims.items() if cid not in helper_claims
+    }
     settings = {k["id"]: k for k in ir["knowledges"] if k["type"] == "setting"}
     questions = {k["id"]: k for k in ir["knowledges"] if k["type"] == "question"}
 
@@ -57,6 +75,8 @@ def _knowledge_diagnostics(ir: dict) -> list[str]:
     lines.append(f"  Settings:  {len(settings)}")
     lines.append(f"  Questions: {len(questions)}")
     lines.append(f"  Claims:    {len(claims)}")
+    if helper_claims:
+        lines.append(f"    Generated helper claims: {len(helper_claims)}")
     lines.append(f"    Independent (need prior):  {len(independent)}")
     if n_holes:
         lines.append(f"      Holes (no prior set):   {n_holes}")
@@ -102,7 +122,11 @@ def _knowledge_diagnostics(ir: dict) -> list[str]:
 
 def _hole_report(ir: dict) -> list[str]:
     """Return detailed report of all independent claims without priors (holes)."""
-    claims = {k["id"]: k for k in ir["knowledges"] if k["type"] == "claim"}
+    claims = {
+        k["id"]: k
+        for k in ir["knowledges"]
+        if k["type"] == "claim" and not _is_helper_claim(k)
+    }
     c = classify_ir(ir)
     lines: list[str] = []
     holes: list[tuple[str, dict]] = []

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -163,6 +163,22 @@ def test_check_shows_hole_count_in_summary(tmp_path):
     assert "Holes (no prior set):   1" in result.output
 
 
+def test_check_hides_generated_helper_claims_from_diagnostics(tmp_path):
+    """Generated formal helper claims should not pollute check diagnostics."""
+    pkg_dir = tmp_path / "check_holes"
+    _write_multi_claim_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Generated helper claims:" in result.output
+    assert "__conjunction_result" not in result.output
+    assert "__implication_result" not in result.output
+    assert "_anon_" not in result.output
+
+
 def test_check_no_hole_count_when_all_covered(tmp_path):
     """Summary omits hole count when all independent claims have priors."""
     pkg_dir = tmp_path / "check_holes"


### PR DESCRIPTION
## Summary
- hide generated/private helper claims from gaia check claim diagnostics and hole reports
- keep a helper count so total compiled knowledge remains explainable
- add regression coverage for generated formal helpers

## Validation
- python -m pytest tests/cli/test_check.py
- python -m pytest tests/cli/test_check.py tests/cli/test_brief.py tests/cli/test_obsidian.py tests/cli/test_detailed_reasoning.py
- env PYTHONPATH=/tmp/gaia_v6_ir_scaffold gaia check /tmp/sel_gaia_smoke_e5208