### PR TITLE
[codex] Add Mendel probability example

### DIFF
--- a/examples/mendel-v0-5-gaia/pyproject.toml
+++ b/examples/mendel-v0-5-gaia/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "mendel-v0-5-gaia"
+version = "0.1.0"
+description = "A Gaia v0.5 package for Mendel-style probability semantics"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.gaia]
+type = "knowledge-package"
+namespace = "example"
+
+[tool.gaia.quality]
+allow_holes = true

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
@@ -49,7 +49,7 @@ This leaves the observation's ``reliability`` prior untouched on
 ``f2_count_observation`` and lets the Bayesian marginal live cleanly on the
 derived node. No other semantic is introduced by this node; it would go away
 once the framework separates the ``reliability`` / ``marginal`` / ``belief``
-roles on a Claim.
+roles on a Claim. See issue #485 for the design discussion.
 """
 
 from gaia.lang import associate, claim, contradict, derive, equal, exclusive, note, observe
@@ -202,11 +202,11 @@ mendel_predicts_three_to_one_ratio = derive(
 #
 # The node exists only to carry the Bayesian marginal ``P(count = 295/395)``
 # on a separate Claim from ``f2_count_observation``, which already carries the
-# reliability prior 0.95 via ``PRIORS``. See the module docstring above for
-# the underlying framework issue (``metadata.prior`` doing double duty as both
-# "reliability" and "marginal"). Once the framework separates those two
-# semantics, this intermediate node can be deleted and ``associate`` can
-# target ``f2_count_observation`` directly.
+# reliability prior 0.95 via ``PRIORS``. See the module docstring above, and
+# issue #485, for the underlying framework design (``metadata.prior`` doing
+# double duty as both "reliability" and "marginal"). Once the framework
+# separates those two semantics, this intermediate node can be deleted and
+# ``associate`` can target ``f2_count_observation`` directly.
 # -----------------------------------------------------------------------------
 
 f2_dominant_count_specific = derive(

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
@@ -1,16 +1,42 @@
-"""Mendel-style probability example for Gaia v0.5."""
+"""Mendel-style probability example for Gaia v0.5.
+
+Architecture
+------------
+
+Two theories compete for the same single-factor cross:
+
+* ``mendelian_segregation_model`` — discrete particulate inheritance with a
+  clean ``P(dominant) = 3/4`` generative model for F2 counts.
+* ``blending_inheritance_model`` — continuous averaging of parental traits;
+  denies that discrete dominant/recessive classes exist in F2 at all.
+
+These two theories differ in **kind**, and that difference is reflected in
+how they engage with the data:
+
+* Mendel participates **probabilistically**: it is a generative model and
+  therefore engages with the observed F2 count through a single ``associate``
+  that uses the pointwise binomial PMF as its likelihood.
+* Blending participates **categorically**: it denies the very framework in
+  which one would count dominant vs. recessive individuals, so its conflicts
+  with the data are expressed through ``contradict`` edges at the qualitative
+  framework level, not through a binomial likelihood it cannot produce.
+
+Every probability in this package is traceable to two well-defined settings:
+``MENDELIAN_DOMINANT_PROBABILITY = 3/4`` and a uniform prior ``p ~ U[0, 1]``
+as the diffuse alternative (see ``probabilities.py``).
+"""
 
 from gaia.lang import associate, claim, contradict, derive, equal, exclusive, note, observe
 
 from .probabilities import (
     DOMINANT_COUNT,
-    RATIO_TOLERANCE,
     RECESSIVE_COUNT,
-    mendel_data_association_parameters,
+    mendel_count_association_parameters,
 )
 
 
-association_parameters = mendel_data_association_parameters()
+association_parameters = mendel_count_association_parameters()
+
 
 monohybrid_cross_setup = note(
     "单因子杂交实验从两个稳定亲本品系开始：一个亲本稳定表现显性表型，"
@@ -19,8 +45,10 @@ monohybrid_cross_setup = note(
 
 dominance_background = note("在该性状上，显性遗传因子会在表型上遮蔽隐性遗传因子。")
 
-binomial_sampling_model = note(
-    "F2 的显性/隐性计数被视为有限样本；因此观测比例只需要落在理论比例附近，不需要严格等于理论比例。"
+finite_sample_background = note(
+    "F2 的显性/隐性计数是有限样本，因此用点似然（二项 PMF 在观测计数处的取值）"
+    "衡量模型与数据的贴合度；对手理论取 p ~ Uniform[0,1] 的 diffuse 先验作为"
+    "参考尺度，不引入任何具体的替代二项参数。"
 )
 
 mendelian_segregation_model = claim(
@@ -29,7 +57,8 @@ mendelian_segregation_model = claim(
 )
 
 blending_inheritance_model = claim(
-    "混合遗传模型：亲本性状在后代中发生连续混合；一旦混合，原始隐性性状不应以离散类别稳定恢复。"
+    "混合遗传模型：亲本性状在后代中连续平均；一旦平均，离散的显性/隐性类别"
+    "就不应在 F2 中作为可计数的类型存在。"
 )
 
 competing_models = exclusive(
@@ -40,6 +69,10 @@ competing_models = exclusive(
     label="competing_models",
 )
 
+# -----------------------------------------------------------------------------
+# Observations
+# -----------------------------------------------------------------------------
+
 f1_uniform_dominant_observation = observe(
     "纯种显性亲本与纯种隐性亲本杂交后，F1 后代统一表现显性表型。",
     background=[monohybrid_cross_setup],
@@ -47,8 +80,15 @@ f1_uniform_dominant_observation = observe(
     label="f1_uniform_dominant_observation",
 )
 
+f2_has_discrete_classes_observation = observe(
+    "F2 个体可以被清晰地划分为显性和隐性两个离散表型类别，不存在连续中间态。",
+    background=[monohybrid_cross_setup],
+    rationale="这是单因子杂交实验中 F2 代的定性观察：表型呈两类，不是连续分布。",
+    label="f2_has_discrete_classes_observation",
+)
+
 f2_recessive_reappears_observation = observe(
-    "F1 自交得到的 F2 后代中，隐性表型重新出现。",
+    "F1 自交得到的 F2 后代中，原隐性表型作为离散类别重新出现。",
     background=[monohybrid_cross_setup],
     rationale="这是单因子杂交实验中 F2 代的定性观察。",
     label="f2_recessive_reappears_observation",
@@ -56,11 +96,15 @@ f2_recessive_reappears_observation = observe(
 
 f2_count_observation = observe(
     f"F2 计数为 {DOMINANT_COUNT} 个显性表型和 {RECESSIVE_COUNT} 个隐性表型，"
-    "显性与隐性的比例约为 2.95:1。",
-    background=[monohybrid_cross_setup, binomial_sampling_model],
-    rationale="这是用于统计比较的 F2 显性/隐性计数数据。",
+    f"共 {DOMINANT_COUNT + RECESSIVE_COUNT} 个个体。",
+    background=[monohybrid_cross_setup, f2_has_discrete_classes_observation],
+    rationale="这是用于贝叶斯点似然比较的 F2 显性/隐性计数数据。",
     label="f2_count_observation",
 )
+
+# -----------------------------------------------------------------------------
+# Mendel: qualitative predictions matching the qualitative observations
+# -----------------------------------------------------------------------------
 
 mendel_predicts_f1_dominance = derive(
     "如果孟德尔分离模型成立，纯种显性亲本与纯种隐性亲本杂交后，"
@@ -77,6 +121,24 @@ f1_mendel_match = equal(
     background=[monohybrid_cross_setup],
     rationale="孟德尔模型对 F1 统一显性的预测与观察相符。",
     label="f1_mendel_match",
+)
+
+mendel_predicts_discrete_classes = derive(
+    "孟德尔分离模型下 F2 的基因型组合为 AA:Aa:aa = 1:2:1，"
+    "显性因子遮蔽效应把这三个基因型映射到显性和隐性两个离散表型类别，"
+    "因此 F2 应呈现清晰的两类离散表型而非连续谱。",
+    given=mendelian_segregation_model,
+    background=[monohybrid_cross_setup, dominance_background],
+    rationale="离散因子 + 遮蔽 → 两个离散表型类别。",
+    label="mendel_predicts_discrete_classes",
+)
+
+f2_discrete_classes_mendel_match = equal(
+    mendel_predicts_discrete_classes,
+    f2_has_discrete_classes_observation,
+    background=[monohybrid_cross_setup],
+    rationale="孟德尔模型预言的两类离散表型与观察到的 F2 两类表型一致。",
+    label="f2_discrete_classes_mendel_match",
 )
 
 mendel_predicts_recessive_reappearance = derive(
@@ -98,42 +160,64 @@ f2_reappearance_mendel_match = equal(
 
 mendel_predicts_three_to_one_ratio = derive(
     "如果 F1 个体自交，成对因子分离会给出 AA:Aa:aa = 1:2:1 的基因型比例；"
-    "由于 AA 和 Aa 都表现显性，F2 表型比例应接近显性:隐性 = 3:1。",
+    "由于 AA 和 Aa 都表现显性，F2 显性/隐性计数应服从 Binomial(N, 3/4)，"
+    "期望表型比约为 3:1。",
     given=mendelian_segregation_model,
-    background=[monohybrid_cross_setup, dominance_background],
-    rationale="F1 的两个配子类型等概率结合，产生 1:2:1 的基因型比例。",
+    background=[monohybrid_cross_setup, dominance_background, finite_sample_background],
+    rationale="F1 配子等概率结合，给出 1:2:1 的基因型分布，即每个 F2 个体"
+    "独立以概率 3/4 表现为显性。",
     label="mendel_predicts_three_to_one_ratio",
 )
 
-f2_ratio_near_three_to_one = derive(
-    f"观测到的 F2 比例 2.95:1 落在 3:1 附近 ±{RATIO_TOLERANCE} 的统计窗口内。",
+# -----------------------------------------------------------------------------
+# A single derived data event carrying the specific count for the probabilistic
+# comparison. This is deliberately *not* a tolerance window around the observed
+# ratio; it is just the specific observed value, reified as a proposition that
+# the ``associate`` strategy can target without clashing with the observation's
+# own reliability prior.
+# -----------------------------------------------------------------------------
+
+f2_dominant_count_specific = derive(
+    f"F2 显性表型计数的具体数值为 {DOMINANT_COUNT} / {DOMINANT_COUNT + RECESSIVE_COUNT}。",
     given=f2_count_observation,
-    background=[binomial_sampling_model],
-    rationale="该结论由显性/隐性计数直接计算得到，是后续统计相容性比较的数据事件。",
-    label="f2_ratio_near_three_to_one",
+    background=[monohybrid_cross_setup, finite_sample_background],
+    rationale="把定性观测中的具体计数提取为一个命题，作为 Mendel 与数据进行"
+    "概率比较时使用的数据事件。",
+    label="f2_dominant_count_specific",
 )
 
-mendel_data_association = associate(
+# -----------------------------------------------------------------------------
+# Mendel: the one quantitative link — associate(model, count) via pointwise PMF
+# -----------------------------------------------------------------------------
+
+mendel_count_association = associate(
     mendelian_segregation_model,
-    f2_ratio_near_three_to_one,
-    background=[monohybrid_cross_setup, binomial_sampling_model],
-    p_a_given_b=association_parameters.p_mendelian_given_ratio,
-    p_b_given_a=association_parameters.p_ratio_given_mendelian,
+    f2_dominant_count_specific,
+    background=[monohybrid_cross_setup, finite_sample_background],
+    p_a_given_b=association_parameters.p_mendelian_given_count,
+    p_b_given_a=association_parameters.p_count_given_mendelian,
     prior_a=association_parameters.prior_mendelian,
-    prior_b=association_parameters.prior_ratio,
+    prior_b=association_parameters.prior_count,
     rationale=(
-        "2.95:1 的 F2 比例事件在孟德尔 3:1 模型下的二项窗口概率显著高于"
-        "混合遗传替代模型；这里的 associate 参数由 probabilities.py 计算得到。"
+        "用在观测计数处的点似然 Binomial(N, 3/4).pmf(295) 作为 p(count | Mendel)；"
+        "对照项用 p ~ Uniform[0, 1] 的 diffuse 先验，其任意单点计数的边际概率"
+        "为解析解 1 / (N + 1)。这样所有参数都来自两个明确的假设，"
+        "既没有 tolerance 窗口，也没有人为指定的替代二项参数。"
     ),
-    label="mendel_data_association",
+    label="mendel_count_association",
 )
-mendel_data_association.label = "mendel_data_association"
+
+# -----------------------------------------------------------------------------
+# Blending: three qualitative predictions, each clashing with a qualitative
+# observation via contradict. Blending does NOT participate in associate, by
+# design: it is not a generative model for the dominant/recessive count.
+# -----------------------------------------------------------------------------
 
 blending_predicts_intermediate_f1 = derive(
     "如果混合遗传模型成立，F1 后代应倾向于中间或混合表型，而不是统一表现某一亲本表型。",
     given=blending_inheritance_model,
     background=[monohybrid_cross_setup],
-    rationale="连续混合模型把亲本性状视为在后代中混合。",
+    rationale="连续平均模型把亲本性状视为在后代中均化。",
     label="blending_predicts_intermediate_f1",
 )
 
@@ -145,56 +229,63 @@ f1_blending_conflict = contradict(
     label="f1_blending_conflict",
 )
 
-blending_predicts_no_discrete_reappearance = derive(
-    "如果亲本性状在 F1 中连续混合，原始隐性表型不应在 F2 中作为离散类别稳定恢复。",
+blending_predicts_f2_continuous = derive(
+    "如果亲本性状在 F1 中连续平均，F2 应形成单峰连续分布，"
+    "不能被划分为清晰的显性/隐性两个离散类别。",
+    given=blending_inheritance_model,
+    background=[monohybrid_cross_setup],
+    rationale="连续平均不保留可重新组合的离散遗传单位，因此不给出离散的表型分类。",
+    label="blending_predicts_f2_continuous",
+)
+
+f2_discrete_classes_blending_conflict = contradict(
+    blending_predicts_f2_continuous,
+    f2_has_discrete_classes_observation,
+    background=[monohybrid_cross_setup],
+    rationale="F2 明确划分为两类离散表型，与混合模型的连续分布预测相冲突——"
+    "这是 framework 级别的冲突：blending 否认的是 F2 可被分类这件事本身。",
+    label="f2_discrete_classes_blending_conflict",
+)
+
+blending_predicts_no_recessive_reappearance = derive(
+    "连续平均的性状不保留可以重新组合的离散遗传单位，"
+    "因此原隐性表型不应作为离散类别在 F2 中重新出现。",
     given=blending_inheritance_model,
     background=[monohybrid_cross_setup],
     rationale="混合模型没有保留可重新组合的离散隐性因子。",
-    label="blending_predicts_no_discrete_reappearance",
+    label="blending_predicts_no_recessive_reappearance",
 )
 
 f2_reappearance_blending_conflict = contradict(
-    blending_predicts_no_discrete_reappearance,
+    blending_predicts_no_recessive_reappearance,
     f2_recessive_reappears_observation,
     background=[monohybrid_cross_setup],
-    rationale="F2 隐性表型重新出现与混合模型的预测相冲突。",
+    rationale="F2 隐性表型作为离散类别重新出现，与混合模型的预测相冲突。",
     label="f2_reappearance_blending_conflict",
 )
 
-blending_predicts_no_stable_three_to_one = derive(
-    "混合遗传模型不自然预测 F2 显性/隐性表型会稳定落在 3:1 附近。",
-    given=blending_inheritance_model,
-    background=[monohybrid_cross_setup, binomial_sampling_model],
-    rationale="连续混合模型不是离散 1:2:1 基因型分离模型，因此不直接给出 3:1 表型比例。",
-    label="blending_predicts_no_stable_three_to_one",
-)
-
-ratio_blending_conflict = contradict(
-    blending_predicts_no_stable_three_to_one,
-    f2_ratio_near_three_to_one,
-    background=[binomial_sampling_model],
-    rationale="F2 比例落在 3:1 附近，与混合模型不预测稳定 3:1 的说法相冲突。",
-    label="ratio_blending_conflict",
-)
 
 __all__ = [
     "mendelian_segregation_model",
     "blending_inheritance_model",
     "competing_models",
     "f1_uniform_dominant_observation",
+    "f2_has_discrete_classes_observation",
     "f2_recessive_reappears_observation",
     "f2_count_observation",
     "mendel_predicts_f1_dominance",
     "f1_mendel_match",
+    "mendel_predicts_discrete_classes",
+    "f2_discrete_classes_mendel_match",
     "mendel_predicts_recessive_reappearance",
     "f2_reappearance_mendel_match",
     "mendel_predicts_three_to_one_ratio",
-    "f2_ratio_near_three_to_one",
-    "mendel_data_association",
+    "f2_dominant_count_specific",
+    "mendel_count_association",
     "blending_predicts_intermediate_f1",
     "f1_blending_conflict",
-    "blending_predicts_no_discrete_reappearance",
+    "blending_predicts_f2_continuous",
+    "f2_discrete_classes_blending_conflict",
+    "blending_predicts_no_recessive_reappearance",
     "f2_reappearance_blending_conflict",
-    "blending_predicts_no_stable_three_to_one",
-    "ratio_blending_conflict",
 ]

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
@@ -24,6 +24,32 @@ how they engage with the data:
 Every probability in this package is traceable to two well-defined settings:
 ``MENDELIAN_DOMINANT_PROBABILITY = 3/4`` and a uniform prior ``p ~ U[0, 1]``
 as the diffuse alternative (see ``probabilities.py``).
+
+Why an intermediate ``f2_dominant_count_specific`` node exists
+--------------------------------------------------------------
+
+Semantically the ``associate`` below should relate ``mendelian_segregation_model``
+directly to ``f2_count_observation``. In v0.5 that triggers a framework-level
+collision: ``metadata.prior`` on a Claim is asked to encode two genuinely
+different quantities at once —
+
+* the **reliability / subjective prior** of the observation (0.95, meaning "I
+  trust Mendel's record"), supplied via the ``PRIORS`` dict;
+* the **Bayesian marginal** ``P(count) = Σ_H P(count | H) P(H)`` of the count
+  event (≈ 0.024 for the 295/395 outcome under the {Mendel, diffuse}
+  mixture), supplied via ``associate(..., prior_b=...)``.
+
+These are two different concepts living on the same field, so the inference
+engine sees them as "conflicting marginal providers" and refuses to compile.
+
+As a workaround this package introduces ``f2_dominant_count_specific`` — a
+plain ``derive`` node that carries only the specific numerical event and is
+**not** entered into ``PRIORS`` — and routes the ``associate`` through it.
+This leaves the observation's ``reliability`` prior untouched on
+``f2_count_observation`` and lets the Bayesian marginal live cleanly on the
+derived node. No other semantic is introduced by this node; it would go away
+once the framework separates the ``reliability`` / ``marginal`` / ``belief``
+roles on a Claim.
 """
 
 from gaia.lang import associate, claim, contradict, derive, equal, exclusive, note, observe
