### PR TITLE
Implement Gaia Lang v6 phase 1 knowledge primitives

### DIFF
--- a/gaia/ir/knowledge.py
+++ b/gaia/ir/knowledge.py
@@ -31,6 +31,7 @@ class KnowledgeType(StrEnum):
     CLAIM = "claim"
     SETTING = "setting"
     QUESTION = "question"
+    CONTEXT = "context"
 
 
 class Parameter(BaseModel):
@@ -38,6 +39,7 @@ class Parameter(BaseModel):
 
     name: str
     type: str
+    value: Any | None = None
 
 
 class PackageRef(BaseModel):

--- a/gaia/lang/__init__.py
+++ b/gaia/lang/__init__.py
@@ -24,11 +24,22 @@ from gaia.lang.dsl import (
     setting,
     support,
 )
-from gaia.lang.runtime import Claim, Context, Knowledge, Operator, Question, Setting, Step, Strategy
+from gaia.lang.runtime import (
+    Claim,
+    Context,
+    Grounding,
+    Knowledge,
+    Operator,
+    Question,
+    Setting,
+    Step,
+    Strategy,
+)
 
 __all__ = [
     "Claim",
     "Context",
+    "Grounding",
     "Knowledge",
     "Operator",
     "Question",

--- a/gaia/lang/__init__.py
+++ b/gaia/lang/__init__.py
@@ -9,6 +9,7 @@ from gaia.lang.dsl import (
     composite,
     complement,
     contradiction,
+    context,
     deduction,
     disjunction,
     elimination,
@@ -23,11 +24,15 @@ from gaia.lang.dsl import (
     setting,
     support,
 )
-from gaia.lang.runtime import Knowledge, Operator, Step, Strategy
+from gaia.lang.runtime import Claim, Context, Knowledge, Operator, Question, Setting, Step, Strategy
 
 __all__ = [
+    "Claim",
+    "Context",
     "Knowledge",
     "Operator",
+    "Question",
+    "Setting",
     "Step",
     "Strategy",
     "abduction",
@@ -38,6 +43,7 @@ __all__ = [
     "composite",
     "complement",
     "contradiction",
+    "context",
     "deduction",
     "disjunction",
     "elimination",

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from gaia.ir import (
@@ -31,6 +31,7 @@ from gaia.lang.refs import (
 )
 from gaia.lang.runtime import Knowledge, Operator
 from gaia.lang.runtime.package import CollectedPackage
+from gaia.lang.runtime.param import UNBOUND
 
 _COMPILE_TIME_FORMAL_STRATEGIES = frozenset(
     {
@@ -122,7 +123,20 @@ def _knowledge_id(
 
 def _knowledge_metadata(k: Knowledge) -> dict[str, Any] | None:
     metadata = dict(k.metadata)
+    grounding = getattr(k, "grounding", None)
+    if grounding is not None:
+        metadata["grounding"] = asdict(grounding)
     return metadata or None
+
+
+def _parameter_to_ir(param: dict[str, Any], knowledge_map: dict[int, str]) -> IrParameter:
+    payload = dict(param)
+    value = payload.get("value")
+    if isinstance(value, Knowledge):
+        payload["value"] = knowledge_map[id(value)]
+    elif value is UNBOUND:
+        payload["value"] = None
+    return IrParameter(**payload)
 
 
 def _knowledge_provenance(k: Knowledge) -> list[IrPackageRef] | None:
@@ -286,6 +300,10 @@ def compile_package_artifact(
             return
         knowledge_nodes.append(k)
         seen_knowledge.add(key)
+        for param in k.parameters:
+            value = param.get("value")
+            if isinstance(value, Knowledge):
+                register_knowledge(value)
 
     def register_strategy_knowledge(strategy: Any) -> None:
         for premise in strategy.premises:
@@ -337,7 +355,7 @@ def compile_package_artifact(
             title=getattr(k, "title", None),
             type=k.type,
             content=k.content,
-            parameters=[IrParameter(**p) for p in k.parameters],
+            parameters=[_parameter_to_ir(p, knowledge_map) for p in k.parameters],
             provenance=_knowledge_provenance(k),
             metadata=_knowledge_metadata(k),
             module=getattr(k, "_source_module", None),

--- a/gaia/lang/dsl/__init__.py
+++ b/gaia/lang/dsl/__init__.py
@@ -1,4 +1,4 @@
-from gaia.lang.dsl.knowledge import claim, question, setting
+from gaia.lang.dsl.knowledge import claim, context, question, setting
 from gaia.lang.dsl.operators import complement, contradiction, disjunction, equivalence
 from gaia.lang.dsl.strategies import (
     abduction,
@@ -22,6 +22,7 @@ __all__ = [
     "analogy",
     "case_analysis",
     "claim",
+    "context",
     "compare",
     "composite",
     "complement",

--- a/gaia/lang/dsl/knowledge.py
+++ b/gaia/lang/dsl/knowledge.py
@@ -1,27 +1,32 @@
-"""Gaia Lang v5 — Knowledge DSL functions (claim, setting, question)."""
+"""Gaia Lang v5/v6 — Knowledge DSL functions."""
 
-from gaia.lang.runtime import Knowledge
+from gaia.lang.runtime import Claim, Context, Knowledge, Question, Setting
 
 
-def setting(content: str, *, title: str | None = None, **metadata) -> Knowledge:
+def context(content: str, **metadata) -> Context:
+    """Declare raw unformalized context text."""
+    return Context(content.strip(), metadata=_flatten_metadata(metadata))
+
+
+def setting(content: str, *, title: str | None = None, **metadata) -> Setting:
     """Declare a background assumption. No probability, no BP participation."""
     provenance = metadata.pop("provenance", None)
-    return Knowledge(
+    return Setting(
         content=content.strip(),
-        type="setting",
         title=title,
         provenance=provenance or [],
         metadata=_flatten_metadata(metadata),
     )
 
 
-def question(content: str, *, title: str | None = None, **metadata) -> Knowledge:
+def question(content: str, *, title: str | None = None, **metadata) -> Question:
     """Declare a research question. No probability, no BP participation."""
     provenance = metadata.pop("provenance", None)
-    return Knowledge(
+    targets = metadata.pop("targets", [])
+    return Question(
         content=content.strip(),
-        type="question",
         title=title,
+        targets=targets,
         provenance=provenance or [],
         metadata=_flatten_metadata(metadata),
     )
@@ -42,11 +47,10 @@ def claim(
     parameters: list[dict] | None = None,
     provenance: list[dict[str, str]] | None = None,
     **metadata,
-) -> Knowledge:
+) -> Claim:
     """Declare a scientific assertion. The only type carrying probability."""
-    return Knowledge(
+    return Claim(
         content=content.strip(),
-        type="claim",
         title=title,
         background=background or [],
         parameters=parameters or [],

--- a/gaia/lang/runtime/__init__.py
+++ b/gaia/lang/runtime/__init__.py
@@ -1,3 +1,4 @@
-from gaia.lang.runtime.nodes import Knowledge, Operator, Step, Strategy
+from gaia.lang.runtime.knowledge import Claim, Context, Knowledge, Question, Setting
+from gaia.lang.runtime.nodes import Operator, Step, Strategy
 
-__all__ = ["Knowledge", "Operator", "Step", "Strategy"]
+__all__ = ["Claim", "Context", "Knowledge", "Operator", "Question", "Setting", "Step", "Strategy"]

--- a/gaia/lang/runtime/__init__.py
+++ b/gaia/lang/runtime/__init__.py
@@ -1,4 +1,15 @@
+from gaia.lang.runtime.grounding import Grounding
 from gaia.lang.runtime.knowledge import Claim, Context, Knowledge, Question, Setting
 from gaia.lang.runtime.nodes import Operator, Step, Strategy
 
-__all__ = ["Claim", "Context", "Knowledge", "Operator", "Question", "Setting", "Step", "Strategy"]
+__all__ = [
+    "Claim",
+    "Context",
+    "Grounding",
+    "Knowledge",
+    "Operator",
+    "Question",
+    "Setting",
+    "Step",
+    "Strategy",
+]

--- a/gaia/lang/runtime/grounding.py
+++ b/gaia/lang/runtime/grounding.py
@@ -1,0 +1,22 @@
+"""Grounding metadata for root Claims."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+_VALID_KINDS = frozenset({"assumption", "source_fact", "definition", "imported", "judgment", "open"})
+
+
+@dataclass
+class Grounding:
+    """Explains why a root Claim can have a prior."""
+
+    kind: str
+    rationale: str = ""
+    source_refs: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.kind not in _VALID_KINDS:
+            raise ValueError(
+                f"Invalid grounding kind {self.kind!r}. Must be one of: {sorted(_VALID_KINDS)}"
+            )

--- a/gaia/lang/runtime/grounding.py
+++ b/gaia/lang/runtime/grounding.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-_VALID_KINDS = frozenset({"assumption", "source_fact", "definition", "imported", "judgment", "open"})
+_VALID_KINDS = frozenset(
+    {"assumption", "source_fact", "definition", "imported", "judgment", "open"}
+)
 
 
 @dataclass

--- a/gaia/lang/runtime/knowledge.py
+++ b/gaia/lang/runtime/knowledge.py
@@ -1,0 +1,183 @@
+"""Gaia Lang v6 Knowledge class hierarchy."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from gaia.lang.runtime.grounding import Grounding
+from gaia.lang.runtime.param import UNBOUND
+
+if TYPE_CHECKING:
+    from gaia.lang.runtime.package import CollectedPackage
+
+_current_package: ContextVar[CollectedPackage | None] = ContextVar("_current_package", default=None)
+
+
+class _SafeFormatDict(dict):
+    """Return {key} for missing keys instead of raising KeyError."""
+
+    def __missing__(self, key):
+        return f"{{{key}}}"
+
+
+@dataclass
+class Knowledge:
+    """Base knowledge node. Plain text plus metadata."""
+
+    content: str
+    type: str = "knowledge"
+    title: str | None = None
+    background: list[Knowledge] = field(default_factory=list)
+    parameters: list[dict] = field(default_factory=list)
+    provenance: list[dict[str, str]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    label: str | None = None
+    strategy: Any | None = None
+    _package: CollectedPackage | None = field(default=None, init=False, repr=False, compare=False)
+    _source_module: str | None = field(default=None, init=False, repr=False, compare=False)
+    _declaration_index: int | None = field(default=None, init=False, repr=False, compare=False)
+
+    def __post_init__(self):
+        pkg = _current_package.get()
+        source_module = None
+        if pkg is None:
+            from gaia.lang.runtime.package import infer_package_and_module
+
+            pkg, source_module = infer_package_and_module()
+        if pkg is not None:
+            self._source_module = source_module
+            self._package = pkg
+            pkg._register_knowledge(self)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+
+@dataclass(init=False)
+class Context(Knowledge):
+    """Raw unformalized text. Does not enter BP."""
+
+    def __init__(self, content: str, **kwargs):
+        if "prior" in kwargs:
+            raise TypeError("Context cannot have a prior.")
+        super().__init__(content=content, type="context", **kwargs)
+
+
+@dataclass(init=False)
+class Setting(Knowledge):
+    """Formalized background. No probability."""
+
+    def __init__(self, content: str, **kwargs):
+        if "prior" in kwargs:
+            raise TypeError("Setting cannot have a prior.")
+        super().__init__(content=content, type="setting", **kwargs)
+
+
+@dataclass(init=False)
+class Claim(Knowledge):
+    """Proposition with prior. Participates in BP."""
+
+    prior: float | None = None
+    grounding: Grounding | None = None
+    supports: list[Any] = field(default_factory=list)
+    _param_fields: ClassVar[dict[str, Any]] = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        base_fields = {
+            "content",
+            "type",
+            "title",
+            "background",
+            "parameters",
+            "provenance",
+            "metadata",
+            "label",
+            "strategy",
+            "prior",
+            "grounding",
+            "supports",
+            "targets",
+        }
+        cls._param_fields = {
+            name: ann
+            for name, ann in getattr(cls, "__annotations__", {}).items()
+            if name not in base_fields and not name.startswith("_")
+        }
+
+    def __init__(
+        self,
+        content: str | None = None,
+        *,
+        prior: float | None = None,
+        grounding: Grounding | None = None,
+        supports: list[Any] | None = None,
+        **kwargs,
+    ):
+        param_fields = getattr(self.__class__, "_param_fields", {})
+        param_values: dict[str, Any] = {}
+        knowledge_kwargs: dict[str, Any] = {}
+        for key, value in kwargs.items():
+            if key in param_fields:
+                param_values[key] = value
+            else:
+                knowledge_kwargs[key] = value
+
+        params = []
+        for name, ann in param_fields.items():
+            val = param_values.get(name, UNBOUND)
+            stored_val = val.value if isinstance(val, Enum) else val
+            params.append(
+                {
+                    "name": name,
+                    "type": ann.__name__ if isinstance(ann, type) else str(ann),
+                    "value": stored_val,
+                }
+            )
+
+        template = self.__class__.__doc__ or ""
+        if content is None and template and param_fields:
+            metadata = dict(knowledge_kwargs.get("metadata") or {})
+            metadata["content_template"] = template
+            knowledge_kwargs["metadata"] = metadata
+            render_values: dict[str, Any] = {}
+            for name in param_fields:
+                val = param_values.get(name, UNBOUND)
+                if val is not UNBOUND:
+                    if isinstance(val, Knowledge):
+                        render_values[name] = f"[@{val.label or '?'}]"
+                    elif isinstance(val, Enum):
+                        render_values[name] = val.value
+                    else:
+                        render_values[name] = val
+            content = template.format_map(_SafeFormatDict(render_values))
+
+        for name, val in param_values.items():
+            object.__setattr__(self, name, val)
+
+        super().__init__(
+            content=content or "",
+            type="claim",
+            parameters=params or knowledge_kwargs.pop("parameters", []),
+            **knowledge_kwargs,
+        )
+        self.prior = prior
+        self.grounding = grounding
+        self.supports = list(supports or [])
+
+
+@dataclass(init=False)
+class Question(Knowledge):
+    """Open inquiry. Does not enter BP."""
+
+    targets: list[Claim] = field(default_factory=list)
+
+    def __init__(self, content: str, **kwargs):
+        if "prior" in kwargs:
+            raise TypeError("Question cannot have a prior.")
+        targets = kwargs.pop("targets", [])
+        super().__init__(content=content, type="question", **kwargs)
+        self.targets = list(targets)

--- a/gaia/lang/runtime/knowledge.py
+++ b/gaia/lang/runtime/knowledge.py
@@ -56,7 +56,7 @@ class Knowledge:
         return id(self)
 
 
-@dataclass(init=False)
+@dataclass(init=False, eq=False)
 class Context(Knowledge):
     """Raw unformalized text. Does not enter BP."""
 
@@ -66,7 +66,7 @@ class Context(Knowledge):
         super().__init__(content=content, type="context", **kwargs)
 
 
-@dataclass(init=False)
+@dataclass(init=False, eq=False)
 class Setting(Knowledge):
     """Formalized background. No probability."""
 
@@ -76,7 +76,7 @@ class Setting(Knowledge):
         super().__init__(content=content, type="setting", **kwargs)
 
 
-@dataclass(init=False)
+@dataclass(init=False, eq=False)
 class Claim(Knowledge):
     """Proposition with prior. Participates in BP."""
 
@@ -172,7 +172,7 @@ class Claim(Knowledge):
         self.supports = list(supports or [])
 
 
-@dataclass(init=False)
+@dataclass(init=False, eq=False)
 class Question(Knowledge):
     """Open inquiry. Does not enter BP."""
 

--- a/gaia/lang/runtime/knowledge.py
+++ b/gaia/lang/runtime/knowledge.py
@@ -143,17 +143,20 @@ class Claim(Knowledge):
             metadata = dict(knowledge_kwargs.get("metadata") or {})
             metadata["content_template"] = template
             knowledge_kwargs["metadata"] = metadata
+            rendered_template = template
             render_values: dict[str, Any] = {}
             for name in param_fields:
                 val = param_values.get(name, UNBOUND)
                 if val is not UNBOUND:
                     if isinstance(val, Knowledge):
-                        render_values[name] = f"[@{val.label or '?'}]"
+                        ref = f"[@{val.label or '?'}]"
+                        render_values[name] = ref
+                        rendered_template = rendered_template.replace(f"[@{name}]", ref)
                     elif isinstance(val, Enum):
                         render_values[name] = val.value
                     else:
                         render_values[name] = val
-            content = template.format_map(_SafeFormatDict(render_values))
+            content = rendered_template.format_map(_SafeFormatDict(render_values))
 
         for name, val in param_values.items():
             object.__setattr__(self, name, val)

--- a/gaia/lang/runtime/nodes.py
+++ b/gaia/lang/runtime/nodes.py
@@ -2,47 +2,10 @@
 
 from __future__ import annotations
 
-from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from gaia.lang.runtime.package import CollectedPackage
-
-_current_package: ContextVar[CollectedPackage | None] = ContextVar("_current_package", default=None)
-
-
-@dataclass
-class Knowledge:
-    """A knowledge declaration (claim, setting, or question)."""
-
-    content: str
-    type: str  # "claim" | "setting" | "question"
-    title: str | None = None
-    background: list[Knowledge] = field(default_factory=list)
-    parameters: list[dict] = field(default_factory=list)
-    provenance: list[dict[str, str]] = field(default_factory=list)
-    metadata: dict[str, Any] = field(default_factory=dict)
-    label: str | None = None
-    strategy: Strategy | None = None
-    _package: CollectedPackage | None = field(default=None, init=False, repr=False, compare=False)
-    _source_module: str | None = field(default=None, init=False, repr=False, compare=False)
-    _declaration_index: int | None = field(default=None, init=False, repr=False, compare=False)
-
-    def __post_init__(self):
-        pkg = _current_package.get()
-        source_module = None
-        if pkg is None:
-            from gaia.lang.runtime.package import infer_package_and_module
-
-            pkg, source_module = infer_package_and_module()
-        if pkg is not None:
-            self._source_module = source_module
-            self._package = pkg
-            pkg._register_knowledge(self)
-
-    def __hash__(self) -> int:
-        return id(self)
+from gaia.lang.runtime.knowledge import Knowledge, _current_package
 
 
 @dataclass

--- a/gaia/lang/runtime/package.py
+++ b/gaia/lang/runtime/package.py
@@ -6,7 +6,8 @@ import inspect
 import sys
 from pathlib import Path
 
-from gaia.lang.runtime.nodes import Knowledge, Operator, Strategy, _current_package
+from gaia.lang.runtime.knowledge import Knowledge, _current_package
+from gaia.lang.runtime.nodes import Operator, Strategy
 
 try:
     import tomllib

--- a/gaia/lang/runtime/param.py
+++ b/gaia/lang/runtime/param.py
@@ -1,0 +1,35 @@
+"""Parameterization primitives for Gaia Lang v6."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class _Unbound:
+    """Sentinel for unbound parameters. Not None."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNBOUND"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNBOUND = _Unbound()
+
+
+@dataclass
+class Param:
+    """A single parameter in a parameterized Knowledge type."""
+
+    name: str
+    type: type
+    value: Any = field(default_factory=lambda: UNBOUND)

--- a/tests/cli/test_compile_v6.py
+++ b/tests/cli/test_compile_v6.py
@@ -1,0 +1,53 @@
+"""End-to-end tests for v6 Knowledge types."""
+
+import json
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def test_v6_knowledge_types_compile(tmp_path):
+    """A package using v6 Knowledge types compiles to correct IR."""
+    pkg_dir = tmp_path / "v6_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "v6-pkg-gaia"\nversion = "1.0.0"\n'
+        'description = "v6 test"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "v6_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import Claim, Context, Grounding, Setting\n\n"
+        "ctx = Context('Raw AB test data from dashboard.')\n"
+        "exp = Setting('AB test exp_123: 50/50 randomization.')\n"
+        "hyp = Claim(\n"
+        "    'Variant B is better.',\n"
+        "    prior=0.5,\n"
+        "    grounding=Grounding(kind='judgment', rationale='Uninformative prior.'),\n"
+        ")\n"
+        "__all__ = ['hyp']\n"
+    )
+    (pkg_src / "priors.py").write_text(
+        "from . import hyp\n\n"
+        "PRIORS: dict = {\n"
+        '    hyp: (0.5, "uninformative"),\n'
+        "}\n"
+    )
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Compile failed: {result.output}"
+
+    ir_path = pkg_dir / ".gaia" / "ir.json"
+    assert ir_path.exists()
+    ir = json.loads(ir_path.read_text())
+
+    types = {k["type"] for k in ir["knowledges"]}
+    assert "context" in types
+
+    hyp_node = [k for k in ir["knowledges"] if k.get("label") == "hyp"][0]
+    assert hyp_node["metadata"]["grounding"]["kind"] == "judgment"
+    assert hyp_node["metadata"]["grounding"]["rationale"] == "Uninformative prior."

--- a/tests/cli/test_compile_v6.py
+++ b/tests/cli/test_compile_v6.py
@@ -32,10 +32,7 @@ def test_v6_knowledge_types_compile(tmp_path):
         "__all__ = ['hyp']\n"
     )
     (pkg_src / "priors.py").write_text(
-        "from . import hyp\n\n"
-        "PRIORS: dict = {\n"
-        '    hyp: (0.5, "uninformative"),\n'
-        "}\n"
+        'from . import hyp\n\nPRIORS: dict = {\n    hyp: (0.5, "uninformative"),\n}\n'
     )
 
     result = runner.invoke(app, ["compile", str(pkg_dir)])

--- a/tests/gaia/lang/test_compiler_v6.py
+++ b/tests/gaia/lang/test_compiler_v6.py
@@ -1,0 +1,68 @@
+from gaia.lang.compiler.compile import compile_package_artifact
+from gaia.lang.runtime.grounding import Grounding
+from gaia.lang.runtime.knowledge import Claim, Context, Setting
+from gaia.lang.runtime.package import CollectedPackage
+
+
+def test_compile_context_type():
+    """Context Knowledge compiles with type='context'."""
+    with CollectedPackage("v6_test") as pkg:
+        ctx = Context("Raw experiment notes.")
+        ctx.label = "ctx"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "ctx")
+    assert node["type"] == "context"
+
+
+def test_compile_grounding_in_metadata():
+    """Grounding metadata appears in compiled IR."""
+    with CollectedPackage("v6_test") as pkg:
+        claim = Claim(
+            "Measured spectrum deviates from Rayleigh-Jeans law.",
+            grounding=Grounding(kind="source_fact", rationale="Extracted from Fig.2."),
+        )
+        claim.label = "uv_data"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "uv_data")
+    assert node["metadata"]["grounding"]["kind"] == "source_fact"
+    assert "Fig.2" in node["metadata"]["grounding"]["rationale"]
+
+
+def test_compile_parameterized_claim_template():
+    """Parameterized Claim stores content_template in metadata."""
+
+    class TemperatureClaim(Claim):
+        """Cavity temperature is set to {value}K."""
+
+        value: float
+
+    with CollectedPackage("v6_test") as pkg:
+        temp = TemperatureClaim(value=5000.0)
+        temp.label = "temp"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "temp")
+    assert node["content"] == "Cavity temperature is set to 5000.0K."
+    assert node["metadata"]["content_template"] == "Cavity temperature is set to {value}K."
+
+
+def test_compile_parameter_value():
+    """Bound parameter values appear in compiled IR parameters."""
+
+    class ABCounts(Claim):
+        """[@experiment] recorded {ctrl_k}/{ctrl_n} control conversions."""
+
+        experiment: Setting
+        ctrl_n: int
+        ctrl_k: int
+
+    with CollectedPackage("v6_test") as pkg:
+        exp = Setting("AB test exp_123.")
+        exp.label = "exp_123"
+        counts = ABCounts(experiment=exp, ctrl_n=10_000, ctrl_k=500)
+        counts.label = "counts"
+    ir = compile_package_artifact(pkg).to_json()
+    node = next(k for k in ir["knowledges"] if k["label"] == "counts")
+    params = {p["name"]: p for p in node["parameters"]}
+    assert params["ctrl_n"]["value"] == 10_000
+    assert params["ctrl_k"]["value"] == 500
+    assert params["experiment"]["value"] == "github:v6_test::exp_123"

--- a/tests/gaia/lang/test_grounding.py
+++ b/tests/gaia/lang/test_grounding.py
@@ -1,0 +1,20 @@
+import pytest
+
+from gaia.lang.runtime.grounding import Grounding
+
+
+def test_grounding_source_fact():
+    g = Grounding(kind="source_fact", rationale="Extracted from Fig.2.")
+    assert g.kind == "source_fact"
+    assert g.rationale == "Extracted from Fig.2."
+    assert g.source_refs == []
+
+
+def test_grounding_with_source_refs():
+    g = Grounding(kind="source_fact", rationale="From paper.", source_refs=["ctx_1"])
+    assert g.source_refs == ["ctx_1"]
+
+
+def test_grounding_invalid_kind():
+    with pytest.raises(ValueError):
+        Grounding(kind="invalid_kind", rationale="bad")

--- a/tests/gaia/lang/test_knowledge_v6.py
+++ b/tests/gaia/lang/test_knowledge_v6.py
@@ -34,6 +34,12 @@ def test_claim_with_grounding():
     assert c.grounding.kind == "source_fact"
 
 
+def test_claim_is_hashable_for_priors_dict():
+    c = Claim("A proposition.")
+    priors = {c: (0.5, "uninformative")}
+    assert priors[c] == (0.5, "uninformative")
+
+
 def test_question_creation():
     q = Question("Should we ship variant B?")
     assert q.type == "question"
@@ -81,3 +87,9 @@ def test_v5_question_still_works():
     q = question("Question?")
     assert q.type == "question"
     assert isinstance(q, Question)
+
+
+def test_grounding_public_export():
+    from gaia.lang import Grounding as PublicGrounding
+
+    assert PublicGrounding is Grounding

--- a/tests/gaia/lang/test_knowledge_v6.py
+++ b/tests/gaia/lang/test_knowledge_v6.py
@@ -1,0 +1,49 @@
+import pytest
+
+from gaia.lang.runtime.grounding import Grounding
+from gaia.lang.runtime.knowledge import Claim, Context, Question, Setting
+
+
+def test_context_creation():
+    ctx = Context("Raw experiment notes.")
+    assert ctx.content == "Raw experiment notes."
+    assert ctx.type == "context"
+
+
+def test_setting_creation():
+    s = Setting("Blackbody cavity at thermal equilibrium.")
+    assert s.type == "setting"
+    assert s.content == "Blackbody cavity at thermal equilibrium."
+
+
+def test_claim_creation():
+    c = Claim("Energy exchange is quantized.", prior=0.5)
+    assert c.type == "claim"
+    assert c.prior == 0.5
+    assert c.supports == []
+
+
+def test_claim_no_prior():
+    c = Claim("A proposition.")
+    assert c.prior is None
+
+
+def test_claim_with_grounding():
+    g = Grounding(kind="source_fact", rationale="From paper.")
+    c = Claim("UV data.", prior=0.95, grounding=g)
+    assert c.grounding.kind == "source_fact"
+
+
+def test_question_creation():
+    q = Question("Should we ship variant B?")
+    assert q.type == "question"
+
+
+def test_context_cannot_have_prior():
+    with pytest.raises(TypeError):
+        Context("raw text", prior=0.5)
+
+
+def test_setting_cannot_have_prior():
+    with pytest.raises(TypeError):
+        Setting("background", prior=0.5)

--- a/tests/gaia/lang/test_knowledge_v6.py
+++ b/tests/gaia/lang/test_knowledge_v6.py
@@ -47,3 +47,37 @@ def test_context_cannot_have_prior():
 def test_setting_cannot_have_prior():
     with pytest.raises(TypeError):
         Setting("background", prior=0.5)
+
+
+def test_context_dsl_function():
+    from gaia.lang.dsl.knowledge import context
+
+    ctx = context("Raw experiment notes.")
+    assert ctx.type == "context"
+    assert ctx.content == "Raw experiment notes."
+    assert isinstance(ctx, Context)
+
+
+def test_v5_claim_still_works():
+    """v5 claim() function returns a v6 Claim."""
+    from gaia.lang import claim
+
+    c = claim("A proposition.")
+    assert c.type == "claim"
+    assert isinstance(c, Claim)
+
+
+def test_v5_setting_still_works():
+    from gaia.lang import setting
+
+    s = setting("Background info.")
+    assert s.type == "setting"
+    assert isinstance(s, Setting)
+
+
+def test_v5_question_still_works():
+    from gaia.lang import question
+
+    q = question("Question?")
+    assert q.type == "question"
+    assert isinstance(q, Question)

--- a/tests/gaia/lang/test_parameterized_claims.py
+++ b/tests/gaia/lang/test_parameterized_claims.py
@@ -1,4 +1,34 @@
+from enum import Enum
+
+from gaia.lang.runtime.knowledge import Claim, Setting
 from gaia.lang.runtime.param import Param, UNBOUND
+
+
+class MoleculeType(str, Enum):
+    DNA = "DNA"
+    RNA = "RNA"
+    PROTEIN = "protein"
+
+
+class CavityTemperature(Claim):
+    """Cavity temperature is set to {value}K."""
+
+    value: float
+
+
+class InfoTransfer(Claim):
+    """Information can transfer from {src} to {dst}."""
+
+    src: MoleculeType
+    dst: MoleculeType
+
+
+class ABCounts(Claim):
+    """[@experiment] recorded {ctrl_k}/{ctrl_n} control conversions."""
+
+    experiment: Setting
+    ctrl_n: int
+    ctrl_k: int
 
 
 def test_param_unbound_sentinel():
@@ -10,3 +40,44 @@ def test_param_unbound_sentinel():
 def test_param_bound():
     p = Param(name="value", type=float, value=5000.0)
     assert p.value == 5000.0
+
+
+def test_parameterized_claim_content_rendering():
+    temp = CavityTemperature(value=5000.0)
+    assert temp.content == "Cavity temperature is set to 5000.0K."
+
+
+def test_parameterized_claim_parameters():
+    temp = CavityTemperature(value=5000.0)
+    assert len(temp.parameters) == 1
+    assert temp.parameters[0]["name"] == "value"
+    assert temp.parameters[0]["value"] == 5000.0
+
+
+def test_parameterized_claim_enum():
+    transfer = InfoTransfer(src=MoleculeType.DNA, dst=MoleculeType.RNA)
+    assert transfer.content == "Information can transfer from DNA to RNA."
+
+
+def test_partial_binding():
+    transfer = InfoTransfer(src=MoleculeType.DNA)
+    assert "{dst}" in transfer.content
+    assert "DNA" in transfer.content
+
+
+def test_knowledge_parameter_ref_syntax():
+    """Knowledge-typed params render as [@label]."""
+    exp = Setting("AB test exp_123.")
+    exp.label = "exp_123"
+    counts = ABCounts(experiment=exp, ctrl_n=10_000, ctrl_k=500)
+    assert "[@exp_123]" in counts.content
+    assert "500/10000" in counts.content
+
+
+def test_knowledge_parameter_stored_as_reference():
+    """Knowledge param value is the object, not a string."""
+    exp = Setting("AB test.")
+    exp.label = "exp_123"
+    counts = ABCounts(experiment=exp, ctrl_n=10_000, ctrl_k=500)
+    param = [p for p in counts.parameters if p["name"] == "experiment"][0]
+    assert param["value"] is exp

--- a/tests/gaia/lang/test_parameterized_claims.py
+++ b/tests/gaia/lang/test_parameterized_claims.py
@@ -1,0 +1,12 @@
+from gaia.lang.runtime.param import Param, UNBOUND
+
+
+def test_param_unbound_sentinel():
+    p = Param(name="value", type=float)
+    assert p.value is UNBOUND
+    assert p.value is not None
+
+
+def test_param_bound():
+    p = Param(name="value", type=float, value=5000.0)
+    assert p.value == 5000.0

--- a/tests/ir/test_knowledge.py
+++ b/tests/ir/test_knowledge.py
@@ -43,8 +43,8 @@ class TestIsQid:
 
 
 class TestKnowledgeType:
-    def test_three_types(self):
-        assert set(KnowledgeType) == {"claim", "setting", "question"}
+    def test_knowledge_types(self):
+        assert set(KnowledgeType) == {"claim", "setting", "question", "context"}
 
     def test_no_template(self):
         with pytest.raises(ValueError):

--- a/tests/ir/test_knowledge_context.py
+++ b/tests/ir/test_knowledge_context.py
@@ -1,0 +1,15 @@
+from gaia.ir.knowledge import KnowledgeType, Parameter
+
+
+def test_context_knowledge_type():
+    assert KnowledgeType.CONTEXT == "context"
+
+
+def test_parameter_value_field():
+    p = Parameter(name="experiment", type="Setting", value="github:pkg::exp_123")
+    assert p.value == "github:pkg::exp_123"
+
+
+def test_parameter_value_default_none():
+    p = Parameter(name="x", type="int")
+    assert p.value is None


### PR DESCRIPTION
## Summary

Implements the Phase 1 Gaia Lang v6 knowledge-type foundation from `docs/plans/2026-04-21-gaia-lang-v6-phase1-knowledge-types.md`.

- Adds runtime `Param` / `UNBOUND` and `Grounding` primitives.
- Adds the v6 `Knowledge` hierarchy: `Context`, `Setting`, `Claim`, and `Question`.
- Preserves existing `Knowledge(...)` compatibility while making the DSL helpers return the new typed classes.
- Supports parameterized claim templates, including enum `.value` rendering and knowledge-reference lowering.
- Extends IR knowledge with `context` and `Parameter.value`.
- Lowers grounding metadata and parameter values through the compiler.
- Adds focused runtime, compiler, IR, and CLI coverage for the v6 path.

## Verification

- `python -m pytest tests/gaia/lang -q` baseline before changes: 180 passed
- `python -m pytest tests/ir/test_knowledge.py -q` baseline before changes: 27 passed
- `python -m pytest tests/ -x -q`: 859 passed, 8 warnings
- `python -m ruff check .`: passed
- `python -m ruff format --check .`: passed
- `git diff --check`: passed

Note: the first full pytest run hit a transient `npm install` timeout in `tests/cli/test_github_react.py::test_react_app_builds` after 120s. The test is outside this diff, was marked slow already, and passed on isolated rerun in 70.45s before the final full-suite rerun passed.
