### PR TITLE
feat(lang): lift Python functions with compute

### DIFF
--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -408,6 +408,12 @@ def _lower_strategy(
         return
 
     if s.type == StrategyType.COMPUTE:
+        # Claim-producing v6 compute Strategies support their output Claim.
+        # Legacy low-level compute uses ``conclusion`` for a correctness gate
+        # and ``method.output`` for a value/artifact; keep that path neutral.
+        method_output = getattr(s.method, "output", None)
+        if method_output == s.conclusion:
+            _lower_compute_strategy(fg, s, ctr)
         return
 
     if s.type == StrategyType.LIKELIHOOD:
@@ -532,6 +538,32 @@ def _lower_likelihood_strategy(
         [gate],
         strategy.conclusion,
         cpt=[0.5, p_when_gate_true],
+    )
+
+
+def _lower_compute_strategy(fg: FactorGraph, strategy: Strategy, ctr: list[int]) -> None:
+    if not strategy.premises:
+        fg.add_log_likelihood(strategy.conclusion, math.log((1.0 - CROMWELL_EPS) / CROMWELL_EPS))
+        return
+
+    if len(strategy.premises) == 1:
+        gate = strategy.premises[0]
+    else:
+        gate = f"_m_compute_{strategy.strategy_id}"
+        fg.add_variable(gate, 0.5)
+        fg.add_factor(
+            _next_fid("compute_gate", ctr),
+            FactorType.CONJUNCTION,
+            strategy.premises,
+            gate,
+        )
+    fg.add_factor(
+        _next_fid("compute_out", ctr),
+        FactorType.SOFT_ENTAILMENT,
+        [gate],
+        strategy.conclusion,
+        p1=1.0 - CROMWELL_EPS,
+        p2=0.5,
     )
 
 

--- a/gaia/lang/__init__.py
+++ b/gaia/lang/__init__.py
@@ -6,6 +6,8 @@ from gaia.lang.dsl import (
     case_analysis,
     claim,
     claim_class,
+    ComputedArgument,
+    ComputedReturn,
     compare,
     composite,
     complement,
@@ -32,6 +34,8 @@ from gaia.lang.runtime import ComputeResult, Knowledge, LikelihoodScore, Operato
 
 __all__ = [
     "ComputeResult",
+    "ComputedArgument",
+    "ComputedReturn",
     "Knowledge",
     "LikelihoodScore",
     "Operator",

--- a/gaia/lang/dsl/__init__.py
+++ b/gaia/lang/dsl/__init__.py
@@ -1,4 +1,9 @@
-from gaia.lang.dsl.claim_classes import ParameterizedClaim, claim_class
+from gaia.lang.dsl.claim_classes import (
+    ComputedArgument,
+    ComputedReturn,
+    ParameterizedClaim,
+    claim_class,
+)
 from gaia.lang.dsl.knowledge import claim, context, question, setting
 from gaia.lang.dsl.operators import complement, contradiction, disjunction, equivalence
 from gaia.lang.dsl.strategies import (
@@ -26,6 +31,8 @@ __all__ = [
     "case_analysis",
     "claim",
     "claim_class",
+    "ComputedArgument",
+    "ComputedReturn",
     "compare",
     "composite",
     "complement",

--- a/gaia/lang/dsl/claim_classes.py
+++ b/gaia/lang/dsl/claim_classes.py
@@ -166,3 +166,27 @@ def claim_class(cls: type | None = None, **options: Any):
     if cls is None:
         return decorate
     return decorate(cls)
+
+
+class ComputedArgument(ParameterizedClaim):
+    """Default human-readable Claim for a lifted Python function argument."""
+
+    template = "The argument {name} of Python function {function_ref} is {value}."
+    kind = "compute_argument"
+    metadata = {"generated": True, "helper_kind": "compute_argument", "prior": 0.999}
+
+    function_ref: str
+    name: str
+    value: object
+
+
+class ComputedReturn(ParameterizedClaim):
+    """Default human-readable Claim for a lifted Python function return value."""
+
+    template = "Python function {function_ref} returned {value} for arguments {arguments}."
+    kind = "compute_return"
+    metadata = {"generated": True, "helper_kind": "compute_return", "prior": 0.999}
+
+    function_ref: str
+    arguments: dict
+    value: object

--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 from copy import deepcopy
+from functools import wraps
+from inspect import signature
 from typing import Literal
 
 from gaia.lang.runtime import ComputeResult, Knowledge, LikelihoodScore, Step, Strategy
+from gaia.lang.dsl.claim_classes import ComputedArgument, ComputedReturn
 from gaia.lang.runtime.nodes import ReasonInput
 from gaia.lang.runtime.nodes import _current_package
 from gaia.lang.dsl.operators import _validate_reason_prior
@@ -271,7 +275,7 @@ def infer(
     )
 
 
-def compute(
+def _compute_strategy(
     fn,
     *,
     inputs: dict[str, Knowledge] | list[Knowledge],
@@ -317,6 +321,159 @@ def compute(
     )
     _attach_strategy(correctness, strategy)
     return ComputeResult(output=output, correctness=correctness, strategy=strategy)
+
+
+def _argument_claim(function_ref: str, name: str, value) -> Knowledge:
+    if isinstance(value, Knowledge):
+        return value
+    return ComputedArgument(function_ref=function_ref, name=name, value=value)
+
+
+def _output_claim(
+    output_factory,
+    *,
+    function_ref: str,
+    arguments: dict[str, object],
+    value,
+    kind: str | None,
+    metadata: dict | None,
+) -> Knowledge:
+    if output_factory is None:
+        output = ComputedReturn(function_ref=function_ref, arguments=arguments, value=value)
+    elif isinstance(output_factory, type) or callable(output_factory):
+        try:
+            output = output_factory(**arguments, value=value)
+        except TypeError:
+            output = output_factory(value=value)
+    else:
+        raise TypeError("compute(output=...) must be a parameterized Claim class or factory")
+    if not isinstance(output, Knowledge):
+        raise TypeError("compute output factory must return a Gaia Knowledge claim")
+    output.metadata.setdefault("generated", True)
+    output.metadata.setdefault("helper_kind", "compute_return")
+    output.metadata.setdefault("function_ref", function_ref)
+    if kind is not None:
+        output.metadata.setdefault("kind", kind)
+    if metadata:
+        output.metadata.update(metadata)
+    return output
+
+
+def _compute_decorator(
+    fn,
+    *,
+    output=None,
+    kind: str | None = None,
+    metadata: dict | None = None,
+    code_hash: str | None = None,
+    reason: ReasonInput = "",
+):
+    function_ref = _function_ref(fn)
+    sig = signature(fn)
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        arguments = dict(bound.arguments)
+        result = fn(*args, **kwargs)
+        input_bindings = {
+            name: _argument_claim(function_ref, name, value)
+            for name, value in arguments.items()
+        }
+        output_claim = _output_claim(
+            output,
+            function_ref=function_ref,
+            arguments=arguments,
+            value=result,
+            kind=kind,
+            metadata=metadata,
+        )
+        strategy = Strategy(
+            type="compute",
+            premises=_dedupe_knowledge(list(input_bindings.values())),
+            conclusion=output_claim,
+            reason=reason,
+            metadata={"surface_construct": "compute", "decorator": True},
+            method={
+                "kind": "compute",
+                "function_ref": function_ref,
+                "input_bindings": input_bindings,
+                "output": output_claim,
+                "output_binding": {"value": "return_value"},
+                "code_hash": code_hash,
+            },
+        )
+        _attach_strategy(output_claim, strategy)
+        return output_claim
+
+    wrapper.__gaia_compute__ = True
+    wrapper.__gaia_function_ref__ = function_ref
+    return wrapper
+
+
+def compute(
+    fn: Callable | str | None = None,
+    *,
+    inputs: dict[str, Knowledge] | list[Knowledge] | None = None,
+    output=None,
+    assumptions: list[Knowledge] | None = None,
+    correctness: Knowledge | None = None,
+    output_binding: dict[str, str] | None = None,
+    code_hash: str | None = None,
+    reason: ReasonInput = "",
+    kind: str | None = None,
+    metadata: dict | None = None,
+):
+    """Lift Python code into Gaia compute evidence, or use the legacy low-level form.
+
+    Decorator form:
+
+        @compute(output=MyReturnClaim)
+        def f(...): ...
+
+    Low-level compatibility form remains available with ``inputs=`` and ``output=``.
+    """
+    if inputs is not None:
+        if fn is None:
+            raise TypeError("compute(..., inputs=...) requires a function reference")
+        return _compute_strategy(
+            fn,
+            inputs=inputs,
+            output=output,
+            assumptions=assumptions,
+            correctness=correctness,
+            output_binding=output_binding,
+            code_hash=code_hash,
+            reason=reason,
+        )
+
+    if assumptions is not None or correctness is not None or output_binding is not None:
+        raise TypeError(
+            "compute decorator form does not accept assumptions, correctness, or output_binding"
+        )
+
+    if fn is None:
+        return lambda actual_fn: _compute_decorator(
+            actual_fn,
+            output=output,
+            kind=kind,
+            metadata=metadata,
+            code_hash=code_hash,
+            reason=reason,
+        )
+
+    if callable(fn) and not isinstance(fn, str):
+        return _compute_decorator(
+            fn,
+            output=output,
+            kind=kind,
+            metadata=metadata,
+            code_hash=code_hash,
+            reason=reason,
+        )
+
+    raise TypeError("compute decorator form requires a callable")
 
 
 def likelihood_from(

--- a/tests/gaia/lang/test_v6_surface.py
+++ b/tests/gaia/lang/test_v6_surface.py
@@ -178,3 +178,33 @@ def test_compute_and_likelihood_from_compile_to_v6_methods():
     assert likelihood_ir.method.output_bindings == {"score": "score:ab"}
     assert likelihood_ir.method.premise_bindings["score_correct"] == correctness_id
     assert correctness_id in likelihood_ir.premises
+
+
+def test_compute_decorator_lifts_python_call_to_claim_and_strategy():
+    class SumResult(ParameterizedClaim):
+        template = "Adding {a} and {b} gives {value}."
+
+        a: int
+        b: int
+        value: int
+
+    @compute(output=SumResult, kind="computed_value")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    pkg = CollectedPackage("v6_pkg", namespace="github", version="1.0.0")
+    with pkg:
+        result = add(2, b=3)
+        result.label = "sum_result"
+
+    compiled = compile_package_artifact(pkg)
+    ir_result = next(k for k in compiled.graph.knowledges if k.label == "sum_result")
+    assert ir_result.rendered_content == "Adding 2 and 3 gives 5."
+    assert ir_result.metadata["kind"] == "computed_value"
+
+    compute_ir = next(s for s in compiled.graph.strategies if s.type == "compute")
+    assert compute_ir.conclusion == "github:v6_pkg::sum_result"
+    assert isinstance(compute_ir.method, ComputeMethod)
+    assert compute_ir.method.output == "github:v6_pkg::sum_result"
+    assert set(compute_ir.method.input_bindings) == {"a", "b"}
+    assert len(compute_ir.premises) == 2

--- a/tests/test_lowering.py
+++ b/tests/test_lowering.py
@@ -253,6 +253,37 @@ def test_negative_likelihood_log_lr_lowers_without_soft_entailment_constraint():
     assert like_factor.cpt[1] < 0.27
 
 
+def test_compute_strategy_supports_output_when_inputs_are_true():
+    input_id = "github:lowertest::input"
+    output_id = "github:lowertest::output"
+    strategy = Strategy(
+        scope="local",
+        type="compute",
+        premises=[input_id],
+        conclusion=output_id,
+        method={
+            "kind": "compute",
+            "function_ref": "tests.add",
+            "input_bindings": {"input": input_id},
+            "output": output_id,
+        },
+    )
+    graph = _lg(
+        knowledges=[
+            Knowledge(id=input_id, type="claim", content="Input"),
+            Knowledge(id=output_id, type="claim", content="Output"),
+        ],
+        strategies=[strategy],
+    )
+
+    fg = lower_local_graph(graph, node_priors={input_id: 0.99, output_id: 0.5})
+    compute_factor = next(f for f in fg.factors if f.factor_id.startswith("compute_out"))
+    assert compute_factor.factor_type == FactorType.SOFT_ENTAILMENT
+
+    beliefs, _ = exact_inference(fg)
+    assert beliefs[output_id] > 0.98
+
+
 def test_infer_conditional_lowering():
     s = Strategy(
         scope="local",


### PR DESCRIPTION
## Summary
- extend compute into a decorator that lifts Python calls into parameterized argument/return Claims
- register claim-producing compute Strategies with method bindings while preserving the legacy low-level compute form
- lower claim-producing compute Strategies as support for their output Claim, keeping legacy value/correctness compute neutral

## Tests
- python -m pytest tests/gaia/lang/test_v6_surface.py tests/test_lowering.py -q
- python -m pytest tests/gaia/examples/test_v6_likelihood_examples.py tests/ir/test_validator.py::TestParameterizationValidation -q