@@ -171,10 +197,16 @@ mendel_predicts_three_to_one_ratio = derive(
 
 # -----------------------------------------------------------------------------
 # A single derived data event carrying the specific count for the probabilistic
-# comparison. This is deliberately *not* a tolerance window around the observed
-# ratio; it is just the specific observed value, reified as a proposition that
-# the ``associate`` strategy can target without clashing with the observation's
-# own reliability prior.
+# comparison. This is deliberately NOT a tolerance window around the observed
+# ratio; it is just the specific observed value, reified as a proposition.
+#
+# The node exists only to carry the Bayesian marginal ``P(count = 295/395)``
+# on a separate Claim from ``f2_count_observation``, which already carries the
+# reliability prior 0.95 via ``PRIORS``. See the module docstring above for
+# the underlying framework issue (``metadata.prior`` doing double duty as both
+# "reliability" and "marginal"). Once the framework separates those two
+# semantics, this intermediate node can be deleted and ``associate`` can
+# target ``f2_count_observation`` directly.
 # -----------------------------------------------------------------------------
 
 f2_dominant_count_specific = derive(
@@ -182,7 +214,9 @@ f2_dominant_count_specific = derive(
     given=f2_count_observation,
     background=[monohybrid_cross_setup, finite_sample_background],
     rationale="把定性观测中的具体计数提取为一个命题，作为 Mendel 与数据进行"
-    "概率比较时使用的数据事件。",
+    "概率比较时使用的数据事件；这里也起到把 Bayes 边际和观测可靠性两个概念"
+    "分开存放在两个不同 Claim 上的作用，规避 v0.5 framework 中 metadata.prior"
+    "的一号多用。",
     label="f2_dominant_count_specific",
 )
 

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
@@ -1,0 +1,200 @@
+"""Mendel-style probability example for Gaia v0.5."""
+
+from gaia.lang import associate, claim, contradict, derive, equal, exclusive, note, observe
+
+from .probabilities import (
+    DOMINANT_COUNT,
+    RATIO_TOLERANCE,
+    RECESSIVE_COUNT,
+    mendel_data_association_parameters,
+)
+
+
+association_parameters = mendel_data_association_parameters()
+
+monohybrid_cross_setup = note(
+    "单因子杂交实验从两个稳定亲本品系开始：一个亲本稳定表现显性表型，"
+    "另一个亲本稳定表现隐性表型；二者杂交得到 F1，再让 F1 自交得到 F2。"
+)
+
+dominance_background = note("在该性状上，显性遗传因子会在表型上遮蔽隐性遗传因子。")
+
+binomial_sampling_model = note(
+    "F2 的显性/隐性计数被视为有限样本；因此观测比例只需要落在理论比例附近，不需要严格等于理论比例。"
+)
+
+mendelian_segregation_model = claim(
+    "孟德尔分离模型：遗传因子是离散的；每个个体对某一性状携带一对因子；"
+    "形成配子时成对因子分离，受精时重新配对；显性因子会遮蔽隐性因子。"
+)
+
+blending_inheritance_model = claim(
+    "混合遗传模型：亲本性状在后代中发生连续混合；一旦混合，原始隐性性状不应以离散类别稳定恢复。"
+)
+
+competing_models = exclusive(
+    mendelian_segregation_model,
+    blending_inheritance_model,
+    background=[monohybrid_cross_setup],
+    rationale="在同一个单因子性状解释上，离散分离模型和连续混合模型是竞争解释。",
+    label="competing_models",
+)
+
+f1_uniform_dominant_observation = observe(
+    "纯种显性亲本与纯种隐性亲本杂交后，F1 后代统一表现显性表型。",
+    background=[monohybrid_cross_setup],
+    rationale="这是单因子杂交实验中 F1 代的定性观察。",
+    label="f1_uniform_dominant_observation",
+)
+
+f2_recessive_reappears_observation = observe(
+    "F1 自交得到的 F2 后代中，隐性表型重新出现。",
+    background=[monohybrid_cross_setup],
+    rationale="这是单因子杂交实验中 F2 代的定性观察。",
+    label="f2_recessive_reappears_observation",
+)
+
+f2_count_observation = observe(
+    f"F2 计数为 {DOMINANT_COUNT} 个显性表型和 {RECESSIVE_COUNT} 个隐性表型，"
+    "显性与隐性的比例约为 2.95:1。",
+    background=[monohybrid_cross_setup, binomial_sampling_model],
+    rationale="这是用于统计比较的 F2 显性/隐性计数数据。",
+    label="f2_count_observation",
+)
+
+mendel_predicts_f1_dominance = derive(
+    "如果孟德尔分离模型成立，纯种显性亲本与纯种隐性亲本杂交后，"
+    "F1 后代都应携带一个显性因子和一个隐性因子，并表现显性表型。",
+    given=mendelian_segregation_model,
+    background=[monohybrid_cross_setup, dominance_background],
+    rationale="显性因子在杂合 F1 个体中遮蔽隐性因子。",
+    label="mendel_predicts_f1_dominance",
+)
+
+f1_mendel_match = equal(
+    mendel_predicts_f1_dominance,
+    f1_uniform_dominant_observation,
+    background=[monohybrid_cross_setup],
+    rationale="孟德尔模型对 F1 统一显性的预测与观察相符。",
+    label="f1_mendel_match",
+)
+
+mendel_predicts_recessive_reappearance = derive(
+    "如果 F1 个体仍携带被遮蔽的隐性因子，那么 F1 自交后，部分 F2 个体会继承"
+    "两个隐性因子并重新表现隐性表型。",
+    given=mendelian_segregation_model,
+    background=[monohybrid_cross_setup, dominance_background],
+    rationale="分离模型保留了隐性因子，并允许它在 F2 中重新组合为纯合隐性。",
+    label="mendel_predicts_recessive_reappearance",
+)
+
+f2_reappearance_mendel_match = equal(
+    mendel_predicts_recessive_reappearance,
+    f2_recessive_reappears_observation,
+    background=[monohybrid_cross_setup],
+    rationale="孟德尔模型对 F2 隐性重现的预测与观察相符。",
+    label="f2_reappearance_mendel_match",
+)
+
+mendel_predicts_three_to_one_ratio = derive(
+    "如果 F1 个体自交，成对因子分离会给出 AA:Aa:aa = 1:2:1 的基因型比例；"
+    "由于 AA 和 Aa 都表现显性，F2 表型比例应接近显性:隐性 = 3:1。",
+    given=mendelian_segregation_model,
+    background=[monohybrid_cross_setup, dominance_background],
+    rationale="F1 的两个配子类型等概率结合，产生 1:2:1 的基因型比例。",
+    label="mendel_predicts_three_to_one_ratio",
+)
+
+f2_ratio_near_three_to_one = derive(
+    f"观测到的 F2 比例 2.95:1 落在 3:1 附近 ±{RATIO_TOLERANCE} 的统计窗口内。",
+    given=f2_count_observation,
+    background=[binomial_sampling_model],
+    rationale="该结论由显性/隐性计数直接计算得到，是后续统计相容性比较的数据事件。",
+    label="f2_ratio_near_three_to_one",
+)
+
+mendel_data_association = associate(
+    mendelian_segregation_model,
+    f2_ratio_near_three_to_one,
+    background=[monohybrid_cross_setup, binomial_sampling_model],
+    p_a_given_b=association_parameters.p_mendelian_given_ratio,
+    p_b_given_a=association_parameters.p_ratio_given_mendelian,
+    prior_a=association_parameters.prior_mendelian,
+    prior_b=association_parameters.prior_ratio,
+    rationale=(
+        "2.95:1 的 F2 比例事件在孟德尔 3:1 模型下的二项窗口概率显著高于"
+        "混合遗传替代模型；这里的 associate 参数由 probabilities.py 计算得到。"
+    ),
+    label="mendel_data_association",
+)
+mendel_data_association.label = "mendel_data_association"
+
+blending_predicts_intermediate_f1 = derive(
+    "如果混合遗传模型成立，F1 后代应倾向于中间或混合表型，而不是统一表现某一亲本表型。",
+    given=blending_inheritance_model,
+    background=[monohybrid_cross_setup],
+    rationale="连续混合模型把亲本性状视为在后代中混合。",
+    label="blending_predicts_intermediate_f1",
+)
+
+f1_blending_conflict = contradict(
+    blending_predicts_intermediate_f1,
+    f1_uniform_dominant_observation,
+    background=[monohybrid_cross_setup],
+    rationale="F1 统一显性与混合模型的中间表型预测相冲突。",
+    label="f1_blending_conflict",
+)
+
+blending_predicts_no_discrete_reappearance = derive(
+    "如果亲本性状在 F1 中连续混合，原始隐性表型不应在 F2 中作为离散类别稳定恢复。",
+    given=blending_inheritance_model,
+    background=[monohybrid_cross_setup],
+    rationale="混合模型没有保留可重新组合的离散隐性因子。",
+    label="blending_predicts_no_discrete_reappearance",
+)
+
+f2_reappearance_blending_conflict = contradict(
+    blending_predicts_no_discrete_reappearance,
+    f2_recessive_reappears_observation,
+    background=[monohybrid_cross_setup],
+    rationale="F2 隐性表型重新出现与混合模型的预测相冲突。",
+    label="f2_reappearance_blending_conflict",
+)
+
+blending_predicts_no_stable_three_to_one = derive(
+    "混合遗传模型不自然预测 F2 显性/隐性表型会稳定落在 3:1 附近。",
+    given=blending_inheritance_model,
+    background=[monohybrid_cross_setup, binomial_sampling_model],
+    rationale="连续混合模型不是离散 1:2:1 基因型分离模型，因此不直接给出 3:1 表型比例。",
+    label="blending_predicts_no_stable_three_to_one",
+)
+
+ratio_blending_conflict = contradict(
+    blending_predicts_no_stable_three_to_one,
+    f2_ratio_near_three_to_one,
+    background=[binomial_sampling_model],
+    rationale="F2 比例落在 3:1 附近，与混合模型不预测稳定 3:1 的说法相冲突。",
+    label="ratio_blending_conflict",
+)
+
+__all__ = [
+    "mendelian_segregation_model",
+    "blending_inheritance_model",
+    "competing_models",
+    "f1_uniform_dominant_observation",
+    "f2_recessive_reappears_observation",
+    "f2_count_observation",
+    "mendel_predicts_f1_dominance",
+    "f1_mendel_match",
+    "mendel_predicts_recessive_reappearance",
+    "f2_reappearance_mendel_match",
+    "mendel_predicts_three_to_one_ratio",
+    "f2_ratio_near_three_to_one",
+    "mendel_data_association",
+    "blending_predicts_intermediate_f1",
+    "f1_blending_conflict",
+    "blending_predicts_no_discrete_reappearance",
+    "f2_reappearance_blending_conflict",
+    "blending_predicts_no_stable_three_to_one",
+    "ratio_blending_conflict",
+]

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
@@ -1,0 +1,35 @@
+from mendel_v0_5 import (
+    blending_inheritance_model,
+    f1_uniform_dominant_observation,
+    f2_count_observation,
+    f2_recessive_reappears_observation,
+    mendelian_segregation_model,
+)
+from mendel_v0_5.probabilities import mendel_data_association_parameters
+
+
+association_parameters = mendel_data_association_parameters()
+
+
+PRIORS = {
+    mendelian_segregation_model: (
+        association_parameters.prior_mendelian,
+        "在观察单因子杂交结果之前，让孟德尔分离模型保持中性先验。",
+    ),
+    blending_inheritance_model: (
+        association_parameters.prior_blending,
+        "在观察单因子杂交结果之前，让混合遗传模型保持中性先验。",
+    ),
+    f1_uniform_dominant_observation: (
+        0.95,
+        "把 F1 统一显性作为可靠的实验观察。",
+    ),
+    f2_recessive_reappears_observation: (
+        0.95,
+        "把 F2 隐性表型重新出现作为可靠的实验观察。",
+    ),
+    f2_count_observation: (
+        0.95,
+        "把 F2 显性/隐性计数作为可靠的实验观察。",
+    ),
+}

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
@@ -2,27 +2,29 @@ from mendel_v0_5 import (
     blending_inheritance_model,
     f1_uniform_dominant_observation,
     f2_count_observation,
+    f2_has_discrete_classes_observation,
     f2_recessive_reappears_observation,
     mendelian_segregation_model,
 )
-from mendel_v0_5.probabilities import mendel_data_association_parameters
-
-
-association_parameters = mendel_data_association_parameters()
+from mendel_v0_5.probabilities import PRIOR_MENDELIAN_MODEL
 
 
 PRIORS = {
     mendelian_segregation_model: (
-        association_parameters.prior_mendelian,
+        PRIOR_MENDELIAN_MODEL,
         "在观察单因子杂交结果之前，让孟德尔分离模型保持中性先验。",
     ),
     blending_inheritance_model: (
-        association_parameters.prior_blending,
+        1.0 - PRIOR_MENDELIAN_MODEL,
         "在观察单因子杂交结果之前，让混合遗传模型保持中性先验。",
     ),
     f1_uniform_dominant_observation: (
         0.95,
         "把 F1 统一显性作为可靠的实验观察。",
+    ),
+    f2_has_discrete_classes_observation: (
+        0.95,
+        "把 F2 呈两类离散表型作为可靠的实验观察。",
     ),
     f2_recessive_reappears_observation: (
         0.95,

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py
@@ -1,4 +1,20 @@
-"""Probability calculations for the Mendel v0.5 example package."""
+"""Probability calculations for the Mendel v0.5 example package.
+
+The statistical comparison is between two clearly identified alternatives:
+
+* Mendelian segregation: a point hypothesis with a known dominant probability
+  ``p = 3/4`` under a single-factor cross.
+* A diffuse alternative: the dominant probability ``p`` is unknown and assigned
+  a uniform prior on ``[0, 1]``. Its marginal likelihood for any specific
+  dominant count ``k`` in ``N`` trials has the closed-form value ``1 / (N + 1)``
+  (since ``∫₀¹ C(N, k) p^k (1 - p)^(N - k) dp = 1 / (N + 1)``).
+
+Every number produced by this module is therefore traceable to ``MENDELIAN_P``
+and the uniform-over-``p`` reference measure. There is no tolerance window,
+no post-hoc ratio band, and no strawman binomial with an arbitrary second
+``p``. The likelihood handed to ``associate`` is the pointwise binomial PMF
+evaluated at the observed count.
+"""
 
 from __future__ import annotations
 
@@ -8,91 +24,60 @@ from typing import NamedTuple
 
 DOMINANT_COUNT = 295
 RECESSIVE_COUNT = 100
-RATIO_TOLERANCE = 0.15
+TOTAL_COUNT = DOMINANT_COUNT + RECESSIVE_COUNT
 
 MENDELIAN_DOMINANT_PROBABILITY = 3 / 4
-BLENDING_ALTERNATIVE_DOMINANT_PROBABILITY = 2 / 3
 PRIOR_MENDELIAN_MODEL = 0.5
-PRIOR_BLENDING_MODEL = 0.5
 
 
-class RatioLikelihoods(NamedTuple):
-    p_ratio_given_mendelian: float
-    p_ratio_given_blending: float
-
-
-class MendelDataAssociation(NamedTuple):
-    p_ratio_given_mendelian: float
-    p_ratio_given_blending: float
+class MendelCountAssociation(NamedTuple):
+    p_count_given_mendelian: float
+    p_count_given_diffuse: float
     prior_mendelian: float
-    prior_blending: float
-    prior_ratio: float
-    p_mendelian_given_ratio: float
-    p_blending_given_ratio: float
+    prior_count: float
+    p_mendelian_given_count: float
 
 
-def binomial_ratio_window_likelihood(
-    *,
-    dominant_count: int,
-    recessive_count: int,
-    dominant_probability: float,
-    ratio_tolerance: float,
-) -> float:
-    """Probability of seeing a dominant:recessive ratio near the observed ratio."""
-    total = dominant_count + recessive_count
-    observed_ratio = dominant_count / recessive_count
-    lower = observed_ratio - ratio_tolerance
-    upper = observed_ratio + ratio_tolerance
-
-    probability = 0.0
-    for dominant in range(total + 1):
-        recessive = total - dominant
-        if recessive == 0:
-            continue
-        ratio = dominant / recessive
-        if lower <= ratio <= upper:
-            probability += (
-                comb(total, dominant)
-                * dominant_probability**dominant
-                * (1 - dominant_probability) ** recessive
-            )
-    return probability
+def binomial_pmf(*, n: int, k: int, p: float) -> float:
+    """Pointwise binomial probability ``P(X = k | n, p)``."""
+    return comb(n, k) * p**k * (1 - p) ** (n - k)
 
 
-def mendel_ratio_likelihoods() -> RatioLikelihoods:
-    """Compute likelihoods for the observed 2.95:1 F2 ratio."""
-    return RatioLikelihoods(
-        p_ratio_given_mendelian=binomial_ratio_window_likelihood(
-            dominant_count=DOMINANT_COUNT,
-            recessive_count=RECESSIVE_COUNT,
-            dominant_probability=MENDELIAN_DOMINANT_PROBABILITY,
-            ratio_tolerance=RATIO_TOLERANCE,
-        ),
-        p_ratio_given_blending=binomial_ratio_window_likelihood(
-            dominant_count=DOMINANT_COUNT,
-            recessive_count=RECESSIVE_COUNT,
-            dominant_probability=BLENDING_ALTERNATIVE_DOMINANT_PROBABILITY,
-            ratio_tolerance=RATIO_TOLERANCE,
-        ),
+def diffuse_count_marginal(*, n: int) -> float:
+    """Marginal likelihood of any single count under ``p ~ Uniform[0, 1]``.
+
+    Using ``∫₀¹ C(n, k) p^k (1 - p)^(n - k) dp = 1 / (n + 1)``, this is the
+    probability of observing any specific ``k`` when ``p`` is unknown and
+    uniformly distributed on ``[0, 1]``. It is independent of ``k``.
+    """
+    return 1.0 / (n + 1)
+
+
+def mendel_count_association_parameters() -> MendelCountAssociation:
+    """Compute Bayes-consistent ``associate`` parameters for the Mendel ↔ count relation.
+
+    The posterior is formed by marginalising over the Mendelian point hypothesis
+    and the diffuse alternative:
+
+    ``P(count) = P(M) · P(count | M) + (1 − P(M)) · P(count | diffuse)``
+    """
+    p_count_given_mendelian = binomial_pmf(
+        n=TOTAL_COUNT,
+        k=DOMINANT_COUNT,
+        p=MENDELIAN_DOMINANT_PROBABILITY,
     )
+    p_count_given_diffuse = diffuse_count_marginal(n=TOTAL_COUNT)
 
-
-def mendel_data_association_parameters() -> MendelDataAssociation:
-    """Compute Bayes-consistent associate() parameters for model-data comparison."""
-    likelihoods = mendel_ratio_likelihoods()
-    p_ratio = (
-        PRIOR_MENDELIAN_MODEL * likelihoods.p_ratio_given_mendelian
-        + PRIOR_BLENDING_MODEL * likelihoods.p_ratio_given_blending
+    prior_count = (
+        PRIOR_MENDELIAN_MODEL * p_count_given_mendelian
+        + (1.0 - PRIOR_MENDELIAN_MODEL) * p_count_given_diffuse
     )
-    p_mendel_given_ratio = PRIOR_MENDELIAN_MODEL * likelihoods.p_ratio_given_mendelian / p_ratio
-    p_blending_given_ratio = PRIOR_BLENDING_MODEL * likelihoods.p_ratio_given_blending / p_ratio
+    p_mendelian_given_count = PRIOR_MENDELIAN_MODEL * p_count_given_mendelian / prior_count
 
-    return MendelDataAssociation(
-        p_ratio_given_mendelian=likelihoods.p_ratio_given_mendelian,
-        p_ratio_given_blending=likelihoods.p_ratio_given_blending,
+    return MendelCountAssociation(
+        p_count_given_mendelian=p_count_given_mendelian,
+        p_count_given_diffuse=p_count_given_diffuse,
         prior_mendelian=PRIOR_MENDELIAN_MODEL,
-        prior_blending=PRIOR_BLENDING_MODEL,
-        prior_ratio=p_ratio,
-        p_mendelian_given_ratio=p_mendel_given_ratio,
-        p_blending_given_ratio=p_blending_given_ratio,
+        prior_count=prior_count,
+        p_mendelian_given_count=p_mendelian_given_count,
     )

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py
@@ -1,0 +1,98 @@
+"""Probability calculations for the Mendel v0.5 example package."""
+
+from __future__ import annotations
+
+from math import comb
+from typing import NamedTuple
+
+
+DOMINANT_COUNT = 295
+RECESSIVE_COUNT = 100
+RATIO_TOLERANCE = 0.15
+
+MENDELIAN_DOMINANT_PROBABILITY = 3 / 4
+BLENDING_ALTERNATIVE_DOMINANT_PROBABILITY = 2 / 3
+PRIOR_MENDELIAN_MODEL = 0.5
+PRIOR_BLENDING_MODEL = 0.5
+
+
+class RatioLikelihoods(NamedTuple):
+    p_ratio_given_mendelian: float
+    p_ratio_given_blending: float
+
+
+class MendelDataAssociation(NamedTuple):
+    p_ratio_given_mendelian: float
+    p_ratio_given_blending: float
+    prior_mendelian: float
+    prior_blending: float
+    prior_ratio: float
+    p_mendelian_given_ratio: float
+    p_blending_given_ratio: float
+
+
+def binomial_ratio_window_likelihood(
+    *,
+    dominant_count: int,
+    recessive_count: int,
+    dominant_probability: float,
+    ratio_tolerance: float,
+) -> float:
+    """Probability of seeing a dominant:recessive ratio near the observed ratio."""
+    total = dominant_count + recessive_count
+    observed_ratio = dominant_count / recessive_count
+    lower = observed_ratio - ratio_tolerance
+    upper = observed_ratio + ratio_tolerance
+
+    probability = 0.0
+    for dominant in range(total + 1):
+        recessive = total - dominant
+        if recessive == 0:
+            continue
+        ratio = dominant / recessive
+        if lower <= ratio <= upper:
+            probability += (
+                comb(total, dominant)
+                * dominant_probability**dominant
+                * (1 - dominant_probability) ** recessive
+            )
+    return probability
+
+
+def mendel_ratio_likelihoods() -> RatioLikelihoods:
+    """Compute likelihoods for the observed 2.95:1 F2 ratio."""
+    return RatioLikelihoods(
+        p_ratio_given_mendelian=binomial_ratio_window_likelihood(
+            dominant_count=DOMINANT_COUNT,
+            recessive_count=RECESSIVE_COUNT,
+            dominant_probability=MENDELIAN_DOMINANT_PROBABILITY,
+            ratio_tolerance=RATIO_TOLERANCE,
+        ),
+        p_ratio_given_blending=binomial_ratio_window_likelihood(
+            dominant_count=DOMINANT_COUNT,
+            recessive_count=RECESSIVE_COUNT,
+            dominant_probability=BLENDING_ALTERNATIVE_DOMINANT_PROBABILITY,
+            ratio_tolerance=RATIO_TOLERANCE,
+        ),
+    )
+
+
+def mendel_data_association_parameters() -> MendelDataAssociation:
+    """Compute Bayes-consistent associate() parameters for model-data comparison."""
+    likelihoods = mendel_ratio_likelihoods()
+    p_ratio = (
+        PRIOR_MENDELIAN_MODEL * likelihoods.p_ratio_given_mendelian
+        + PRIOR_BLENDING_MODEL * likelihoods.p_ratio_given_blending
+    )
+    p_mendel_given_ratio = PRIOR_MENDELIAN_MODEL * likelihoods.p_ratio_given_mendelian / p_ratio
+    p_blending_given_ratio = PRIOR_BLENDING_MODEL * likelihoods.p_ratio_given_blending / p_ratio
+
+    return MendelDataAssociation(
+        p_ratio_given_mendelian=likelihoods.p_ratio_given_mendelian,
+        p_ratio_given_blending=likelihoods.p_ratio_given_blending,
+        prior_mendelian=PRIOR_MENDELIAN_MODEL,
+        prior_blending=PRIOR_BLENDING_MODEL,
+        prior_ratio=p_ratio,
+        p_mendelian_given_ratio=p_mendel_given_ratio,
+        p_blending_given_ratio=p_blending_given_ratio,
+    )

--- a/tests/test_mendel_v05_example.py
+++ b/tests/test_mendel_v05_example.py
@@ -1,0 +1,110 @@
+"""Regression tests for the v0.5 Mendel probability example package."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import importlib.util
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+
+runner = CliRunner()
+
+
+def _copy_mendel_example(tmp_path: Path) -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    source = repo_root / "examples" / "mendel-v0-5-gaia"
+    assert source.exists(), "Mendel v0.5 example package is missing"
+    package = tmp_path / "mendel-v0-5-gaia"
+    shutil.copytree(source, package, ignore=shutil.ignore_patterns(".gaia", "__pycache__"))
+    return package
+
+
+def _accept_all_reviews(package: Path) -> None:
+    from gaia.cli._packages import (
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        load_gaia_package,
+    )
+    from gaia.ir import ReviewManifest, ReviewStatus
+
+    loaded = load_gaia_package(package)
+    apply_package_priors(loaded)
+    compiled = compile_loaded_package_artifact(loaded)
+    assert compiled.review is not None
+    accepted = [
+        review.model_copy(update={"status": ReviewStatus.ACCEPTED, "round": 2})
+        for review in compiled.review.reviews
+    ]
+    (package / ".gaia" / "review_manifest.json").write_text(
+        json.dumps(ReviewManifest(reviews=accepted).model_dump(mode="json"), indent=2)
+    )
+
+
+def _beliefs_by_label(package: Path) -> dict[str | None, float]:
+    beliefs = json.loads((package / ".gaia" / "beliefs.json").read_text())
+    return {item["label"]: item["belief"] for item in beliefs["beliefs"]}
+
+
+def _load_probability_module(package: Path):
+    module_path = package / "src" / "mendel_v0_5" / "probabilities.py"
+    spec = importlib.util.spec_from_file_location("mendel_v0_5_probabilities", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Path):
+    package = _copy_mendel_example(tmp_path)
+    probabilities = _load_probability_module(package)
+
+    compile_result = runner.invoke(app, ["compile", str(package)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    association_parameters = probabilities.mendel_data_association_parameters()
+
+    ir = json.loads((package / ".gaia" / "ir.json").read_text())
+    knowledge_by_label = {item["label"]: item for item in ir["knowledges"] if item.get("label")}
+    strategy_types = {item["type"] for item in ir["strategies"]}
+    association = knowledge_by_label["mendel_data_association"]
+
+    assert "infer" not in strategy_types
+    assert "associate" in strategy_types
+    assert "mendelian_segregation_model" in knowledge_by_label
+    assert "blending_inheritance_model" in knowledge_by_label
+    assert "f2_ratio_near_three_to_one" in knowledge_by_label
+    assert association["metadata"]["helper_kind"] == "association"
+    assert association["metadata"]["relation"]["p_a_given_b"] == pytest.approx(
+        association_parameters.p_mendelian_given_ratio
+    )
+    assert association["metadata"]["relation"]["p_b_given_a"] == pytest.approx(
+        association_parameters.p_ratio_given_mendelian
+    )
+    assert association["metadata"]["relation"]["prior_a"] == pytest.approx(
+        association_parameters.prior_mendelian
+    )
+    assert association["metadata"]["relation"]["prior_b"] == pytest.approx(
+        association_parameters.prior_ratio
+    )
+
+    _accept_all_reviews(package)
+
+    infer_result = runner.invoke(app, ["infer", str(package)])
+    assert infer_result.exit_code == 0, infer_result.output
+
+    beliefs = _beliefs_by_label(package)
+
+    assert beliefs["f2_ratio_near_three_to_one"] > association_parameters.prior_ratio
+    assert beliefs["mendelian_segregation_model"] > association_parameters.prior_mendelian
+    assert beliefs["blending_inheritance_model"] < 0.5
+    assert beliefs["mendelian_segregation_model"] == pytest.approx(0.9994315850994945)
+    assert beliefs["blending_inheritance_model"] == pytest.approx(0.00047284967827781446)
+    assert beliefs["f2_count_observation"] == pytest.approx(0.87519129844639)
+    assert beliefs["f2_ratio_near_three_to_one"] == pytest.approx(0.8942732068909091)

--- a/tests/test_mendel_v05_example.py
+++ b/tests/test_mendel_v05_example.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import shutil
-import importlib.util
 from pathlib import Path
 
 import pytest
@@ -68,30 +68,67 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     compile_result = runner.invoke(app, ["compile", str(package)])
     assert compile_result.exit_code == 0, compile_result.output
 
-    association_parameters = probabilities.mendel_data_association_parameters()
+    association_parameters = probabilities.mendel_count_association_parameters()
 
     ir = json.loads((package / ".gaia" / "ir.json").read_text())
     knowledge_by_label = {item["label"]: item for item in ir["knowledges"] if item.get("label")}
     strategy_types = {item["type"] for item in ir["strategies"]}
-    association = knowledge_by_label["mendel_data_association"]
+    association = knowledge_by_label["mendel_count_association"]
 
+    # The package uses a single associate (Mendel ↔ count) and three qualitative
+    # contradict edges against blending. It declares no `infer` strategy of its own.
     assert "infer" not in strategy_types
     assert "associate" in strategy_types
-    assert "mendelian_segregation_model" in knowledge_by_label
-    assert "blending_inheritance_model" in knowledge_by_label
-    assert "f2_ratio_near_three_to_one" in knowledge_by_label
+
+    # Core claims and observations are present.
+    for label in (
+        "mendelian_segregation_model",
+        "blending_inheritance_model",
+        "f1_uniform_dominant_observation",
+        "f2_has_discrete_classes_observation",
+        "f2_recessive_reappears_observation",
+        "f2_count_observation",
+        "mendel_predicts_f1_dominance",
+        "mendel_predicts_discrete_classes",
+        "mendel_predicts_recessive_reappearance",
+        "mendel_predicts_three_to_one_ratio",
+        "f2_dominant_count_specific",
+        "f1_mendel_match",
+        "f2_discrete_classes_mendel_match",
+        "f2_reappearance_mendel_match",
+        "blending_predicts_intermediate_f1",
+        "blending_predicts_f2_continuous",
+        "blending_predicts_no_recessive_reappearance",
+        "f1_blending_conflict",
+        "f2_discrete_classes_blending_conflict",
+        "f2_reappearance_blending_conflict",
+    ):
+        assert label in knowledge_by_label, f"missing knowledge {label}"
+
+    # The Mendel↔count associate uses the pointwise binomial PMF on one side and
+    # the Bayes-consistent posterior on the other. All four numbers are fully
+    # determined by ``MENDELIAN_DOMINANT_PROBABILITY`` and a uniform prior on p.
     assert association["metadata"]["helper_kind"] == "association"
     assert association["metadata"]["relation"]["p_a_given_b"] == pytest.approx(
-        association_parameters.p_mendelian_given_ratio
+        association_parameters.p_mendelian_given_count
     )
     assert association["metadata"]["relation"]["p_b_given_a"] == pytest.approx(
-        association_parameters.p_ratio_given_mendelian
+        association_parameters.p_count_given_mendelian
     )
     assert association["metadata"]["relation"]["prior_a"] == pytest.approx(
         association_parameters.prior_mendelian
     )
     assert association["metadata"]["relation"]["prior_b"] == pytest.approx(
-        association_parameters.prior_ratio
+        association_parameters.prior_count
+    )
+
+    # The diffuse alternative has the closed-form marginal 1/(N+1).
+    assert association_parameters.p_count_given_diffuse == pytest.approx(1.0 / (295 + 100 + 1))
+    # Sanity-check direction: a point likelihood peaked near the Mendelian mode
+    # must beat a Uniform(p) reference measure at the same count.
+    assert (
+        association_parameters.p_count_given_mendelian
+        > association_parameters.p_count_given_diffuse
     )
 
     _accept_all_reviews(package)
@@ -101,10 +138,13 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
 
     beliefs = _beliefs_by_label(package)
 
-    assert beliefs["f2_ratio_near_three_to_one"] > association_parameters.prior_ratio
+    # Directional belief checks: Mendel should rise above its prior and dominate
+    # blending. We avoid hard-coded posterior values to stay robust to future
+    # changes in the inference engine's numerical details.
     assert beliefs["mendelian_segregation_model"] > association_parameters.prior_mendelian
-    assert beliefs["blending_inheritance_model"] < 0.5
-    assert beliefs["mendelian_segregation_model"] == pytest.approx(0.9994315850994945)
-    assert beliefs["blending_inheritance_model"] == pytest.approx(0.00047284967827781446)
-    assert beliefs["f2_count_observation"] == pytest.approx(0.87519129844639)
-    assert beliefs["f2_ratio_near_three_to_one"] == pytest.approx(0.8942732068909091)
+    assert beliefs["mendelian_segregation_model"] > 0.8
+    assert beliefs["blending_inheritance_model"] < 0.2
+    assert beliefs["mendelian_segregation_model"] > beliefs["blending_inheritance_model"]
+    # The count observation's belief is driven upward by the associate and by
+    # the prior we placed on it.
+    assert beliefs["f2_count_observation"] > association_parameters.prior_count


### PR DESCRIPTION
## Summary

- Add a v0.5 Mendel example package with two competing theories: Mendelian segregation and blending inheritance.
- Compute model-data likelihoods from the observed 295:100 F2 count in Python instead of hand-writing probabilities.
- Use `derive`/`equal`/`contradict`/`exclusive` for qualitative reasoning and `associate` for the statistical model-data comparison.
- Add an end-to-end regression test that compiles the package, accepts reviews, runs inference, and fixes the resulting belief behavior.

## Validation

- `python -m ruff check tests/test_mendel_v05_example.py examples/mendel-v0-5-gaia/src/mendel_v0_5`
- `python -m ruff format --check tests/test_mendel_v05_example.py examples/mendel-v0-5-gaia/src/mendel_v0_5`
- `git diff --check`
- `python -m pytest tests/test_mendel_v05_example.py tests/test_galileo_v05_example.py tests/cli/test_infer.py tests/gaia/lang/test_compiler_actions.py tests/gaia/lang/test_composition.py -q`
- `python -m pytest -q`
