### PR TITLE
Align Gaia v6 review and lowering semantics

### DIFF
--- a/docs/plans/2026-04-21-gaia-lang-v6-phase1-knowledge-types.md
+++ b/docs/plans/2026-04-21-gaia-lang-v6-phase1-knowledge-types.md
@@ -473,6 +473,7 @@ Add to `gaia/lang/runtime/knowledge.py` in the `Claim` class:
 ```python
 # In Claim class, add __init_subclass__ to collect typed fields from annotations
 # and __init__ override to handle template rendering
+from enum import Enum
 
 class Claim(Knowledge):
     """Proposition with prior. Participates in BP."""
@@ -511,7 +512,8 @@ class Claim(Knowledge):
         params = []
         for name, ann in param_fields.items():
             val = param_values.get(name, UNBOUND)
-            params.append({"name": name, "type": ann.__name__ if isinstance(ann, type) else str(ann), "value": val})
+            stored_val = val.value if isinstance(val, Enum) else val
+            params.append({"name": name, "type": ann.__name__ if isinstance(ann, type) else str(ann), "value": stored_val})
 
         # Render content from docstring template
         template = self.__class__.__doc__ or ""
@@ -523,7 +525,12 @@ class Claim(Knowledge):
             for name in param_fields:
                 val = param_values.get(name, UNBOUND)
                 if val is not UNBOUND:
-                    render_values[name] = val if not isinstance(val, Knowledge) else f"[@{val.label or '?'}]"
+                    if isinstance(val, Knowledge):
+                        render_values[name] = f"[@{val.label or '?'}]"
+                    elif isinstance(val, Enum):
+                        render_values[name] = val.value
+                    else:
+                        render_values[name] = val
                 # Leave unbound as {name} placeholder
             content = template.format_map(_SafeFormatDict(render_values))
 
@@ -606,6 +613,8 @@ for name in param_fields:
     if val is not UNBOUND:
         if isinstance(val, Knowledge):
             render_values[name] = f"[@{val.label or '?'}]"
+        elif isinstance(val, Enum):
+            render_values[name] = val.value
         else:
             render_values[name] = val
 ```
@@ -784,32 +793,71 @@ git commit -m "feat(lang): add context() DSL, export v6 Knowledge types, v5 comp
 # tests/gaia/lang/test_compiler_v6.py
 from gaia.lang.runtime.knowledge import Claim, Setting, Context
 from gaia.lang.runtime.grounding import Grounding
+from gaia.lang.compiler.compile import compile_package_artifact
+from gaia.lang.runtime.package import CollectedPackage
 
 
 def test_compile_context_type(tmp_path):
     """Context Knowledge compiles with type='context'."""
-    # Create a minimal package with a Context node
-    # Use existing test fixtures pattern from test_compiler.py
-    # Verify ir["knowledges"] contains a node with type="context"
-    pass  # detailed implementation depends on existing test helpers
+    with CollectedPackage("v6_test") as pkg:
+        ctx = Context("Raw experiment notes.")
+        ctx.label = "ctx"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "ctx")
+    assert node["type"] == "context"
 
 
 def test_compile_grounding_in_metadata(tmp_path):
     """Grounding metadata appears in compiled IR."""
-    pass  # verify metadata.grounding in compiled knowledge node
+    with CollectedPackage("v6_test") as pkg:
+        claim = Claim(
+            "Measured spectrum deviates from Rayleigh-Jeans law.",
+            grounding=Grounding(kind="source_fact", rationale="Extracted from Fig.2."),
+        )
+        claim.label = "uv_data"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "uv_data")
+    assert node["metadata"]["grounding"]["kind"] == "source_fact"
+    assert "Fig.2" in node["metadata"]["grounding"]["rationale"]
 
 
 def test_compile_parameterized_claim_template(tmp_path):
     """Parameterized Claim stores content_template in metadata."""
-    pass  # verify metadata.content_template in compiled knowledge node
+    class TemperatureClaim(Claim):
+        """Cavity temperature is set to {value}K."""
+        value: float
+
+    with CollectedPackage("v6_test") as pkg:
+        temp = TemperatureClaim(value=5000.0)
+        temp.label = "temp"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "temp")
+    assert node["content"] == "Cavity temperature is set to 5000.0K."
+    assert node["metadata"]["content_template"] == "Cavity temperature is set to {value}K."
 
 
 def test_compile_parameter_value(tmp_path):
     """Bound parameter values appear in compiled IR parameters."""
