### PR TITLE
feat(lang): add parameterized claim classes

### DIFF
--- a/gaia/lang/__init__.py
+++ b/gaia/lang/__init__.py
@@ -5,6 +5,7 @@ from gaia.lang.dsl import (
     analogy,
     case_analysis,
     claim,
+    claim_class,
     compare,
     composite,
     complement,
@@ -25,6 +26,7 @@ from gaia.lang.dsl import (
     question,
     setting,
     support,
+    ParameterizedClaim,
 )
 from gaia.lang.runtime import ComputeResult, Knowledge, LikelihoodScore, Operator, Step, Strategy
 
@@ -33,12 +35,14 @@ __all__ = [
     "Knowledge",
     "LikelihoodScore",
     "Operator",
+    "ParameterizedClaim",
     "Step",
     "Strategy",
     "abduction",
     "analogy",
     "case_analysis",
     "claim",
+    "claim_class",
     "compare",
     "composite",
     "complement",

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -60,9 +60,62 @@ class CompiledPackage:
         return self.graph.model_dump(mode="json", exclude_none=True, serialize_as_any=True)
 
 
+def _parameter_fingerprint_value(value: Any) -> Any:
+    if isinstance(value, Knowledge):
+        if value.metadata.get("qid"):
+            return value.metadata["qid"]
+        if value.label:
+            return {"label": value.label}
+        return {"content": value.content_template or value.content}
+    if isinstance(value, list):
+        return [_parameter_fingerprint_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_parameter_fingerprint_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _parameter_fingerprint_value(item) for key, item in value.items()}
+    return value
+
+
+def _parameter_ir_value(value: Any, knowledge_map: dict[int, str]) -> Any:
+    if isinstance(value, Knowledge):
+        return knowledge_map[id(value)]
+    if isinstance(value, list):
+        return [_parameter_ir_value(item, knowledge_map) for item in value]
+    if isinstance(value, tuple):
+        return [_parameter_ir_value(item, knowledge_map) for item in value]
+    if isinstance(value, dict):
+        return {key: _parameter_ir_value(item, knowledge_map) for key, item in value.items()}
+    return value
+
+
+def _runtime_parameters_for_hash(parameters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            **parameter,
+            "value": _parameter_fingerprint_value(parameter.get("value")),
+        }
+        for parameter in parameters
+    ]
+
+
+def _knowledge_parameters_to_ir(
+    k: Knowledge, knowledge_map: dict[int, str]
+) -> list[IrParameter]:
+    return [
+        IrParameter(
+            **{
+                **parameter,
+                "value": _parameter_ir_value(parameter.get("value"), knowledge_map),
+            }
+        )
+        for parameter in k.parameters
+    ]
+
+
 def _content_hash(k: Knowledge) -> str:
     """SHA-256(type + content + sorted(parameters))."""
-    params_str = json.dumps(sorted(k.parameters, key=lambda p: p.get("name", "")), sort_keys=True)
+    params = _runtime_parameters_for_hash(k.parameters)
+    params_str = json.dumps(sorted(params, key=lambda p: p.get("name", "")), sort_keys=True)
     content = k.content_template if k.content_template is not None else k.content
     raw = f"{k.type}|{content}|{params_str}"
     return hashlib.sha256(raw.encode()).hexdigest()
@@ -442,7 +495,7 @@ def compile_package_artifact(
             content=k.content,
             content_template=k.content_template,
             rendered_content=k.rendered_content,
-            parameters=[IrParameter(**p) for p in k.parameters],
+            parameters=_knowledge_parameters_to_ir(k, knowledge_map),
             provenance=_knowledge_provenance(k),
             metadata=_knowledge_metadata(k),
             module=getattr(k, "_source_module", None),

--- a/gaia/lang/dsl/__init__.py
+++ b/gaia/lang/dsl/__init__.py
@@ -1,3 +1,4 @@
+from gaia.lang.dsl.claim_classes import ParameterizedClaim, claim_class
 from gaia.lang.dsl.knowledge import claim, context, question, setting
 from gaia.lang.dsl.operators import complement, contradiction, disjunction, equivalence
 from gaia.lang.dsl.strategies import (
@@ -24,6 +25,7 @@ __all__ = [
     "analogy",
     "case_analysis",
     "claim",
+    "claim_class",
     "compare",
     "composite",
     "complement",
@@ -41,6 +43,7 @@ __all__ = [
     "likelihood_from",
     "mathematical_induction",
     "noisy_and",
+    "ParameterizedClaim",
     "question",
     "setting",
     "support",

--- a/gaia/lang/dsl/claim_classes.py
+++ b/gaia/lang/dsl/claim_classes.py
@@ -1,0 +1,168 @@
+"""Parameterized Claim class helpers for Gaia Lang v6."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, get_args, get_origin, get_type_hints
+
+from gaia.lang.runtime import Knowledge
+
+
+_RESERVED_KWARGS = {
+    "background",
+    "label",
+    "metadata",
+    "provenance",
+    "rendered_content",
+    "title",
+}
+
+
+def _annotation_name(annotation: Any) -> str:
+    origin = get_origin(annotation)
+    if origin is not None:
+        args = ", ".join(_annotation_name(arg) for arg in get_args(annotation))
+        origin_name = getattr(origin, "__name__", str(origin))
+        return f"{origin_name}[{args}]"
+    return getattr(annotation, "__name__", str(annotation).replace("typing.", ""))
+
+
+def _render_value(value: Any) -> str:
+    if isinstance(value, Knowledge):
+        return (
+            value.rendered_content
+            or value.title
+            or value.content
+            or value.label
+            or "<knowledge>"
+        )
+    return str(value)
+
+
+class _SafeFormatDict(dict):
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
+def _render_template(template: str, values: dict[str, Any]) -> str:
+    rendered_values = {name: _render_value(value) for name, value in values.items()}
+    return template.format_map(_SafeFormatDict(rendered_values))
+
+
+def _default_template(cls: type) -> str:
+    fields = ", ".join(f"{name}={{{name}}}" for name in _claim_fields(cls))
+    class_name = getattr(cls, "__name__", "ParameterizedClaim")
+    return f"{class_name}({fields})"
+
+
+def _claim_fields(cls: type) -> dict[str, Any]:
+    declared = getattr(cls, "__annotations__", {})
+    hints = get_type_hints(cls)
+    return {
+        name: hints.get(name, annotation)
+        for name, annotation in declared.items()
+        if not name.startswith("_") and name not in _RESERVED_KWARGS
+    }
+
+
+def instantiate_claim_class(cls: type, **kwargs: Any) -> Knowledge:
+    """Instantiate ``cls`` as a human-readable parameterized claim."""
+    fields = _claim_fields(cls)
+    field_values: dict[str, Any] = {}
+    metadata = dict(getattr(cls, "metadata", {}) or {})
+    metadata.update(dict(kwargs.pop("metadata", {}) or {}))
+
+    title = kwargs.pop("title", getattr(cls, "title", None))
+    label = kwargs.pop("label", None)
+    background = kwargs.pop("background", None)
+    provenance = kwargs.pop("provenance", None)
+    rendered_content = kwargs.pop("rendered_content", None)
+
+    unknown = set(kwargs) - set(fields)
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise TypeError(f"{cls.__name__} got unexpected parameter(s): {names}")
+
+    missing = [name for name in fields if name not in kwargs]
+    if missing:
+        names = ", ".join(missing)
+        raise TypeError(f"{cls.__name__} missing required parameter(s): {names}")
+
+    for name in fields:
+        field_values[name] = kwargs[name]
+
+    template = getattr(cls, "template", None) or _default_template(cls)
+    rendered = rendered_content or _render_template(template, field_values)
+    parameters = [
+        {
+            "name": name,
+            "type": _annotation_name(fields[name]),
+            "value": value,
+        }
+        for name, value in field_values.items()
+    ]
+    metadata.setdefault("claim_class", f"{cls.__module__}.{cls.__qualname__}")
+    if getattr(cls, "kind", None):
+        metadata.setdefault("kind", getattr(cls, "kind"))
+
+    knowledge = Knowledge(
+        content=rendered,
+        type="claim",
+        title=title,
+        content_template=template,
+        rendered_content=rendered,
+        background=background or [],
+        parameters=parameters,
+        provenance=provenance or [],
+        metadata=metadata,
+    )
+    if label is not None:
+        knowledge.label = _normalize_label(label)
+    return knowledge
+
+
+def _normalize_label(label: str) -> str:
+    normalized = re.sub(r"[^a-z0-9_]", "_", label.strip().lower())
+    if not normalized:
+        return "_anon"
+    if not (normalized[0].isalpha() or normalized[0] == "_"):
+        normalized = f"_{normalized}"
+    return normalized
+
+
+class ParameterizedClaim:
+    """Base class for v6 human-readable parameterized Claim classes.
+
+    Subclasses are factories: calling ``MyClaim(...)`` returns a runtime
+    ``Knowledge(type="claim")`` with canonical parameters and rendered text.
+    """
+
+    template: str
+
+    def __new__(cls, **kwargs: Any):
+        if cls is ParameterizedClaim:
+            return super().__new__(cls)
+        return instantiate_claim_class(cls, **kwargs)
+
+
+def claim_class(cls: type | None = None, **options: Any):
+    """Decorator form for defining a parameterized claim factory."""
+
+    def decorate(target: type):
+        for key, value in options.items():
+            setattr(target, key, value)
+
+        class DecoratedParameterizedClaim(target, ParameterizedClaim):  # type: ignore[misc, valid-type]
+            pass
+
+        DecoratedParameterizedClaim.__name__ = target.__name__
+        DecoratedParameterizedClaim.__qualname__ = target.__qualname__
+        DecoratedParameterizedClaim.__module__ = target.__module__
+        DecoratedParameterizedClaim.__annotations__ = dict(
+            getattr(target, "__annotations__", {})
+        )
+        return DecoratedParameterizedClaim
+
+    if cls is None:
+        return decorate
+    return decorate(cls)

--- a/tests/gaia/lang/test_v6_surface.py
+++ b/tests/gaia/lang/test_v6_surface.py
@@ -3,7 +3,9 @@
 from gaia.ir import ComputeMethod, ModuleUseMethod
 from gaia.lang import (
     LikelihoodScore,
+    ParameterizedClaim,
     claim,
+    claim_class,
     compute,
     context,
     likelihood_from,
@@ -48,6 +50,62 @@ def test_parameterized_claim_template_and_values_compile():
     assert ir_counts.content_template == "[@experiment] recorded {ctrl_k}/{ctrl_n} control conversions."
     assert ir_counts.rendered_content == "AB test exp_123 recorded 500/10000 control conversions."
     assert {p.name: p.value for p in ir_counts.parameters}["ctrl_k"] == 500
+
+
+def test_parameterized_claim_class_compiles_human_text_and_values():
+    class GaussianLogLR(ParameterizedClaim):
+        template = (
+            "The Gaussian log-likelihood ratio is {value}, comparing candidate "
+            "{candidate_mean} against baseline {baseline_mean} for observed {observed}."
+        )
+
+        observed: float
+        candidate_mean: float
+        baseline_mean: float
+        value: float
+
+    pkg = CollectedPackage("v6_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        score = GaussianLogLR(
+            observed=1.2,
+            candidate_mean=0.96,
+            baseline_mean=1.9,
+            value=2.4,
+        )
+        score.label = "al_score"
+
+    compiled = compile_package_artifact(pkg)
+    ir_score = next(k for k in compiled.graph.knowledges if k.label == "al_score")
+    assert ir_score.content_template == GaussianLogLR.template
+    assert ir_score.rendered_content == (
+        "The Gaussian log-likelihood ratio is 2.4, comparing candidate "
+        "0.96 against baseline 1.9 for observed 1.2."
+    )
+    assert {p.name: p.value for p in ir_score.parameters}["value"] == 2.4
+    assert ir_score.metadata["claim_class"].endswith(".GaussianLogLR")
+
+
+def test_claim_class_decorator_converts_knowledge_parameters_to_qids():
+    @claim_class(kind="observation")
+    class CountReported:
+        template = "{experiment} reported {count} observations."
+
+        experiment: object
+        count: int
+
+    pkg = CollectedPackage("v6_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        exp = setting("Experiment exp_123.")
+        exp.label = "exp_123"
+        counted = CountReported(experiment=exp, count=10, label="counted")
+
+    compiled = compile_package_artifact(pkg)
+    ir_counted = next(k for k in compiled.graph.knowledges if k.label == "counted")
+    values = {p.name: p.value for p in ir_counted.parameters}
+    assert values["experiment"] == "github:v6_pkg::exp_123"
+    assert values["count"] == 10
+    assert ir_counted.rendered_content == "Experiment exp_123. reported 10 observations."
+    assert ir_counted.metadata["kind"] == "observation"
 
 
 def test_compute_and_likelihood_from_compile_to_v6_methods():


### PR DESCRIPTION
## Summary
- add a lightweight ParameterizedClaim / claim_class authoring surface
- lower class instances to human-readable Knowledge with content_template, rendered_content, and canonical parameters
- compile Knowledge-valued parameters to QID values for stable IR identity

## Tests
- python -m pytest tests/gaia/lang/test_v6_surface.py tests/ir/test_knowledge.py tests/ir/test_graphs.py tests/ir/test_validator.py::TestParameterizationValidation -q