### PR TITLE
[codex] Return evidence from v6 infer

### DIFF
--- a/docs/ideas/probabilistic-correlation-relation.md
+++ b/docs/ideas/probabilistic-correlation-relation.md
@@ -1,10 +1,11 @@
 # Probabilistic Correlation Relation for Gaia v0.5
 
-> **Status:** Idea
+> **Status:** Idea, narrowed after follow-up discussion
 >
-> This note records a possible replacement for the current v6 `infer()`
-> surface. It is not an implementation plan. The goal is to clarify the
-> semantic center before changing the DSL, IR, or BP lowering.
+> This note records a possible future `correlate()` / `evidence_for()`
+> relation surface. It is no longer the preferred replacement for `infer()`:
+> `infer()` remains a directional probabilistic action where a hypothesis
+> predicts an evidence-shaped conclusion.
 
 ## 1. Motivation
 
@@ -12,8 +13,8 @@ The current v6 design exposes statistical evidence as:
 
 ```python
 infer(
+    E,
     hypothesis=H,
-    evidence=E,
     p_e_given_h=...,
     p_e_given_not_h=...,
 )
@@ -29,8 +30,9 @@ often awkward for LLM-assisted scientific formalization:
 - The word `infer` sounds like a reasoning action, while the object being
   authored is really a probabilistic relation between two Claims.
 
-The design question is whether Gaia should treat this as a `Relate`-like
-primitive rather than a `Support`-like or `Infer`-like primitive.
+The design question for this note is whether Gaia also needs a separate
+`Relate`-like primitive for symmetric or bidirectional probabilistic
+correlations. That primitive should not replace `infer()`.
 
 ## 2. Jaynes Interpretation
 
@@ -338,16 +340,18 @@ This note does not propose:
 
 ## 12. Working Recommendation
 
-For v0.5 iteration, the cleanest path is:
+For future iteration, if Gaia needs an explicit probabilistic relation surface,
+the cleanest path is:
 
-1. Treat the current `infer()` concept as a probabilistic relation, not a
-   support action.
-2. Prototype a Lang surface named `correlate()` that returns a reviewable
+1. Keep `infer()` as a directional probabilistic action: `H` predicts `E`, and
+   observed `E` updates belief in `H`.
+2. Prototype a separate Lang surface named `correlate()` that returns a reviewable
    relation helper Claim.
 3. Provide `evidence_for()` as a scientific wrapper over `correlate()`.
-4. Keep the existing `Strategy(type="infer")` lowering path initially, but
-   preserve the original calibration form in metadata.
+4. Lower `correlate()` separately, or temporarily through `Strategy(type="infer")`
+   only when a directional factor is explicitly chosen.
 5. Classify helper relation shape from relative update against base rates.
 
-This keeps the semantics Jaynes-compatible while making LLM-assisted
-formalization ask easier, positive-direction probability questions.
+This keeps `infer()` aligned with the action hierarchy while preserving a place
+to explore easier, positive-direction probability questions for LLM-assisted
+formalization.

--- a/docs/specs/2026-04-21-gaia-lang-v6-design.md
+++ b/docs/specs/2026-04-21-gaia-lang-v6-design.md
@@ -509,26 +509,29 @@ derive(
 
 ### 7.1 infer
 
-Statistical evidence update based on Jaynes/Bayes framework. All parameters are keyword-only.
+Statistical evidence update based on Jaynes/Bayes framework. The first
+argument is the evidence or prediction-shaped Claim `E`, aligning `infer()` with
+other action verbs that return their conclusion Claim. Probability arguments
+remain keyword-only to avoid swapping the two conditional probabilities.
 
 ```python
 infer(
+    evidence: Claim | str,
     *,
     hypothesis: Claim,
-    evidence: Claim,
     background: list[Setting | Claim] = [],
     p_e_given_h: float,
     p_e_given_not_h: float,
     rationale: str = "",
-) -> StatisticalSupport
+) -> Claim
 ```
 
 No `given` parameter — assumptions and conditions go in `background` (not in BP). If assumptions are questionable, reviewer rejects the Strategy via ReviewManifest.
 
 ```python