-    pass  # verify Parameter.value in compiled knowledge node
+    class ABCounts(Claim):
+        """[@experiment] recorded {ctrl_k}/{ctrl_n} control conversions."""
+        experiment: Setting
+        ctrl_n: int
+        ctrl_k: int
+
+    with CollectedPackage("v6_test") as pkg:
+        exp = Setting("AB test exp_123.")
+        exp.label = "exp_123"
+        counts = ABCounts(experiment=exp, ctrl_n=10_000, ctrl_k=500)
+        counts.label = "counts"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "counts")
+    params = {p["name"]: p for p in node["parameters"]}
+    assert params["ctrl_n"]["value"] == 10_000
+    assert params["ctrl_k"]["value"] == 500
+    assert params["experiment"]["value"] == "github:v6_test::exp_123"
 ```
 
-Note: Detailed test implementations should follow existing patterns in `tests/gaia/lang/test_compiler.py` and `tests/cli/test_compile.py`.
+These tests are intentionally concrete: Step 2 must fail before compiler support exists, and Step 4 must prove that the compiler writes the new IR fields.
 
 - [ ] **Step 2: Run — verify fails**
 

--- a/docs/plans/2026-04-21-gaia-lang-v6-phase2-action-hierarchy.md
+++ b/docs/plans/2026-04-21-gaia-lang-v6-phase2-action-hierarchy.md
@@ -4,7 +4,7 @@
 
 **Goal:** Implement the Action class hierarchy (Support/Relate/Infer) with DSL verbs (`derive`, `observe`, `compute`, `equal`, `contradict`, `infer`), `Claim.supports` tracking, first-argument sugar (str → Claim), and `Action.label` with QID-style identity.
 
-**Architecture:** Action is a parallel type to Knowledge (not a subclass). DSL verbs are factory functions that create Action subclass instances and attach them to `Claim.supports`. Actions track their `warrants` (helper Claims needing review). The existing v5 `Strategy` dataclass in `nodes.py` is replaced by the Action hierarchy; v5 DSL functions (`support()`, `deduction()`, etc.) become compat wrappers.
+**Architecture:** Action is a parallel type to Knowledge (not a subclass). DSL verbs are factory functions that create Action subclass instances, register them in `CollectedPackage.actions`, and attach support actions to `Claim.supports` as a convenience index. The compiler consumes `CollectedPackage.actions`; `Claim.supports` is for InquiryState/user inspection and must not be the only source of truth. Actions track their qualitative `warrants` (helper Claims needing review). The existing v5 `Strategy` dataclass in `nodes.py` remains as a compatibility/internal bridge while v6 Actions are introduced; v5 DSL functions (`support()`, `deduction()`, etc.) become deprecated compat wrappers.
 
 **Tech Stack:** Python 3.12+, dataclasses, pytest
 
@@ -122,6 +122,15 @@ class Action:
     background: list = field(default_factory=list)  # list[Setting | Claim]
     warrants: list = field(default_factory=list)  # list[Claim] with metadata.review=True
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        from gaia.lang.runtime.knowledge import _current_package
+        pkg = _current_package.get()
+        if pkg is None:
+            from gaia.lang.runtime.package import infer_package_from_callstack
+            pkg = infer_package_from_callstack()
+        if pkg is not None:
+            pkg._register_action(self)
 
 
 # ── Support (directional: given → conclusion) ──
@@ -261,6 +270,14 @@ def test_derive_with_background():
     bg = Setting("Lab conditions.")
     C = derive("Conclusion.", given=A, background=[bg], rationale="Test.")
     assert C.supports[0].background == [bg]
+
+
+def test_derive_registers_action_with_package():
+    from gaia.lang.runtime.package import CollectedPackage
+    with CollectedPackage("v6_test") as pkg:
+        A = Claim("Premise.")
+        C = derive("Conclusion.", given=A, rationale="Test.")
+    assert pkg.actions == [C.supports[0]]
 ```
 
 - [ ] **Step 2: Run — verify fails**
@@ -297,6 +314,7 @@ def derive(
         conclusion=conclusion,
         given=given,
     )
+    # Action.__post_init__ registers with CollectedPackage.actions.
     conclusion.supports.append(action)
     return conclusion
 ```
@@ -326,11 +344,13 @@ def test_observe_with_given():
     assert isinstance(data.supports[0], Observe)
 
 
-def test_observe_root_fact_adds_grounding():
+def test_observe_root_fact_adds_grounding_and_reviewable_action():
     data = observe("UV spectrum data.", rationale="Measured at 5 points.")
     assert data.grounding is not None
     assert data.grounding.kind == "source_fact"
-    assert len(data.supports) == 0  # no Strategy for root fact
+    assert len(data.supports) == 1  # reviewable root Observe action
+    assert isinstance(data.supports[0], Observe)
+    assert data.supports[0].given == ()
 ```
 
 - [ ] **Step 2: Run — verify fails**
@@ -349,16 +369,11 @@ def observe(
     rationale: str = "",
     label: str | None = None,
 ) -> Claim:
-    """Empirical observation. No-premise observe adds Grounding instead of Strategy."""
+    """Empirical observation. No-premise observe is reviewable grounding."""
     if isinstance(conclusion, str):
         conclusion = Claim(conclusion)
     if isinstance(given, Knowledge):
         given = (given,)
