### PR TITLE
Implement Gaia Lang v6 inquiry and quality gate

### DIFF
--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -350,7 +350,7 @@ def _lower_strategy(
         _ensure_claim_var(fg, p, priors, claim_ids)
 
     if s.type == StrategyType.INFER:
-        cpt = strat_params.get(s.strategy_id)
+        cpt = s.conditional_probabilities or strat_params.get(s.strategy_id)
         if not cpt:
             cpt = [0.5] * (1 << len(s.premises))
         if infer_degraded:
@@ -401,7 +401,7 @@ def _lower_strategy(
         return
 
     if s.type == StrategyType.NOISY_AND:
-        raw = strat_params.get(s.strategy_id) or [0.5]
+        raw = s.conditional_probabilities or strat_params.get(s.strategy_id) or [0.5]
         p = float(raw[0])
         premises = list(s.premises)
         if len(premises) == 1:

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -903,6 +903,15 @@ def collect_foreign_node_priors(
     return foreign_priors
 
 
+def collect_strategy_conditional_params(compiled) -> dict[str, list[float]]:
+    """Collect v6 strategy CPT records keyed by strategy id for BP lowering."""
+    return {
+        record.strategy_id: list(record.conditional_probabilities)
+        for record in compiled.strategy_param_records
+        if record.strategy_id
+    }
+
+
 @dataclass
 class DependencyGraph:
     """A dependency's compiled IR loaded from disk."""

--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -903,15 +903,6 @@ def collect_foreign_node_priors(
     return foreign_priors
 
 
-def collect_strategy_conditional_params(compiled) -> dict[str, list[float]]:
-    """Collect v6 strategy CPT records keyed by strategy id for BP lowering."""
-    return {
-        record.strategy_id: list(record.conditional_probabilities)
-        for record in compiled.strategy_param_records
-        if record.strategy_id
-    }
-
-
 @dataclass
 class DependencyGraph:
     """A dependency's compiled IR loaded from disk."""

--- a/gaia/cli/commands/_inquiry.py
+++ b/gaia/cli/commands/_inquiry.py
@@ -47,6 +47,20 @@ def _review_status(manifest: ReviewManifest, target_id: str | None) -> str | Non
     return status.value if status is not None else None
 
 
+def _grounding_action_label(knowledge: dict[str, Any]) -> str | None:
+    metadata = knowledge.get("metadata") or {}
+    grounding = metadata.get("grounding")
+    if not isinstance(grounding, dict):
+        return None
+    action_label = grounding.get("action_label")
+    return action_label if isinstance(action_label, str) and action_label else None
+
+
+def _has_grounding(knowledge: dict[str, Any]) -> bool:
+    metadata = knowledge.get("metadata") or {}
+    return isinstance(metadata.get("grounding"), dict)
+
+
 def _exported_claim_ids(ir: dict[str, Any]) -> set[str]:
     return {
         knowledge["id"]
@@ -91,6 +105,19 @@ def build_goal_trees(
         if knowledge_id in seen:
             return node
         next_seen = {*seen, knowledge_id}
+
+        if _has_grounding(knowledge):
+            action_label = _grounding_action_label(knowledge)
+            target_id = knowledge_id if action_label else None
+            node.incoming.append(
+                InquiryEdge(
+                    kind="grounding",
+                    label=_action_label({"action_label": action_label}, "grounding"),
+                    target_id=target_id,
+                    status=_review_status(review_manifest, target_id),
+                    inputs=[],
+                )
+            )
 
         for strategy in strategies_by_conclusion.get(knowledge_id, []):
             strategy_id = strategy.get("strategy_id")

--- a/gaia/cli/commands/_inquiry.py
+++ b/gaia/cli/commands/_inquiry.py
@@ -1,0 +1,192 @@
+"""InquiryState rendering for goal-oriented Gaia package review."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from gaia.ir import ReviewManifest
+
+
+@dataclass
+class InquiryEdge:
+    kind: str
+    label: str
+    target_id: str | None
+    status: str | None
+    inputs: list["InquiryNode"] = field(default_factory=list)
+
+
+@dataclass
+class InquiryNode:
+    knowledge_id: str
+    label: str
+    content: str
+    incoming: list[InquiryEdge] = field(default_factory=list)
+
+    @property
+    def is_hole(self) -> bool:
+        return not self.incoming
+
+
+def _knowledge_label(knowledge: dict[str, Any]) -> str:
+    return knowledge.get("label") or knowledge.get("id", "").split("::")[-1]
+
+
+def _action_label(metadata: dict[str, Any] | None, fallback: str) -> str:
+    label = (metadata or {}).get("action_label") or fallback
+    if "::action::" in label:
+        return label.split("::action::", 1)[1]
+    return label
+
+
+def _review_status(manifest: ReviewManifest, target_id: str | None) -> str | None:
+    if target_id is None:
+        return None
+    status = manifest.latest_status(target_id)
+    return status.value if status is not None else None
+
+
+def _exported_claim_ids(ir: dict[str, Any]) -> set[str]:
+    return {
+        knowledge["id"]
+        for knowledge in ir.get("knowledges", [])
+        if knowledge.get("id") and knowledge.get("type") == "claim" and knowledge.get("exported")
+    }
+
+
+def build_goal_trees(
+    ir: dict[str, Any],
+    review_manifest: ReviewManifest,
+    exported_ids: set[str] | None = None,
+) -> list[InquiryNode]:
+    """Build dependency trees by walking backward from exported Claims."""
+
+    goal_ids = exported_ids or _exported_claim_ids(ir)
+    knowledge_by_id = {
+        knowledge["id"]: knowledge
+        for knowledge in ir.get("knowledges", [])
+        if knowledge.get("id") and knowledge.get("type") == "claim"
+    }
+
+    strategies_by_conclusion: dict[str, list[dict[str, Any]]] = {}
+    for strategy in ir.get("strategies", []):
+        conclusion = strategy.get("conclusion")
+        if conclusion:
+            strategies_by_conclusion.setdefault(conclusion, []).append(strategy)
+
+    operators_by_conclusion: dict[str, list[dict[str, Any]]] = {}
+    for operator in ir.get("operators", []):
+        conclusion = operator.get("conclusion")
+        if conclusion:
+            operators_by_conclusion.setdefault(conclusion, []).append(operator)
+
+    def build_node(knowledge_id: str, seen: set[str]) -> InquiryNode:
+        knowledge = knowledge_by_id.get(knowledge_id, {"id": knowledge_id, "content": ""})
+        node = InquiryNode(
+            knowledge_id=knowledge_id,
+            label=_knowledge_label(knowledge),
+            content=knowledge.get("content", ""),
+        )
+        if knowledge_id in seen:
+            return node
+        next_seen = {*seen, knowledge_id}
+
+        for strategy in strategies_by_conclusion.get(knowledge_id, []):
+            strategy_id = strategy.get("strategy_id")
+            edge = InquiryEdge(
+                kind="strategy",
+                label=_action_label(strategy.get("metadata"), strategy_id or "strategy"),
+                target_id=strategy_id,
+                status=_review_status(review_manifest, strategy_id),
+                inputs=[
+                    build_node(premise, next_seen)
+                    for premise in strategy.get("premises", [])
+                    if premise
+                ],
+            )
+            node.incoming.append(edge)
+
+        for operator in operators_by_conclusion.get(knowledge_id, []):
+            operator_id = operator.get("operator_id")
+            edge = InquiryEdge(
+                kind="operator",
+                label=_action_label(operator.get("metadata"), operator_id or "operator"),
+                target_id=operator_id,
+                status=_review_status(review_manifest, operator_id),
+                inputs=[
+                    build_node(variable, next_seen)
+                    for variable in operator.get("variables", [])
+                    if variable
+                ],
+            )
+            node.incoming.append(edge)
+
+        return node
+
+    return [
+        build_node(goal_id, set()) for goal_id in sorted(goal_ids) if goal_id in knowledge_by_id
+    ]
+
+
+def _walk(node: InquiryNode):
+    yield node
+    for edge in node.incoming:
+        yield edge
+        for child in edge.inputs:
+            yield from _walk(child)
+
+
+def _summary(trees: list[InquiryNode]) -> dict[str, int]:
+    holes: set[str] = set()
+    edge_statuses: dict[str, str] = {}
+    for tree in trees:
+        for item in _walk(tree):
+            if isinstance(item, InquiryNode) and item.is_hole:
+                holes.add(item.knowledge_id)
+            elif isinstance(item, InquiryEdge) and item.target_id and item.status:
+                edge_statuses[item.target_id] = item.status
+    return {
+        "goals": len(trees),
+        "accepted": sum(1 for status in edge_statuses.values() if status == "accepted"),
+        "unreviewed": sum(1 for status in edge_statuses.values() if status == "unreviewed"),
+        "blocked": sum(
+            1 for status in edge_statuses.values() if status in {"rejected", "needs_inputs"}
+        ),
+        "holes": len(holes),
+    }
+
+
+def _render_node(lines: list[str], node: InquiryNode, indent: int) -> None:
+    pad = " " * indent
+    marker = " [hole]" if node.is_hole else ""
+    lines.append(f"{pad}- {node.label}{marker}")
+    for edge in node.incoming:
+        status = f" [{edge.status}]" if edge.status else ""
+        lines.append(f"{pad}  <- {edge.label}{status}")
+        for child in edge.inputs:
+            _render_node(lines, child, indent + 5)
+
+
+def render_inquiry(trees: list[InquiryNode]) -> str:
+    counts = _summary(trees)
+    lines = [
+        "Inquiry",
+        "Summary:",
+        f"  Goals: {counts['goals']}",
+        f"  Accepted warrants: {counts['accepted']}",
+        f"  Unreviewed: {counts['unreviewed']}",
+        f"  Blocked: {counts['blocked']}",
+        f"  Structural holes: {counts['holes']}",
+        "",
+    ]
+    for index, tree in enumerate(trees, start=1):
+        marker = " [hole]" if tree.is_hole else ""
+        lines.append(f"Goal {index}: {tree.label}{marker}")
+        for edge in tree.incoming:
+            status = f" [{edge.status}]" if edge.status else ""
+            lines.append(f"  <- {edge.label}{status}")
+            for child in edge.inputs:
+                _render_node(lines, child, 5)
+        lines.append("")
+    return "\n".join(lines).rstrip()

--- a/gaia/cli/commands/_quality_gate.py
+++ b/gaia/cli/commands/_quality_gate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from gaia.cli._packages import GaiaCliError
-from gaia.cli.commands._inquiry import InquiryNode, build_goal_trees
+from gaia.cli.commands._inquiry import InquiryEdge, InquiryNode, build_goal_trees
 from gaia.cli.commands._review_manifest import latest_reviews
 from gaia.ir import ReviewManifest, ReviewStatus
 
@@ -63,6 +63,15 @@ def _structural_holes(trees: list[InquiryNode]) -> list[InquiryNode]:
     return sorted(holes.values(), key=lambda node: node.label)
 
 
+def _reachable_review_targets(trees: list[InquiryNode]) -> set[str]:
+    targets: set[str] = set()
+    for tree in trees:
+        for item in _walk(tree):
+            if isinstance(item, InquiryEdge) and item.target_id:
+                targets.add(item.target_id)
+    return targets
+
+
 def check_quality_gate(
     ir: dict[str, Any],
     beliefs: dict[str, Any] | None,
@@ -73,12 +82,15 @@ def check_quality_gate(
     failures: list[str] = []
     goals = exported_ids or _exported_claim_ids(ir)
     trees = build_goal_trees(ir, review_manifest, goals)
+    reachable_targets = _reachable_review_targets(trees)
 
     if not config.allow_holes:
         for hole in _structural_holes(trees):
             failures.append(f"Structural hole: {hole.label} has no warrant chain")
 
     for review in latest_reviews(review_manifest):
+        if review.target_id not in reachable_targets:
+            continue
         if review.status != ReviewStatus.ACCEPTED:
             failures.append(
                 f"Unreviewed/rejected: {review.action_label} (status={review.status.value})"

--- a/gaia/cli/commands/_quality_gate.py
+++ b/gaia/cli/commands/_quality_gate.py
@@ -1,0 +1,107 @@
+"""Quality gate checks for Gaia packages."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gaia.cli._packages import GaiaCliError
+from gaia.cli.commands._inquiry import InquiryNode, build_goal_trees
+from gaia.cli.commands._review_manifest import latest_reviews
+from gaia.ir import ReviewManifest, ReviewStatus
+
+
+@dataclass
+class QualityConfig:
+    min_posterior: float | None = None
+    allow_holes: bool = False
+
+
+def load_quality_config(tool_gaia_quality: dict[str, Any] | None) -> QualityConfig:
+    config = tool_gaia_quality or {}
+    min_posterior = config.get("min_posterior")
+    return QualityConfig(
+        min_posterior=float(min_posterior) if min_posterior is not None else None,
+        allow_holes=bool(config.get("allow_holes", False)),
+    )
+
+
+def load_beliefs(pkg_path: str | Path) -> dict[str, Any] | None:
+    path = Path(pkg_path) / ".gaia" / "beliefs.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GaiaCliError(f"Error: {path} is not valid JSON: {exc}") from exc
+
+
+def _exported_claim_ids(ir: dict[str, Any]) -> set[str]:
+    return {
+        knowledge["id"]
+        for knowledge in ir.get("knowledges", [])
+        if knowledge.get("id") and knowledge.get("type") == "claim" and knowledge.get("exported")
+    }
+
+
+def _walk(node: InquiryNode):
+    yield node
+    for edge in node.incoming:
+        yield edge
+        for child in edge.inputs:
+            yield from _walk(child)
+
+
+def _structural_holes(trees: list[InquiryNode]) -> list[InquiryNode]:
+    holes: dict[str, InquiryNode] = {}
+    for tree in trees:
+        for item in _walk(tree):
+            if isinstance(item, InquiryNode) and item.is_hole:
+                holes[item.knowledge_id] = item
+    return sorted(holes.values(), key=lambda node: node.label)
+
+
+def check_quality_gate(
+    ir: dict[str, Any],
+    beliefs: dict[str, Any] | None,
+    review_manifest: ReviewManifest,
+    config: QualityConfig,
+    exported_ids: set[str] | None = None,
+) -> list[str]:
+    failures: list[str] = []
+    goals = exported_ids or _exported_claim_ids(ir)
+    trees = build_goal_trees(ir, review_manifest, goals)
+
+    if not config.allow_holes:
+        for hole in _structural_holes(trees):
+            failures.append(f"Structural hole: {hole.label} has no warrant chain")
+
+    for review in latest_reviews(review_manifest):
+        if review.status != ReviewStatus.ACCEPTED:
+            failures.append(
+                f"Unreviewed/rejected: {review.action_label} (status={review.status.value})"
+            )
+
+    if config.min_posterior is not None:
+        if beliefs is None:
+            failures.append("Missing beliefs: run `gaia infer` before using min_posterior")
+        else:
+            belief_by_id = {
+                entry.get("knowledge_id"): float(entry.get("belief"))
+                for entry in beliefs.get("beliefs", [])
+                if isinstance(entry, dict)
+                and isinstance(entry.get("knowledge_id"), str)
+                and isinstance(entry.get("belief"), int | float)
+            }
+            for knowledge_id in sorted(goals):
+                belief = belief_by_id.get(knowledge_id)
+                if belief is None:
+                    failures.append(f"Missing belief: {knowledge_id}")
+                elif belief < config.min_posterior:
+                    failures.append(
+                        f"Low posterior: {knowledge_id} = {belief:.3f} < {config.min_posterior}"
+                    )
+
+    return failures

--- a/gaia/cli/commands/_review_manifest.py
+++ b/gaia/cli/commands/_review_manifest.py
@@ -1,0 +1,61 @@
+"""Shared ReviewManifest loading helpers for CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from gaia.cli._packages import GaiaCliError
+from gaia.ir import Review, ReviewManifest
+from gaia.lang.review.manifest import generate_review_manifest
+
+REVIEW_MANIFEST_REL_PATH = Path(".gaia") / "review_manifest.json"
+
+
+def _generated_manifest(compiled) -> ReviewManifest:
+    return getattr(compiled, "review", None) or generate_review_manifest(compiled)
+
+
+def merge_review_manifests(
+    generated: ReviewManifest,
+    persisted: ReviewManifest,
+) -> ReviewManifest:
+    """Merge persisted review rounds onto the generated target list.
+
+    Generated entries ensure newly compiled v6 action targets still appear as
+    unreviewed. Persisted entries preserve manual reviewer decisions for matching
+    target ids. Stale persisted targets are ignored because they no longer map to
+    the compiled package.
+    """
+
+    generated_target_ids = {review.target_id for review in generated.reviews}
+    reviews = list(generated.reviews)
+    reviews.extend(
+        review for review in persisted.reviews if review.target_id in generated_target_ids
+    )
+    return ReviewManifest(reviews=reviews)
+
+
+def latest_reviews(manifest: ReviewManifest) -> list[Review]:
+    latest: dict[str, Review] = {}
+    for review in manifest.reviews:
+        current = latest.get(review.target_id)
+        if current is None or review.round > current.round:
+            latest[review.target_id] = review
+    return sorted(latest.values(), key=lambda review: review.action_label)
+
+
+def load_or_generate_review_manifest(pkg_path: str | Path, compiled) -> ReviewManifest:
+    generated = _generated_manifest(compiled)
+    path = Path(pkg_path) / REVIEW_MANIFEST_REL_PATH
+    if not path.exists():
+        return generated
+
+    try:
+        data = json.loads(path.read_text())
+        persisted = ReviewManifest.model_validate(data)
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        raise GaiaCliError(f"Error: {path} is not a valid ReviewManifest: {exc}") from exc
+    return merge_review_manifests(generated, persisted)

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -282,8 +282,6 @@ def check_command(
     if warrants:
         for line in _warrant_report(review_manifest, blind=blind):
             typer.echo(line)
-        if blind:
-            return
 
     if inquiry:
         from gaia.cli.commands._inquiry import build_goal_trees, render_inquiry
@@ -315,8 +313,12 @@ def check_command(
         typer.echo("")
         typer.echo("Quality gate passed")
 
-    for line in _knowledge_diagnostics(ir):
-        typer.echo(line)
+    if warrants and blind and not (brief or show or hole):
+        return
+
+    if not (warrants and blind):
+        for line in _knowledge_diagnostics(ir):
+            typer.echo(line)
 
     if brief or show:
         from gaia.cli.commands._brief import (

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -203,6 +203,11 @@ def check_command(
         "--blind",
         help="With --warrants, omit status values and prior diagnostics",
     ),
+    inquiry: bool = typer.Option(
+        False,
+        "--inquiry",
+        help="Show goal-oriented reasoning progress and review status",
+    ),
 ) -> None:
     """Validate structure and artifact consistency for a Gaia knowledge package."""
     try:
@@ -261,16 +266,26 @@ def check_command(
         f"{len(ir['operators'])} operators"
     )
 
-    if warrants:
+    review_manifest = None
+    if warrants or inquiry:
         try:
             review_manifest = load_or_generate_review_manifest(loaded.pkg_path, compiled)
         except GaiaCliError as exc:
             typer.echo(str(exc), err=True)
             raise typer.Exit(1)
+
+    if warrants:
         for line in _warrant_report(review_manifest, blind=blind):
             typer.echo(line)
         if blind:
             return
+
+    if inquiry:
+        from gaia.cli.commands._inquiry import build_goal_trees, render_inquiry
+
+        trees = build_goal_trees(ir, review_manifest)
+        typer.echo("")
+        typer.echo(render_inquiry(trees))
 
     for line in _knowledge_diagnostics(ir):
         typer.echo(line)

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -208,6 +208,11 @@ def check_command(
         "--inquiry",
         help="Show goal-oriented reasoning progress and review status",
     ),
+    gate: bool = typer.Option(
+        False,
+        "--gate",
+        help="Run quality gate checks and exit non-zero on failure",
+    ),
 ) -> None:
     """Validate structure and artifact consistency for a Gaia knowledge package."""
     try:
@@ -267,7 +272,7 @@ def check_command(
     )
 
     review_manifest = None
-    if warrants or inquiry:
+    if warrants or inquiry or gate:
         try:
             review_manifest = load_or_generate_review_manifest(loaded.pkg_path, compiled)
         except GaiaCliError as exc:
@@ -286,6 +291,29 @@ def check_command(
         trees = build_goal_trees(ir, review_manifest)
         typer.echo("")
         typer.echo(render_inquiry(trees))
+
+    if gate:
+        from gaia.cli.commands._quality_gate import (
+            check_quality_gate,
+            load_beliefs,
+            load_quality_config,
+        )
+
+        try:
+            config = load_quality_config(loaded.gaia_config.get("quality"))
+            beliefs = load_beliefs(loaded.pkg_path)
+            failures = check_quality_gate(ir, beliefs, review_manifest, config)
+        except GaiaCliError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(1)
+        if failures:
+            typer.echo("")
+            typer.echo("Quality gate failed:")
+            for failure in failures:
+                typer.echo(f"  - {failure}")
+            raise typer.Exit(1)
+        typer.echo("")
+        typer.echo("Quality gate passed")
 
     for line in _knowledge_diagnostics(ir):
         typer.echo(line)

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -10,9 +10,12 @@ from gaia.cli._packages import GaiaCliError, load_gaia_package, validate_fills_r
 from gaia.cli._packages import apply_package_priors
 from gaia.cli._packages import compile_loaded_package_artifact
 from gaia.cli.commands._classify import classify_ir, node_role
+from gaia.cli.commands._review_manifest import (
+    latest_reviews,
+    load_or_generate_review_manifest,
+)
 from gaia.ir import LocalCanonicalGraph
 from gaia.ir.validator import validate_local_graph
-from gaia.lang.review.manifest import generate_review_manifest
 
 
 def _get_prior(k: dict) -> float | None:
@@ -154,9 +157,8 @@ def _hole_report(ir: dict) -> list[str]:
     return lines
 
 
-def _warrant_report(compiled, *, blind: bool = False) -> list[str]:
-    manifest = compiled.review or generate_review_manifest(compiled)
-    reviews = sorted(manifest.reviews, key=lambda review: review.action_label)
+def _warrant_report(manifest, *, blind: bool = False) -> list[str]:
+    reviews = latest_reviews(manifest)
     lines: list[str] = []
     lines.append("")
     lines.append(f"Review warrants: {len(reviews)}")
@@ -260,7 +262,12 @@ def check_command(
     )
 
     if warrants:
-        for line in _warrant_report(compiled, blind=blind):
+        try:
+            review_manifest = load_or_generate_review_manifest(loaded.pkg_path, compiled)
+        except GaiaCliError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(1)
+        for line in _warrant_report(review_manifest, blind=blind):
             typer.echo(line)
         if blind:
             return

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -14,6 +14,7 @@ from gaia.cli._packages import (
     GaiaCliError,
     apply_package_priors,
     collect_foreign_node_priors,
+    collect_strategy_conditional_params,
     compile_loaded_package_artifact,
     ensure_package_env,
     gaia_lang_version,
@@ -85,6 +86,7 @@ def infer_command(
         raise typer.Exit(1)
 
     if depth != 0:
+        strategy_params = collect_strategy_conditional_params(compiled)
         # Joint cross-package inference: merge dependency factor graphs
         try:
             dep_compiled = load_dependency_compiled_graphs(loaded.project_config, depth=depth)
@@ -109,7 +111,11 @@ def infer_command(
 
         # Lower local graph WITHOUT foreign node priors — the dep graphs
         # provide the full reasoning structure instead of flat priors
-        local_fg = lower_local_graph(compiled.graph, review_manifest=review_manifest)
+        local_fg = lower_local_graph(
+            compiled.graph,
+            strategy_conditional_params=strategy_params,
+            review_manifest=review_manifest,
+        )
         local_prefix = f"{compiled.graph.namespace}:{compiled.graph.package_name}::"
 
         if dep_factor_graphs:
@@ -130,6 +136,7 @@ def infer_command(
         factor_graph = lower_local_graph(
             compiled.graph,
             node_priors=foreign_priors or None,
+            strategy_conditional_params=collect_strategy_conditional_params(compiled),
             review_manifest=review_manifest,
         )
     fg_errors = factor_graph.validate()

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -14,7 +14,6 @@ from gaia.cli._packages import (
     GaiaCliError,
     apply_package_priors,
     collect_foreign_node_priors,
-    collect_strategy_conditional_params,
     compile_loaded_package_artifact,
     ensure_package_env,
     gaia_lang_version,
@@ -86,7 +85,6 @@ def infer_command(
         raise typer.Exit(1)
 
     if depth != 0:
-        strategy_params = collect_strategy_conditional_params(compiled)
         # Joint cross-package inference: merge dependency factor graphs
         try:
             dep_compiled = load_dependency_compiled_graphs(loaded.project_config, depth=depth)
@@ -113,7 +111,6 @@ def infer_command(
         # provide the full reasoning structure instead of flat priors
         local_fg = lower_local_graph(
             compiled.graph,
-            strategy_conditional_params=strategy_params,
             review_manifest=review_manifest,
         )
         local_prefix = f"{compiled.graph.namespace}:{compiled.graph.package_name}::"
@@ -136,7 +133,6 @@ def infer_command(
         factor_graph = lower_local_graph(
             compiled.graph,
             node_priors=foreign_priors or None,
-            strategy_conditional_params=collect_strategy_conditional_params(compiled),
             review_manifest=review_manifest,
         )
     fg_errors = factor_graph.validate()

--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -20,8 +20,8 @@ from gaia.cli._packages import (
     load_dependency_compiled_graphs,
     load_gaia_package,
 )
+from gaia.cli.commands._review_manifest import load_or_generate_review_manifest
 from gaia.ir.validator import validate_local_graph
-from gaia.lang.review.manifest import generate_review_manifest
 
 
 def _write_json(path, payload) -> None:
@@ -53,6 +53,7 @@ def infer_command(
         loaded = load_gaia_package(path)
         apply_package_priors(loaded)
         compiled = compile_loaded_package_artifact(loaded)
+        review_manifest = load_or_generate_review_manifest(loaded.pkg_path, compiled)
     except GaiaCliError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)
@@ -96,7 +97,8 @@ def infer_command(
 
         dep_factor_graphs: list[tuple[str, FactorGraph, str]] = []
         for dep in dep_compiled:
-            dep_fg = lower_local_graph(dep.graph, review_manifest=generate_review_manifest(dep))
+            dep_review_manifest = load_or_generate_review_manifest(dep.root, dep)
+            dep_fg = lower_local_graph(dep.graph, review_manifest=dep_review_manifest)
             dep_prefix = f"{dep.graph.namespace}:{dep.graph.package_name}::"
             dep_factor_graphs.append((dep.import_name, dep_fg, dep_prefix))
             typer.echo(
@@ -107,8 +109,7 @@ def infer_command(
 
         # Lower local graph WITHOUT foreign node priors — the dep graphs
         # provide the full reasoning structure instead of flat priors
-        local_review_manifest = compiled.review or generate_review_manifest(compiled)
-        local_fg = lower_local_graph(compiled.graph, review_manifest=local_review_manifest)
+        local_fg = lower_local_graph(compiled.graph, review_manifest=review_manifest)
         local_prefix = f"{compiled.graph.namespace}:{compiled.graph.package_name}::"
 
         if dep_factor_graphs:
@@ -126,7 +127,6 @@ def infer_command(
         foreign_priors = collect_foreign_node_priors(compiled.graph, loaded.pkg_path)
         if foreign_priors:
             typer.echo(f"Loaded {len(foreign_priors)} upstream belief(s) for foreign nodes")
-        review_manifest = compiled.review or generate_review_manifest(compiled)
         factor_graph = lower_local_graph(
             compiled.graph,
             node_priors=foreign_priors or None,

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -14,7 +14,6 @@ from gaia.cli._packages import (
     GaiaCliError,
     apply_package_priors,
     build_package_manifests,
-    collect_strategy_conditional_params,
     load_gaia_package,
 )
 from gaia.cli._packages import compile_loaded_package_artifact
@@ -394,7 +393,6 @@ def register_command(
     factor_graph = lower_local_graph(
         compiled.graph,
         node_priors=foreign_priors or None,
-        strategy_conditional_params=collect_strategy_conditional_params(compiled),
     )
     fg_errors = factor_graph.validate()
     if fg_errors:

--- a/gaia/cli/commands/register.py
+++ b/gaia/cli/commands/register.py
@@ -14,6 +14,7 @@ from gaia.cli._packages import (
     GaiaCliError,
     apply_package_priors,
     build_package_manifests,
+    collect_strategy_conditional_params,
     load_gaia_package,
 )
 from gaia.cli._packages import compile_loaded_package_artifact
@@ -390,7 +391,11 @@ def register_command(
     # foreign nodes instead of falling back to 0.5.
     # Mirror infer_command: load dep_beliefs so foreign nodes get upstream priors.
     foreign_priors = collect_foreign_node_priors(compiled.graph, loaded.pkg_path)
-    factor_graph = lower_local_graph(compiled.graph, node_priors=foreign_priors or None)
+    factor_graph = lower_local_graph(
+        compiled.graph,
+        node_priors=foreign_priors or None,
+        strategy_conditional_params=collect_strategy_conditional_params(compiled),
+    )
     fg_errors = factor_graph.validate()
     if fg_errors:
         for error in fg_errors:

--- a/gaia/ir/review.py
+++ b/gaia/ir/review.py
@@ -22,7 +22,7 @@ class Review(BaseModel):
 
     review_id: str
     action_label: str
-    target_kind: Literal["strategy", "operator"]
+    target_kind: Literal["strategy", "operator", "knowledge"]
     target_id: str
     status: ReviewStatus
     audit_question: str

--- a/gaia/ir/strategy.py
+++ b/gaia/ir/strategy.py
@@ -147,6 +147,7 @@ class Strategy(BaseModel):
 
     # local layer
     steps: list[Step] | None = None  # reasoning process (local only, None at global)
+    conditional_probabilities: list[float] | None = None  # infer/noisy_and CPT parameters
 
     # traceability
     metadata: dict[str, Any] | None = None
@@ -204,6 +205,21 @@ class Strategy(BaseModel):
                 self.conclusion,
                 structure_hash=self._structure_hash(),
             )
+        if self.conditional_probabilities is not None:
+            clamped = [max(1e-3, min(1 - 1e-3, float(p))) for p in self.conditional_probabilities]
+            if self.type == StrategyType.INFER:
+                expected = 1 << len(self.premises)
+                if len(clamped) != expected:
+                    raise ValueError(
+                        f"infer strategy with {len(self.premises)} premises requires "
+                        f"{expected} conditional_probabilities, got {len(clamped)}"
+                    )
+            elif self.type == StrategyType.NOISY_AND:
+                if len(clamped) != 1:
+                    raise ValueError(
+                        f"noisy_and strategy requires 1 conditional_probability, got {len(clamped)}"
+                    )
+            object.__setattr__(self, "conditional_probabilities", clamped)
         return self
 
     # No leaf type restriction — per §3.5.1, named strategies (deduction, abduction,

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -21,7 +21,6 @@ from gaia.ir import (
     ReviewManifest,
     Step as IrStep,
     Strategy as IrStrategy,
-    StrategyParamRecord,
     formalize_named_strategy,
     make_qid,
 )
@@ -69,7 +68,6 @@ class CompiledPackage:
     strategies_by_object: dict[int, IrStrategy]
     action_label_map: dict[str, str] = field(default_factory=dict)
     target_action_labels_by_id: dict[str, str] = field(default_factory=dict)
-    strategy_param_records: list[StrategyParamRecord] = field(default_factory=list)
     review: ReviewManifest | None = None
 
     def to_json(self) -> dict[str, Any]:
@@ -534,7 +532,6 @@ def compile_package_artifact(
 
     action_label_map: dict[str, str] = {}
     target_action_labels_by_id: dict[str, str] = {}
-    strategy_param_records: list[StrategyParamRecord] = []
 
     def _record_action_target(action_label: str, target_id: str | None) -> None:
         if target_id is None:
@@ -661,15 +658,8 @@ def compile_package_artifact(
             conclusion=knowledge_map[id(action.evidence)],
             background=[knowledge_map[id(bg)] for bg in action.background] or None,
             steps=_action_steps(action.rationale),
+            conditional_probabilities=[action.p_e_given_not_h, action.p_e_given_h],
             metadata=metadata,
-        )
-        strategy_param_records.append(
-            StrategyParamRecord(
-                strategy_id=strategy.strategy_id,
-                conditional_probabilities=[action.p_e_given_not_h, action.p_e_given_h],
-                source_id="author",
-                justification=action.rationale,
-            )
         )
         _record_action_target(action_label, strategy.strategy_id)
         return strategy
@@ -819,7 +809,6 @@ def compile_package_artifact(
         strategies_by_object=dict(compiled_strategies),
         action_label_map=action_label_map,
         target_action_labels_by_id=target_action_labels_by_id,
-        strategy_param_records=strategy_param_records,
     )
     from gaia.lang.review.manifest import generate_review_manifest
 

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -542,7 +542,29 @@ def compile_package_artifact(
         action_label_map[action_label] = target_id
         target_action_labels_by_id[target_id] = action_label
 
-    def _compile_support_action(action: Support, action_index: int) -> IrStrategy:
+    def _attach_grounding_action(
+        action: Support,
+        *,
+        action_label: str,
+        conclusion_id: str,
+        background_ids: list[str] | None,
+    ) -> None:
+        for i, ir_k in enumerate(ir_knowledges):
+            if ir_k.id != conclusion_id:
+                continue
+            metadata = dict(ir_k.metadata) if ir_k.metadata else {}
+            grounding = dict(metadata.get("grounding") or {})
+            grounding["action_label"] = action_label
+            grounding["pattern"] = "observation"
+            if background_ids:
+                grounding["background"] = background_ids
+            if action.rationale and not grounding.get("rationale"):
+                grounding["rationale"] = action.rationale
+            metadata["grounding"] = grounding
+            ir_knowledges[i] = ir_k.model_copy(update={"metadata": metadata})
+            return
+
+    def _compile_support_action(action: Support, action_index: int) -> IrStrategy | None:
         if action.conclusion is None:
             raise ValueError("Support action requires a conclusion")
         premise_ids = [knowledge_map[id(given)] for given in action.given]
@@ -562,6 +584,16 @@ def compile_package_artifact(
             pattern=pattern,
             extra=extra,
         )
+
+        if isinstance(action, Observe) and not premise_ids:
+            _attach_grounding_action(
+                action,
+                action_label=action_label,
+                conclusion_id=conclusion_id,
+                background_ids=background_ids,
+            )
+            _record_action_target(action_label, conclusion_id)
+            return None
 
         if premise_ids:
             result = formalize_named_strategy(
@@ -642,7 +674,7 @@ def compile_package_artifact(
         _record_action_target(action_label, strategy.strategy_id)
         return strategy
 
-    def compile_action(action: Any, action_index: int) -> IrStrategy | IrOperator:
+    def compile_action(action: Any, action_index: int) -> IrStrategy | IrOperator | None:
         if isinstance(action, Support):
             return _compile_support_action(action, action_index)
         if isinstance(action, Relate):
@@ -662,6 +694,8 @@ def compile_package_artifact(
     action_operators: list[IrOperator] = []
     for action_index, action in enumerate(getattr(pkg, "actions", [])):
         target = compile_action(action, action_index)
+        if target is None:
+            continue
         if isinstance(target, IrOperator):
             action_operators.append(target)
         else:

--- a/gaia/lang/review/manifest.py
+++ b/gaia/lang/review/manifest.py
@@ -59,6 +59,23 @@ def _strategy_question(strategy: Any, action_type: str, labels: dict[str, str]) 
     )
 
 
+def _grounding_action_label(knowledge: Any) -> str | None:
+    metadata = knowledge.metadata or {}
+    grounding = metadata.get("grounding")
+    if not isinstance(grounding, dict):
+        return None
+    action_label = grounding.get("action_label")
+    return action_label if isinstance(action_label, str) and action_label else None
+
+
+def _grounding_question(knowledge: Any, labels: dict[str, str]) -> str:
+    knowledge_id = knowledge.id or ""
+    return generate_audit_question(
+        "observe",
+        conclusion_label=labels.get(knowledge_id, knowledge.label or knowledge_id or "?"),
+    )
+
+
 def _operator_question(operator: Any, action_type: str, labels: dict[str, str]) -> str:
     a = operator.variables[0] if operator.variables else ""
     b = operator.variables[1] if len(operator.variables) > 1 else ""
@@ -73,6 +90,22 @@ def generate_review_manifest(compiled: Any) -> ReviewManifest:
     """Generate unreviewed Review records for each v6 action target."""
     labels = _labels_by_id(compiled)
     reviews: list[Review] = []
+
+    for knowledge in compiled.graph.knowledges:
+        action_label = _grounding_action_label(knowledge)
+        if not action_label or not knowledge.id:
+            continue
+        reviews.append(
+            Review(
+                review_id=_review_id("knowledge", knowledge.id),
+                action_label=action_label,
+                target_kind="knowledge",
+                target_id=knowledge.id,
+                status=ReviewStatus.UNREVIEWED,
+                audit_question=_grounding_question(knowledge, labels),
+                round=1,
+            )
+        )
 
     for strategy in compiled.graph.strategies:
         metadata = strategy.metadata or {}

--- a/tests/cli/test_compile_v6_actions.py
+++ b/tests/cli/test_compile_v6_actions.py
@@ -51,7 +51,14 @@ def test_compile_v6_actions_package(tmp_path):
         for s in ir["strategies"]
         if s.get("metadata") and "pattern" in s["metadata"]
     }
-    assert {"observation", "derivation", "inference"} <= strategy_patterns
+    assert {"derivation", "inference"} <= strategy_patterns
+
+    grounding_patterns = {
+        k["metadata"]["grounding"]["pattern"]
+        for k in ir["knowledges"]
+        if (k.get("metadata") or {}).get("grounding") and "pattern" in k["metadata"]["grounding"]
+    }
+    assert "observation" in grounding_patterns
 
     operator_types = {op["operator"] for op in ir["operators"]}
     assert {"equivalence", "contradiction"} <= operator_types
@@ -65,6 +72,12 @@ def test_compile_v6_actions_package(tmp_path):
         op["metadata"]["action_label"]
         for op in ir["operators"]
         if op.get("metadata") and "action_label" in op["metadata"]
+    )
+    action_labels.extend(
+        k["metadata"]["grounding"]["action_label"]
+        for k in ir["knowledges"]
+        if (k.get("metadata") or {}).get("grounding")
+        and "action_label" in k["metadata"]["grounding"]
     )
     assert "github:v6_actions::action::observe_uv" in action_labels
     assert "github:v6_actions::action::favor_planck" in action_labels

--- a/tests/cli/test_compile_v6_actions.py
+++ b/tests/cli/test_compile_v6_actions.py
@@ -52,6 +52,13 @@ def test_compile_v6_actions_package(tmp_path):
         if s.get("metadata") and "pattern" in s["metadata"]
     }
     assert {"derivation", "inference"} <= strategy_patterns
+    infer_strategy = next(
+        s
+        for s in ir["strategies"]
+        if (s.get("metadata") or {}).get("action_label")
+        == "github:v6_actions::action::bayes_update"
+    )
+    assert infer_strategy["conditional_probabilities"] == [0.1, 0.9]
 
     grounding_patterns = {
         k["metadata"]["grounding"]["pattern"]

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -211,6 +211,62 @@ def test_infer_uses_accepted_review_manifest(tmp_path):
     assert belief_by_label["hypothesis"] > 0.4
 
 
+def test_infer_uses_v6_infer_action_cpt(tmp_path):
+    """gaia infer must pass v6 InferAction CPT records into BP lowering."""
+    from gaia.cli._packages import (
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        load_gaia_package,
+    )
+    from gaia.ir import ReviewManifest, ReviewStatus
+
+    pkg_dir = tmp_path / "v6_cpt_infer"
+    _write_base_package(pkg_dir, name="v6_cpt_infer")
+    (pkg_dir / "v6_cpt_infer" / "__init__.py").write_text(
+        "from gaia.lang import claim, infer\n\n"
+        'hypothesis = claim("Hypothesis.")\n'
+        'evidence = claim("Evidence.")\n'
+        "infer(\n"
+        "    hypothesis=hypothesis,\n"
+        "    evidence=evidence,\n"
+        "    p_e_given_h=0.95,\n"
+        "    p_e_given_not_h=0.05,\n"
+        '    rationale="Hypothesis strongly predicts evidence.",\n'
+        '    label="bayes_update",\n'
+        ")\n"
+        '__all__ = ["hypothesis", "evidence"]\n'
+    )
+    (pkg_dir / "v6_cpt_infer" / "priors.py").write_text(
+        "from . import evidence, hypothesis\n\n"
+        "PRIORS = {\n"
+        '    hypothesis: (0.2, "Low base rate."),\n'
+        '    evidence: (0.9, "Observed evidence."),\n'
+        "}\n"
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    loaded = load_gaia_package(pkg_dir)
+    apply_package_priors(loaded)
+    compiled = compile_loaded_package_artifact(loaded)
+    assert compiled.review is not None
+    accepted = [
+        review.model_copy(update={"status": ReviewStatus.ACCEPTED, "round": 2})
+        for review in compiled.review.reviews
+    ]
+    (pkg_dir / ".gaia" / "review_manifest.json").write_text(
+        json.dumps(ReviewManifest(reviews=accepted).model_dump(mode="json"), indent=2)
+    )
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    beliefs = json.loads((pkg_dir / ".gaia" / "beliefs.json").read_text())
+    belief_by_label = {item["label"]: item["belief"] for item in beliefs["beliefs"]}
+    assert belief_by_label["hypothesis"] > 0.5
+
+
 def test_infer_with_accepted_root_observe_review(tmp_path):
     """Accepted no-premise observe reviews should not lower as empty deductions."""
     from gaia.cli._packages import (

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -212,7 +212,7 @@ def test_infer_uses_accepted_review_manifest(tmp_path):
 
 
 def test_infer_uses_v6_infer_action_cpt(tmp_path):
-    """gaia infer must pass v6 InferAction CPT records into BP lowering."""
+    """gaia infer must lower v6 InferAction CPTs from the compiled IR strategy."""
     from gaia.cli._packages import (
         apply_package_priors,
         compile_loaded_package_artifact,

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -157,6 +157,60 @@ def test_infer_gates_unreviewed_v6_actions(tmp_path):
     assert belief_by_label["hypothesis"] == pytest.approx(0.4)
 
 
+def test_infer_uses_accepted_review_manifest(tmp_path):
+    """Accepted persisted reviews allow v6 actions to participate in infer."""
+    from gaia.cli._packages import (
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        load_gaia_package,
+    )
+    from gaia.ir import ReviewManifest, ReviewStatus
+
+    pkg_dir = tmp_path / "v6_review_infer"
+    _write_base_package(pkg_dir, name="v6_review_infer")
+    (pkg_dir / "v6_review_infer" / "__init__.py").write_text(
+        "from gaia.lang import claim, derive\n\n"
+        'evidence = claim("Evidence.")\n'
+        "hypothesis = derive(\n"
+        '    "Hypothesis.",\n'
+        "    given=evidence,\n"
+        '    rationale="Evidence supports hypothesis.",\n'
+        '    label="support_hypothesis",\n'
+        ")\n"
+        '__all__ = ["evidence", "hypothesis"]\n'
+    )
+    (pkg_dir / "v6_review_infer" / "priors.py").write_text(
+        "from . import evidence, hypothesis\n\n"
+        "PRIORS = {\n"
+        '    evidence: (0.9, "Direct observation."),\n'
+        '    hypothesis: (0.4, "Base rate."),\n'
+        "}\n"
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    loaded = load_gaia_package(pkg_dir)
+    apply_package_priors(loaded)
+    compiled = compile_loaded_package_artifact(loaded)
+    assert compiled.review is not None
+    accepted = [
+        review.model_copy(update={"status": ReviewStatus.ACCEPTED, "round": 2})
+        for review in compiled.review.reviews
+    ]
+    review_path = pkg_dir / ".gaia" / "review_manifest.json"
+    review_path.write_text(
+        json.dumps(ReviewManifest(reviews=accepted).model_dump(mode="json"), indent=2)
+    )
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    beliefs = json.loads((pkg_dir / ".gaia" / "beliefs.json").read_text())
+    belief_by_label = {item["label"]: item["belief"] for item in beliefs["beliefs"]}
+    assert belief_by_label["hypothesis"] > 0.4
+
+
 def test_infer_loads_upstream_beliefs_for_foreign_nodes(tmp_path, monkeypatch):
     """When dep_beliefs are present, foreign nodes use upstream beliefs as priors."""
     # Create upstream dependency package

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -211,6 +211,50 @@ def test_infer_uses_accepted_review_manifest(tmp_path):
     assert belief_by_label["hypothesis"] > 0.4
 
 
+def test_infer_with_accepted_root_observe_review(tmp_path):
+    """Accepted no-premise observe reviews should not lower as empty deductions."""
+    from gaia.cli._packages import (
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        load_gaia_package,
+    )
+    from gaia.ir import ReviewManifest, ReviewStatus
+
+    pkg_dir = tmp_path / "root_observe_infer"
+    _write_base_package(pkg_dir, name="root_observe_infer")
+    (pkg_dir / "root_observe_infer" / "__init__.py").write_text(
+        "from gaia.lang import observe\n\n"
+        'root = observe("Root measurement.", rationale="Measured.", label="root_obs")\n'
+        '__all__ = ["root"]\n'
+    )
+    (pkg_dir / "root_observe_infer" / "priors.py").write_text(
+        'from . import root\n\nPRIORS = {\n    root: (0.82, "Measurement reliability."),\n}\n'
+    )
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    loaded = load_gaia_package(pkg_dir)
+    apply_package_priors(loaded)
+    compiled = compile_loaded_package_artifact(loaded)
+    assert compiled.review is not None
+    assert [review.target_kind for review in compiled.review.reviews] == ["knowledge"]
+    accepted = [
+        review.model_copy(update={"status": ReviewStatus.ACCEPTED, "round": 2})
+        for review in compiled.review.reviews
+    ]
+    (pkg_dir / ".gaia" / "review_manifest.json").write_text(
+        json.dumps(ReviewManifest(reviews=accepted).model_dump(mode="json"), indent=2)
+    )
+
+    result = runner.invoke(app, ["infer", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+
+    beliefs = json.loads((pkg_dir / ".gaia" / "beliefs.json").read_text())
+    belief_by_label = {item["label"]: item["belief"] for item in beliefs["beliefs"]}
+    assert belief_by_label["root"] == pytest.approx(0.82)
+
+
 def test_infer_loads_upstream_beliefs_for_foreign_nodes(tmp_path, monkeypatch):
     """When dep_beliefs are present, foreign nodes use upstream beliefs as priors."""
     # Create upstream dependency package

--- a/tests/cli/test_inquiry.py
+++ b/tests/cli/test_inquiry.py
@@ -1,0 +1,94 @@
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+from gaia.ir import ReviewManifest, ReviewStatus
+from gaia.lang import Claim, derive, observe
+from gaia.lang.compiler import compile_package_artifact
+from gaia.lang.review.manifest import generate_review_manifest
+from gaia.lang.runtime.package import CollectedPackage
+
+runner = CliRunner()
+
+
+def _write_inquiry_package(pkg_dir) -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "inquiry-demo-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "inquiry_demo"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, derive\n\n"
+        'a = claim("A.")\n'
+        'b = claim("B.")\n'
+        'c = derive("C.", given=(a, b), rationale="A and B imply C.", label="derive_c")\n'
+        'hole = claim("Unwarranted exported claim.")\n'
+        '__all__ = ["c", "hole"]\n'
+    )
+
+
+def test_inquiry_shows_exported_goals_and_holes(tmp_path):
+    pkg_dir = tmp_path / "inquiry_demo"
+    _write_inquiry_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", "--inquiry", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "Goal 1:" in result.output
+    assert "Goal 2:" in result.output
+    assert "hole [hole]" in result.output
+    assert "Structural holes:" in result.output
+
+
+def test_inquiry_shows_warrant_status():
+    from gaia.cli.commands._inquiry import build_goal_trees, render_inquiry
+
+    with CollectedPackage("inquiry_pkg") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        data = observe("Observation.", rationale="Measured.", label="observe_data")
+        data.label = "data"
+        c = derive("C.", given=(a, data), rationale="A and data imply C.", label="derive_c")
+        c.label = "c"
+        pkg._exported_labels = {"c"}
+
+    compiled = compile_package_artifact(pkg)
+    generated = generate_review_manifest(compiled)
+    accepted = generated.reviews[0].model_copy(update={"status": ReviewStatus.ACCEPTED, "round": 2})
+    manifest = ReviewManifest(reviews=[*generated.reviews, accepted])
+
+    trees = build_goal_trees(compiled.to_json(), manifest)
+    output = render_inquiry(trees)
+
+    assert "[accepted]" in output
+    assert "[unreviewed]" in output
+
+
+def test_inquiry_shows_support_tree(tmp_path):
+    pkg_dir = tmp_path / "inquiry_demo"
+    _write_inquiry_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", "--inquiry", str(pkg_dir)])
+    assert result.exit_code == 0, result.output
+    assert "derive_c [unreviewed]" in result.output
+    assert "- a [hole]" in result.output
+    assert "- b [hole]" in result.output
+
+
+def test_check_inquiry_flag(tmp_path):
+    pkg_dir = tmp_path / "inquiry_demo"
+    _write_inquiry_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--inquiry"])
+    assert result.exit_code == 0, result.output
+    assert "Inquiry" in result.output
+    assert "Summary" in result.output

--- a/tests/cli/test_quality_gate.py
+++ b/tests/cli/test_quality_gate.py
@@ -1,0 +1,144 @@
+import json
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def test_quality_gate_default_config():
+    from gaia.cli.commands._quality_gate import load_quality_config
+
+    config = load_quality_config({})
+    assert config.allow_holes is False
+    assert config.min_posterior is None
+
+
+def test_quality_gate_custom_config():
+    from gaia.cli.commands._quality_gate import load_quality_config
+
+    config = load_quality_config({"min_posterior": 0.7})
+    assert config.min_posterior == 0.7
+    assert config.allow_holes is False
+
+
+def _write_gate_package(pkg_dir, source: str, *, quality: str = "") -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "gate-demo-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+        f"{quality}"
+    )
+    pkg_src = pkg_dir / "gate_demo"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(source)
+
+
+def _accept_all_reviews(pkg_dir) -> None:
+    from gaia.cli._packages import compile_loaded_package_artifact, load_gaia_package
+    from gaia.ir import ReviewManifest, ReviewStatus
+
+    loaded = load_gaia_package(pkg_dir)
+    compiled = compile_loaded_package_artifact(loaded)
+    assert compiled.review is not None
+    accepted = [
+        review.model_copy(update={"status": ReviewStatus.ACCEPTED, "round": 2})
+        for review in compiled.review.reviews
+    ]
+    (pkg_dir / ".gaia" / "review_manifest.json").write_text(
+        json.dumps(ReviewManifest(reviews=accepted).model_dump(mode="json"), indent=2)
+    )
+
+
+def test_gate_fails_on_structural_hole(tmp_path):
+    pkg_dir = tmp_path / "gate_demo"
+    _write_gate_package(
+        pkg_dir,
+        "from gaia.lang import claim\n\n"
+        'hole = claim("Unwarranted exported claim.")\n'
+        '__all__ = ["hole"]\n',
+    )
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
+    assert result.exit_code != 0
+    assert "structural hole" in result.output.lower()
+
+
+def test_gate_fails_on_unreviewed(tmp_path):
+    pkg_dir = tmp_path / "gate_demo"
+    _write_gate_package(
+        pkg_dir,
+        "from gaia.lang import derive, observe\n\n"
+        'data = observe("Data.", rationale="Measured.", label="observe_data")\n'
+        'conclusion = derive("Conclusion.", given=data, rationale="Data implies conclusion.", label="derive_c")\n'
+        '__all__ = ["conclusion"]\n',
+    )
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
+    assert result.exit_code != 0
+    assert "unreviewed" in result.output.lower()
+
+
+def test_gate_fails_on_unreviewed_root_observe(tmp_path):
+    pkg_dir = tmp_path / "gate_demo"
+    _write_gate_package(
+        pkg_dir,
+        "from gaia.lang import observe\n\n"
+        'root = observe("Root fact.", rationale="Measured.", label="root_obs")\n'
+        '__all__ = ["root"]\n',
+    )
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
+    assert result.exit_code != 0
+    assert "unreviewed" in result.output.lower()
+
+
+def test_gate_fails_on_low_posterior(tmp_path):
+    pkg_dir = tmp_path / "gate_demo"
+    _write_gate_package(
+        pkg_dir,
+        "from gaia.lang import observe\n\n"
+        'root = observe("Root fact.", rationale="Measured.", label="root_obs")\n'
+        '__all__ = ["root"]\n',
+        quality="\n[tool.gaia.quality]\nmin_posterior = 0.9\n",
+    )
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+    _accept_all_reviews(pkg_dir)
+    (pkg_dir / ".gaia" / "beliefs.json").write_text(
+        json.dumps(
+            {
+                "beliefs": [
+                    {
+                        "knowledge_id": "github:gate_demo::root",
+                        "label": "root",
+                        "belief": 0.7,
+                    }
+                ]
+            },
+            indent=2,
+        )
+    )
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
+    assert result.exit_code != 0
+    assert "low posterior" in result.output.lower()
+
+
+def test_gate_passes_when_all_met(tmp_path):
+    pkg_dir = tmp_path / "gate_demo"
+    _write_gate_package(
+        pkg_dir,
+        "from gaia.lang import derive, observe\n\n"
+        'data = observe("Data.", rationale="Measured.", label="observe_data")\n'
+        'conclusion = derive("Conclusion.", given=data, rationale="Data implies conclusion.", label="derive_c")\n'
+        '__all__ = ["conclusion"]\n',
+    )
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+    _accept_all_reviews(pkg_dir)
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
+    assert result.exit_code == 0, result.output
+    assert "Quality gate passed" in result.output

--- a/tests/cli/test_quality_gate.py
+++ b/tests/cli/test_quality_gate.py
@@ -51,6 +51,31 @@ def _accept_all_reviews(pkg_dir) -> None:
     )
 
 
+def _accept_reviews_except(pkg_dir, action_label_fragment: str) -> None:
+    from gaia.cli._packages import compile_loaded_package_artifact, load_gaia_package
+    from gaia.ir import ReviewManifest, ReviewStatus
+
+    loaded = load_gaia_package(pkg_dir)
+    compiled = compile_loaded_package_artifact(loaded)
+    assert compiled.review is not None
+    reviews = [
+        review.model_copy(
+            update={
+                "status": (
+                    ReviewStatus.UNREVIEWED
+                    if action_label_fragment in review.action_label
+                    else ReviewStatus.ACCEPTED
+                ),
+                "round": 2,
+            }
+        )
+        for review in compiled.review.reviews
+    ]
+    (pkg_dir / ".gaia" / "review_manifest.json").write_text(
+        json.dumps(ReviewManifest(reviews=reviews).model_dump(mode="json"), indent=2)
+    )
+
+
 def test_gate_fails_on_structural_hole(tmp_path):
     pkg_dir = tmp_path / "gate_demo"
     _write_gate_package(
@@ -78,6 +103,21 @@ def test_gate_fails_on_unreviewed(tmp_path):
     result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
     assert result.exit_code != 0
     assert "unreviewed" in result.output.lower()
+
+
+def test_gate_still_runs_with_blind_warrant_report(tmp_path):
+    pkg_dir = tmp_path / "gate_demo"
+    _write_gate_package(
+        pkg_dir,
+        "from gaia.lang import observe\n\n"
+        'root = observe("Root fact.", rationale="Measured.", label="root_obs")\n'
+        '__all__ = ["root"]\n',
+    )
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--warrants", "--blind", "--gate"])
+    assert result.exit_code != 0
+    assert "quality gate failed" in result.output.lower()
+    assert "root_obs" in result.output
 
 
 def test_gate_fails_on_unreviewed_root_observe(tmp_path):
@@ -138,6 +178,25 @@ def test_gate_passes_when_all_met(tmp_path):
     compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
     assert compile_result.exit_code == 0, compile_result.output
     _accept_all_reviews(pkg_dir)
+
+    result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
+    assert result.exit_code == 0, result.output
+    assert "Quality gate passed" in result.output
+
+
+def test_gate_ignores_unexported_unreachable_draft_actions(tmp_path):
+    pkg_dir = tmp_path / "gate_demo"
+    _write_gate_package(
+        pkg_dir,
+        "from gaia.lang import derive, observe\n\n"
+        'data = observe("Data.", rationale="Measured.", label="observe_data")\n'
+        'conclusion = derive("Conclusion.", given=data, rationale="Data implies conclusion.", label="derive_c")\n'
+        'draft = observe("Unrelated draft measurement.", rationale="Draft.", label="draft_obs")\n'
+        '__all__ = ["conclusion"]\n',
+    )
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+    _accept_reviews_except(pkg_dir, "draft_obs")
 
     result = runner.invoke(app, ["check", str(pkg_dir), "--gate"])
     assert result.exit_code == 0, result.output

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -99,6 +99,47 @@ def _write_package_with_local_hole_and_bridge(pkg_dir) -> None:
     )
 
 
+def _write_package_with_v6_infer(pkg_dir) -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / ".gitignore").write_text(".gaia/\nuv.lock\n")
+    (pkg_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "register-infer-gaia"\n'
+        'version = "1.2.0"\n'
+        'description = "Registration demo with v6 infer CPTs"\n'
+        "dependencies = [\n"
+        '  "gaia-lang>=0.1.0",\n'
+        "]\n\n"
+        "[tool.gaia]\n"
+        'namespace = "github"\n'
+        'type = "knowledge-package"\n'
+        'uuid = "8fae1bcb-6c5c-5d91-9de7-b76f0689c8ff"\n'
+    )
+    pkg_src = pkg_dir / "register_infer"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.lang import claim, infer\n\n"
+        'hypothesis = claim("Hypothesis.")\n'
+        'evidence = claim("Evidence.")\n'
+        "infer(\n"
+        "    hypothesis=hypothesis,\n"
+        "    evidence=evidence,\n"
+        "    p_e_given_h=0.95,\n"
+        "    p_e_given_not_h=0.05,\n"
+        '    rationale="Hypothesis strongly predicts evidence.",\n'
+        '    label="bayes_update",\n'
+        ")\n"
+        '__all__ = ["hypothesis", "evidence"]\n'
+    )
+    (pkg_src / "priors.py").write_text(
+        "from . import evidence, hypothesis\n\n"
+        "PRIORS = {\n"
+        '    hypothesis: (0.2, "Low base rate."),\n'
+        '    evidence: (0.9, "Observed evidence."),\n'
+        "}\n"
+    )
+
+
 def _init_git_repo(pkg_dir, remote_dir) -> None:
     _run(["git", "init"], cwd=pkg_dir)
     _run(["git", "config", "user.name", "Gaia Test"], cwd=pkg_dir)
@@ -172,6 +213,37 @@ def test_register_dry_run_emits_registration_plan(tmp_path):
     assert len(beliefs_manifest["beliefs"]) >= 1
     exported_labels = {b["label"] for b in beliefs_manifest["beliefs"]}
     assert "exported_claim" in exported_labels
+
+
+def test_register_beliefs_use_v6_infer_action_cpt(tmp_path):
+    """register-generated beliefs.json must use v6 InferAction CPT records."""
+    pkg_dir = tmp_path / "register_infer"
+    remote_dir = tmp_path / "register_infer_remote.git"
+    _write_package_with_v6_infer(pkg_dir)
+    _init_git_repo(pkg_dir, remote_dir)
+
+    compile_result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    _run(["git", "tag", "v1.2.0"], cwd=pkg_dir)
+    _run(["git", "push", "origin", "v1.2.0"], cwd=pkg_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "register",
+            str(pkg_dir),
+            "--repo",
+            "https://github.com/example/RegisterInfer.gaia",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    plan = json.loads(result.output)
+    release_dir = "packages/register-infer/releases/1.2.0"
+    beliefs_manifest = json.loads(plan["files"][f"{release_dir}/beliefs.json"])
+    belief_by_label = {item["label"]: item["belief"] for item in beliefs_manifest["beliefs"]}
+    assert belief_by_label["hypothesis"] > 0.5
 
 
 def test_register_writes_registry_metadata_to_local_checkout(tmp_path):

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -216,7 +216,7 @@ def test_register_dry_run_emits_registration_plan(tmp_path):
 
 
 def test_register_beliefs_use_v6_infer_action_cpt(tmp_path):
-    """register-generated beliefs.json must use v6 InferAction CPT records."""
+    """register-generated beliefs.json must use v6 InferAction CPTs from IR strategies."""
     pkg_dir = tmp_path / "register_infer"
     remote_dir = tmp_path / "register_infer_remote.git"
     _write_package_with_v6_infer(pkg_dir)

--- a/tests/cli/test_review_manifest_io.py
+++ b/tests/cli/test_review_manifest_io.py
@@ -1,0 +1,47 @@
+import json
+
+from gaia.cli.commands._review_manifest import load_or_generate_review_manifest
+from gaia.ir import ReviewManifest, ReviewStatus
+from gaia.lang import Claim, derive
+from gaia.lang.compiler import compile_package_artifact
+from gaia.lang.runtime.package import CollectedPackage
+
+
+def _compiled_with_reviewable_action():
+    with CollectedPackage("review_io") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        c = derive("C.", given=a, rationale="A implies C.", label="derive_c")
+        c.label = "c"
+    return compile_package_artifact(pkg)
+
+
+def test_load_or_generate_review_manifest_uses_generated_default(tmp_path):
+    compiled = _compiled_with_reviewable_action()
+
+    manifest = load_or_generate_review_manifest(tmp_path, compiled)
+
+    assert isinstance(manifest, ReviewManifest)
+    assert len(manifest.reviews) == 1
+    assert manifest.reviews[0].status == ReviewStatus.UNREVIEWED
+
+
+def test_load_or_generate_review_manifest_merges_persisted_latest_status(tmp_path):
+    compiled = _compiled_with_reviewable_action()
+    generated = compiled.review
+    assert generated is not None
+    accepted_review = generated.reviews[0].model_copy(
+        update={"status": ReviewStatus.ACCEPTED, "round": 2}
+    )
+    review_path = tmp_path / ".gaia" / "review_manifest.json"
+    review_path.parent.mkdir()
+    review_path.write_text(
+        json.dumps(
+            ReviewManifest(reviews=[accepted_review]).model_dump(mode="json"),
+            indent=2,
+        )
+    )
+
+    manifest = load_or_generate_review_manifest(tmp_path, compiled)
+
+    assert manifest.latest_status(accepted_review.target_id) == ReviewStatus.ACCEPTED

--- a/tests/gaia/lang/test_compiler_actions.py
+++ b/tests/gaia/lang/test_compiler_actions.py
@@ -111,7 +111,7 @@ def test_compile_equal_and_contradict_actions_to_operators():
     assert by_operator["contradiction"].conclusion == "github:v6_actions::conflict_helper"
 
 
-def test_compile_infer_action_to_strategy_and_cpt_record():
+def test_compile_infer_action_to_strategy_cpt():
     with CollectedPackage("v6_actions") as pkg:
         h = Claim("H.")
         h.label = "h"
@@ -138,8 +138,8 @@ def test_compile_infer_action_to_strategy_and_cpt_record():
     assert strategy.background == ["github:v6_actions::reliable"]
     assert strategy.metadata["action_label"] == "github:v6_actions::action::bayes_update"
     assert strategy.steps[0].reasoning == "Bayes."
-    assert compiled.strategy_param_records[0].strategy_id == strategy.strategy_id
-    assert compiled.strategy_param_records[0].conditional_probabilities == [0.2, 0.8]
+    assert strategy.conditional_probabilities == [0.2, 0.8]
+    assert not hasattr(compiled, "strategy_param_records")
 
     stat_support = _knowledge_by_label(compiled)["stat_support"]
     assert stat_support.metadata["helper_kind"] == "statistical_support"

--- a/tests/gaia/lang/test_compiler_actions.py
+++ b/tests/gaia/lang/test_compiler_actions.py
@@ -50,21 +50,20 @@ def test_compile_derive_action_to_deduction_formal_strategy():
     assert conjunction_helpers[0].metadata["review"] is False
 
 
-def test_compile_root_observe_action_to_reviewable_strategy_and_grounding():
+def test_compile_root_observe_action_to_reviewable_grounding():
     with CollectedPackage("v6_actions") as pkg:
         data = observe("UV spectrum data.", rationale="Measured.", label="observe_uv")
         data.label = "uv"
 
     compiled = compile_package_artifact(pkg)
-    strategy = compiled.graph.strategies[0]
-    assert strategy.type == "deduction"
-    assert strategy.premises == []
-    assert strategy.conclusion == "github:v6_actions::uv"
-    assert strategy.metadata["pattern"] == "observation"
-    assert strategy.metadata["action_label"] == "github:v6_actions::action::observe_uv"
+    assert compiled.graph.strategies == []
+    assert compiled.action_label_map["github:v6_actions::action::observe_uv"] == (
+        "github:v6_actions::uv"
+    )
 
     uv = _knowledge_by_label(compiled)["uv"]
     assert uv.metadata["grounding"]["kind"] == "source_fact"
+    assert uv.metadata["grounding"]["action_label"] == "github:v6_actions::action::observe_uv"
 
 
 def test_compile_compute_action_to_deduction_with_compute_metadata():

--- a/tests/gaia/lang/test_review_manifest.py
+++ b/tests/gaia/lang/test_review_manifest.py
@@ -62,6 +62,10 @@ def test_generate_review_manifest_for_v6_actions():
     by_action = {review.action_label: review for review in manifest.reviews}
     assert by_action["github:review_pkg::action::derive_c"].target_kind == "strategy"
     assert "[@c]" in by_action["github:review_pkg::action::derive_c"].audit_question
+    assert by_action["github:review_pkg::action::observe_data"].target_kind == "knowledge"
+    assert by_action["github:review_pkg::action::observe_data"].target_id == (
+        "github:review_pkg::data"
+    )
     assert by_action["github:review_pkg::action::same"].target_kind == "operator"
     assert "[@a]" in by_action["github:review_pkg::action::conflict"].audit_question
     assert "[@data]" in by_action["github:review_pkg::action::bayes_update"].audit_question


### PR DESCRIPTION
## Summary
- load persisted `.gaia/review_manifest.json` so manually accepted ReviewManifest rounds can gate inference and checks
- add `gaia check --inquiry` to render exported goals, support trees, review statuses, and structural holes
- add `gaia check --gate` with structural-hole checks, accepted-warrant checks, and optional `[tool.gaia.quality].min_posterior` enforcement

## Tests
- python -m pytest tests/ -x -q
- python -m ruff check .
- python -m ruff format --check .
- git diff --check

Stacked on #470 (`feat/v6-lang-phase4-review-manifest`).