### PR TITLE
Implement Gaia Lang v6 review manifests

### DIFF
--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -12,6 +12,7 @@ from gaia.ir.formalize import formalize_named_strategy
 from gaia.ir.graphs import LocalCanonicalGraph
 from gaia.ir.knowledge import KnowledgeType
 from gaia.ir.operator import Operator, OperatorType
+from gaia.ir.review import ReviewManifest, ReviewStatus
 from gaia.ir.strategy import (
     _FORMAL_STRATEGY_TYPES,
     CompositeStrategy,
@@ -59,6 +60,20 @@ def _next_fid(prefix: str, i: list[int]) -> str:
     return f"{prefix}_f{i[0]}"
 
 
+def _review_target_allowed(
+    target_id: str | None,
+    metadata: dict | None,
+    review_manifest: ReviewManifest | None,
+) -> bool:
+    if review_manifest is None:
+        return True
+    if not metadata or not metadata.get("action_label"):
+        return True
+    if not target_id:
+        return False
+    return review_manifest.latest_status(target_id) == ReviewStatus.ACCEPTED
+
+
 def lower_local_graph(
     canonical: LocalCanonicalGraph,
     *,
@@ -66,6 +81,7 @@ def lower_local_graph(
     strategy_conditional_params: dict[str, list[float]] | None = None,
     expand_formal: bool = True,
     infer_use_degraded_noisy_and: bool = False,
+    review_manifest: ReviewManifest | None = None,
 ) -> FactorGraph:
     """Build a FactorGraph from a local canonical Gaia IR graph.
 
@@ -84,6 +100,11 @@ def lower_local_graph(
     infer_use_degraded_noisy_and:
         If True, lower ``infer`` with CONJUNCTION+SOFT_ENTAILMENT using only
         all-true / all-false CPT entries (information loss for general CPT).
+    review_manifest:
+        Optional qualitative ReviewManifest. When present, v6 action-backed
+        strategies/operators are lowered only after their latest review is
+        accepted. Legacy IR targets without ``metadata.action_label`` are not
+        gated.
     """
     priors = node_priors or {}
     # Auto-formalized helper claims (labels starting with ``__``, e.g.
@@ -108,8 +129,14 @@ def lower_local_graph(
     fg = FactorGraph()
     ctr = [0]
 
+    lowerable_operators = [
+        op
+        for op in canonical.operators
+        if _review_target_allowed(op.operator_id, op.metadata, review_manifest)
+    ]
+
     relation_concl_ids: set[str] = set()
-    for op in canonical.operators:
+    for op in lowerable_operators:
         if op.operator in _RELATION_OPS:
             relation_concl_ids.add(op.conclusion)
 
@@ -130,7 +157,7 @@ def lower_local_graph(
 
     strat_by_id = {s.strategy_id: s for s in canonical.strategies if s.strategy_id}
 
-    for op in canonical.operators:
+    for op in lowerable_operators:
         fid = _next_fid("op", ctr)
         ft = _OPERATOR_MAP[op.operator]
         for vid in op.variables:
@@ -143,6 +170,8 @@ def lower_local_graph(
 
     seen_strategies: set[str] = set()
     for s in canonical.strategies:
+        if not _review_target_allowed(s.strategy_id, s.metadata, review_manifest):
+            continue
         _lower_strategy(
             fg,
             s,
@@ -157,6 +186,7 @@ def lower_local_graph(
             canonical.namespace,
             canonical.package_name,
             seen_strategies=seen_strategies,
+            review_manifest=review_manifest,
         )
 
     return fg
@@ -221,7 +251,11 @@ def _lower_strategy(
     namespace: str,
     package_name: str,
     seen_strategies: set[str] | None = None,
+    review_manifest: ReviewManifest | None = None,
 ) -> None:
+    if not _review_target_allowed(s.strategy_id, s.metadata, review_manifest):
+        return
+
     # Dedup: when ``seen_strategies`` is provided (lower_local_graph
     # passes a fresh set), skip strategies that have already been
     # lowered.  Composite strategies recursively lower their
@@ -253,6 +287,7 @@ def _lower_strategy(
                 namespace,
                 package_name,
                 seen_strategies=seen_strategies,
+                review_manifest=review_manifest,
             )
         return
 
@@ -438,6 +473,7 @@ def _lower_strategy(
             namespace,
             package_name,
             seen_strategies=seen_strategies,
+            review_manifest=review_manifest,
         )
         return
 

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -12,6 +12,7 @@ from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.cli.commands._classify import classify_ir, node_role
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
+from gaia.lang.review.manifest import generate_review_manifest
 
 
 def _get_prior(k: dict) -> float | None:
@@ -153,6 +154,27 @@ def _hole_report(ir: dict) -> list[str]:
     return lines
 
 
+def _warrant_report(compiled, *, blind: bool = False) -> list[str]:
+    manifest = compiled.review or generate_review_manifest(compiled)
+    reviews = sorted(manifest.reviews, key=lambda review: review.action_label)
+    lines: list[str] = []
+    lines.append("")
+    lines.append(f"Review warrants: {len(reviews)}")
+    if not reviews:
+        lines.append("  No reviewable v6 actions.")
+        return lines
+
+    for review in reviews:
+        lines.append(f"  - {review.action_label}")
+        lines.append(f"    target: {review.target_kind} {review.target_id}")
+        if blind:
+            lines.append("    status:")
+        else:
+            lines.append(f"    status: {review.status.value}")
+        lines.append(f"    question: {review.audit_question}")
+    return lines
+
+
 def check_command(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
     brief: bool = typer.Option(
@@ -168,6 +190,16 @@ def check_command(
         False,
         "--hole",
         help="Show detailed prior review report for all independent claims",
+    ),
+    warrants: bool = typer.Option(
+        False,
+        "--warrants",
+        help="Show v6 ReviewManifest warrants with audit questions",
+    ),
+    blind: bool = typer.Option(
+        False,
+        "--blind",
+        help="With --warrants, omit status values and prior diagnostics",
     ),
 ) -> None:
     """Validate structure and artifact consistency for a Gaia knowledge package."""
@@ -226,6 +258,12 @@ def check_command(
         f"{len(ir['strategies'])} strategies, "
         f"{len(ir['operators'])} operators"
     )
+
+    if warrants:
+        for line in _warrant_report(compiled, blind=blind):
+            typer.echo(line)
+        if blind:
+            return
 
     for line in _knowledge_diagnostics(ir):
         typer.echo(line)

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -21,6 +21,7 @@ from gaia.cli._packages import (
     load_gaia_package,
 )
 from gaia.ir.validator import validate_local_graph
+from gaia.lang.review.manifest import generate_review_manifest
 
 
 def _write_json(path, payload) -> None:
@@ -39,8 +40,9 @@ def infer_command(
     """Run BP inference on a compiled knowledge package.
 
     Priors come from claim metadata (set by priors.py and reason+prior
-    DSL pairing during compilation). The lowering layer reads
-    metadata["prior"] directly — no review sidecar needed.
+    DSL pairing during compilation). For v6 action-backed Strategy/Operator
+    targets, ReviewManifest gates whether the target participates in BP;
+    review status is qualitative and never supplies numeric priors.
 
     With ``--depth N`` (N>0), dependency packages' factor graphs are
     merged for joint cross-package inference instead of using flat
@@ -94,7 +96,7 @@ def infer_command(
 
         dep_factor_graphs: list[tuple[str, FactorGraph, str]] = []
         for dep in dep_compiled:
-            dep_fg = lower_local_graph(dep.graph)
+            dep_fg = lower_local_graph(dep.graph, review_manifest=generate_review_manifest(dep))
             dep_prefix = f"{dep.graph.namespace}:{dep.graph.package_name}::"
             dep_factor_graphs.append((dep.import_name, dep_fg, dep_prefix))
             typer.echo(
@@ -105,7 +107,8 @@ def infer_command(
 
         # Lower local graph WITHOUT foreign node priors — the dep graphs
         # provide the full reasoning structure instead of flat priors
-        local_fg = lower_local_graph(compiled.graph)
+        local_review_manifest = compiled.review or generate_review_manifest(compiled)
+        local_fg = lower_local_graph(compiled.graph, review_manifest=local_review_manifest)
         local_prefix = f"{compiled.graph.namespace}:{compiled.graph.package_name}::"
 
         if dep_factor_graphs:
@@ -123,7 +126,12 @@ def infer_command(
         foreign_priors = collect_foreign_node_priors(compiled.graph, loaded.pkg_path)
         if foreign_priors:
             typer.echo(f"Loaded {len(foreign_priors)} upstream belief(s) for foreign nodes")
-        factor_graph = lower_local_graph(compiled.graph, node_priors=foreign_priors or None)
+        review_manifest = compiled.review or generate_review_manifest(compiled)
+        factor_graph = lower_local_graph(
+            compiled.graph,
+            node_priors=foreign_priors or None,
+            review_manifest=review_manifest,
+        )
     fg_errors = factor_graph.validate()
     if fg_errors:
         for error in fg_errors:

--- a/gaia/ir/__init__.py
+++ b/gaia/ir/__init__.py
@@ -33,6 +33,7 @@ from gaia.ir.parameterization import (
     ResolutionPolicy,
     StrategyParamRecord,
 )
+from gaia.ir.review import Review, ReviewManifest, ReviewStatus
 
 __all__ = [
     # Knowledge
@@ -62,4 +63,8 @@ __all__ = [
     "PriorRecord",
     "ResolutionPolicy",
     "StrategyParamRecord",
+    # Review
+    "Review",
+    "ReviewManifest",
+    "ReviewStatus",
 ]

--- a/gaia/ir/review.py
+++ b/gaia/ir/review.py
@@ -1,0 +1,45 @@
+"""ReviewManifest — qualitative package-level review layer for Gaia IR v6."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ReviewStatus(StrEnum):
+    UNREVIEWED = "unreviewed"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    NEEDS_INPUTS = "needs_inputs"
+
+
+class Review(BaseModel):
+    """Qualitative review record for a compiled Strategy or Operator target."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    review_id: str
+    action_label: str
+    target_kind: Literal["strategy", "operator"]
+    target_id: str
+    status: ReviewStatus
+    audit_question: str
+    reviewer_notes: str | None = None
+    timestamp: str | None = None
+    round: int = 1
+
+
+class ReviewManifest(BaseModel):
+    """Collection of qualitative review records."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reviews: list[Review] = []
+
+    def latest_status(self, target_id: str) -> ReviewStatus | None:
+        relevant = [review for review in self.reviews if review.target_id == target_id]
+        if not relevant:
+            return None
+        return max(relevant, key=lambda review: review.round).status

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -18,6 +18,7 @@ from gaia.ir import (
     Operator as IrOperator,
     Parameter as IrParameter,
     PackageRef as IrPackageRef,
+    ReviewManifest,
     Step as IrStep,
     Strategy as IrStrategy,
     StrategyParamRecord,
@@ -69,6 +70,7 @@ class CompiledPackage:
     action_label_map: dict[str, str] = field(default_factory=dict)
     target_action_labels_by_id: dict[str, str] = field(default_factory=dict)
     strategy_param_records: list[StrategyParamRecord] = field(default_factory=list)
+    review: ReviewManifest | None = None
 
     def to_json(self) -> dict[str, Any]:
         return self.graph.model_dump(mode="json", exclude_none=True, serialize_as_any=True)
@@ -777,7 +779,7 @@ def compile_package_artifact(
         module_titles=module_titles if module_titles else None,
     )
 
-    return CompiledPackage(
+    compiled = CompiledPackage(
         graph=graph,
         knowledge_ids_by_object=dict(knowledge_map),
         strategies_by_object=dict(compiled_strategies),
@@ -785,6 +787,10 @@ def compile_package_artifact(
         target_action_labels_by_id=target_action_labels_by_id,
         strategy_param_records=strategy_param_records,
     )
+    from gaia.lang.review.manifest import generate_review_manifest
+
+    compiled.review = generate_review_manifest(compiled)
+    return compiled
 
 
 def compile_package(

--- a/gaia/lang/review/__init__.py
+++ b/gaia/lang/review/__init__.py
@@ -1,0 +1,6 @@
+"""Review helpers for Gaia Lang v6."""
+
+from gaia.lang.review.manifest import generate_review_manifest
+from gaia.lang.review.templates import generate_audit_question
+
+__all__ = ["generate_audit_question", "generate_review_manifest"]

--- a/gaia/lang/review/manifest.py
+++ b/gaia/lang/review/manifest.py
@@ -1,0 +1,113 @@
+"""Generate ReviewManifest records from compiled v6 action targets."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from gaia.ir import Review, ReviewManifest, ReviewStatus
+from gaia.lang.review.templates import generate_audit_question
+
+
+def _review_id(target_kind: str, target_id: str) -> str:
+    digest = hashlib.sha256(f"{target_kind}|{target_id}".encode()).hexdigest()[:12]
+    return f"rev_{digest}"
+
+
+def _labels_by_id(compiled: Any) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    for knowledge in compiled.graph.knowledges:
+        if not knowledge.id:
+            continue
+        if knowledge.label:
+            labels[knowledge.id] = knowledge.label
+        else:
+            labels[knowledge.id] = knowledge.id.split("::")[-1]
+    return labels
+
+
+def _strategy_action_type(strategy: Any) -> str:
+    pattern = (strategy.metadata or {}).get("pattern")
+    if pattern == "observation":
+        return "observe"
+    if pattern == "computation":
+        return "compute"
+    if pattern == "inference":
+        return "infer"
+    return "derive"
+
+
+def _operator_action_type(operator: Any) -> str:
+    if operator.operator == "equivalence":
+        return "equal"
+    if operator.operator == "contradiction":
+        return "contradict"
+    return str(operator.operator)
+
+
+def _strategy_question(strategy: Any, action_type: str, labels: dict[str, str]) -> str:
+    if action_type == "infer":
+        hypothesis = strategy.premises[0] if strategy.premises else ""
+        return generate_audit_question(
+            "infer",
+            hypothesis_label=labels.get(hypothesis, hypothesis),
+            evidence_label=labels.get(strategy.conclusion, strategy.conclusion or "?"),
+        )
+    return generate_audit_question(
+        action_type,
+        conclusion_label=labels.get(strategy.conclusion, strategy.conclusion or "?"),
+    )
+
+
+def _operator_question(operator: Any, action_type: str, labels: dict[str, str]) -> str:
+    a = operator.variables[0] if operator.variables else ""
+    b = operator.variables[1] if len(operator.variables) > 1 else ""
+    return generate_audit_question(
+        action_type,
+        a_label=labels.get(a, a),
+        b_label=labels.get(b, b),
+    )
+
+
+def generate_review_manifest(compiled: Any) -> ReviewManifest:
+    """Generate unreviewed Review records for each v6 action target."""
+    labels = _labels_by_id(compiled)
+    reviews: list[Review] = []
+
+    for strategy in compiled.graph.strategies:
+        metadata = strategy.metadata or {}
+        action_label = metadata.get("action_label")
+        if not action_label or not strategy.strategy_id:
+            continue
+        action_type = _strategy_action_type(strategy)
+        reviews.append(
+            Review(
+                review_id=_review_id("strategy", strategy.strategy_id),
+                action_label=action_label,
+                target_kind="strategy",
+                target_id=strategy.strategy_id,
+                status=ReviewStatus.UNREVIEWED,
+                audit_question=_strategy_question(strategy, action_type, labels),
+                round=1,
+            )
+        )
+
+    for operator in compiled.graph.operators:
+        metadata = operator.metadata or {}
+        action_label = metadata.get("action_label")
+        if not action_label or not operator.operator_id:
+            continue
+        action_type = _operator_action_type(operator)
+        reviews.append(
+            Review(
+                review_id=_review_id("operator", operator.operator_id),
+                action_label=action_label,
+                target_kind="operator",
+                target_id=operator.operator_id,
+                status=ReviewStatus.UNREVIEWED,
+                audit_question=_operator_question(operator, action_type, labels),
+                round=1,
+            )
+        )
+
+    return ReviewManifest(reviews=reviews)

--- a/gaia/lang/review/templates.py
+++ b/gaia/lang/review/templates.py
@@ -1,0 +1,26 @@
+"""Audit-question templates for Gaia Lang v6 review targets."""
+
+from __future__ import annotations
+
+
+class _MissingLabelDict(dict):
+    def __missing__(self, key):
+        return "?"
+
+
+_TEMPLATES = {
+    "derive": "Do the listed premises suffice to establish [@{conclusion_label}]?",
+    "observe": "Is the observation of [@{conclusion_label}] reliable under the stated conditions?",
+    "compute": "Is the computation of [@{conclusion_label}] correctly implemented?",
+    "infer": (
+        "Is the statistical association between [@{hypothesis_label}] and "
+        "[@{evidence_label}] valid at the stated probabilities?"
+    ),
+    "equal": "Are [@{a_label}] and [@{b_label}] truly equivalent?",
+    "contradict": "Do [@{a_label}] and [@{b_label}] truly contradict?",
+}
+
+
+def generate_audit_question(action_type: str, **labels) -> str:
+    template = _TEMPLATES.get(action_type, "Is this reasoning step valid?")
+    return template.format_map(_MissingLabelDict(labels))

--- a/tests/cli/test_check_warrants.py
+++ b/tests/cli/test_check_warrants.py
@@ -1,0 +1,68 @@
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_v6_warrant_package(pkg_dir, *, with_prior: bool = False) -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "check-warrants-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "check_warrants"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, derive, equal\n\n"
+        'premise = claim("Evidence A is reliable.")\n'
+        'evidence = claim("Evidence B matches Evidence A.")\n'
+        'same = equal(premise, evidence, rationale="The two evidence records match.", label="same_evidence")\n'
+        "conclusion = derive(\n"
+        '    "The hypothesis is supported.",\n'
+        "    given=(premise, same),\n"
+        '    rationale="The matched evidence supports the hypothesis.",\n'
+        '    label="derive_conclusion",\n'
+        ")\n"
+        '__all__ = ["conclusion"]\n'
+    )
+    if with_prior:
+        (pkg_src / "priors.py").write_text(
+            "from . import premise\n\n"
+            'PRIORS = {premise: (0.83, "Author confidence in the observed evidence.")}\n'
+        )
+
+
+def test_check_warrants_outputs_review_list(tmp_path):
+    pkg_dir = tmp_path / "check_warrants"
+    _write_v6_warrant_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", "--warrants", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Review warrants:" in result.output
+    assert "github:check_warrants::action::derive_conclusion" in result.output
+    assert "github:check_warrants::action::same_evidence" in result.output
+    assert "Do the listed premises suffice" in result.output
+    assert "Are [@premise] and [@evidence] truly equivalent?" in result.output
+    assert "status: unreviewed" in result.output
+
+
+def test_check_warrants_blind_omits_author_priors_and_status_values(tmp_path):
+    pkg_dir = tmp_path / "check_warrants"
+    _write_v6_warrant_package(pkg_dir, with_prior=True)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", "--warrants", "--blind", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Review warrants:" in result.output
+    assert "github:check_warrants::action::derive_conclusion" in result.output
+    assert "Do the listed premises suffice" in result.output
+    assert "status:" in result.output
+    assert "status: unreviewed" not in result.output
+    assert "0.83" not in result.output
+    assert "prior=" not in result.output

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
@@ -120,6 +121,40 @@ def test_infer_with_deduction_strategy(tmp_path):
 
     result = runner.invoke(app, ["infer", str(pkg_dir)])
     assert result.exit_code == 0, result.output
+
+
+def test_infer_gates_unreviewed_v6_actions(tmp_path):
+    """Unreviewed v6 actions do not update beliefs during infer."""
+    pkg_dir = tmp_path / "v6_review_infer"
+    _write_base_package(pkg_dir, name="v6_review_infer")
+    (pkg_dir / "v6_review_infer" / "__init__.py").write_text(
+        "from gaia.lang import claim, derive\n\n"
+        'evidence = claim("Evidence.")\n'
+        "hypothesis = derive(\n"
+        '    "Hypothesis.",\n'
+        "    given=evidence,\n"
+        '    rationale="Evidence supports hypothesis.",\n'
+        '    label="support_hypothesis",\n'
+        ")\n"
+        '__all__ = ["evidence", "hypothesis"]\n'
+    )
+    (pkg_dir / "v6_review_infer" / "priors.py").write_text(
+        "from . import evidence, hypothesis\n\n"
+        "PRIORS = {\n"
+        '    evidence: (0.9, "Direct observation."),\n'
+        '    hypothesis: (0.4, "Base rate."),\n'
+        "}\n"
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    beliefs = json.loads((pkg_dir / ".gaia" / "beliefs.json").read_text())
+    belief_by_label = {item["label"]: item["belief"] for item in beliefs["beliefs"]}
+    assert belief_by_label["hypothesis"] == pytest.approx(0.4)
 
 
 def test_infer_loads_upstream_beliefs_for_foreign_nodes(tmp_path, monkeypatch):

--- a/tests/gaia/bp/test_review_gating.py
+++ b/tests/gaia/bp/test_review_gating.py
@@ -1,0 +1,72 @@
+from gaia.bp import lower_local_graph
+from gaia.ir import ReviewManifest, ReviewStatus
+from gaia.lang import Claim, derive, equal
+from gaia.lang.compiler import compile_package_artifact
+from gaia.lang.review.manifest import generate_review_manifest
+from gaia.lang.runtime.package import CollectedPackage
+
+
+def _accepted_manifest(manifest: ReviewManifest) -> ReviewManifest:
+    return ReviewManifest(
+        reviews=[
+            review.model_copy(update={"status": ReviewStatus.ACCEPTED})
+            for review in manifest.reviews
+        ]
+    )
+
+
+def test_unreviewed_strategy_excluded_from_bp():
+    with CollectedPackage("review_bp") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        b = derive("B.", given=a, rationale="A implies B.", label="derive_b")
+        b.label = "b"
+
+    compiled = compile_package_artifact(pkg)
+    manifest = generate_review_manifest(compiled)
+    factor_graph = lower_local_graph(compiled.graph, review_manifest=manifest)
+    assert not factor_graph.factors
+
+
+def test_accepted_strategy_included_in_bp():
+    with CollectedPackage("review_bp") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        b = derive("B.", given=a, rationale="A implies B.", label="derive_b")
+        b.label = "b"
+
+    compiled = compile_package_artifact(pkg)
+    manifest = _accepted_manifest(generate_review_manifest(compiled))
+    factor_graph = lower_local_graph(compiled.graph, review_manifest=manifest)
+    assert factor_graph.factors
+
+
+def test_unreviewed_operator_excluded_from_bp():
+    with CollectedPackage("review_bp") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        b = Claim("B.")
+        b.label = "b"
+        helper = equal(a, b, rationale="Same.", label="same")
+        helper.label = "same_helper"
+
+    compiled = compile_package_artifact(pkg)
+    manifest = generate_review_manifest(compiled)
+    factor_graph = lower_local_graph(compiled.graph, review_manifest=manifest)
+    assert not factor_graph.factors
+    assert factor_graph.variables["github:review_bp::same_helper"] == 0.5
+
+
+def test_accepted_review_does_not_set_priors():
+    with CollectedPackage("review_bp") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        b = Claim("B.")
+        b.label = "b"
+        helper = equal(a, b, rationale="Same.", label="same")
+        helper.label = "same_helper"
+
+    compiled = compile_package_artifact(pkg)
+    manifest = _accepted_manifest(generate_review_manifest(compiled))
+    factor_graph = lower_local_graph(compiled.graph, review_manifest=manifest)
+    assert factor_graph.variables["github:review_bp::same_helper"] == 1.0 - 1e-3

--- a/tests/gaia/ir/test_review.py
+++ b/tests/gaia/ir/test_review.py
@@ -1,0 +1,65 @@
+import pytest
+from pydantic import ValidationError
+
+from gaia.ir.review import Review, ReviewManifest, ReviewStatus
+
+
+def test_review_status_enum():
+    assert ReviewStatus.UNREVIEWED == "unreviewed"
+    assert ReviewStatus.ACCEPTED == "accepted"
+    assert ReviewStatus.REJECTED == "rejected"
+    assert ReviewStatus.NEEDS_INPUTS == "needs_inputs"
+
+
+def test_review_creation():
+    review = Review(
+        review_id="rev_001",
+        action_label="github:blackbody::action::planck_resolves",
+        target_kind="strategy",
+        target_id="lcs_abc123",
+        status=ReviewStatus.UNREVIEWED,
+        audit_question="Do premises suffice to establish [@quantum_hyp]?",
+        round=1,
+    )
+    assert review.status == "unreviewed"
+    assert review.action_label == "github:blackbody::action::planck_resolves"
+
+
+def test_review_manifest_latest_status():
+    r1 = Review(
+        review_id="rev_001",
+        action_label="a",
+        target_kind="strategy",
+        target_id="lcs_1",
+        status="unreviewed",
+        audit_question="?",
+        round=1,
+    )
+    r2 = Review(
+        review_id="rev_002",
+        action_label="a",
+        target_kind="strategy",
+        target_id="lcs_1",
+        status="accepted",
+        audit_question="?",
+        round=2,
+    )
+    manifest = ReviewManifest(reviews=[r1, r2])
+    assert manifest.latest_status("lcs_1") == "accepted"
+
+
+def test_review_manifest_missing_status():
+    assert ReviewManifest().latest_status("missing") is None
+
+
+def test_review_rejects_probability_fields():
+    with pytest.raises(ValidationError):
+        Review(
+            review_id="rev_bad",
+            action_label="a",
+            target_kind="strategy",
+            target_id="lcs_1",
+            status="accepted",
+            audit_question="?",
+            prior=0.9,
+        )

--- a/tests/gaia/lang/test_review_manifest.py
+++ b/tests/gaia/lang/test_review_manifest.py
@@ -1,0 +1,67 @@
+from gaia.lang import Claim, contradict, derive, equal, infer, observe
+from gaia.lang.compiler import compile_package_artifact
+from gaia.lang.review.manifest import generate_review_manifest
+from gaia.lang.review.templates import generate_audit_question
+from gaia.lang.runtime.package import CollectedPackage
+
+
+def test_audit_question_for_derive():
+    question = generate_audit_question("derive", conclusion_label="quantum_hyp")
+    assert "[@quantum_hyp]" in question
+    assert "premises" in question.lower()
+
+
+def test_audit_question_for_observe():
+    question = generate_audit_question("observe", conclusion_label="uv_data")
+    assert "[@uv_data]" in question
+    assert "observation" in question.lower() or "reliable" in question.lower()
+
+
+def test_audit_question_for_infer():
+    question = generate_audit_question(
+        "infer", hypothesis_label="quantum_hyp", evidence_label="spectrum"
+    )
+    assert "[@quantum_hyp]" in question
+    assert "[@spectrum]" in question
+
+
+def test_audit_question_for_equal():
+    question = generate_audit_question("equal", a_label="pred", b_label="obs")
+    assert "[@pred]" in question
+    assert "[@obs]" in question
+
+
+def test_generate_review_manifest_for_v6_actions():
+    with CollectedPackage("review_pkg") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        b = Claim("B.")
+        b.label = "b"
+        c = derive("C.", given=(a, b), rationale="A and B imply C.", label="derive_c")
+        c.label = "c"
+        data = observe("Observation.", rationale="Measured.", label="observe_data")
+        data.label = "data"
+        eq = equal(c, data, rationale="Same.", label="same")
+        eq.label = "same_helper"
+        conflict = contradict(a, data, rationale="Conflict.", label="conflict")
+        conflict.label = "conflict_helper"
+        infer(
+            hypothesis=c,
+            evidence=data,
+            p_e_given_h=0.8,
+            p_e_given_not_h=0.2,
+            rationale="Bayes.",
+            label="bayes_update",
+        )
+
+    compiled = compile_package_artifact(pkg)
+    manifest = generate_review_manifest(compiled)
+    assert len(manifest.reviews) == 5
+    assert {review.status for review in manifest.reviews} == {"unreviewed"}
+
+    by_action = {review.action_label: review for review in manifest.reviews}
+    assert by_action["github:review_pkg::action::derive_c"].target_kind == "strategy"
+    assert "[@c]" in by_action["github:review_pkg::action::derive_c"].audit_question
+    assert by_action["github:review_pkg::action::same"].target_kind == "operator"
+    assert "[@a]" in by_action["github:review_pkg::action::conflict"].audit_question
+    assert "[@data]" in by_action["github:review_pkg::action::bayes_update"].audit_question

--- a/tests/gaia/lang/test_review_manifest.py
+++ b/tests/gaia/lang/test_review_manifest.py
@@ -65,3 +65,16 @@ def test_generate_review_manifest_for_v6_actions():
     assert by_action["github:review_pkg::action::same"].target_kind == "operator"
     assert "[@a]" in by_action["github:review_pkg::action::conflict"].audit_question
     assert "[@data]" in by_action["github:review_pkg::action::bayes_update"].audit_question
+
+
+def test_compiled_package_carries_review_manifest_outside_graph_json():
+    with CollectedPackage("review_pkg") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        c = derive("C.", given=a, rationale="A implies C.", label="derive_c")
+        c.label = "c"
+
+    compiled = compile_package_artifact(pkg)
+    assert compiled.review is not None
+    assert len(compiled.review.reviews) == 1
+    assert "review" not in compiled.to_json()


### PR DESCRIPTION
## Summary
- add qualitative Review/ReviewManifest models and deterministic audit-question generation for v6 action targets
- attach generated review manifests to CompiledPackage without serializing them into canonical IR JSON
- gate BP lowering and gaia infer on accepted v6 review status while leaving legacy targets ungated
- add gaia check --warrants and --warrants --blind output

## Tests
- python -m pytest tests/ -x -q
- python -m ruff check .
- python -m ruff format --check .
- git diff --check

Stacked on #469 (feat/v6-lang-phase2-actions).