-    if not given:
-        # Root fact — grounding only, no Strategy
-        if conclusion.grounding is None:
-            conclusion.grounding = Grounding(kind="source_fact", rationale=rationale)
-        return conclusion
     action = Observe(
         label=label,
         rationale=rationale,
@@ -366,6 +381,12 @@ def observe(
         conclusion=conclusion,
         given=given,
     )
+    # Root fact — add grounding and keep a reviewable Observe action.
+    # The compiler lowers it to FormalStrategy(type="deduction", premises=[],
+    # metadata.pattern="observation"); BP lowering treats it as reviewed source
+    # grounding, not as support from an empty premise set.
+    if not given and conclusion.grounding is None:
+        conclusion.grounding = Grounding(kind="source_fact", rationale=rationale)
     conclusion.supports.append(action)
     return conclusion
 ```
@@ -448,6 +469,7 @@ def compute(
         given=given,
         fn=fn,
     )
+    # Action.__post_init__ registers with CollectedPackage.actions.
     conclusion.supports.append(action)
     return conclusion
 
@@ -467,6 +489,7 @@ def compute_decorator(fn):
             given=tuple(args),
             fn=fn,
         )
+        # Action.__post_init__ registers with CollectedPackage.actions.
         conclusion.supports.append(action)
         return conclusion
 
@@ -666,12 +689,14 @@ def infer(
 # tests/gaia/lang/test_v5_compat.py
 
 def test_v5_support_still_works():
-    """v5 support() delegates to v6 derive()."""
+    """v5 support() still preserves prior while warning."""
     from gaia.lang import claim, support
+    import pytest
     a = claim("A.")
     b = claim("B.")
-    s = support([a], b, reason="test", prior=0.9)
-    # Should still work, prior is ignored in v6 but no error
+    with pytest.warns(DeprecationWarning):
+        s = support([a], b, reason="test", prior=0.9)
+    assert s.metadata["prior"] == 0.9
 
 
 def test_v5_equivalence_still_works():
@@ -688,7 +713,7 @@ def test_v5_equivalence_still_works():
 
 Key changes:
 - `gaia/lang/__init__.py`: export `derive`, `observe`, `compute`, `equal`, `contradict`, `infer`, `Action`, `Derive`, `Observe`, `Compute`, `Equal`, `Contradict`, `Infer`
-- `gaia/lang/dsl/strategies.py`: `support()` delegates to `derive()`
+- `gaia/lang/dsl/strategies.py`: `support()` emits `DeprecationWarning` and preserves existing v5 support-prior semantics; it must not silently delegate to prior-free `derive()`
 - `gaia/lang/dsl/operators.py`: `equivalence()` delegates to `equal()`, `contradiction()` delegates to `contradict()`
 - `gaia/lang/runtime/package.py`: add `_register_action()` + `actions: list[Action]` to CollectedPackage
 

--- a/docs/plans/2026-04-21-gaia-lang-v6-phase3-compiler.md
+++ b/docs/plans/2026-04-21-gaia-lang-v6-phase3-compiler.md
@@ -4,7 +4,7 @@
 
 **Goal:** Update the compiler to lower v6 Action objects to IR Strategy/Operator, including `action_label` in metadata, `rationale` → `steps`, helper claim warrant metadata (`review` flag), and `infer()` → `Strategy(type="infer")` + CPT.
 
-**Architecture:** The compiler walks `CollectedPackage.actions` (new) alongside existing `strategies` and `operators`. Each Action subclass has a lowering path: Support actions → `FormalStrategy(type="deduction")`, Relate actions → `Operator`, Infer actions → `Strategy(type="infer")` + `StrategyParamRecord`. The `action_label` is stored in `metadata.action_label` and mapped bidirectionally to `strategy_id`.
+**Architecture:** The compiler walks `CollectedPackage.actions` (new) alongside existing `strategies` and `operators`. Each Action subclass has a lowering path: Support actions → `FormalStrategy(type="deduction")`, Relate actions → `Operator`, Infer actions → `Strategy(type="infer")` + `StrategyParamRecord`. The `action_label` is stored in `metadata.action_label` and mapped bidirectionally to the compiled target ID (`strategy_id` for Strategies, `operator_id` for Operators).
 
 **Tech Stack:** Python 3.12+, Pydantic v2, pytest
 
@@ -74,12 +74,14 @@ def _compile_action(action: Action, knowledge_map, namespace, package_name):
 ### Task 2: Compile Observe → FormalStrategy with pattern="observation"
 
 - [ ] Same pattern as derive, but `metadata.pattern = "observation"`.
-- [ ] No-premise observe: verify no Strategy is generated (only Grounding on Claim).
+- [ ] No-premise observe: verify a reviewable `FormalStrategy(type="deduction", premises=[], metadata.pattern="observation")` is generated and the Claim also carries `Grounding(kind="source_fact")`.
+- [ ] Verify BP lowering treats no-premise observe as a reviewed source grounding, not as a support edge from an empty premise set.
 - [ ] Commit
 
 ### Task 3: Compile Compute → FormalStrategy with metadata.compute
 
-- [ ] Same pattern as derive, but `metadata.compute = {function_ref, code_hash, ...}`.
+- [ ] Same pattern as derive, but `metadata.pattern = "computation"` and `metadata.compute = {function_ref, code_hash, ...}`.
+- [ ] Verify compute never introduces a new `StrategyType.COMPUTATION`; it lowers to deduction with computation metadata.
 - [ ] Commit
 
 ---
@@ -143,13 +145,13 @@ def _compile_infer(action: Infer, knowledge_map, namespace, package_name):
 
 ---
 
-## Chunk 3: action_label ↔ strategy_id Mapping
+## Chunk 3: action_label ↔ target_id Mapping
 
 ### Task 7: Bidirectional label mapping
 
 - [ ] **Step 1: Write test**
 
-Verify that compiled IR has `metadata.action_label` on strategies and that the `CompiledPackage` exposes a mapping `action_label → strategy_id`.
+Verify that compiled IR has `metadata.action_label` on strategies/operators and that the `CompiledPackage` exposes a mapping `action_label → target_id`.
 
 - [ ] **Step 2: Add `action_label_map` to CompiledPackage**
 - [ ] **Step 3: Commit**

--- a/docs/plans/2026-04-21-gaia-lang-v6-phase4-review-manifest.md
+++ b/docs/plans/2026-04-21-gaia-lang-v6-phase4-review-manifest.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implement ReviewManifest with Review records, auto-generated audit questions, multi-round review support, and pessimistic default (unreviewed Strategies don't participate in inference).
+**Goal:** Implement ReviewManifest with qualitative Review records, auto-generated audit questions, multi-round review support, and pessimistic default (unreviewed Strategies/Operators don't participate in inference).
 
-**Architecture:** ReviewManifest is a package-level artifact separate from the semantic graph. The compiler auto-generates Review entries for each Action/Strategy with `status="unreviewed"`. `gaia check --warrants` exports the manifest for review. BP lowering skips strategies whose latest Review status is not "accepted". Audit questions are templated from Action type with `[@...]` refs.
+**Architecture:** ReviewManifest is a package-level artifact separate from the semantic graph. The compiler auto-generates Review entries for each reviewable Action target (Strategy or Operator) with `status="unreviewed"`. `gaia check --warrants` exports the manifest for review. BP lowering skips Strategy/Operator targets whose latest Review status is not "accepted". ReviewManifest is not a calibration layer: it has no prior, likelihood, or policy field, and accepted Review status never by itself sets a numeric helper Claim probability. Audit questions are templated from Action type with `[@...]` refs.
 
 **Tech Stack:** Python 3.12+, Pydantic v2, pytest
 
@@ -32,7 +32,7 @@
 | File | Changes |
 |---|---|
 | `gaia/ir/graphs.py` | `GaiaPackageArtifact` gains `review: ReviewManifest \| None` |
-| `gaia/bp/lowering.py` | Skip strategies without accepted Review |
+| `gaia/bp/lowering.py` | Skip reviewable strategies/operators without accepted Review |
 | `gaia/cli/commands/check.py` | Add `--warrants` and `--warrants --blind` flags |
 | `gaia/cli/commands/infer.py` | Pass ReviewManifest to BP lowering |
 
@@ -46,6 +46,9 @@
 
 ```python
 # tests/gaia/ir/test_review.py
+import pytest
+from pydantic import ValidationError
+
 from gaia.ir.review import Review, ReviewManifest, ReviewStatus
 
 
@@ -60,7 +63,8 @@ def test_review_creation():
     r = Review(
         review_id="rev_001",
         action_label="planck_resolves",
-        strategy_id="lcs_abc123",
+        target_kind="strategy",
+        target_id="lcs_abc123",
         status=ReviewStatus.UNREVIEWED,
         audit_question="Do premises suffice to establish [@quantum_hyp]?",
         round=1,
@@ -70,16 +74,29 @@ def test_review_creation():
 
 
 def test_review_manifest():
-    r = Review(review_id="rev_001", action_label="a", strategy_id="lcs_1", status="unreviewed", audit_question="?", round=1)
+    r = Review(review_id="rev_001", action_label="a", target_kind="strategy", target_id="lcs_1", status="unreviewed", audit_question="?", round=1)
     m = ReviewManifest(reviews=[r])
     assert len(m.reviews) == 1
 
 
 def test_review_manifest_latest_status():
-    r1 = Review(review_id="rev_001", action_label="a", strategy_id="lcs_1", status="unreviewed", audit_question="?", round=1)
-    r2 = Review(review_id="rev_002", action_label="a", strategy_id="lcs_1", status="accepted", audit_question="?", round=2)
+    r1 = Review(review_id="rev_001", action_label="a", target_kind="strategy", target_id="lcs_1", status="unreviewed", audit_question="?", round=1)
+    r2 = Review(review_id="rev_002", action_label="a", target_kind="strategy", target_id="lcs_1", status="accepted", audit_question="?", round=2)
     m = ReviewManifest(reviews=[r1, r2])
     assert m.latest_status("lcs_1") == "accepted"
+
+
+def test_review_rejects_probability_fields():
+    with pytest.raises(ValidationError):
+        Review(
+            review_id="rev_bad",
+            action_label="a",
+            target_kind="strategy",
+            target_id="lcs_1",
+            status="accepted",
+            audit_question="?",
+            prior=0.9,
+        )
 ```
 
 - [ ] **Step 2: Implement**
@@ -91,8 +108,9 @@ def test_review_manifest_latest_status():
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ReviewStatus(StrEnum):
@@ -103,9 +121,12 @@ class ReviewStatus(StrEnum):
 
 
 class Review(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     review_id: str
     action_label: str
-    strategy_id: str
+    target_kind: Literal["strategy", "operator"]
+    target_id: str
     status: ReviewStatus
     audit_question: str
     reviewer_notes: str | None = None
@@ -114,10 +135,12 @@ class Review(BaseModel):
 
 
 class ReviewManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     reviews: list[Review] = []
 
-    def latest_status(self, strategy_id: str) -> ReviewStatus | None:
-        relevant = [r for r in self.reviews if r.strategy_id == strategy_id]
+    def latest_status(self, target_id: str) -> ReviewStatus | None:
+        relevant = [r for r in self.reviews if r.target_id == target_id]
         if not relevant:
             return None
         return max(relevant, key=lambda r: r.round).status
@@ -125,6 +148,8 @@ class ReviewManifest(BaseModel):
 
 - [ ] **Step 3: Run — verify passes**
 - [ ] **Step 4: Commit**
+
+Review records are qualitative accept/reject/needs-inputs records only; extra probability or calibration fields must fail validation.
 
 ---
 
@@ -185,8 +210,8 @@ def generate_audit_question(action_type: str, **labels) -> str:
 
 ### Task 3: Manifest generation from compiled package
 
-- [ ] **Step 1: Write test** — compile a package, generate ReviewManifest, verify one Review per Strategy
-- [ ] **Step 2: Implement `generate_review_manifest()`** — walks compiled strategies, creates Review entries
+- [ ] **Step 1: Write test** — compile a package, generate ReviewManifest, verify one Review per reviewable Strategy and Operator
+- [ ] **Step 2: Implement `generate_review_manifest()`** — walks compiled strategies/operators, creates Review entries with `target_kind` and `target_id`
 - [ ] **Step 3: Commit**
 
 ---
@@ -211,11 +236,18 @@ def test_accepted_strategy_included_in_bp():
     """Accepted strategy participates in inference."""
     # Same graph, but Review status = "accepted"
     # Run BP → B's posterior should be updated
+
+
+def test_review_manifest_does_not_set_priors():
+    """Accepted Review gates inclusion but does not mutate Claim priors."""
+    # Build graph with helper Claims carrying their normal compiled/default priors
+    # Mark strategy accepted
+    # Run BP lowering and verify no prior/calibration value is read from Review
 ```
 
 - [ ] **Step 2: Modify lowering.py**
 
-In `lower_local_graph()`, accept optional `ReviewManifest`. Before lowering each strategy, check `manifest.latest_status(strategy_id)`. Skip if not "accepted".
+In `lower_local_graph()`, accept optional `ReviewManifest`. Before lowering each reviewable Strategy or Operator, check `manifest.latest_status(strategy_id_or_operator_id)`. Skip if not "accepted". If accepted, use the normal lowering semantics already encoded in the IR and parameterization records; do not read or synthesize any prior from the Review.
 
 - [ ] **Step 3: Run — verify passes**
 - [ ] **Step 4: Commit**
@@ -240,7 +272,9 @@ def test_check_warrants_outputs_review_list(tmp_path):
 
 def test_check_warrants_blind(tmp_path):
     """gaia check --warrants --blind omits author priors."""
-    pass
+    # Create package with author priors on Claims and one derive action
+    # Run gaia check --warrants --blind
+    # Verify audit questions and action labels are present, but numeric priors are absent
 ```
 
 - [ ] **Step 2: Implement in check.py** — add `--warrants` flag, generate + display ReviewManifest

--- a/docs/plans/2026-04-21-gaia-lang-v6-phase5-inquiry-quality-gate.md
+++ b/docs/plans/2026-04-21-gaia-lang-v6-phase5-inquiry-quality-gate.md
@@ -4,7 +4,7 @@
 
 **Goal:** Implement InquiryState (`gaia check --inquiry`) showing goal-oriented reasoning progress with Review status, and Quality Gate (`gaia check --gate`) for CI with configurable thresholds.
 
-**Architecture:** InquiryState traverses `Claim.supports` trees (Lang-level, self-contained) or IR graph (compiled level) to build dependency trees for each exported Claim. Quality Gate reads `[tool.gaia.quality]` from pyproject.toml and checks: no structural holes, all warrants accepted, posterior thresholds met.
+**Architecture:** InquiryState traverses `Claim.supports` trees (Lang-level, self-contained) or IR graph (compiled level) to build dependency trees for each exported Claim. The compiled path uses IR Strategy/Operator records plus ReviewManifest as the source of truth; `Claim.supports` is only a source-level convenience index. Quality Gate reads `[tool.gaia.quality]` from pyproject.toml and checks: no structural holes, all warrants accepted, root observations reviewed, posterior thresholds met.
 
 **Tech Stack:** Python 3.12+, pytest, typer (CLI)
 
@@ -64,7 +64,9 @@ def test_inquiry_shows_support_tree(tmp_path):
 
 def test_inquiry_summary(tmp_path):
     """InquiryState shows summary: warranted claims, unreviewed, holes."""
-    pass
+    # Create package with one accepted derive, one unreviewed root observe, and one exported hole
+    # Run gaia check --inquiry
+    # Verify Summary counts accepted, unreviewed, and holes separately
 ```
 
 - [ ] **Step 2: Implement `_inquiry.py`**
@@ -179,6 +181,14 @@ def test_gate_fails_on_unreviewed(tmp_path):
     assert result.exit_code != 0
 
 
+def test_gate_fails_on_unreviewed_root_observe(tmp_path):
+    """A grounded root observation still needs accepted review."""
+    # Package with observe("root fact") and Grounding, but ReviewManifest status remains unreviewed
+    result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
+    assert result.exit_code != 0
+    assert "unreviewed" in result.output.lower()
+
+
 def test_gate_fails_on_low_posterior(tmp_path):
     """Quality gate fails if exported Claim posterior < min_posterior."""
     # Package with min_posterior=0.9, but posterior is 0.7
@@ -212,12 +222,21 @@ def check_quality_gate(
             if not _has_warrant_chain(ir, kid):
                 failures.append(f"Structural hole: {kid} has no warrant chain")
 
-    # 2. All warrants accepted
+    # 2. All warrants accepted, including no-premise observe strategies and relate operators.
+    # ReviewManifest is qualitative only; it gates inclusion but never sets priors.
     if review_manifest:
         for s in ir.get("strategies", []):
             status = review_manifest.latest_status(s["strategy_id"])
             if status != ReviewStatus.ACCEPTED:
                 label = (s.get("metadata") or {}).get("action_label", s["strategy_id"])
+                failures.append(f"Unreviewed/rejected: {label} (status={status})")
+        for o in ir.get("operators", []):
+            oid = o.get("operator_id")
+            if not oid:
+                continue
+            status = review_manifest.latest_status(oid)
+            if status != ReviewStatus.ACCEPTED:
+                label = (o.get("metadata") or {}).get("action_label", oid)
                 failures.append(f"Unreviewed/rejected: {label} (status={status})")
 
     # 3. Posterior threshold

--- a/docs/specs/2026-04-21-gaia-ir-v6-design.md
+++ b/docs/specs/2026-04-21-gaia-ir-v6-design.md
@@ -34,7 +34,8 @@ Old interpretation:
 
 New interpretation:
   Strategy has no probability. Uncertainty is on explicit premise Claims.
-  Helper claim priors are set by reviewer via ReviewManifest, not by author.
+  ReviewManifest makes qualitative accept/reject/needs-inputs decisions.
+  Numeric warrant strength is produced by the accepted lowering policy, not by Review.
 ```
 
 ### Core rules
@@ -42,7 +43,7 @@ New interpretation:
 1. **Only `Claim` carries epistemic probability.** Setting, Context, Question do not.
 2. **Strategy carries no probability.** Uncertainty is expressed through explicit premise Claims.
 3. **Operator remains deterministic** and continues to produce `conclusion` helper Claims.
-4. **Generated helper Claims are neutral** unless reviewed and accepted.
+4. **Generated helper Claims are qualitative audit targets** unless their owning Strategy/Operator is reviewed and accepted.
 5. **`Review` is a review record in `ReviewManifest`**, not a Claim and not a probability variable.
 6. **Statistical evidence** uses existing `Strategy(type="infer")` with CPT encoding P(E|H) and P(E|¬H).
 
@@ -144,10 +145,10 @@ Existing types are reused:
 
 | v6 Lang verb | StrategyType | Notes |
 |---|---|---|
-| `derive()` | `deduction` or `support` | Existing |
-| `observe()` with premises | `deduction` or `support` | `metadata.pattern = "observation"` |
-| `observe()` no premises | No Strategy | Only adds Grounding to the Claim |
-| `compute()` | `deduction` or `support` | `metadata.compute = {...}` |
+| `derive()` | `deduction` | Existing FormalStrategy lowering |
+| `observe()` with premises | `deduction` | `metadata.pattern = "observation"` |
+| `observe()` no premises | `deduction` | Reviewable root-observation Strategy with `premises=[]`; adds Grounding to the Claim; lowering does not create a support edge from non-existent premises |
+| `compute()` | `deduction` | `metadata.pattern = "computation"`, `metadata.compute = {...}` |
 | `infer()` | `infer` | Existing; `premises=[H]`, `conclusion=E`, CPT = `[p_e_given_not_h, p_e_given_h]` |
 
 ### 2.3 Operator — No Change
@@ -183,9 +184,10 @@ class ReviewStatus(StrEnum):
 class Review:
     review_id: str
     action_label: str           # references Lang Action label (human-readable)
-    strategy_id: str            # points to the IR Strategy (hash-based)
+    target_kind: Literal["strategy", "operator"]
+    target_id: str              # Strategy.strategy_id or Operator.operator_id
     status: ReviewStatus
-    audit_question: str         # auto-generated from Strategy type
+    audit_question: str         # auto-generated from target type / pattern
     reviewer_notes: str | None = None
     timestamp: str
     round: int                  # supports multi-round review
@@ -193,11 +195,11 @@ class Review:
 
 ### 3.3 Multi-round review
 
-A single Strategy can have multiple Review records across review rounds. The latest Review's status determines whether the Strategy participates in inference.
+A single Strategy or Operator can have multiple Review records across review rounds. The latest Review's status determines whether the target participates in inference.
 
 ### 3.4 Default behavior
 
-**Unreviewed Strategies do NOT participate in inference** (pessimistic default). A Strategy must be explicitly accepted before it contributes to belief propagation.
+**Unreviewed Strategy/Operator targets do NOT participate in inference** (pessimistic default). A target must be explicitly accepted before it contributes to belief propagation.
 
 ### 3.5 Review has no probability
 
@@ -205,13 +207,21 @@ A single Strategy can have multiple Review records across review rounds. The lat
 Review is procedural review state, not epistemic uncertainty.
 ```
 
-If reviewer finds an issue, the fix is to modify the reasoning graph directly: add missing premise Claims, adjust Claim priors, or mark the Review as `needs_inputs`.
+Review records therefore do not carry priors, likelihoods, or calibration values. They only decide whether a Strategy/Operator is accepted for lowering. If a reviewer finds an issue, the fix is qualitative and structural: add missing premise Claims, adjust Claim priors in the parameterization layer, or mark the Review as `needs_inputs`.
+
+Accepted review status authorizes the existing lowering policy to assign runtime semantics:
+
+- accepted `derive`/`observe`/`compute` FormalStrategy instances participate in lowering
+- accepted `equal`/`contradict` Operators participate in lowering
+- deterministic/formal warrant helpers use the backend's standard assertion/default policy
+- accepted `infer` uses its explicit CPT record
+- unreviewed/rejected/needs-inputs Strategy/Operator targets are excluded from inference
 
 ### 3.6 Auto-generated audit questions
 
-Audit questions are automatically generated from Strategy type, using `[@...]` reference templates:
+Audit questions are automatically generated from target type, using `[@...]` reference templates:
 
-| Strategy type / pattern | Audit question template |
+| Target type / pattern | Audit question template |
 |---|---|
 | deduction / derivation | "Do the listed premises suffice to establish [@conclusion]?" |
 | deduction / observation | "Is the observation of [@conclusion] reliable under the stated conditions?" |
@@ -234,8 +244,8 @@ Templates are rendered to concrete questions using the referenced Claims' labels
 | `Question(...)` | `Knowledge(type="question")` |
 | `derive(...)` | `FormalStrategy(type="deduction")` + conjunction + implication helpers |
 | `observe(...)` with given | `FormalStrategy(type="deduction", metadata.pattern="observation")` |
-| `observe(...)` no given | `Grounding(kind="source_fact")` on the Claim |
-| `compute(...)` / `@compute` | `FormalStrategy(type="deduction", metadata.compute={...})` |
+| `observe(...)` no given | `FormalStrategy(type="deduction", premises=[], metadata.pattern="observation")` + `Grounding(kind="source_fact")` on the Claim |
+| `compute(...)` / `@compute` | `FormalStrategy(type="deduction", metadata.pattern="computation", metadata.compute={...})` |
 | `equal(A, B)` | `Operator(type="equivalence")` + Equivalence helper Claim |
 | `contradict(A, B)` | `Operator(type="contradiction")` + Contradiction helper Claim |
 | `infer(...)` | `Strategy(type="infer", premises=[H], conclusion=E)` + CPT `[p_e_given_not_h, p_e_given_h]` + StatisticalSupport helper |
@@ -264,7 +274,7 @@ Templates are rendered to concrete questions using the referenced Claims' labels
 ### 5.3 New types
 
 - `ReviewManifest` — package-level review state
-- `Review` — individual Strategy review record
+- `Review` — individual Strategy/Operator review record
 
 ### 5.4 Unchanged
 

--- a/docs/specs/2026-04-21-gaia-lang-v6-design.md
+++ b/docs/specs/2026-04-21-gaia-lang-v6-design.md
@@ -14,7 +14,7 @@
 1. **Claim-first authoring**: Authors declare Claims, then connect them with warranted reasoning verbs.
 2. **Three verb categories**: Support (directional), Relate (logical), Infer (statistical).
 3. **No probability on Strategy**: Uncertainty is expressed through explicit premise Claims, not edge weights.
-4. **Warrant is review state**: ReviewManifest records whether each reasoning step has been accepted by a reviewer.
+4. **Warrant is review state**: ReviewManifest records qualitative accept/reject/needs-inputs decisions; it does not carry priors.
 5. **Parameterized Claims**: Docstring templates with `[@ref]` for Knowledge parameters and `{param}` for value parameters.
 6. **IR-first compilability**: Every construct compiles to Gaia IR. No new IR node types beyond what the companion IR spec defines.
 
@@ -255,7 +255,9 @@ s = derive("Energy is quantized.", given=(A, B), rationale="...", label="planck_
 # Action QID: "github:blackbody::action::planck_resolves"
 ```
 
-At compile time, the label is stored in `Strategy.metadata.action_label`. The Strategy retains its existing hash-based `strategy_id` (`lcs_...`). The compiler maintains a bidirectional `action_label ↔ strategy_id` mapping.
+At compile time, the label is stored in the compiled target's `metadata.action_label`. Strategy targets retain hash-based `strategy_id` values (`lcs_...`); Operator targets retain hash-based `operator_id` values (`lco_...`). The compiler maintains a bidirectional `action_label ↔ target_id` mapping.
+
+Actions are registered in the collected package when created. `Claim.supports` is a convenience index for InquiryState and user inspection, not the compiler's only source of truth.
 
 **Warrants:** `warrants` tracks the helper Claims that need review (e.g., `Implies(AllTrue(A,B), C)` for derive). These are the audit targets in ReviewManifest.
 
@@ -269,7 +271,7 @@ Claim("AllTrue(A, B) implies C.", metadata={"generated": True, "helper_kind": "i
 Claim("AllTrue(A, B).", metadata={"generated": True, "helper_kind": "conjunction_result", "review": False})
 ```
 
-No subclass hierarchy for helpers — the `metadata.review` flag distinguishes warrants from mechanical helpers. Only `metadata.review == True` claims go into `Action.warrants` and ReviewManifest.
+No subclass hierarchy for helpers — the `metadata.review` flag distinguishes warrants from mechanical helpers. Only `metadata.review == True` helper Claims go into `Action.warrants`; ReviewManifest entries are generated per reviewable Action target and may reference those helper Claims in the audit question.
 
 ### 4.3 Claim.supports
 
@@ -300,9 +302,9 @@ InquiryState traverses `claim.supports` to build the dependency tree.
 |---|---|
 | `Derive` | `FormalStrategy(type="deduction", metadata.action_label=label)` |
 | `Observe` | `FormalStrategy(type="deduction", metadata={action_label, pattern="observation"})` |
-| `Compute` | `FormalStrategy(type="deduction", metadata={action_label, compute={...}})` |
-| `Equal` | `Operator(type="equivalence")` |
-| `Contradict` | `Operator(type="contradiction")` |
+| `Compute` | `FormalStrategy(type="deduction", metadata={action_label, pattern="computation", compute={...}})` |
+| `Equal` | `Operator(type="equivalence", metadata.action_label=label)` |
+| `Contradict` | `Operator(type="contradiction", metadata.action_label=label)` |
 | `Infer` | `Strategy(type="infer", metadata.action_label=label)` + CPT |
 
 ### 4.5 First argument sugar
@@ -415,7 +417,7 @@ observe(
 )
 ```
 
-Does NOT generate a Strategy. Instead adds `Grounding(kind="source_fact")` to the Claim.
+Generates a reviewable `Observe` Action that lowers to `FormalStrategy(type="deduction", premises=[], metadata.pattern="observation")`, and also adds `Grounding(kind="source_fact")` to the Claim. During BP lowering, the root observation does not create a support edge from non-existent premises; review acceptance only authorizes the grounded Claim to be treated as a reviewed source fact.
 
 ### 5.3 compute
 
@@ -450,7 +452,7 @@ Decorator extracts:
 - Output type from return annotation → conclusion Claim class
 - Docstring → rationale
 
-Compiles to `Strategy(type="computation")` + `ComputationMethod`.
+Compiles to `FormalStrategy(type="deduction", metadata.pattern="computation")` with `metadata.compute = {function_ref, code_hash, ...}`. There is no `StrategyType.COMPUTATION` in IR v6.
 
 **Compute chains**: One compute's output (Claim subclass) can be input to another compute, automatically forming reasoning chains.
 
@@ -564,14 +566,16 @@ Convenience wrappers like `ab_test()`, `binomial_test()`, `t_test()` are deferre
 
 ### 9.1 Review
 
-Users do not write Review objects directly. When the compiler emits a Strategy, a Review is automatically generated in ReviewManifest with `status="unreviewed"`.
+Users do not write Review objects directly. When the compiler emits a reviewable Strategy or Operator, a Review is automatically generated in ReviewManifest with `status="unreviewed"`.
 
-Reviews reference Actions by `action_label`, not by IR strategy_id:
+Reviews reference Actions by `action_label` and the compiled IR target by kind/id:
 
 ```python
 class Review:
     review_id: str
     action_label: str              # references Action.label (human-readable)
+    target_kind: Literal["strategy", "operator"]
+    target_id: str                 # Strategy.strategy_id or Operator.operator_id
     status: ReviewStatus           # unreviewed | accepted | rejected | needs_inputs
     audit_question: str            # auto-generated
     reviewer_notes: str | None = None
@@ -580,7 +584,7 @@ class Review:
 
 Audit questions are auto-generated from Action type using `[@...]` templates:
 
-| Strategy type | Audit question template |
+| Target type | Audit question template |
 |---|---|
 | deduction | "Do the listed premises suffice to establish [@conclusion]?" |
 | observation | "Is the observation of [@conclusion] reliable under the stated conditions?" |
@@ -596,20 +600,22 @@ gaia check --warrants              # Export all warrants with audit questions
 gaia check --warrants --blind      # Export with empty status (avoid anchoring bias)
 ```
 
-Reviewer sets status for each Warrant:
+Reviewer sets status for each review target:
 
 ```
-accepted        — Strategy participates in inference
-rejected        — Strategy is excluded
+accepted        — Strategy/Operator target participates in inference
+rejected        — Strategy/Operator target is excluded
 needs_inputs    — Missing premise Claims needed
-unreviewed      — Default; Strategy does NOT participate (pessimistic)
+unreviewed      — Default; target does NOT participate (pessimistic)
 ```
 
 If reviewer marks `needs_inputs`, the fix is to add explicit Claims to the reasoning graph and regenerate.
 
 ### 9.3 Multi-round review
 
-Same Strategy can be reviewed multiple times (different rounds). Latest status determines whether it participates.
+Same Strategy/Operator target can be reviewed multiple times (different rounds). Latest status determines whether it participates.
+
+ReviewManifest is qualitative: it has no prior, likelihood, or calibration field. Accepted status enables the relevant lowering rule; rejected, unreviewed, and needs-inputs statuses exclude that Strategy/Operator from inference until the graph or review state changes.
 
 ---
 
@@ -723,8 +729,8 @@ knowledge.metadata["gaia"]["provenance"] = {
 | `Question(...)` | `Knowledge(type="question")` |
 | `derive(...)` | `FormalStrategy(type="deduction")` + conjunction + implication helpers |
 | `observe(...)` with given | `FormalStrategy(type="deduction", metadata.pattern="observation")` |
-| `observe(...)` no given | `Grounding(kind="source_fact")` on the Claim |
-| `compute(...)` / `@compute` | `FormalStrategy(type="deduction", metadata.compute={...})` |
+| `observe(...)` no given | `FormalStrategy(type="deduction", premises=[], metadata.pattern="observation")` + `Grounding(kind="source_fact")` on the Claim |
+| `compute(...)` / `@compute` | `FormalStrategy(type="deduction", metadata={pattern="computation", compute={...}})` |
 | `equal(A, B)` | `Operator(type="equivalence")` + Equivalence helper |
 | `contradict(A, B)` | `Operator(type="contradiction")` + Contradiction helper |
 | `infer(...)` | `Strategy(type="infer", premises=[H], conclusion=E)` + CPT `[p_e_given_not_h, p_e_given_h]` + StatisticalSupport helper |
@@ -744,7 +750,7 @@ knowledge.metadata["gaia"]["provenance"] = {
 | `claim("...")` | `Claim("...")` or subclass | Uppercase, class style |
 | `setting("...")` | `Setting("...")` | Uppercase |
 | `question("...")` | `Question("...")` | Uppercase |
-| `support([a], b, prior=0.9)` | `derive(b, given=a, rationale=...)` | No prior |
+| `support([a], b, prior=0.9)` | Deprecated compat wrapper | Emits `DeprecationWarning`; must preserve existing v5 support-prior behavior until a migration tool rewrites it |
 | `deduction([a], b)` | `derive(b, given=a, rationale=...)` | No prior, no type= |
 | `contradiction(a, b)` | `contradict(a, b, rationale=...)` | Returns helper Claim |
 | `equivalence(a, b)` | `equal(a, b, rationale=...)` | Returns helper Claim |
@@ -756,7 +762,7 @@ knowledge.metadata["gaia"]["provenance"] = {
 
 ### 13.2 Compatibility
 
-v5 function-style API (`claim()`, `support()`, `deduction()`, etc.) is preserved as a deprecated compatibility layer compiling to the same IR. New packages should use v6 API.
+v5 function-style API (`claim()`, `support()`, `deduction()`, etc.) is preserved as a deprecated compatibility layer compiling to the same IR. Calls that carry v5-only semantics, especially `support(..., prior=...)`, must emit `DeprecationWarning` but must not silently drop the prior. New packages should use v6 API.
 
 ---
 


### PR DESCRIPTION
## Summary

This follow-up to PR #450 tightens the April 21 Gaia v6 specs and implementation plans around review and lowering semantics:

- make no-premise `observe()` a reviewable deduction `FormalStrategy` with `premises=[]` plus Grounding, instead of an unreviewed grounding-only path
- clarify `compute()` lowers to deduction with `metadata.pattern="computation"` and `metadata.compute`, with no new computation strategy type
- keep `ReviewManifest` qualitative only: no priors, likelihoods, calibration, or policy fields; accepted review gates existing lowering semantics
- require Review targets to cover both Strategies and Operators via `target_kind` / `target_id`
- ensure v6 Actions register in `CollectedPackage.actions`, with `Claim.supports` only a convenience index
- preserve v5 `support(..., prior=...)` behavior while emitting `DeprecationWarning`
- replace placeholder compiler-plan tests and fix Enum parameter rendering through `.value`

## Verification

- `git diff --check HEAD~1 HEAD`
- grep check for stale semantics: no remaining matches for grounding-only root observe, `Strategy(type="computation")`, silently ignored support priors, or ReviewManifest-set helper priors