-support = infer(
+evidence = infer(
+    spectrum_data,
     hypothesis=quantum_hyp,
-    evidence=spectrum_data,
     background=[exp_setting, reliable_measurement, calibrated],
     p_e_given_h=0.9,
     p_e_given_not_h=0.05,
@@ -536,11 +539,16 @@ support = infer(
 )
 ```
 
-Returns `StatisticalSupport` helper Claim. Compiles to `Strategy(type="infer", premises=[H], conclusion=E)` + CPT `[p_e_given_not_h, p_e_given_h]`.
+Returns the evidence Claim `E`. Internally, the action still creates a
+reviewable `StatisticalSupport` helper Claim so ReviewManifest can audit the
+probabilistic warrant. Compiles to `Strategy(type="infer", premises=[H],
+conclusion=E)` + CPT `[p_e_given_not_h, p_e_given_h]`.
 
 ### 7.2 Semantics
 
-`infer()` creates a bidirectional factor between hypothesis and evidence:
+`infer()` creates a directional predictive factor from hypothesis to evidence.
+Because BP messages flow both ways, an accepted/observed `E` can still update
+belief in `H`:
 
 ```
 odds(H) *= P(E|H) / P(E|¬H)

--- a/gaia/lang/dsl/infer_verb.py
+++ b/gaia/lang/dsl/infer_verb.py
@@ -15,9 +15,10 @@ def _claim_ref(claim: Claim) -> str:
 
 
 def infer(
+    evidence_or_legacy=None,
     *args,
     hypothesis: Claim | None = None,
-    evidence: Claim | None = None,
+    evidence: Claim | str | None = None,
     background: list[Knowledge] | None = None,
     p_e_given_h: float | None = None,
     p_e_given_not_h: float | None = None,
@@ -25,24 +26,33 @@ def infer(
     label: str | None = None,
     **legacy_kwargs,
 ) -> Claim:
-    """Bayesian inference. Returns a statistical-support helper Claim.
+    """Bayesian inference. Returns the evidence Claim.
 
-    The v6 shape is keyword-only. The old v5 ``infer([premises], conclusion, ...)``
-    form is preserved as a deprecated compatibility path.
+    The canonical v6 shape is ``infer(evidence, hypothesis=..., ...)``. The old
+    v5 ``infer([premises], conclusion, ...)`` form is preserved as a deprecated
+    compatibility path.
     """
-    if args:
-        if isinstance(args[0], (list, tuple)):
-            from gaia.lang.dsl.strategies import infer as legacy_infer
+    if isinstance(evidence_or_legacy, (list, tuple)):
+        from gaia.lang.dsl.strategies import infer as legacy_infer
 
-            warnings.warn(
-                "infer([premises], conclusion, ...) is deprecated; use keyword-only "
-                "infer(hypothesis=..., evidence=..., p_e_given_h=..., "
-                "p_e_given_not_h=...) instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return legacy_infer(*args, **legacy_kwargs)
-        raise TypeError("v6 infer() arguments are keyword-only")
+        warnings.warn(
+            "infer([premises], conclusion, ...) is deprecated; use "
+            "infer(evidence, hypothesis=..., p_e_given_h=..., "
+            "p_e_given_not_h=...) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return legacy_infer(evidence_or_legacy, *args, **legacy_kwargs)
+
+    if args:
+        raise TypeError("v6 infer() accepts only one positional evidence argument")
+    if legacy_kwargs:
+        unexpected = next(iter(legacy_kwargs))
+        raise TypeError(f"infer() got an unexpected keyword argument: '{unexpected}'")
+    if evidence_or_legacy is not None:
+        if evidence is not None:
+            raise TypeError("infer() got evidence both positionally and by keyword")
+        evidence = evidence_or_legacy
 
     if hypothesis is None:
         raise TypeError("infer() missing required keyword argument: 'hypothesis'")
@@ -52,6 +62,12 @@ def infer(
         raise TypeError("infer() missing required keyword argument: 'p_e_given_h'")
     if p_e_given_not_h is None:
         raise TypeError("infer() missing required keyword argument: 'p_e_given_not_h'")
+    if isinstance(evidence, str):
+        evidence = Claim(evidence)
+    if not isinstance(evidence, Claim):
+        raise TypeError("infer() evidence must be a Claim or string")
+    if not isinstance(hypothesis, Claim):
+        raise TypeError("infer() hypothesis must be a Claim")
 
     helper = Claim(
         f"{_claim_ref(evidence)} statistically supports {_claim_ref(hypothesis)}.",
@@ -68,4 +84,5 @@ def infer(
         helper=helper,
     )
     action.warrants.append(helper)
-    return helper
+    evidence.supports.append(action)
+    return evidence

--- a/gaia/lang/review/templates.py
+++ b/gaia/lang/review/templates.py
@@ -13,8 +13,8 @@ _TEMPLATES = {
     "observe": "Is the observation of [@{conclusion_label}] reliable under the stated conditions?",
     "compute": "Is the computation of [@{conclusion_label}] correctly implemented?",
     "infer": (
-        "Is the statistical association between [@{hypothesis_label}] and "
-        "[@{evidence_label}] valid at the stated probabilities?"
+        "Does [@{hypothesis_label}] predict [@{evidence_label}] at the stated "
+        "conditional probabilities?"
     ),
     "equal": "Are [@{a_label}] and [@{b_label}] truly equivalent?",
     "contradict": "Do [@{a_label}] and [@{b_label}] truly contradict?",

--- a/tests/cli/test_compile_v6_actions.py
+++ b/tests/cli/test_compile_v6_actions.py
@@ -24,9 +24,9 @@ def test_compile_v6_actions_package(tmp_path):
         'classical = claim("Classical model predicts divergent UV spectrum.")\n'
         'agreement = equal(prediction, data, rationale="Prediction matches data.", label="match")\n'
         'conflict = contradict(classical, data, rationale="Prediction conflicts.", label="conflict")\n'
-        "stat_support = infer(\n"
+        "data = infer(\n"
+        "    data,\n"
         "    hypothesis=prediction,\n"
-        "    evidence=data,\n"
         "    background=[calibrated],\n"
         "    p_e_given_h=0.9,\n"
         "    p_e_given_not_h=0.1,\n"
@@ -35,8 +35,8 @@ def test_compile_v6_actions_package(tmp_path):
         ")\n"
         "favored = derive(\n"
         '    "Planck model is favored.",\n'
-        "    given=(agreement, conflict, stat_support),\n"
-        '    rationale="Agreement, conflict, and Bayes support favor Planck.",\n'
+        "    given=(agreement, conflict, data),\n"
+        '    rationale="Agreement, conflict, and observed data favor Planck.",\n'
         '    label="favor_planck",\n'
         ")\n"
         '__all__ = ["favored"]\n'

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -227,8 +227,8 @@ def test_infer_uses_v6_infer_action_cpt(tmp_path):
         'hypothesis = claim("Hypothesis.")\n'
         'evidence = claim("Evidence.")\n'
         "infer(\n"
+        "    evidence,\n"
         "    hypothesis=hypothesis,\n"
-        "    evidence=evidence,\n"
         "    p_e_given_h=0.95,\n"
         "    p_e_given_not_h=0.05,\n"
         '    rationale="Hypothesis strongly predicts evidence.",\n'

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -122,8 +122,8 @@ def _write_package_with_v6_infer(pkg_dir) -> None:
         'hypothesis = claim("Hypothesis.")\n'
         'evidence = claim("Evidence.")\n'
         "infer(\n"
+        "    evidence,\n"
         "    hypothesis=hypothesis,\n"
-        "    evidence=evidence,\n"
         "    p_e_given_h=0.95,\n"
         "    p_e_given_not_h=0.05,\n"
         '    rationale="Hypothesis strongly predicts evidence.",\n'

--- a/tests/gaia/lang/test_compiler_actions.py
+++ b/tests/gaia/lang/test_compiler_actions.py
@@ -119,15 +119,18 @@ def test_compile_infer_action_to_strategy_cpt():
         e.label = "e"
         bg = Claim("Measurement reliable.")
         bg.label = "reliable"
-        helper = infer(
+        result = infer(
+            e,
             hypothesis=h,
-            evidence=e,
             background=[bg],
             p_e_given_h=0.8,
             p_e_given_not_h=0.2,
             rationale="Bayes.",
             label="bayes_update",
         )
+        assert result is e
+        helper = pkg.actions[0].helper
+        assert helper is not None
         helper.label = "stat_support"
 
     compiled = compile_package_artifact(pkg)

--- a/tests/gaia/lang/test_infer.py
+++ b/tests/gaia/lang/test_infer.py
@@ -6,23 +6,45 @@ from gaia.lang.runtime.knowledge import Claim, Setting
 from gaia.lang.runtime.package import CollectedPackage
 
 
-def test_infer_returns_statistical_support():
+def test_infer_returns_positional_evidence_and_keeps_helper_on_action():
+    with CollectedPackage("v6_test") as pkg:
+        h = Claim("Quantum theory is correct.", prior=0.5)
+        e = Claim("Planck spectrum observed.", prior=0.95)
+        result = infer(
+            e,
+            hypothesis=h,
+            p_e_given_h=0.9,
+            p_e_given_not_h=0.05,
+            rationale="Strong evidence.",
+        )
+
+    assert result is e
+    action = pkg.actions[0]
+    assert action.evidence is e
+    assert action.hypothesis is h
+    assert action in e.supports
+    assert action.helper is not None
+    assert action.helper is not e
+    assert action.helper.metadata.get("generated") is True
+    assert action.helper.metadata.get("helper_kind") == "statistical_support"
+    assert action.helper.metadata.get("review") is True
+    assert action.warrants == [action.helper]
+
+
+def test_infer_keyword_evidence_also_returns_evidence():
     h = Claim("Quantum theory is correct.", prior=0.5)
     e = Claim("Planck spectrum observed.", prior=0.95)
-    support = infer(
+    result = infer(
         hypothesis=h,
         evidence=e,
         p_e_given_h=0.9,
         p_e_given_not_h=0.05,
         rationale="Strong evidence.",
     )
-    assert isinstance(support, Claim)
-    assert support.metadata.get("generated") is True
-    assert support.metadata.get("helper_kind") == "statistical_support"
-    assert support.metadata.get("review") is True
+    assert result is e
 
 
-def test_infer_all_keyword_only_for_v6_shape():
+def test_infer_rejects_ambiguous_extra_positional_v6_shape():
     h = Claim("H.")
     e = Claim("E.")
     with pytest.raises(TypeError):
@@ -34,15 +56,16 @@ def test_infer_registers_action_and_warrant():
         h = Claim("H.")
         e = Claim("E.")
         bg = Setting("Experiment conditions.")
-        helper = infer(
+        result = infer(
+            e,
             hypothesis=h,
-            evidence=e,
             background=[bg],
             p_e_given_h=0.8,
             p_e_given_not_h=0.2,
             rationale="Test.",
             label="bayes_update",
         )
+    assert result is e
     assert len(pkg.actions) == 1
     action = pkg.actions[0]
     assert isinstance(action, Infer)
@@ -52,8 +75,9 @@ def test_infer_registers_action_and_warrant():
     assert action.background == [bg]
     assert action.p_e_given_h == 0.8
     assert action.p_e_given_not_h == 0.2
-    assert action.helper is helper
-    assert action.warrants == [helper]
+    assert action in e.supports
+    assert action.helper is not None
+    assert action.warrants == [action.helper]
 
 
 def test_infer_preserves_v5_positional_shape():

--- a/tests/gaia/lang/test_infer.py
+++ b/tests/gaia/lang/test_infer.py
@@ -44,6 +44,27 @@ def test_infer_keyword_evidence_also_returns_evidence():
     assert result is e
 
 
+def test_infer_string_evidence_creates_and_returns_evidence_claim():
+    with CollectedPackage("v6_test") as pkg:
+        h = Claim("Quantum theory is correct.", prior=0.5)
+        result = infer(
+            "Planck spectrum observed.",
+            hypothesis=h,
+            p_e_given_h=0.9,
+            p_e_given_not_h=0.05,
+            rationale="Strong evidence.",
+        )
+
+    assert isinstance(result, Claim)
+    assert result.content == "Planck spectrum observed."
+    action = pkg.actions[0]
+    assert action.evidence is result
+    assert action.hypothesis is h
+    assert action in result.supports
+    assert action.helper is not None
+    assert action.warrants == [action.helper]
+
+
 def test_infer_rejects_ambiguous_extra_positional_v6_shape():
     h = Claim("H.")
     e = Claim("E.")

--- a/tests/gaia/lang/test_review_manifest.py
+++ b/tests/gaia/lang/test_review_manifest.py
@@ -23,6 +23,8 @@ def test_audit_question_for_infer():
     )
     assert "[@quantum_hyp]" in question
     assert "[@spectrum]" in question
+    assert "predict" in question.lower()
+    assert "association" not in question.lower()
 
 
 def test_audit_question_for_equal():

--- a/tests/gaia/lang/test_review_manifest.py
+++ b/tests/gaia/lang/test_review_manifest.py
@@ -46,8 +46,8 @@ def test_generate_review_manifest_for_v6_actions():
         conflict = contradict(a, data, rationale="Conflict.", label="conflict")
         conflict.label = "conflict_helper"
         infer(
+            data,
             hypothesis=c,
-            evidence=data,
             p_e_given_h=0.8,
             p_e_given_not_h=0.2,
             rationale="Bayes.",


### PR DESCRIPTION
## Summary

- Change the v6 `infer()` surface to accept canonical `infer(evidence, *, hypothesis=...)` calls and return the evidence Claim.
- Keep the generated StatisticalSupport helper as an internal review/warrant artifact on the Infer action.
- Update v6 specs, the correlation idea note, and affected tests/fixtures to reflect directional predictive semantics.

## Validation

- `ruff check gaia/lang/dsl/infer_verb.py tests/gaia/lang/test_infer.py tests/gaia/lang/test_compiler_actions.py tests/gaia/lang/test_review_manifest.py tests/cli/test_compile_v6_actions.py tests/cli/test_infer.py tests/cli/test_register.py`
- `pytest tests/gaia/lang/test_infer.py tests/gaia/lang/test_compiler_actions.py tests/gaia/lang/test_review_manifest.py tests/cli/test_compile_v6_actions.py tests/cli/test_infer.py::test_infer_uses_v6_infer_action_cpt tests/cli/test_register.py::test_register_beliefs_use_v6_infer_action_cpt`
- `pytest`
