### PR TITLE
[codex] fix inquiry review regressions

### DIFF
--- a/gaia/inquiry/diagnostics.py
+++ b/gaia/inquiry/diagnostics.py
@@ -122,6 +122,17 @@ def from_validation(warnings: list[str], errors: list[str]) -> list[Diagnostic]:
     return out
 
 
+def _strategy_id(s) -> str:
+    return getattr(s, "strategy_id", None) or getattr(s, "id", "") or ""
+
+
+def _strategy_label(s) -> str:
+    sid = _strategy_id(s)
+    if sid:
+        return sid.split("::")[-1]
+    return getattr(s, "label", "") or ""
+
+
 def _attach_anchor(d: Diagnostic, anchors: dict[str, SourceAnchor] | None) -> Diagnostic:
     if anchors and d.label in anchors:
         d.source_anchor = anchors[d.label]
@@ -341,8 +352,8 @@ def detect_warrant_status(
         return out
     rejected = rejected_strategy_targets or set()
     for s in getattr(graph, "strategies", []) or []:
-        sid = getattr(s, "id", "") or ""
-        label = sid.split("::")[-1] if sid else getattr(s, "label", "") or ""
+        sid = _strategy_id(s)
+        label = _strategy_label(s)
         meta = dict(getattr(s, "metadata", None) or {})
         if sid in rejected or label in rejected:
             d = Diagnostic(
@@ -402,8 +413,8 @@ def detect_blocked_warrant_path(
     if not hole_ids:
         return out
     for s in getattr(graph, "strategies", []) or []:
-        sid = getattr(s, "id", "") or ""
-        label = sid.split("::")[-1] if sid else ""
+        sid = _strategy_id(s)
+        label = _strategy_label(s)
         premises = list(getattr(s, "premises", None) or [])
         blocking = sorted(p for p in premises if p in hole_ids)
         if not blocking:
@@ -545,8 +556,8 @@ def detect_overstrong_strategy_without_provenance(
         return True
 
     for s in getattr(graph, "strategies", []) or []:
-        sid = getattr(s, "id", "") or ""
-        label = sid.split("::")[-1] if sid else ""
+        sid = _strategy_id(s)
+        label = _strategy_label(s)
         meta = dict(getattr(s, "metadata", None) or {})
         if _nonempty(meta.get("provenance")) or _nonempty(meta.get("justification")):
             continue

--- a/gaia/inquiry/diff.py
+++ b/gaia/inquiry/diff.py
@@ -138,11 +138,19 @@ def _knowledges_by_type_id(ir: dict, kind: str) -> dict[str, dict]:
 
 
 def _strategies_by_id(ir: dict) -> dict[str, dict]:
-    return {s["id"]: s for s in ir.get("strategies", []) or []}
+    return {
+        (s.get("id") or s.get("strategy_id")): s
+        for s in ir.get("strategies", []) or []
+        if s.get("id") or s.get("strategy_id")
+    }
 
 
 def _operators_by_id(ir: dict) -> dict[str, dict]:
-    return {o["id"]: o for o in ir.get("operators", []) or []}
+    return {
+        (o.get("id") or o.get("operator_id")): o
+        for o in ir.get("operators", []) or []
+        if o.get("id") or o.get("operator_id")
+    }
 
 
 def _label(item: dict) -> str:

--- a/gaia/inquiry/review.py
+++ b/gaia/inquiry/review.py
@@ -19,6 +19,7 @@ from gaia.cli._packages import (
     compile_loaded_package_artifact,
     ensure_package_env,
     load_gaia_package,
+    load_dependency_compiled_graphs,
 )
 from gaia.cli.commands.check_core import (
     KnowledgeBreakdown,
@@ -163,11 +164,13 @@ def run_review(
     compile_status = "error"
     ir_hash: str | None = None
     counts = {"knowledge": 0, "strategies": 0, "operators": 0}
+    project_config: dict[str, Any] | None = None
 
     # Step 1: compile via Gaia.
     try:
         ensure_package_env(pkg_path)
         loaded = load_gaia_package(str(pkg_path))
+        project_config = loaded.project_config
         apply_package_priors(loaded)
         compiled = compile_loaded_package_artifact(loaded)
         graph = compiled.graph
@@ -207,7 +210,15 @@ def run_review(
     semantic_diff = compute_semantic_diff(ir_dict, baseline_snap)
 
     # Step 5: inference via gaia.bp; enrich with baseline belief deltas.
-    belief_report = _build_belief_report(graph, pkg_path, no_infer, errors, focus)
+    belief_report = _build_belief_report(
+        graph,
+        pkg_path,
+        no_infer,
+        errors,
+        focus,
+        depth=depth,
+        project_config=project_config,
+    )
     if belief_report["ran_inference"] and baseline_snap is not None:
         _annotate_belief_deltas(belief_report, baseline_snap)
 
@@ -268,7 +279,7 @@ def run_review(
     )
 
     # Persist snapshot for future diffs.
-    save_snapshot(
+    actual_review_id = save_snapshot(
         pkg_path,
         review_id=review_id,
         created_at=created_at,
@@ -276,10 +287,11 @@ def run_review(
         ir_dict=ir_dict,
         beliefs=belief_report.get("beliefs", []),
     )
+    report.review_id = actual_review_id
 
-    state.last_review_id = review_id
+    state.last_review_id = actual_review_id
     if state.baseline_review_id is None:
-        state.baseline_review_id = review_id
+        state.baseline_review_id = actual_review_id
     state.mode = mode
     save_state(pkg_path, state)
 
@@ -351,21 +363,29 @@ def _graph_to_ir_dict(graph) -> dict | None:
         )
     strategies = []
     for s in getattr(graph, "strategies", []) or []:
+        sid = getattr(s, "strategy_id", None) or getattr(s, "id", "") or ""
         strategies.append(
             {
-                "id": getattr(s, "id", ""),
+                "id": sid,
+                "strategy_id": sid,
+                "type": _normalize_type(getattr(s, "type", "")),
                 "conclusion": getattr(s, "conclusion", None),
                 "premises": list(getattr(s, "premises", []) or []),
                 "background": list(getattr(s, "background", []) or []),
+                "metadata": dict(getattr(s, "metadata", {}) or {}),
             }
         )
     operators = []
     for o in getattr(graph, "operators", []) or []:
+        oid = getattr(o, "operator_id", None) or getattr(o, "id", "") or ""
         operators.append(
             {
-                "id": getattr(o, "id", ""),
+                "id": oid,
+                "operator_id": oid,
+                "operator": _normalize_type(getattr(o, "operator", "")),
                 "conclusion": getattr(o, "conclusion", None),
                 "variables": list(getattr(o, "variables", []) or []),
+                "metadata": dict(getattr(o, "metadata", {}) or {}),
             }
         )
     return {"knowledges": knowledges, "strategies": strategies, "operators": operators}
@@ -434,6 +454,9 @@ def _build_belief_report(
     no_infer: bool,
     errors: list[str],
     focus: FocusBinding,
+    *,
+    depth: int = 0,
+    project_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     out: dict[str, Any] = {
         "ran_inference": False,
@@ -447,11 +470,23 @@ def _build_belief_report(
     if errors:
         return out
     try:
-        from gaia.bp import lower_local_graph
+        from gaia.bp import lower_local_graph, merge_factor_graphs
         from gaia.bp.engine import InferenceEngine
 
-        foreign = collect_foreign_node_priors(graph, pkg_path)
-        fg = lower_local_graph(graph, node_priors=foreign or None)
+        if depth != 0:
+            dep_compiled = load_dependency_compiled_graphs(project_config or {}, depth=depth)
+            dep_factor_graphs = []
+            for dep in dep_compiled:
+                dep_fg = lower_local_graph(dep.graph)
+                dep_prefix = f"{dep.graph.namespace}:{dep.graph.package_name}::"
+                dep_factor_graphs.append((dep.import_name, dep_fg, dep_prefix))
+            fg = lower_local_graph(graph)
+            if dep_factor_graphs:
+                local_prefix = f"{graph.namespace}:{graph.package_name}::"
+                fg = merge_factor_graphs(fg, dep_factor_graphs, local_prefix=local_prefix)
+        else:
+            foreign = collect_foreign_node_priors(graph, pkg_path)
+            fg = lower_local_graph(graph, node_priors=foreign or None)
         fg_errs = fg.validate()
         if fg_errs:
             errors.extend(fg_errs)

--- a/gaia/inquiry/snapshot.py
+++ b/gaia/inquiry/snapshot.py
@@ -47,8 +47,12 @@ def save_snapshot(
     ir_hash: str | None,
     ir_dict: dict | None,
     beliefs: list[dict[str, Any]],
-) -> Path:
-    """Persist the minimal snapshot needed to diff future reviews."""
+) -> str:
+    """Persist the minimal snapshot needed to diff future reviews.
+
+    Returns the actual review id written to disk, including a collision suffix
+    when multiple reviews are minted in the same second.
+    """
     base_dir = reviews_dir(pkg_path)
     path = base_dir / f"{review_id}.json"
     # 同秒且 ir_hash 不变会产生相同 review_id；追加递增后缀避免覆盖之前的 snapshot。
@@ -68,7 +72,7 @@ def save_snapshot(
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     tmp.replace(path)
-    return path
+    return review_id
 
 
 def load_snapshot(pkg_path: str | Path, review_id: str) -> dict | None:

--- a/tests/inquiry/test_regressions.py
+++ b/tests/inquiry/test_regressions.py
@@ -1,0 +1,180 @@
+"""Regression tests for inquiry review integration bugs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from gaia.inquiry.focus import FocusBinding
+from gaia.inquiry.review import run_review
+from gaia.inquiry.state import load_state
+
+
+def _write_pkg(pkg_dir: Path, body: str, name: str = "regress_pkg") -> None:
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg_dir / name
+    src.mkdir(exist_ok=True)
+    (src / "__init__.py").write_text(body, encoding="utf-8")
+
+
+def test_semantic_diff_tracks_added_strategy_by_strategy_id(tmp_path: Path) -> None:
+    pkg = tmp_path / "p"
+    base_body = (
+        "from gaia.lang import claim, support\n"
+        'a = claim("A", metadata={"prior": 0.5})\n'
+        'b = claim("B", metadata={"prior": 0.7})\n'
+        'c = claim("C")\n'
+        "s1 = support(premises=[a], conclusion=c)\n"
+        '__all__ = ["a", "b", "c", "s1"]\n'
+    )
+    _write_pkg(pkg, base_body)
+    first = run_review(pkg, no_infer=True)
+
+    updated_body = base_body.replace(
+        '__all__ = ["a", "b", "c", "s1"]\n',
+        's2 = support(premises=[b], conclusion=c)\n__all__ = ["a", "b", "c", "s1", "s2"]\n',
+    )
+    (pkg / "regress_pkg" / "__init__.py").write_text(updated_body, encoding="utf-8")
+
+    second = run_review(pkg, no_infer=True, since=first.review_id)
+
+    assert len(second.semantic_diff.added_strategies) == 1
+    assert second.semantic_diff.added_strategies[0].startswith("lcs_")
+    assert not second.semantic_diff.changed_strategies
+
+
+def test_warrant_diagnostics_keep_strategy_id(tmp_path: Path) -> None:
+    pkg = tmp_path / "p"
+    _write_pkg(
+        pkg,
+        "from gaia.lang import claim, support\n"
+        'a = claim("A")\n'
+        'c = claim("C")\n'
+        "s = support(premises=[a], conclusion=c)\n"
+        '__all__ = ["a", "c", "s"]\n',
+    )
+
+    report = run_review(pkg, no_infer=True)
+    warrant_diags = [
+        d for d in report.diagnostics if d.kind in {"unreviewed_warrant", "blocked_warrant_path"}
+    ]
+
+    assert warrant_diags
+    assert all(d.target.startswith("lcs_") for d in warrant_diags)
+    assert all(d.label.startswith("lcs_") for d in warrant_diags)
+    assert all("``" not in d.suggested_edit for d in warrant_diags)
+
+
+def test_snapshot_collision_updates_report_and_state_to_actual_id(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pkg = tmp_path / "p"
+    _write_pkg(
+        pkg,
+        'from gaia.lang import claim\na = claim("A", metadata={"prior": 0.5})\n__all__ = ["a"]\n',
+    )
+    monkeypatch.setattr("gaia.inquiry.review.mint_review_id", lambda _hash, _mode: "fixed")
+
+    first = run_review(pkg, no_infer=True)
+    second = run_review(pkg, no_infer=True)
+
+    assert first.review_id == "fixed"
+    assert second.review_id == "fixed-2"
+    assert load_state(pkg).last_review_id == "fixed-2"
+
+    review_files = sorted(p.stem for p in (pkg / ".gaia" / "inquiry" / "reviews").glob("*.json"))
+    assert review_files == ["fixed", "fixed-2"]
+    stored = json.loads((pkg / ".gaia" / "inquiry" / "reviews" / "fixed-2.json").read_text())
+    assert stored["review_id"] == "fixed-2"
+
+
+def test_run_review_passes_depth_to_belief_report(tmp_path: Path, monkeypatch) -> None:
+    pkg = tmp_path / "p"
+    _write_pkg(
+        pkg,
+        'from gaia.lang import claim\na = claim("A", metadata={"prior": 0.5})\n__all__ = ["a"]\n',
+    )
+    seen: list[int] = []
+
+    def fake_belief_report(graph, pkg_path, no_infer, errors, focus, depth=0, **_kwargs):
+        seen.append(depth)
+        return {
+            "ran_inference": False,
+            "beliefs": [],
+            "focus": None,
+            "largest_increases": [],
+            "largest_decreases": [],
+        }
+
+    monkeypatch.setattr("gaia.inquiry.review._build_belief_report", fake_belief_report)
+
+    run_review(pkg, no_infer=False, depth=2)
+
+    assert seen == [2]
+
+
+def test_belief_report_depth_uses_joint_dependency_graph(tmp_path: Path, monkeypatch) -> None:
+    import gaia.bp as bp
+    import gaia.bp.engine as engine_mod
+    import gaia.inquiry.review as review_mod
+
+    local_graph = SimpleNamespace(namespace="github", package_name="local", knowledges=[])
+    dep_graph = SimpleNamespace(namespace="github", package_name="dep", knowledges=[])
+    local_fg = SimpleNamespace(name="local", validate=lambda: [])
+    dep_fg = SimpleNamespace(name="dep", validate=lambda: [])
+    merged_fg = SimpleNamespace(name="merged", validate=lambda: [])
+    seen: dict[str, object] = {}
+
+    def fake_load_deps(project_config, depth):
+        seen["project_config"] = project_config
+        seen["depth"] = depth
+        return [SimpleNamespace(import_name="dep_pkg", graph=dep_graph)]
+
+    def fake_lower(graph, node_priors=None):
+        seen.setdefault("lowered", []).append((graph.package_name, node_priors))
+        return dep_fg if graph is dep_graph else local_fg
+
+    def fake_merge(local, deps, local_prefix):
+        seen["merge"] = (local, deps, local_prefix)
+        return merged_fg
+
+    class FakeEngine:
+        def run(self, factor_graph):
+            seen["engine_graph"] = factor_graph
+            return SimpleNamespace(bp_result=SimpleNamespace(beliefs={}))
+
+    def fail_foreign_priors(*_args, **_kwargs):
+        raise AssertionError("depth inference must not use flat foreign priors")
+
+    monkeypatch.setattr(
+        review_mod, "load_dependency_compiled_graphs", fake_load_deps, raising=False
+    )
+    monkeypatch.setattr(review_mod, "collect_foreign_node_priors", fail_foreign_priors)
+    monkeypatch.setattr(bp, "lower_local_graph", fake_lower)
+    monkeypatch.setattr(bp, "merge_factor_graphs", fake_merge)
+    monkeypatch.setattr(engine_mod, "InferenceEngine", FakeEngine)
+
+    report = review_mod._build_belief_report(
+        local_graph,
+        tmp_path,
+        no_infer=False,
+        errors=[],
+        focus=FocusBinding(raw=None, kind="none"),
+        depth=1,
+        project_config={"project": {"dependencies": ["dep-gaia"]}},
+    )
+
+    assert report["ran_inference"] is True
+    assert seen["depth"] == 1
+    assert seen["engine_graph"] is merged_fg
+    assert seen["merge"] == (
+        local_fg,
+        [("dep_pkg", dep_fg, "github:dep::")],
+        "github:local::",
+    )


### PR DESCRIPTION
## Summary

Fixes the three review regressions found in PR #479:

- Preserve compiled strategy/operator identities by mapping `strategy_id` / `operator_id` into the inquiry IR adapter, and use strategy ids in warrant diagnostics.
- Align `gaia inquiry review --depth` with `gaia infer --depth` by using dependency graph loading and factor-graph merge when depth is non-zero.
- Return and persist the actual snapshot `review_id` when same-second collisions add a suffix.

## Validation

- `python -m pytest tests/inquiry/test_regressions.py -q` — 5 passed
- `python -m pytest tests/inquiry -q` — 134 passed
- `python -m pytest -q` — 960 passed, 8 warnings
- `ruff check .` — passed
- `ruff format --check .` — 143 files already formatted