### PR TITLE
Design spec: Correlate family — evidence() verb + given gates + marginal_* rename

### DIFF
--- a/docs/specs/2026-04-25-evidence-factor-design.md
+++ b/docs/specs/2026-04-25-evidence-factor-design.md
@@ -1,0 +1,619 @@
+# Evidence Factor — Design Spec
+
+> **Status:** Target design
+> **Date:** 2026-04-25
+> **Scope:** A new `evidence()` DSL verb, a new `EvidenceFactor` Action IR entity, a small initial library of pluggable `LikelihoodModel` classes, and the BP lowering that ties these together with Claim priors and methodological-assumption gates.
+> **Relationship to other docs:**
+> - Subsumes the narrow `associate.prior_* ↔ PRIORS` field-collision fix tracked in **issue #485** by making the `prior_*` kwargs unnecessary rather than renaming them.
+> - Implements a v0.5-compatible subset of the `EvidenceFactor` direction proposed in **issue #448**; defers the full "remove probabilistic warrant" rework.
+> - Extends (does not replace) the `gaia.evidence` canonical template direction discussed in `2026-04-24-gaia-composition-primitive-design.md` §1.3 / §11.4 — `evidence()` plays the same role in the Correlate family that `compute()` plays in the Support family.
+
+---
+
+## 0. Motivation
+
+### 0.1 The concrete failure
+
+The v0.5 Mendel example (PR #482) reaches a hard collision in the inference engine:
+
+```
+ValueError: associate strategy lcs_...: conflicting marginal providers for
+'...:f2_count_observation': metadata.prior=0.95, associate prior=0.024
+```
+
+The two numbers are not conflicting estimates of the same quantity:
+
+| 0.95 | 0.024 |
+|---|---|
+| `P(R = 1)` — marginal that the reporter (Mendel) recorded the count accurately | `P(O = 1 \| R = 1) = Σ_M P(O=1 \| M) P(M)` — marginal of the specific count event under the hypothesis mixture, conditional on an accurate report |
+
+Both are legitimate marginals of the same underlying joint `P(M, R, O)` — but along **different axes**. Gaia v0.5 currently has a single `metadata.prior` slot per Claim that is asked to carry both, so when a package supplies them from two different authoring sites (`PRIORS` dict and `associate(..., prior_b=...)`), the inference engine sees them as an inconsistency and refuses to compile.
+
+### 0.2 Why `associate` / `infer` can't solve this cleanly
+
+`associate` and `infer` pass a small number of opaque scalars (`p_e_given_h`, `p_e_given_not_h`, `prior_a`, `prior_b`) through to the IR. These scalars are computed by the user outside the framework (see `examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py` for a typical case). The framework has no view into the underlying statistical model, so it cannot:
+
+1. Introspect the likelihood family (e.g., "this is Binomial(N, 3/4)") for review tooling or sensitivity analysis.
+2. Consume structured data off the observation Claim (e.g., `metadata.dominant = 295`) — the Claim content is natural-language text and the scalar has to be pre-computed externally.
+3. Treat methodological assumptions (independence, measurement validity, stopping rules) as first-class Claims that gate the factor's strength.
+4. Compose multiple independent observations of the same hypothesis without duplicating user arithmetic.
+5. Swap the alternative hypothesis (e.g., diffuse prior vs. coin-flip null vs. specific alternative) without rewriting every scalar.
+
+### 0.3 What this spec changes
+
+Introduces **one new DSL verb**, **one new Action subclass**, and **a small `LikelihoodModel` protocol** with a starter library. The existing `infer()` and `associate()` verbs are retained as thin shorthands over the new verb and remain source-compatible.
+
+---
+
+## 1. DSL surface: `evidence()`
+
+### 1.1 Signature
+
+```python
+def evidence(
+    conclusion: Claim | list[Claim],
+    *,
+    data: Claim | list[Claim],
+    model: LikelihoodModel,
+    assumptions: list[Claim] | None = None,
+    query: str | dict | None = None,
+    background: list[Knowledge] | None = None,
+    rationale: str = "",
+    label: str | None = None,
+) -> Claim:
+    """Statistical evidence: an observation Claim updates one or more hypothesis
+    Claims through a pluggable likelihood model. Returns a generated helper Claim
+    with ``metadata.helper_kind = "evidence"``.
+    """
+```
+
+### 1.2 Parameters
+
+| Name | Type | Meaning |
+|---|---|---|
+| `conclusion` | `Claim \| list[Claim]` | The hypothesis (or hypotheses, for model comparison) whose belief is updated by the evidence. Must already exist as a `Claim` before the call. |
+| `data` | `Claim \| list[Claim]` | The observation Claim(s). Each must have `metadata` fields matching what `model` expects (see §3.2). `prior` on `data` retains its reliability semantics (§5.1) and is **not** touched by `evidence()`. |
+| `model` | `LikelihoodModel` | A pluggable statistical model. Owns the likelihood computation for H and for the alternative, plus the mapping from `data.metadata` → model inputs. See §3. |
+| `assumptions` | `list[Claim] \| None` | Validity gates. Claims whose posterior belief multiplicatively scales the evidence factor's strength (§5.2). If any gate's posterior approaches 0, the factor loses force; if all are near 1, the factor operates at full strength. |
+| `query` | `str \| dict \| None` | An optional structured description of what quantity the user cares about (e.g., `"theta_B > theta_A"`). Consumed by `model.factor_potential` for parametric queries; stored on the helper Claim's metadata for review tooling. |
+| `background` | `list[Knowledge] \| None` | Contextual notes, as with other Actions. Non-probabilistic. |
+| `rationale`, `label` | `str`, `str \| None` | Standard Action metadata. |
+
+### 1.3 Return value
+
+Following the Correlate-family convention established by `infer()` and `associate()` in v0.5 (`helper_kind = "likelihood"` / `"association"`), `evidence()` returns a **generated helper Claim** with:
+
+```python
+helper.metadata = {
+    "generated": True,
+    "helper_kind": "evidence",
+    "review": True,
+    "model_class": model.__class__.__name__,
+    "model_params": model.serialise_params(),
+    "query": query,
+    "relation": {
+        "type": "evidence",
+        "conclusion": conclusion,
+        "data": data,
+        "assumptions": assumptions or [],
+    },
+}
+```
+
+The helper is attached to each target Claim's `supports` list (one helper per target, sharing identity via `_structure_hash` of the evidence factor — see §2.3).
+
+### 1.4 Invariants
+
+- `evidence()` **never writes `claim.prior`** on any input Claim. All inference output flows through the BP lowering into posteriors (`claim.belief`).
+- `evidence()` **does not accept `prior_*` kwargs**. The Bayesian marginal that was exposed as `prior_b` in `associate()` is now computed inside `model.factor_potential` and stored transiently in the BP factor, never on a Claim.
+- `assumptions` entries must be `Claim` objects (they must have a `prior` themselves so they can gate the factor). `background` is for non-probabilistic `Knowledge` (typically `Note`).
+
+---
+
+## 2. IR layer: `EvidenceFactor` Action
+
+### 2.1 Class hierarchy placement
+
+```python
+# gaia/lang/runtime/action.py
+@dataclass
+class Correlate(Action):
+    """Probabilistic soft constraint between Claims."""
+    helper: Claim | None = None
+
+@dataclass
+class Infer(Correlate): ...       # unchanged
+@dataclass
+class Associate(Correlate): ...   # unchanged
+
+# NEW:
+@dataclass
+class EvidenceFactor(Correlate):
+    """Statistical evidence via pluggable likelihood model."""
+    conclusion: tuple[Claim, ...] = ()
+    data: tuple[Claim, ...] = ()
+    assumptions: tuple[Claim, ...] = ()
+    model: LikelihoodModel | None = None
+    query: str | dict | None = None
+```
+
+### 2.2 Compiled IR strategy
+
+`EvidenceFactor` compiles to a new IR strategy type:
+
+```python
+IrStrategy(
+    scope="local",
+    type="evidence",
+    premises=[knowledge_map[id(c)] for c in action.conclusion],
+    conclusion=knowledge_map[id(action.helper)],
+    background=[...],
+    metadata={
+        "model_class": action.model.__class__.__name__,
+        "model_params": action.model.serialise_params(),
+        "query": action.query,
+        "data_refs": [knowledge_map[id(d)] for d in action.data],
+        "assumption_refs": [knowledge_map[id(a)] for a in action.assumptions],
+        "factor_potential": action.model.compile_potential(
+            data=[d.metadata for d in action.data],
+            query=action.query,
+        ),  # serialised numeric form; see §3.3
+    },
+)
+```
+
+Note that individual scalar likelihoods are **not** stored at the IR top level (as `p_a_given_b`, `prior_a`, etc. are for `associate`). Instead the numerical content is encapsulated in `metadata.factor_potential`, a model-specific serialised form (e.g. a tuple `(log_lik_h, log_lik_not_h)` for two-hypothesis cases, or a general table for K hypotheses — see §3.3).
+
+### 2.3 Identity / structure hash
+
+Following v0.5 precedent:
+
+```python
+structure_hash = SHA-256(canonical_json({
+    "type": "evidence",
+    "conclusion": sorted([c.claim_id for c in conclusion]),
+    "data": sorted([d.claim_id for d in data]),
+    "assumptions": sorted([a.claim_id for a in assumptions]),
+    "model_class": model.__class__.__name__,
+    "model_params": model.serialise_params(),
+    "query": query,
+}))
+```
+
+Two `evidence()` calls with the same model, same data, same gates, and same query deduplicate to the same helper Claim and the same IR strategy.
+
+---
+
+## 3. Model protocol: `LikelihoodModel`
+
+### 3.1 Abstract base
+
+```python
+# gaia/lang/runtime/likelihood.py (new module)
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+class LikelihoodModel(ABC):
+    """A pluggable statistical model consumed by ``evidence()``."""
+
+    @abstractmethod
+    def expected_fields(self) -> list[str]:
+        """Names of ``data.metadata`` keys this model reads."""
+
+    @abstractmethod
+    def log_likelihood(
+        self,
+        *,
+        hypothesis_index: int,          # 0-based index into conclusion tuple
+        data_values: list[dict],        # one dict per ``data`` Claim
+        query: str | dict | None,
+    ) -> float:
+        """Log P(data | hypothesis_index, query)."""
+
+    def log_likelihood_alternative(
+        self,
+        *,
+        data_values: list[dict],
+        query: str | dict | None,
+    ) -> float | None:
+        """Log of the alternative / baseline likelihood, for two-hypothesis models.
+        Returning ``None`` means 'no built-in alternative'; the BP engine will then
+        need multiple entries in ``conclusion`` to form the Bayes factor."""
+        return None
+
+    def compile_potential(
+        self,
+        *,
+        data: list[dict],
+        query: str | dict | None,
+    ) -> dict[str, Any]:
+        """Return a serialisable summary of the factor potential sufficient for
+        BP lowering. Default: ``{"log_lik_h": ..., "log_lik_not_h": ...}`` for the
+        binary case. Override for K-ary models."""
+        ...
+
+    def serialise_params(self) -> dict[str, Any]:
+        """Emit a JSON-serialisable view of the model's own constructor parameters
+        for IR storage. Default: shallow ``__dict__``."""
+        return {k: v for k, v in vars(self).items() if not k.startswith("_")}
+```
+
+### 3.2 Contract with `data.metadata`
+
+For each `data` Claim in an `evidence()` call, the framework:
+
+1. Reads `model.expected_fields()`.
+2. Looks up each expected field on `data.metadata`.
+3. Builds a single `dict` of that Claim's inputs.
+4. Passes the list of these dicts as `data_values`.
+
+A compile-time check raises a clear error if a required field is missing:
+
+```
+EvidenceModelContractError: BinomialAgainstDiffusePrior expects fields
+['dominant', 'total'] on data Claim 'f2_count_observation' but only
+['dominant'] is present.
+```
+
+### 3.3 Factor potential encoding
+
+For the two-hypothesis case (one conclusion Claim, a built-in alternative), the potential is stored as:
+
+```python
+{
+    "kind": "binary_bayes_factor",
+    "log_lik_h": -3.065,          # e.g. log Binomial(395, 3/4).pmf(295)
+    "log_lik_not_h": -5.981,      # e.g. log(1 / (395 + 1))
+    "log_bayes_factor": 2.916,    # redundant but stored for review convenience
+}
+```
+
+For K conclusions without a built-in alternative:
+
+```python
+{
+    "kind": "k_way_likelihood",
+    "log_likelihoods": [-3.065, -7.412, -9.109],  # one per conclusion
+}
+```
+
+Additional `kind` values MAY be added as new model families are introduced; the IR schema treats `metadata.factor_potential` as an open, model-owned record.
+
+---
+
+## 4. Initial model library
+
+The spec commits to shipping the following concrete models in the same PR that lands `evidence()`. Others can follow.
+
+### 4.1 `ScalarBayesFactor`
+
+The degenerate compatibility model. Wraps a pair of scalars exactly as `infer()` does today.
+
+```python
+class ScalarBayesFactor(LikelihoodModel):
+    def __init__(self, *, p_h: float, p_not_h: float): ...
+
+    def expected_fields(self): return []
+    def log_likelihood(self, *, hypothesis_index, data_values, query):
+        return log(self.p_h) if hypothesis_index == 0 else log(self.p_not_h)
+    def log_likelihood_alternative(self, **_): return log(self.p_not_h)
+```
+
+Purpose: makes `infer()` implementable as a shorthand (§6.1) and gives users a migration escape hatch.
+
+### 4.2 `BinomialPointLikelihood`
+
+```python
+class BinomialPointLikelihood(LikelihoodModel):
+    def __init__(self, *, p: float, count_field: str = "dominant", total_field: str = "total"): ...
+```
+
+Returns only the point likelihood under `p`. No built-in alternative; users compose two of these via `PointwiseRatio` (§4.6) if they want an explicit Bayes factor.
+
+### 4.3 `BinomialAgainstDiffusePrior`
+
+```python
+class BinomialAgainstDiffusePrior(LikelihoodModel):
+    def __init__(self, *, p: float, count_field: str = "dominant", total_field: str = "total"): ...
+```
+
+Two hypotheses:
+
+- **H**: `X ~ Binomial(N, p)` with supplied `p`.
+- **¬H**: `X ~ Binomial(N, p')` with `p' ~ Uniform[0, 1]`. Marginal likelihood `1 / (N + 1)`, closed form.
+
+This is the canonical "is this specific Mendelian ratio better than generic binomial chance?" model.
+
+### 4.4 `BinomialVsBinomial`
+
+```python
+class BinomialVsBinomial(LikelihoodModel):
+    def __init__(self, *, p_h: float, p_alt: float, ...): ...
+```
+
+Point-against-point for scenarios where the alternative is a specific binomial (e.g., coin-flip null at `p_alt = 0.5`).
+
+### 4.5 `GaussianMeasurementModel`
+
+```python
+class GaussianMeasurementModel(LikelihoodModel):
+    def __init__(self, *, sigma: float, value_field: str = "value"): ...
+```
+
+`X ~ Normal(mu_h, sigma)` under the hypothesis; alternative is either explicit (another `GaussianMeasurementModel` via `PointwiseRatio`) or a specified broad Gaussian prior on `mu`. Deferred details in §9.
+
+### 4.6 `PointwiseRatio`
+
+```python
+class PointwiseRatio(LikelihoodModel):
+    def __init__(self, *, numerator: LikelihoodModel, denominator: LikelihoodModel): ...
+```
+
+Composes two sub-models into a Bayes-factor model. Used when the user wants H vs. a hand-picked alternative that isn't the diffuse default.
+
+### 4.7 (Future) `TwoBinomialModel`, `PoissonPointLikelihood`, `IndependentBinomialBatch`
+
+Listed here for scoping — not part of the landing PR. `IndependentBinomialBatch` would take a list of `data` entries and multiply likelihoods, enabling the Mendel-with-seven-traits scenario.
+
+---
+
+## 5. BP lowering
+
+### 5.1 Claim prior remains reliability
+
+`claim.prior` (the value written by `PRIORS` or defaulted on `Claim(... prior=0.5)`) is treated **unambiguously as reliability / subjective prior**. It is the marginal P(claim is true) under the user's "report-accuracy" axis and is independent of any statistical likelihood.
+
+`evidence()` never writes `claim.prior`. The inference engine reads `claim.prior` as the initial belief state for BP, as it always has.
+
+### 5.2 Factor potential gated by assumptions
+
+Each `EvidenceFactor` contributes a BP factor whose potential is the `LikelihoodModel`'s `log_likelihood` output, **scaled by a gating term derived from `assumptions`**:
+
+```text
+log φ_evidence(conclusion | data) =
+    log_likelihood(hypothesis | data) · g(assumptions)
+```
+
+where the gating function `g` is:
+
+```text
+g(assumptions) = ∏_{A ∈ assumptions} claim_belief(A)
+```
+
+evaluated at each BP iteration using the current posterior of each gate Claim. This yields the intuitive behaviour:
+
+- All gates at posterior 1 → factor at full strength (equivalent to `g = 1`).
+- Any gate at posterior 0 → factor contributes 0 log-likelihood (effectively deleted from the graph).
+- Gate posteriors in between scale the factor smoothly.
+
+### 5.3 Composition with hypothesis prior and posterior
+
+For a single-conclusion evidence factor with a binary bayes factor potential, the BP update on `conclusion.belief` is:
+
+```text
+posterior(H)        prior(H)         exp(log_lik_h · g)
+─────────────── = ─────────────── · ──────────────────────
+posterior(¬H)     prior(¬H)         exp(log_lik_not_h · g)
+```
+
+which reduces to standard Bayes when `g = 1`, and becomes a no-op when `g = 0`.
+
+### 5.4 Interaction with `exclusive` and multi-target evidence
+
+If `conclusion = [H1, H2, ...]` and the hypotheses are declared `exclusive(H1, H2, ...)`, BP enforces `Σ belief(H_i) = 1` after each evidence-factor update, giving standard K-way model comparison. If they are not exclusive, the K likelihoods enter independently and each H_i's belief moves only by its own BF against the reference (no cross-normalisation).
+
+---
+
+## 6. Relation to existing verbs
+
+### 6.1 `infer()` becomes a shorthand
+
+```python
+def infer(evidence_claim, *, hypothesis, p_e_given_h, p_e_given_not_h,
+          prior_hypothesis=None, prior_evidence=None, ...):
+    if prior_hypothesis is not None or prior_evidence is not None:
+        warnings.warn(
+            "infer()'s prior_hypothesis / prior_evidence kwargs are deprecated. "
+            "The reliability prior belongs on PRIORS; the Bayes marginal is "
+            "computed inside evidence().model. See #485.",
+            DeprecationWarning,
+        )
+    return evidence(
+        conclusion=hypothesis,
+        data=evidence_claim,
+        model=ScalarBayesFactor(p_h=p_e_given_h, p_not_h=p_e_given_not_h),
+        rationale=rationale,
+        label=label,
+    )
+```
+
+Semantics preserved for existing callers; `prior_*` kwargs accepted but ignored and warned about. The hard `ValueError` on PRIORS conflict is removed entirely because `evidence()` doesn't write `claim.prior`.
+
+### 6.2 `associate()` becomes a shorthand
+
+Analogous to `infer`, `associate(a, b, p_a_given_b, p_b_given_a, prior_a, prior_b)` is rewritten as a symmetric evidence factor:
+
+```python
+evidence(
+    conclusion=[a, b],
+    data=[],  # associate has no separate "data" Claim; both sides are hypotheses
+    model=SymmetricScalarAssociation(p_a_given_b=..., p_b_given_a=...),
+)
+```
+
+(A `SymmetricScalarAssociation` model is added to the starter library for this purpose.) `prior_a` / `prior_b` kwargs accepted with a deprecation warning; they do not participate in the BP factor and do not write to `claim.prior`.
+
+### 6.3 Review manifest
+
+`EvidenceFactor`'s helper Claim gets the same review lifecycle (`unreviewed` → `accepted` / `rejected`) as existing Correlate helpers. No changes to review infrastructure are required.
+
+---
+
+## 7. Worked example: Mendel
+
+### 7.1 Before (current PR #482)
+
+```python
+# probabilities.py — user hand-computes ALL five scalars
+association_parameters = mendel_count_association_parameters()
+
+# __init__.py
+f2_count_observation = observe("F2 counts 295:100 ...")               # PRIORS = 0.95
+
+f2_dominant_count_specific = derive(                                  # workaround node
+    "F2 dominant count = 295 of 395",
+    given=f2_count_observation,
+)
+
+associate(
+    mendelian_segregation_model,
+    f2_dominant_count_specific,
+    p_a_given_b=association_parameters.p_mendelian_given_count,
+    p_b_given_a=association_parameters.p_count_given_mendelian,
+    prior_a=0.5,
+    prior_b=association_parameters.prior_count,
+    rationale="...",
+)
+```
+
+Drawbacks: 5 hand-computed scalars; a workaround `derive` node that exists only to dodge the `metadata.prior` collision; framework has no view into `BinomialModel(p=3/4)`; blending's `2/3` strawman used to previously live in the same `probabilities.py`.
+
+### 7.2 After
+
+```python
+# probabilities.py — DELETED entirely; the model owns the computation
+
+# __init__.py
+f2_count_observation = Claim(                                         # PRIORS = 0.95 (reliability)
+    "F2 counts 295 dominant / 100 recessive",
+    role="observation",
+    metadata={"dominant": 295, "total": 395},
+)
+
+mendelian_segregation_model = Claim(
+    "Mendelian segregation: p(dominant) = 3/4 in F2.",
+    prior=0.5,
+    role="hypothesis",
+)
+
+independent_bernoulli_valid = Claim(
+    "F2 individuals behave as independent Bernoulli trials with shared p.",
+    prior=0.9,
+)
+
+evidence(
+    conclusion=mendelian_segregation_model,
+    data=f2_count_observation,
+    assumptions=[independent_bernoulli_valid],
+    model=BinomialAgainstDiffusePrior(p=3/4),
+    rationale="Mendelian segregation predicts Binomial(N, 3/4); the diffuse "
+              "alternative is p ~ Uniform[0, 1] with marginal 1/(N+1).",
+)
+
+# Blending still participates, but only qualitatively, through contradicts:
+blending_predicts_f2_continuous = derive(...)
+f2_discrete_classes_blending_conflict = contradict(
+    blending_predicts_f2_continuous, f2_has_discrete_classes_observation,
+)
+# etc. — unchanged from PR #482's refactored form.
+```
+
+Gains:
+
+- `probabilities.py` deleted — 100 lines of user-maintained numerical code replaced by `BinomialAgainstDiffusePrior(p=3/4)`.
+- `f2_dominant_count_specific` workaround node deleted — `evidence()` targets the observation directly.
+- No PRIORS collision — `evidence()` doesn't write `claim.prior`.
+- `independent_bernoulli_valid` is now a first-class Claim whose posterior gates the evidence; a reviewer can change its prior to do methodological sensitivity analysis without touching any of the statistical code.
+- Replacing `BinomialAgainstDiffusePrior(p=3/4)` with `BinomialVsBinomial(p_h=3/4, p_alt=1/2)` (the "Mendel vs coin-flip null" variant) is a one-line swap.
+
+---
+
+## 8. Migration plan
+
+### Phase A — Landable in one PR (~1 week scope)
+
+1. Add `LikelihoodModel` protocol and the starter library: `ScalarBayesFactor`, `BinomialPointLikelihood`, `BinomialAgainstDiffusePrior`, `BinomialVsBinomial`, `PointwiseRatio`, `SymmetricScalarAssociation`, `GaussianMeasurementModel`.
+2. Add `EvidenceFactor` Action subclass and its compile rule.
+3. Add `evidence()` DSL verb and export from `gaia.lang`.
+4. Implement BP lowering for `evidence` strategies, including assumption gating (§5.2).
+5. Rewrite `infer()` and `associate()` as shorthands over `evidence()` (§6). Remove the hard `ValueError` on PRIORS conflict.
+6. Add a `test_evidence_verb.py` regression suite covering: basic binary factor, gate scaling, multi-target model comparison, deprecated-kwargs warnings.
+7. Document in `docs/foundations/language/gaia-language-spec.md`.
+
+### Phase B — Example migrations (~1 week scope)
+
+1. Migrate `examples/mendel-v0-5-gaia/` to `evidence() + BinomialAgainstDiffusePrior`. Delete `probabilities.py` and the workaround `derive` node.
+2. Audit `examples/galileo-v0-5-gaia/` — Galileo is currently purely qualitative, so likely unaffected; confirm.
+3. Document the migration in `examples/` README and link from issue #485.
+
+### Phase C — Extended model library (indefinite timeline)
+
+Add `TwoBinomialModel` (AB test), `PoissonPointLikelihood`, `IndependentBinomialBatch` (multi-trait Mendel), `HierarchicalBinomial`. Driven by user demand from real packages.
+
+### Backward compatibility guarantees
+
+- All existing `infer()` and `associate()` calls in v0.5 packages continue to compile and produce the same BP factors.
+- The `prior_hypothesis` / `prior_evidence` / `prior_a` / `prior_b` kwargs are accepted for one release, with a `DeprecationWarning` pointing to `evidence()` and this spec. Removal scheduled for the release after that.
+- `metadata.prior` field on Claims is unchanged.
+
+---
+
+## 9. Open questions
+
+### 9.1 Gating function
+
+§5.2 uses `g = ∏ posterior(assumption_i)` (AND semantics). Alternatives include:
+
+- A "noisy-AND" via the existing `noisy_and` operator, letting users declare failure-independence between gates explicitly.
+- A configurable `gate_semantics` kwarg on `evidence()` for `"and"` vs `"or"` vs `"noisy_and"`.
+
+Default AND is probably right for v0.5; noisy-AND is a plausible follow-up.
+
+### 9.2 Continuous Gaussian alternative
+
+`GaussianMeasurementModel` against a broad-Gaussian alternative on the mean parameter: analytic? Numeric integration? Discretised latent? Needs spec-level decision before landing. Deferring to Phase A.2 implementation choice.
+
+### 9.3 `data` with unreliable reporter
+
+Currently the spec lets `f2_count_observation.prior < 1` act as an authorship reliability. But this is not yet propagated into the evidence factor's potential (only `assumptions` entries are). Two options:
+
+1. Treat the observation Claim itself as an implicit gate: `g_effective = data.prior · ∏ assumptions.posterior`.
+2. Require users to lift reliability into an explicit `Claim("reporter accurate", ...)` and put it into `assumptions`. More verbose but more explicit about what's being modeled.
+
+This spec currently leaves this as author convention — reliability lives on `data.prior` and is consulted by the BP engine as the Claim's marginal for the reliability axis, but the factor doesn't multiplicatively scale by it. Revisit once the Mendel migration is done.
+
+### 9.4 Model identity and deterministic hashing
+
+`serialise_params()` is the basis for structure-hash-level identity (§2.3). Need to commit that JSON-canonicalisation rules are identical to `ComposedAction` (`2026-04-24-gaia-composition-primitive-design.md` §1.2). Likely a shared utility.
+
+### 9.5 Naming bikeshed
+
+- `evidence()` vs `support_statistical()` vs `likelihood()` — we pick `evidence()` to match the verb-as-noun convention of `observe`/`derive`/`compute`/`infer`/`associate` and the `helper_kind = "evidence"` tag.
+- `LikelihoodModel` vs `StatisticalModel` vs `EvidenceModel` — `LikelihoodModel` emphasises the mathematical role (it returns `log P(data | H)`), while `EvidenceModel` would emphasise the DSL role. Mild preference for `LikelihoodModel`; flag for reviewer feedback.
+
+---
+
+## 10. Acceptance criteria
+
+Phase A is complete when:
+
+- [ ] `evidence()` verb exists in `gaia.lang` and is exported from `gaia.lang.__init__`.
+- [ ] `EvidenceFactor` Action subclass exists in `gaia.lang.runtime.action`.
+- [ ] Six starter `LikelihoodModel` classes exist with unit tests verifying their `log_likelihood` math matches hand-computed references to 1e-9 relative.
+- [ ] `test_evidence_verb.py` covers: binary BF, gate scaling, deprecated `infer`/`associate` paths, PRIORS non-conflict.
+- [ ] Mendel example compiles without `probabilities.py`, without `f2_dominant_count_specific`, and produces `P(Mendel | data) > 0.9` and `P(blending | data) < 0.1` (the current directional assertions in `test_mendel_v05_example.py` continue to pass unchanged).
+- [ ] `docs/foundations/language/gaia-language-spec.md` documents `evidence()` at spec level.
+- [ ] Issue #485 can be closed with a reference to the merged PR.
+
+---
+
+## 11. Relation to issue #448
+
+Issue #448 proposes a broader v6 rework that would also remove `Associate` / `Infer` entirely and reshape the `Strategy` IR. This spec:
+
+- **Lands on v0.5** without a v6 rework, by keeping `Associate` / `Infer` as thin shorthands (§6).
+- **Implements #448's core statistical move**: "statistical uncertainty is represented by explicit evidence / likelihood factors" — `EvidenceFactor` + `LikelihoodModel` is exactly that.
+- **Defers #448's other moves**: removing probabilistic warrant entirely, reshaping `Strategy.type` to only `{support, deduction, definition, source_support, computation_support}`, moving Claim roles to metadata. These can follow in a later PR that takes `evidence()` as its starting point.
+
+In other words, this spec is the **minimum viable subset of #448 that resolves the immediate Mendel failure and opens up model-swap / sensitivity / multi-observation capabilities**, without requiring v6's full re-authoring of the language surface.

--- a/docs/specs/2026-04-25-evidence-factor-design.md
+++ b/docs/specs/2026-04-25-evidence-factor-design.md
@@ -1,596 +1,510 @@
-# Evidence Factor — Design Spec
+# Correlate Family — Design Spec
 
-> **Status:** Target design
-> **Date:** 2026-04-25
-> **Scope:** A new `evidence()` DSL verb, a new `EvidenceFactor` Action IR entity, a small initial library of pluggable `LikelihoodModel` classes, and the BP lowering that ties these together with Claim priors and methodological-assumption gates.
+> **Status:** Target design (rev2 of 2026-04-25)
+> **Date:** 2026-04-26 (revised)
+> **Scope:** A v0.5-compatible refactor of the three Correlate-family verbs:
+>   1. **Add** a new `evidence()` verb for structured statistical models (consumes `gaia.stats.DistributionSpec` from PR #487).
+>   2. **Add** a `given` kwarg to `infer()` and `associate()` for methodological-assumption gates (parallel to the `given` kwarg on Support-family verbs).
+>   3. **Rename** `prior_*` kwargs to `marginal_*` to reflect their true Bayesian role — they are the joint-distribution marginals of the local factor, not observation priors.
+>   4. **Remove** `infer.prior_evidence` entirely — it was mathematically redundant: `P(E)` is fully determined by `marginal_h`, `p_e_given_h`, and `p_e_given_not_h` via the law of total probability.
+>
 > **Relationship to other docs:**
-> - Subsumes the narrow `associate.prior_* ↔ PRIORS` field-collision fix tracked in **issue #485** by making the `prior_*` kwargs unnecessary rather than renaming them.
-> - Implements a v0.5-compatible subset of the `EvidenceFactor` direction proposed in **issue #448**; defers the full "remove probabilistic warrant" rework.
-> - Extends (does not replace) the `gaia.evidence` canonical template direction discussed in `2026-04-24-gaia-composition-primitive-design.md` §1.3 / §11.4 — `evidence()` plays the same role in the Correlate family that `compute()` plays in the Support family.
+>   - Resolves the narrow `associate.prior_* ↔ PRIORS` field collision tracked in **issue #485** by routing `marginal_*` to a separate Claim metadata slot and eliminating the naming overload.
+>   - Builds directly on the `DistributionSpec` / `gaia.stats` foundation landed in **PR #487**. The `evidence()` verb's `model=` kwarg is exactly a `DistributionSpec`.
+>   - Implements a v0.5-compatible slice of the statistical-evidence direction proposed in **issue #448**; defers #448's broader "remove probabilistic warrant" rework.
+>
+> **Revision note:** Rev1 (dated 2026-04-25) proposed a single-verb `evidence()` that would replace `infer` and `associate` via a unified `LikelihoodModel` protocol. Review feedback surfaced that (a) `infer` and `associate` exist for genuine LLM-authoring reasons — they capture two distinct cognitive postures on specifying Bayes factors; (b) a single-verb design with mutex kwargs is not Pythonic and is error-prone for both humans and LLMs. Rev2 preserves the three-verb structure, makes the naming semantically correct, and narrows new surface to what #485 and #487 together demand.
 
 ---
 
 ## 0. Motivation
 
-### 0.1 The concrete failure
+### 0.1 The concrete failures
 
-The v0.5 Mendel example (PR #482) reaches a hard collision in the inference engine:
+Two separate issues motivate this spec; both surface on the same PR:
+
+**(a) Field collision between `PRIORS` and `associate.prior_*`.**
+
+PR #482 (the Mendel example) reaches a hard collision at `gaia infer` time:
 
 ```
 ValueError: associate strategy lcs_...: conflicting marginal providers for
 '...:f2_count_observation': metadata.prior=0.95, associate prior=0.024
 ```
 
-The two numbers are not conflicting estimates of the same quantity:
+These two values are not inconsistent estimates of the same quantity — they are *different Bayesian quantities*:
 
 | 0.95 | 0.024 |
 |---|---|
-| `P(R = 1)` — marginal that the reporter (Mendel) recorded the count accurately | `P(O = 1 \| R = 1) = Σ_M P(O=1 \| M) P(M)` — marginal of the specific count event under the hypothesis mixture, conditional on an accurate report |
+| `P(R = 1)` — the **reliability** marginal (the observer / record is reliable), supplied via `PRIORS[observation_claim] = 0.95`. Independent of the observation's numerical content. | `P(O | R = 1) = Σ_M P(O | M) P(M)` — the **Bayesian marginal** of the specific numerical event under the hypothesis mixture, conditional on an accurate record. Supplied via `associate(..., prior_b=0.024)`. |
 
-Both are legitimate marginals of the same underlying joint `P(M, R, O)` — but along **different axes**. Gaia v0.5 currently has a single `metadata.prior` slot per Claim that is asked to carry both, so when a package supplies them from two different authoring sites (`PRIORS` dict and `associate(..., prior_b=...)`), the inference engine sees them as an inconsistency and refuses to compile.
+Both are legitimate marginals of the same underlying joint `P(M, R, O)`, but along **different axes**. v0.5 stores both in `claim.metadata["prior"]`, so a package that supplies both (via `PRIORS` and `associate` in the same file) gets a compile-time rejection.
 
-### 0.2 Why `associate` / `infer` can't solve this cleanly
+**(b) The user-facing kwarg name `prior_*` is the language-level root of the collision.**
 
-`associate` and `infer` pass a small number of opaque scalars (`p_e_given_h`, `p_e_given_not_h`, `prior_a`, `prior_b`) through to the IR. These scalars are computed by the user outside the framework (see `examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py` for a typical case). The framework has no view into the underlying statistical model, so it cannot:
+Even if the field routing were fixed, a `prior_a` / `prior_b` / `prior_hypothesis` / `prior_evidence` kwarg on a Correlate-family verb is **genuinely misleading**: authors read "prior" and understand it as "the claim's subjective prior belief" (matching `PRIORS`), while the kwarg's actual mathematical role is the **joint-distribution marginal** of the local 2×2 factor. Fixing the field collision without fixing the name leaves users confused about why their `PRIORS[claim] = 0.95` is ignored when `associate(claim, ..., prior_a=0.3)` is in scope.
 
-1. Introspect the likelihood family (e.g., "this is Binomial(N, 3/4)") for review tooling or sensitivity analysis.
-2. Consume structured data off the observation Claim (e.g., `metadata.dominant = 295`) — the Claim content is natural-language text and the scalar has to be pre-computed externally.
-3. Treat methodological assumptions (independence, measurement validity, stopping rules) as first-class Claims that gate the factor's strength.
-4. Compose multiple independent observations of the same hypothesis without duplicating user arithmetic.
-5. Swap the alternative hypothesis (e.g., diffuse prior vs. coin-flip null vs. specific alternative) without rewriting every scalar.
+### 0.2 Why `infer` / `associate` can't express methodological gates
 
-### 0.3 What this spec changes
+Neither `infer` nor `associate` has a way to express "this evidence is only valid under methodological assumption A" — e.g., "independent Bernoulli trials," "randomization valid," "instrument calibrated." In v0.5 these typically land in `background=[Note(...)]`, which does not affect BP. A reviewer who doubts the methodology has no structural way to discount the evidence.
 
-Introduces **one new DSL verb**, **one new Action subclass**, and **a small `LikelihoodModel` protocol** with a starter library. The existing `infer()` and `associate()` verbs are retained as thin shorthands over the new verb and remain source-compatible.
+The Support family (`derive` / `observe` / `compute`) already has a `given=` kwarg that carries premises; they participate in BP. We can extend the same convention to the Correlate family.
+
+### 0.3 What `evidence()` adds that `infer` / `associate` genuinely cannot
+
+When a user has a **generative model** (Binomial, Gaussian, Poisson, …) with *structured data parameters*, `infer` and `associate` both require the user to pre-compute `P(E|H)` and `P(E|¬H)` as scalars outside the framework. This is the `examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py` pattern — 80+ lines of user-maintained numerical code for every statistical example.
+
+With PR #487 having landed `gaia.stats.DistributionSpec`, the framework can consume the generative model directly. A new verb `evidence()` makes this the canonical path.
 
 ---
 
-## 1. DSL surface: `evidence()`
+## 1. Design principles
 
-### 1.1 Signature
+From the conversation that produced rev2:
+
+1. **Each verb corresponds to one LLM cognitive posture.** Three verbs, three Pythonic signatures, no mutex kwargs. Authors (human or LLM) choose the verb that matches how they are thinking about the problem:
+   - `evidence` — "I have a generative model; framework compute the likelihood."
+   - `infer` — "Given H vs ¬H, here are the two likelihoods I can estimate."
+   - `associate` — "These two generic propositions have mutual conditionals I can estimate."
+
+2. **Minimum parameter sets.** Each verb requires exactly the numbers mathematically needed to determine the factor potential. Over-specified kwargs (like `infer.prior_evidence`) are removed, not kept for compatibility.
+
+3. **Reuse PR #487 infrastructure.** `evidence.model` is a `DistributionSpec`; no new `LikelihoodModel` protocol is introduced. `gaia.stats.Normal / Binomial / ...` constructors are the model authoring surface.
+
+4. **Backward compatibility for `infer` / `associate`.** Existing packages continue to compile. Renamed kwargs are accepted via deprecated aliases for one release with `DeprecationWarning`. No hard break in v0.5.
+
+5. **The PRIORS collision fix is a framework change, not a signature change.** `marginal_*` values write to `claim.metadata["bayes_marginal"]`, not `claim.metadata["prior"]`, so the collision disappears by construction regardless of which verb wrote them.
+
+---
+
+## 2. The three Correlate verbs
+
+### 2.1 `evidence()` — NEW
+
+**When to use:** the author has an identifiable structured generative model (binomial, Gaussian, Poisson, custom) and the data Claim carries enough structured metadata for the model to evaluate its likelihood.
+
+**Signature:**
 
 ```python
 def evidence(
-    conclusion: Claim | list[Claim],
+    conclusion: Claim,                            # positional
     *,
-    data: Claim | list[Claim],
-    model: LikelihoodModel,
-    assumptions: list[Claim] | None = None,
-    query: str | dict | None = None,
+    data: Claim,
+    model: DistributionSpec,                      # from gaia.stats (PR #487)
+    given: list[Claim] | None = None,             # methodological gates
     background: list[Knowledge] | None = None,
     rationale: str = "",
     label: str | None = None,
-) -> Claim:
-    """Statistical evidence: an observation Claim updates one or more hypothesis
-    Claims through a pluggable likelihood model. Returns a generated helper Claim
-    with ``metadata.helper_kind = "evidence"``.
+) -> Claim:                                       # returns helper Claim
+    """Bayesian evidence update via a structured statistical model.
+
+    The framework computes ``P(data | conclusion)`` and
+    ``P(data | ¬conclusion)`` internally from ``model`` and
+    ``data.metadata``. See §3.2 for gate semantics.
+
+    Returns a generated helper Claim with ``helper_kind="evidence"``.
+    ``conclusion.belief`` is updated via BP, not returned directly.
     """
 ```
 
-### 1.2 Parameters
-
-| Name | Type | Meaning |
-|---|---|---|
-| `conclusion` | `Claim \| list[Claim]` | The hypothesis (or hypotheses, for model comparison) whose belief is updated by the evidence. Must already exist as a `Claim` before the call. |
-| `data` | `Claim \| list[Claim]` | The observation Claim(s). Each must have `metadata` fields matching what `model` expects (see §3.2). `prior` on `data` retains its reliability semantics (§5.1) and is **not** touched by `evidence()`. |
-| `model` | `LikelihoodModel` | A pluggable statistical model. Owns the likelihood computation for H and for the alternative, plus the mapping from `data.metadata` → model inputs. See §3. |
-| `assumptions` | `list[Claim] \| None` | Validity gates. Claims whose posterior belief multiplicatively scales the evidence factor's strength (§5.2). If any gate's posterior approaches 0, the factor loses force; if all are near 1, the factor operates at full strength. |
-| `query` | `str \| dict \| None` | An optional structured description of what quantity the user cares about (e.g., `"theta_B > theta_A"`). Consumed by `model.factor_potential` for parametric queries; stored on the helper Claim's metadata for review tooling. |
-| `background` | `list[Knowledge] \| None` | Contextual notes, as with other Actions. Non-probabilistic. |
-| `rationale`, `label` | `str`, `str \| None` | Standard Action metadata. |
-
-### 1.3 Return value
-
-Following the Correlate-family convention established by `infer()` and `associate()` in v0.5 (`helper_kind = "likelihood"` / `"association"`), `evidence()` returns a **generated helper Claim** with:
+**Example:**
 
 ```python
-helper.metadata = {
-    "generated": True,
-    "helper_kind": "evidence",
-    "review": True,
-    "model_class": model.__class__.__name__,
-    "model_params": model.serialise_params(),
-    "query": query,
-    "relation": {
-        "type": "evidence",
-        "conclusion": conclusion,
-        "data": data,
-        "assumptions": assumptions or [],
-    },
-}
+from gaia.stats import Binomial
+
+evidence(
+    mendelian_segregation_model,
+    data=f2_count_observation,                    # metadata = {"dominant": 295, "total": 395}
+    model=Binomial(n=395, p=3/4),
+    given=[independent_bernoulli_valid],
+)
 ```
 
-The helper is attached to each target Claim's `supports` list (one helper per target, sharing identity via `_structure_hash` of the evidence factor — see §2.3).
+**Mathematical specification:** `model` determines the likelihood `P(data | conclusion)` under the point hypothesis (conclusion is true). The framework derives the likelihood under `¬conclusion` from the `DistributionSpec` `kind` field (see §4.3 for the dispatch rules). `conclusion`'s belief is updated via the resulting Bayes factor, scaled by the gate function from §3.2.
 
-### 1.4 Invariants
+### 2.2 `infer()` — modified
 
-- `evidence()` **never writes `claim.prior`** on any input Claim. All inference output flows through the BP lowering into posteriors (`claim.belief`).
-- `evidence()` **does not accept `prior_*` kwargs**. The Bayesian marginal that was exposed as `prior_b` in `associate()` is now computed inside `model.factor_potential` and stored transiently in the BP factor, never on a Claim.
-- `assumptions` entries must be `Claim` objects (they must have a `prior` themselves so they can gate the factor). `background` is for non-probabilistic `Knowledge` (typically `Note`).
+**When to use:** the author (typically an LLM or human expert) has counterfactual intuition about how likely the evidence would be under the hypothesis versus under its negation. No structured model is available.
+
+**Signature (changes from v0.5 highlighted):**
+
+```python
+def infer(
+    evidence: Claim,                              # positional (unchanged)
+    *,
+    hypothesis: Claim,                            # (unchanged)
+    p_e_given_h: float | Claim,                   # (unchanged)
+    p_e_given_not_h: float | Claim,               # (unchanged)
+    marginal_h: float | None = None,              # RENAMED from prior_hypothesis
+    given: list[Claim] | None = None,             # NEW
+    background: list[Knowledge] | None = None,    # (unchanged)
+    rationale: str = "",
+    label: str | None = None,
+    # prior_hypothesis kwarg accepted as deprecated alias for marginal_h
+    # prior_evidence kwarg accepted but raises DeprecationWarning; its value is ignored
+    #   (see §3.3 for migration guidance)
+) -> Claim:
+    """Bayesian evidence update via counterfactual scalar likelihoods.
+
+    The caller supplies ``p_e_given_h`` = P(E | H) and
+    ``p_e_given_not_h`` = P(E | ¬H), and optionally ``marginal_h`` = P(H).
+    If ``marginal_h`` is None, the framework uses H's prior from ``PRIORS``
+    or the framework default. ``P(E)`` is computed internally via the law of
+    total probability; it is not a user-provided quantity.
+    """
+```
+
+**Example (unchanged from v0.5 except for the new kwargs):**
+
+```python
+infer(
+    observation_high_freq_spectrum_finite,
+    hypothesis=hypothesis_planck_radiation_quantized,
+    p_e_given_h=0.95,
+    p_e_given_not_h=0.1,
+    marginal_h=0.3,
+    given=[experimental_setup_valid],
+)
+```
+
+**Why `prior_evidence` is removed:** for a 2-way factor over H and E, the 2×2 joint distribution has 3 degrees of freedom. Specifying `p_e_given_h`, `p_e_given_not_h`, and `marginal_h` already determines all three. `P(E)` is then:
+
+\[
+P(E) = p_{e|h} \cdot P(H) + p_{e|\neg h} \cdot (1 - P(H))
+\]
+
+A user-supplied `prior_evidence` is either redundant (if Bayes-consistent with the other three) or dangerous (if inconsistent). Either way, the framework should compute it, not accept it. Migration of existing `prior_evidence` call sites is covered in §3.3.
+
+### 2.3 `associate()` — modified
+
+**When to use:** two propositions have mutual conditional dependencies with no natural "data / hypothesis" directional split — for example, two theoretical claims that imply each other, or two observational summaries.
+
+**Signature (changes highlighted):**
+
+```python
+def associate(
+    a: Claim,                                     # positional (unchanged)
+    b: Claim,                                     # positional (unchanged)
+    *,
+    p_a_given_b: float | Claim,                   # (unchanged)
+    p_b_given_a: float | Claim,                   # (unchanged)
+    marginal_a: float | None = None,              # RENAMED from prior_a
+    marginal_b: float | None = None,              # RENAMED from prior_b
+    given: list[Claim] | None = None,             # NEW
+    background: list[Knowledge] | None = None,    # (unchanged)
+    rationale: str = "",
+    label: str | None = None,
+    # prior_a / prior_b accepted as deprecated aliases for marginal_a / marginal_b
+) -> Claim:
+    """Symmetric Bayesian factor between two Claims.
+
+    The caller supplies ``p_a_given_b`` and ``p_b_given_a`` (required) and
+    optionally either or both of ``marginal_a``, ``marginal_b``. The 2×2
+    joint has 3 degrees of freedom; given both conditionals, exactly one
+    marginal closes the system. When both marginals are provided they must
+    satisfy ``p_a_given_b · marginal_b = p_b_given_a · marginal_a`` (Bayes
+    coherence); the framework warns on inconsistency.
+    """
+```
+
+**Why keep both marginal kwargs when only one is strictly needed:** `associate` is semantically symmetric — neither operand is privileged as "data" or "hypothesis." Forcing the author to choose which marginal to supply breaks that symmetry. Keeping both as `Optional` preserves the symmetric authoring experience while allowing minimal specification (one) or explicit closure (two, with coherence check).
 
 ---
 
-## 2. IR layer: `EvidenceFactor` Action
+## 3. Framework-level changes (shared by all three verbs)
 
-### 2.1 Class hierarchy placement
+### 3.1 `marginal_*` routes to `metadata["bayes_marginal"]`, not `metadata["prior"]`
+
+Today, compile-time writes `associate.prior_a` → `claim.metadata["prior"]`, where it collides with PRIORS. Under this spec:
+
+```python
+# gaia/lang/compiler/compile.py, in _compile_associate_action (paraphrased):
+if action.marginal_a is not None:
+    claim_a.metadata.setdefault("bayes_marginal", {})[action_label] = action.marginal_a
+# metadata["prior"] is never written by Correlate actions.
+```
+
+The per-label `bayes_marginal` dict allows multiple Correlate actions to coexist on the same Claim without collision. Inference reads whichever entry matches the currently-evaluated factor.
+
+`metadata["prior"]` continues to be the single-valued **reliability** field set by `PRIORS`. Its meaning is unambiguous: pre-inference initial belief in the Claim, independent of any Bayes factor.
+
+### 3.2 `given` gate semantics in BP lowering
+
+Each Correlate factor's potential is multiplicatively scaled by the product of its gate Claims' current beliefs:
+
+\[
+\log \phi_{\text{factor}} \;=\; \log \phi_{\text{raw}} \;\cdot\; \prod_{g \in \text{given}} \text{belief}(g)
+\]
+
+Behaviour:
+
+- All gates at belief 1 → factor at full strength (`∏ = 1`).
+- Any gate at belief 0 → factor contributes 0 log-likelihood (effectively deleted).
+- Gates in between → smooth multiplicative scaling.
+- `given` Claims must themselves have `PRIORS` entries (they are belief variables), enforced at compile time.
+
+This is the same gate semantics Support-family verbs already implicitly use for their `given` field.
+
+### 3.3 Deprecation and migration
+
+**Automatic alias (accepted for one release):**
+
+| Old kwarg | New kwarg | Behaviour |
+|---|---|---|
+| `associate(prior_a=x)` | `associate(marginal_a=x)` | `DeprecationWarning`, forward value to new name |
+| `associate(prior_b=x)` | `associate(marginal_b=x)` | same |
+| `infer(prior_hypothesis=x)` | `infer(marginal_h=x)` | same |
+
+**Removed without alias:**
+
+- `infer(prior_evidence=x)` — emits `DeprecationWarning` explaining that `P(E)` is now computed internally. The passed value is ignored. Two migration targets:
+  1. If the caller was expressing observation reliability (`"P(the observation record is correct)"`), lift it to an explicit `Claim` and pass it via `given=[reliability_claim]`.
+  2. If the caller was pre-computing `P(E)` from `marginal_h` and the two likelihoods for Bayes closure, simply delete the argument; the framework now does this internally.
+
+**One full release cycle:** deprecated aliases live for v0.5.x; removed in v0.6. Removal happens by a separate PR; this spec only lands the renames + warnings.
+
+---
+
+## 4. IR layer
+
+### 4.1 Action field renames
 
 ```python
 # gaia/lang/runtime/action.py
-@dataclass
-class Correlate(Action):
-    """Probabilistic soft constraint between Claims."""
-    helper: Claim | None = None
 
 @dataclass
-class Infer(Correlate): ...       # unchanged
-@dataclass
-class Associate(Correlate): ...   # unchanged
+class Infer(Correlate):
+    hypothesis: Claim | None = None
+    evidence: Claim | None = None
+    p_e_given_h: float | Claim = 0.5
+    p_e_given_not_h: float | Claim = 0.5
+    marginal_h: float | None = None                   # was prior_hypothesis
+    given: tuple[Claim, ...] = ()                     # NEW
+    # prior_evidence: REMOVED
 
-# NEW:
 @dataclass
-class EvidenceFactor(Correlate):
-    """Statistical evidence via pluggable likelihood model."""
-    conclusion: tuple[Claim, ...] = ()
-    data: tuple[Claim, ...] = ()
-    assumptions: tuple[Claim, ...] = ()
-    model: LikelihoodModel | None = None
-    query: str | dict | None = None
+class Associate(Correlate):
+    a: Claim | None = None
+    b: Claim | None = None
+    p_a_given_b: float | Claim = 0.5
+    p_b_given_a: float | Claim = 0.5
+    marginal_a: float | None = None                   # was prior_a
+    marginal_b: float | None = None                   # was prior_b
+    given: tuple[Claim, ...] = ()                     # NEW
 ```
 
-### 2.2 Compiled IR strategy
+### 4.2 `EvidenceFactor` Action — new
+
+```python
+@dataclass
+class EvidenceFactor(Correlate):
+    conclusion: Claim | None = None
+    data: Claim | None = None
+    model: DistributionSpec | None = None             # from gaia.ir.schemas
+    given: tuple[Claim, ...] = ()
+```
+
+### 4.3 Compile-time potential dispatch for `evidence()`
+
+The compile phase resolves `model.kind` to a potential-construction function that reads `data.metadata` and produces `(log_lik_h, log_lik_not_h)`:
+
+```
+"binomial"      → binomial_pmf(data.metadata[count_field], data.metadata[total_field], p) / (1/(N+1))
+"normal"        → gaussian_pdf(data.metadata[value_field], μ, σ) / reference_Gaussian(broad_μ_prior)
+"poisson"       → poisson_pmf(data.metadata[count_field], rate) / exponential_reference
+...
+"custom"        → invoke model.callable_ref (requires scipy adapter, PR #487 later slice 2)
+```
+
+The reference measure (the "¬H" likelihood) for each built-in kind is documented in a table alongside the dispatcher. For `binomial`, the built-in reference is the uniform-over-p diffuse prior (closed form `1/(N+1)`), which is what the current Mendel example uses by hand.
+
+Users who want a non-default reference construct the factor via `infer()` with explicit scalars, not `evidence()`.
+
+### 4.4 IR strategy type
 
 `EvidenceFactor` compiles to a new IR strategy type:
 
 ```python
 IrStrategy(
-    scope="local",
     type="evidence",
-    premises=[knowledge_map[id(c)] for c in action.conclusion],
-    conclusion=knowledge_map[id(action.helper)],
-    background=[...],
+    premises=[conclusion_id, data_id],
+    conclusion=helper_id,
     metadata={
-        "model_class": action.model.__class__.__name__,
-        "model_params": action.model.serialise_params(),
-        "query": action.query,
-        "data_refs": [knowledge_map[id(d)] for d in action.data],
-        "assumption_refs": [knowledge_map[id(a)] for a in action.assumptions],
-        "factor_potential": action.model.compile_potential(
-            data=[d.metadata for d in action.data],
-            query=action.query,
-        ),  # serialised numeric form; see §3.3
+        "model": action.model.model_dump(mode="json"),   # JSON-native, from PR #487 schema
+        "gates": [g_id for g in action.given],
+        "log_lik_h": ...,                                # numeric, from dispatcher
+        "log_lik_not_h": ...,
     },
 )
 ```
 
-Note that individual scalar likelihoods are **not** stored at the IR top level (as `p_a_given_b`, `prior_a`, etc. are for `associate`). Instead the numerical content is encapsulated in `metadata.factor_potential`, a model-specific serialised form (e.g. a tuple `(log_lik_h, log_lik_not_h)` for two-hypothesis cases, or a general table for K hypotheses — see §3.3).
+### 4.5 Helper Claim (returned by all three verbs)
 
-### 2.3 Identity / structure hash
-
-Following v0.5 precedent:
+Consistent with the existing Correlate convention:
 
 ```python
-structure_hash = SHA-256(canonical_json({
-    "type": "evidence",
-    "conclusion": sorted([c.claim_id for c in conclusion]),
-    "data": sorted([d.claim_id for d in data]),
-    "assumptions": sorted([a.claim_id for a in assumptions]),
-    "model_class": model.__class__.__name__,
-    "model_params": model.serialise_params(),
-    "query": query,
-}))
-```
-
-Two `evidence()` calls with the same model, same data, same gates, and same query deduplicate to the same helper Claim and the same IR strategy.
-
----
-
-## 3. Model protocol: `LikelihoodModel`
-
-### 3.1 Abstract base
-
-```python
-# gaia/lang/runtime/likelihood.py (new module)
-
-from abc import ABC, abstractmethod
-from typing import Any
-
-class LikelihoodModel(ABC):
-    """A pluggable statistical model consumed by ``evidence()``."""
-
-    @abstractmethod
-    def expected_fields(self) -> list[str]:
-        """Names of ``data.metadata`` keys this model reads."""
-
-    @abstractmethod
-    def log_likelihood(
-        self,
-        *,
-        hypothesis_index: int,          # 0-based index into conclusion tuple
-        data_values: list[dict],        # one dict per ``data`` Claim
-        query: str | dict | None,
-    ) -> float:
-        """Log P(data | hypothesis_index, query)."""
-
-    def log_likelihood_alternative(
-        self,
-        *,
-        data_values: list[dict],
-        query: str | dict | None,
-    ) -> float | None:
-        """Log of the alternative / baseline likelihood, for two-hypothesis models.
-        Returning ``None`` means 'no built-in alternative'; the BP engine will then
-        need multiple entries in ``conclusion`` to form the Bayes factor."""
-        return None
-
-    def compile_potential(
-        self,
-        *,
-        data: list[dict],
-        query: str | dict | None,
-    ) -> dict[str, Any]:
-        """Return a serialisable summary of the factor potential sufficient for
-        BP lowering. Default: ``{"log_lik_h": ..., "log_lik_not_h": ...}`` for the
-        binary case. Override for K-ary models."""
-        ...
-
-    def serialise_params(self) -> dict[str, Any]:
-        """Emit a JSON-serialisable view of the model's own constructor parameters
-        for IR storage. Default: shallow ``__dict__``."""
-        return {k: v for k, v in vars(self).items() if not k.startswith("_")}
-```
-
-### 3.2 Contract with `data.metadata`
-
-For each `data` Claim in an `evidence()` call, the framework:
-
-1. Reads `model.expected_fields()`.
-2. Looks up each expected field on `data.metadata`.
-3. Builds a single `dict` of that Claim's inputs.
-4. Passes the list of these dicts as `data_values`.
-
-A compile-time check raises a clear error if a required field is missing:
-
-```
-EvidenceModelContractError: BinomialAgainstDiffusePrior expects fields
-['dominant', 'total'] on data Claim 'f2_count_observation' but only
-['dominant'] is present.
-```
-
-### 3.3 Factor potential encoding
-
-For the two-hypothesis case (one conclusion Claim, a built-in alternative), the potential is stored as:
-
-```python
-{
-    "kind": "binary_bayes_factor",
-    "log_lik_h": -3.065,          # e.g. log Binomial(395, 3/4).pmf(295)
-    "log_lik_not_h": -5.981,      # e.g. log(1 / (395 + 1))
-    "log_bayes_factor": 2.916,    # redundant but stored for review convenience
+helper.metadata = {
+    "generated": True,
+    "helper_kind": "evidence" | "likelihood" | "association",
+    "review": True,
+    "relation": {"type": <kind>, ...},
 }
 ```
 
-For K conclusions without a built-in alternative:
-
-```python
-{
-    "kind": "k_way_likelihood",
-    "log_likelihoods": [-3.065, -7.412, -9.109],  # one per conclusion
-}
-```
-
-Additional `kind` values MAY be added as new model families are introduced; the IR schema treats `metadata.factor_potential` as an open, model-owned record.
+`infer()` keeps `helper_kind = "likelihood"`; `associate()` keeps `helper_kind = "association"`; `evidence()` uses `helper_kind = "evidence"`.
 
 ---
 
-## 4. Initial model library
+## 5. Relation to PR #487
 
-The spec commits to shipping the following concrete models in the same PR that lands `evidence()`. Others can follow.
+PR #487 is the enabling foundation for this spec. Specifically:
 
-### 4.1 `ScalarBayesFactor`
+- `gaia.ir.schemas.DistributionSpec` is the exact type of `evidence.model`. No wrapping, no adapter.
+- `gaia.stats.{Normal, Binomial, LogNormal, StudentT, Cauchy, Poisson, Exponential, Beta, from_callable}` are the authoring constructors. No additional constructors need to be added by this spec.
+- `gaia.ir.schemas.QuantityLiteral` handles unit-bearing `data.metadata` fields (e.g., `GaussianMeasurementModel` use cases). No compile-boundary work is duplicated.
+- `gaia.unit.q()` lets authors write `data.metadata = {"value": q(80, "K")}` and have it normalised to `QuantityLiteral` at compile time.
 
-The degenerate compatibility model. Wraps a pair of scalars exactly as `infer()` does today.
-
-```python
-class ScalarBayesFactor(LikelihoodModel):
-    def __init__(self, *, p_h: float, p_not_h: float): ...
-
-    def expected_fields(self): return []
-    def log_likelihood(self, *, hypothesis_index, data_values, query):
-        return log(self.p_h) if hypothesis_index == 0 else log(self.p_not_h)
-    def log_likelihood_alternative(self, **_): return log(self.p_not_h)
-```
-
-Purpose: makes `infer()` implementable as a shorthand (§6.1) and gives users a migration escape hatch.
-
-### 4.2 `BinomialPointLikelihood`
-
-```python
-class BinomialPointLikelihood(LikelihoodModel):
-    def __init__(self, *, p: float, count_field: str = "dominant", total_field: str = "total"): ...
-```
-
-Returns only the point likelihood under `p`. No built-in alternative; users compose two of these via `PointwiseRatio` (§4.6) if they want an explicit Bayes factor.
-
-### 4.3 `BinomialAgainstDiffusePrior`
-
-```python
-class BinomialAgainstDiffusePrior(LikelihoodModel):
-    def __init__(self, *, p: float, count_field: str = "dominant", total_field: str = "total"): ...
-```
-
-Two hypotheses:
-
-- **H**: `X ~ Binomial(N, p)` with supplied `p`.
-- **¬H**: `X ~ Binomial(N, p')` with `p' ~ Uniform[0, 1]`. Marginal likelihood `1 / (N + 1)`, closed form.
-
-This is the canonical "is this specific Mendelian ratio better than generic binomial chance?" model.
-
-### 4.4 `BinomialVsBinomial`
-
-```python
-class BinomialVsBinomial(LikelihoodModel):
-    def __init__(self, *, p_h: float, p_alt: float, ...): ...
-```
-
-Point-against-point for scenarios where the alternative is a specific binomial (e.g., coin-flip null at `p_alt = 0.5`).
-
-### 4.5 `GaussianMeasurementModel`
-
-```python
-class GaussianMeasurementModel(LikelihoodModel):
-    def __init__(self, *, sigma: float, value_field: str = "value"): ...
-```
-
-`X ~ Normal(mu_h, sigma)` under the hypothesis; alternative is either explicit (another `GaussianMeasurementModel` via `PointwiseRatio`) or a specified broad Gaussian prior on `mu`. Deferred details in §9.
-
-### 4.6 `PointwiseRatio`
-
-```python
-class PointwiseRatio(LikelihoodModel):
-    def __init__(self, *, numerator: LikelihoodModel, denominator: LikelihoodModel): ...
-```
-
-Composes two sub-models into a Bayes-factor model. Used when the user wants H vs. a hand-picked alternative that isn't the diffuse default.
-
-### 4.7 (Future) `TwoBinomialModel`, `PoissonPointLikelihood`, `IndependentBinomialBatch`
-
-Listed here for scoping — not part of the landing PR. `IndependentBinomialBatch` would take a list of `data` entries and multiply likelihoods, enabling the Mendel-with-seven-traits scenario.
+#487's "Later Slices" list includes (slice 3) "A first evidence composition/template such as gaussian measurement." This spec is that slice, for all built-in `DistributionSpec.kind` values at once rather than one-model-at-a-time.
 
 ---
 
-## 5. BP lowering
+## 6. Relation to issue #448
 
-### 5.1 Claim prior remains reliability
+#448's v6 direction proposes a more radical rework — removing probabilistic warrant from `Support`, reshaping `Strategy.type`, and moving Claim roles to metadata. This spec:
 
-`claim.prior` (the value written by `PRIORS` or defaulted on `Claim(... prior=0.5)`) is treated **unambiguously as reliability / subjective prior**. It is the marginal P(claim is true) under the user's "report-accuracy" axis and is independent of any statistical likelihood.
-
-`evidence()` never writes `claim.prior`. The inference engine reads `claim.prior` as the initial belief state for BP, as it always has.
-
-### 5.2 Factor potential gated by assumptions
-
-Each `EvidenceFactor` contributes a BP factor whose potential is the `LikelihoodModel`'s `log_likelihood` output, **scaled by a gating term derived from `assumptions`**:
-
-```text
-log φ_evidence(conclusion | data) =
-    log_likelihood(hypothesis | data) · g(assumptions)
-```
-
-where the gating function `g` is:
-
-```text
-g(assumptions) = ∏_{A ∈ assumptions} claim_belief(A)
-```
-
-evaluated at each BP iteration using the current posterior of each gate Claim. This yields the intuitive behaviour:
-
-- All gates at posterior 1 → factor at full strength (equivalent to `g = 1`).
-- Any gate at posterior 0 → factor contributes 0 log-likelihood (effectively deleted from the graph).
-- Gate posteriors in between scale the factor smoothly.
-
-### 5.3 Composition with hypothesis prior and posterior
-
-For a single-conclusion evidence factor with a binary bayes factor potential, the BP update on `conclusion.belief` is:
-
-```text
-posterior(H)        prior(H)         exp(log_lik_h · g)
-─────────────── = ─────────────── · ──────────────────────
-posterior(¬H)     prior(¬H)         exp(log_lik_not_h · g)
-```
-
-which reduces to standard Bayes when `g = 1`, and becomes a no-op when `g = 0`.
-
-### 5.4 Interaction with `exclusive` and multi-target evidence
-
-If `conclusion = [H1, H2, ...]` and the hypotheses are declared `exclusive(H1, H2, ...)`, BP enforces `Σ belief(H_i) = 1` after each evidence-factor update, giving standard K-way model comparison. If they are not exclusive, the K likelihoods enter independently and each H_i's belief moves only by its own BF against the reference (no cross-normalisation).
+- **Implements the core statistical move** of #448: "statistical uncertainty is represented by explicit evidence factors." `EvidenceFactor` is exactly that, and it does not touch the Support family's `given` semantics (which v0.5 already gets right per #448's direction).
+- **Preserves `Infer` and `Associate`** as first-class Correlate verbs. #448 proposed deprecating them, but in-conversation review with the user established that the two verbs serve genuinely distinct LLM-authoring cognitive postures (counterfactual-likelihood vs. mutual-conditional) that both deserve dedicated signatures. Rev2 keeps them.
+- **Defers** the rest of #448 (warrant removal, strategy restructure, role metadata) to a later v6 rework. Nothing in this spec blocks or contradicts that direction.
 
 ---
 
-## 6. Relation to existing verbs
+## 7. Worked example: Mendel migration paths
 
-### 6.1 `infer()` becomes a shorthand
+After this spec lands (alongside #487), the Mendel example's current workaround node `f2_dominant_count_specific` can be eliminated. There are two equally-valid migration targets, depending on whether the author prefers `evidence()` with a structured model or keeps the existing `associate()` call.
 
-```python
-def infer(evidence_claim, *, hypothesis, p_e_given_h, p_e_given_not_h,
-          prior_hypothesis=None, prior_evidence=None, ...):
-    if prior_hypothesis is not None or prior_evidence is not None:
-        warnings.warn(
-            "infer()'s prior_hypothesis / prior_evidence kwargs are deprecated. "
-            "The reliability prior belongs on PRIORS; the Bayes marginal is "
-            "computed inside evidence().model. See #485.",
-            DeprecationWarning,
-        )
-    return evidence(
-        conclusion=hypothesis,
-        data=evidence_claim,
-        model=ScalarBayesFactor(p_h=p_e_given_h, p_not_h=p_e_given_not_h),
-        rationale=rationale,
-        label=label,
-    )
-```
-
-Semantics preserved for existing callers; `prior_*` kwargs accepted but ignored and warned about. The hard `ValueError` on PRIORS conflict is removed entirely because `evidence()` doesn't write `claim.prior`.
-
-### 6.2 `associate()` becomes a shorthand
-
-Analogous to `infer`, `associate(a, b, p_a_given_b, p_b_given_a, prior_a, prior_b)` is rewritten as a symmetric evidence factor:
+### 7.1 Path A — migrate to `evidence()` (recommended for didactic clarity)
 
 ```python
+from gaia.stats import Binomial
+
 evidence(
-    conclusion=[a, b],
-    data=[],  # associate has no separate "data" Claim; both sides are hypotheses
-    model=SymmetricScalarAssociation(p_a_given_b=..., p_b_given_a=...),
+    mendelian_segregation_model,
+    data=f2_count_observation,
+    model=Binomial(n=395, p=3/4),
+    given=[independent_bernoulli_valid],
 )
 ```
 
-(A `SymmetricScalarAssociation` model is added to the starter library for this purpose.) `prior_a` / `prior_b` kwargs accepted with a deprecation warning; they do not participate in the BP factor and do not write to `claim.prior`.
+Changes relative to merged PR #482:
 
-### 6.3 Review manifest
+- `examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py` deleted entirely (all 98 lines).
+- `f2_dominant_count_specific` derive node deleted.
+- `mendel_data_association_parameters()` call deleted.
+- `associate()` call replaced by the `evidence()` call above.
 
-`EvidenceFactor`'s helper Claim gets the same review lifecycle (`unreviewed` → `accepted` / `rejected`) as existing Correlate helpers. No changes to review infrastructure are required.
+`independent_bernoulli_valid` becomes a first-class reviewable Claim (e.g., `Claim("F2 individuals are independent Bernoulli trials with shared p", prior=0.9)`). Reviewers who doubt the independence assumption can lower its prior and see the evidence factor's strength proportionally reduced, without touching any statistical code.
 
----
-
-## 7. Worked example: Mendel
-
-### 7.1 Before (current PR #482)
+### 7.2 Path B — keep `associate()`, just rename kwargs and add `given`
 
 ```python
-# probabilities.py — user hand-computes ALL five scalars
-association_parameters = mendel_count_association_parameters()
-
-# __init__.py
-f2_count_observation = observe("F2 counts 295:100 ...")               # PRIORS = 0.95
-
-f2_dominant_count_specific = derive(                                  # workaround node
-    "F2 dominant count = 295 of 395",
-    given=f2_count_observation,
-)
-
 associate(
     mendelian_segregation_model,
     f2_dominant_count_specific,
-    p_a_given_b=association_parameters.p_mendelian_given_count,
-    p_b_given_a=association_parameters.p_count_given_mendelian,
-    prior_a=0.5,
-    prior_b=association_parameters.prior_count,
-    rationale="...",
+    p_a_given_b=..., p_b_given_a=...,
+    marginal_a=0.5, marginal_b=0.024,              # renamed from prior_a / prior_b
+    given=[independent_bernoulli_valid],           # new
 )
 ```
 
-Drawbacks: 5 hand-computed scalars; a workaround `derive` node that exists only to dodge the `metadata.prior` collision; framework has no view into `BinomialModel(p=3/4)`; blending's `2/3` strawman used to previously live in the same `probabilities.py`.
+Changes relative to merged PR #482:
 
-### 7.2 After
+- `prior_a` / `prior_b` renamed to `marginal_a` / `marginal_b` (old names accepted as deprecated aliases).
+- `given=[...]` added to express the Bernoulli independence gate.
+- `probabilities.py` retained — user continues to hand-compute the four scalars.
+- `f2_dominant_count_specific` retained.
 
-```python
-# probabilities.py — DELETED entirely; the model owns the computation
+This path is available to authors who specifically want LLM-direct-scalar authoring rather than framework-computed likelihood. It's not the *recommended* Mendel migration, but it's a valid pattern for other packages that lean on expert-estimated conditionals.
 
-# __init__.py
-f2_count_observation = Claim(                                         # PRIORS = 0.95 (reliability)
-    "F2 counts 295 dominant / 100 recessive",
-    role="observation",
-    metadata={"dominant": 295, "total": 395},
-)
+### 7.3 What happens to PR #482's workaround node
 
-mendelian_segregation_model = Claim(
-    "Mendelian segregation: p(dominant) = 3/4 in F2.",
-    prior=0.5,
-    role="hypothesis",
-)
+Path A deletes `f2_dominant_count_specific`. Path B retains it. Once this spec lands, the Mendel example's in-file docstring (currently pointing to #485) should be updated to either:
 
-independent_bernoulli_valid = Claim(
-    "F2 individuals behave as independent Bernoulli trials with shared p.",
-    prior=0.9,
-)
+- Path A: remove the workaround explanation entirely.
+- Path B: update the docstring to reflect the new kwarg names.
 
-evidence(
-    conclusion=mendelian_segregation_model,
-    data=f2_count_observation,
-    assumptions=[independent_bernoulli_valid],
-    model=BinomialAgainstDiffusePrior(p=3/4),
-    rationale="Mendelian segregation predicts Binomial(N, 3/4); the diffuse "
-              "alternative is p ~ Uniform[0, 1] with marginal 1/(N+1).",
-)
-
-# Blending still participates, but only qualitatively, through contradicts:
-blending_predicts_f2_continuous = derive(...)
-f2_discrete_classes_blending_conflict = contradict(
-    blending_predicts_f2_continuous, f2_has_discrete_classes_observation,
-)
-# etc. — unchanged from PR #482's refactored form.
-```
-
-Gains:
-
-- `probabilities.py` deleted — 100 lines of user-maintained numerical code replaced by `BinomialAgainstDiffusePrior(p=3/4)`.
-- `f2_dominant_count_specific` workaround node deleted — `evidence()` targets the observation directly.
-- No PRIORS collision — `evidence()` doesn't write `claim.prior`.
-- `independent_bernoulli_valid` is now a first-class Claim whose posterior gates the evidence; a reviewer can change its prior to do methodological sensitivity analysis without touching any of the statistical code.
-- Replacing `BinomialAgainstDiffusePrior(p=3/4)` with `BinomialVsBinomial(p_h=3/4, p_alt=1/2)` (the "Mendel vs coin-flip null" variant) is a one-line swap.
+The docstring update is a separate follow-up PR to the Mendel example; it's not part of this spec's acceptance criteria.
 
 ---
 
 ## 8. Migration plan
 
-### Phase A — Landable in one PR (~1 week scope)
+### Phase A — land signatures + framework routing (~1 week scope)
 
-1. Add `LikelihoodModel` protocol and the starter library: `ScalarBayesFactor`, `BinomialPointLikelihood`, `BinomialAgainstDiffusePrior`, `BinomialVsBinomial`, `PointwiseRatio`, `SymmetricScalarAssociation`, `GaussianMeasurementModel`.
-2. Add `EvidenceFactor` Action subclass and its compile rule.
-3. Add `evidence()` DSL verb and export from `gaia.lang`.
-4. Implement BP lowering for `evidence` strategies, including assumption gating (§5.2).
-5. Rewrite `infer()` and `associate()` as shorthands over `evidence()` (§6). Remove the hard `ValueError` on PRIORS conflict.
-6. Add a `test_evidence_verb.py` regression suite covering: basic binary factor, gate scaling, multi-target model comparison, deprecated-kwargs warnings.
-7. Document in `docs/foundations/language/gaia-language-spec.md`.
+1. Rename `prior_*` → `marginal_*` in `Infer` / `Associate` Action fields, DSL verbs, and IR strategy. Add deprecated alias accepting old names with `DeprecationWarning`.
+2. Remove `infer.prior_evidence` kwarg. Add `DeprecationWarning` for old call sites explaining both migration targets (§3.3).
+3. Add `given: tuple[Claim, ...]` field to `Infer` and `Associate` Actions; add `given` kwarg to both DSL verbs.
+4. Add `EvidenceFactor` Action subclass and `evidence()` DSL verb. Compile rule reads `DistributionSpec.kind` and dispatches to a built-in potential-construction function for each built-in kind.
+5. Framework routing: Correlate-family actions' `marginal_*` values write to `claim.metadata["bayes_marginal"]`, not `claim.metadata["prior"]`. Remove the "conflicting marginal providers" hard `ValueError`.
+6. BP lowering: implement the gate semantics of §3.2 for all three Correlate verbs.
+7. Tests:
+   - `tests/gaia/lang/test_evidence_verb.py` — new.
+   - `tests/gaia/lang/test_infer.py` — extend for `given`, `marginal_h` rename, removed `prior_evidence` warning.
+   - `tests/gaia/lang/test_associate_verb.py` — extend for `given`, `marginal_a/b` rename.
+   - `tests/cli/test_infer.py` — regression that Mendel-like configurations no longer raise the collision error.
 
-### Phase B — Example migrations (~1 week scope)
+### Phase B — example migrations (~1 week scope)
 
-1. Migrate `examples/mendel-v0-5-gaia/` to `evidence() + BinomialAgainstDiffusePrior`. Delete `probabilities.py` and the workaround `derive` node.
-2. Audit `examples/galileo-v0-5-gaia/` — Galileo is currently purely qualitative, so likely unaffected; confirm.
-3. Document the migration in `examples/` README and link from issue #485.
+1. Migrate `examples/mendel-v0-5-gaia/` — Path A. Delete `probabilities.py` and `f2_dominant_count_specific`. Update `test_mendel_v05_example.py`.
+2. Audit `examples/galileo-v0-5-gaia/` — Galileo is qualitative; confirm no change required.
+3. Update `docs/foundations/gaia-lang/dsl.md` with the new verb and kwarg names.
+4. Release note + skill file updates.
 
-### Phase C — Extended model library (indefinite timeline)
+### Phase C — remove deprecated aliases (v0.6)
 
-Add `TwoBinomialModel` (AB test), `PoissonPointLikelihood`, `IndependentBinomialBatch` (multi-trait Mendel), `HierarchicalBinomial`. Driven by user demand from real packages.
+Separate PR, not part of this spec.
 
-### Backward compatibility guarantees
+### Backward-compatibility guarantees
 
-- All existing `infer()` and `associate()` calls in v0.5 packages continue to compile and produce the same BP factors.
-- The `prior_hypothesis` / `prior_evidence` / `prior_a` / `prior_b` kwargs are accepted for one release, with a `DeprecationWarning` pointing to `evidence()` and this spec. Removal scheduled for the release after that.
-- `metadata.prior` field on Claims is unchanged.
+- All v0.5 packages that use `infer` / `associate` continue to compile. Only warnings are emitted.
+- IR format continues to accept old field names for one version (reader-side back-compat).
+- `claim.metadata["prior"]` field unchanged in shape and semantics.
 
 ---
 
 ## 9. Open questions
 
-### 9.1 Gating function
+### 9.1 `given` gating function
 
-§5.2 uses `g = ∏ posterior(assumption_i)` (AND semantics). Alternatives include:
+§3.2 specifies `g = ∏ belief(g_i)` (multiplicative AND). Discussed alternatives:
 
-- A "noisy-AND" via the existing `noisy_and` operator, letting users declare failure-independence between gates explicitly.
-- A configurable `gate_semantics` kwarg on `evidence()` for `"and"` vs `"or"` vs `"noisy_and"`.
+- **Noisy-AND** via Gaia's existing `noisy_and` operator for explicitly-correlated gates.
+- **Configurable** via a `gate_semantics=` kwarg.
 
-Default AND is probably right for v0.5; noisy-AND is a plausible follow-up.
+Recommendation: AND default for v0.5; noisy-AND / configurability as a follow-up when a real package needs it. Correlated gates should be collapsed to a single explicit Claim rather than relying on the gating function to model their correlation.
 
-### 9.2 Continuous Gaussian alternative
+### 9.2 Reference measure for non-binomial `evidence` kinds
 
-`GaussianMeasurementModel` against a broad-Gaussian alternative on the mean parameter: analytic? Numeric integration? Discretised latent? Needs spec-level decision before landing. Deferring to Phase A.2 implementation choice.
+`Binomial` has a canonical diffuse reference (`1 / (N+1)`). For `Normal`, `Poisson`, `Exponential`, etc., there is no single obvious diffuse reference measure. Three options:
 
-### 9.3 `data` with unreliable reporter
+- **Hard-code defaults per kind** (e.g., Gaussian → broad-Gaussian reference with `σ = 10 × σ_model`).
+- **Require the author to supply an alternative** as a second `DistributionSpec`: `evidence(..., model=..., alternative=...)`.
+- **Fall back to `infer()` for non-binomial cases in v0.5**; add `evidence(..., alternative=...)` in a later slice.
 
-Currently the spec lets `f2_count_observation.prior < 1` act as an authorship reliability. But this is not yet propagated into the evidence factor's potential (only `assumptions` entries are). Two options:
+Leaning toward option 3 for the initial landing: ship `evidence()` with `Binomial` only (the PR #482 demand case), and expand built-in coverage incrementally.
 
-1. Treat the observation Claim itself as an implicit gate: `g_effective = data.prior · ∏ assumptions.posterior`.
-2. Require users to lift reliability into an explicit `Claim("reporter accurate", ...)` and put it into `assumptions`. More verbose but more explicit about what's being modeled.
+### 9.3 `associate()` marginal-coherence check
 
-This spec currently leaves this as author convention — reliability lives on `data.prior` and is consulted by the BP engine as the Claim's marginal for the reliability axis, but the factor doesn't multiplicatively scale by it. Revisit once the Mendel migration is done.
+When both `marginal_a` and `marginal_b` are provided and inconsistent (`p_a_given_b · marginal_b ≠ p_b_given_a · marginal_a` within float tolerance), should the framework:
 
-### 9.4 Model identity and deterministic hashing
+- **Warn and pick one** (which?).
+- **Hard error**.
+- **Accept silently and use an implementation choice** (e.g., `marginal_a`, derive `marginal_b` from Bayes).
 
-`serialise_params()` is the basis for structure-hash-level identity (§2.3). Need to commit that JSON-canonicalisation rules are identical to `ComposedAction` (`2026-04-24-gaia-composition-primitive-design.md` §1.2). Likely a shared utility.
+Recommendation: warn, use the geometric mean of the two implied `marginal_a` values as a tie-break. Revisit if it proves awkward in practice.
 
-### 9.5 Naming bikeshed
+### 9.4 Validation: missing `data.metadata` fields for `evidence.model`
 
-- `evidence()` vs `support_statistical()` vs `likelihood()` — we pick `evidence()` to match the verb-as-noun convention of `observe`/`derive`/`compute`/`infer`/`associate` and the `helper_kind = "evidence"` tag.
-- `LikelihoodModel` vs `StatisticalModel` vs `EvidenceModel` — `LikelihoodModel` emphasises the mathematical role (it returns `log P(data | H)`), while `EvidenceModel` would emphasise the DSL role. Mild preference for `LikelihoodModel`; flag for reviewer feedback.
+If `evidence(..., model=Binomial(n=395, p=3/4))` receives a `data` Claim whose `metadata` lacks `dominant` and `total`, compile should fail with a clear message naming both the expected and actually-present fields. Trivial to implement; flagged here as a UX acceptance bar.
 
 ---
 
@@ -598,22 +512,29 @@ This spec currently leaves this as author convention — reliability lives on `d
 
 Phase A is complete when:
 
-- [ ] `evidence()` verb exists in `gaia.lang` and is exported from `gaia.lang.__init__`.
-- [ ] `EvidenceFactor` Action subclass exists in `gaia.lang.runtime.action`.
-- [ ] Six starter `LikelihoodModel` classes exist with unit tests verifying their `log_likelihood` math matches hand-computed references to 1e-9 relative.
-- [ ] `test_evidence_verb.py` covers: binary BF, gate scaling, deprecated `infer`/`associate` paths, PRIORS non-conflict.
-- [ ] Mendel example compiles without `probabilities.py`, without `f2_dominant_count_specific`, and produces `P(Mendel | data) > 0.9` and `P(blending | data) < 0.1` (the current directional assertions in `test_mendel_v05_example.py` continue to pass unchanged).
-- [ ] `docs/foundations/language/gaia-language-spec.md` documents `evidence()` at spec level.
-- [ ] Issue #485 can be closed with a reference to the merged PR.
+- [ ] `marginal_a` / `marginal_b` / `marginal_h` accepted by `associate()` / `associate()` / `infer()`. Old names accepted with `DeprecationWarning`.
+- [ ] `infer(prior_evidence=...)` raises `DeprecationWarning` and ignores the value; docstring explains the two migration targets.
+- [ ] `given: list[Claim]` accepted by all three Correlate DSL verbs.
+- [ ] `evidence()` verb exported from `gaia.lang`.
+- [ ] `EvidenceFactor` Action subclass compiles and lowers for `DistributionSpec.kind = "binomial"`.
+- [ ] Correlate-family actions no longer write to `claim.metadata["prior"]`.
+- [ ] "conflicting marginal providers" `ValueError` removed from `gaia.cli.main infer`.
+- [ ] BP lowering applies `given` gate multiplier for all three Correlate verbs.
+- [ ] `test_evidence_verb.py` covers: basic binary factor via Binomial, gate scaling, missing-metadata-field error, deprecated-kwargs warnings.
+- [ ] Mendel example migrates to Path A, `test_mendel_v05_example.py` continues to assert `P(Mendel | data) > 0.8` and `P(blending | data) < 0.2`.
+- [ ] Issue #485 can be closed; deprecated-alias removal (Phase C) tracked in a new follow-up issue.
 
 ---
 
-## 11. Relation to issue #448
+## 11. What this spec does NOT propose
 
-Issue #448 proposes a broader v6 rework that would also remove `Associate` / `Infer` entirely and reshape the `Strategy` IR. This spec:
+For clarity, items intentionally left out:
 
-- **Lands on v0.5** without a v6 rework, by keeping `Associate` / `Infer` as thin shorthands (§6).
-- **Implements #448's core statistical move**: "statistical uncertainty is represented by explicit evidence / likelihood factors" — `EvidenceFactor` + `LikelihoodModel` is exactly that.
-- **Defers #448's other moves**: removing probabilistic warrant entirely, reshaping `Strategy.type` to only `{support, deduction, definition, source_support, computation_support}`, moving Claim roles to metadata. These can follow in a later PR that takes `evidence()` as its starting point.
-
-In other words, this spec is the **minimum viable subset of #448 that resolves the immediate Mendel failure and opens up model-swap / sensitivity / multi-observation capabilities**, without requiring v6's full re-authoring of the language surface.
+- **No removal of `infer` or `associate`** — they remain first-class with their distinct cognitive posture.
+- **No unified-verb design** — rev1's single-verb `evidence()` with mutex kwargs is explicitly rejected as un-Pythonic and error-prone.
+- **No `LikelihoodModel` protocol** — rev1's custom protocol is superseded by reusing PR #487's `DistributionSpec`.
+- **No new model classes** — `gaia.stats.*` (from PR #487) is the complete authoring surface.
+- **No continuous-parameter integration** — continuous latent-variable BP is out of scope; custom callable likelihoods go through `from_callable` + scipy adapter (PR #487's later slice 2).
+- **No changes to Support family verbs** (`derive` / `observe` / `compute`) — they already have `given` and do not have the `prior_*` ↔ `PRIORS` collision.
+- **No changes to relation helpers** (`equal` / `contradict` / `exclusive`) — they do not carry probabilities.
+- **No v6-scale rework** — #448's broader direction is acknowledged in §6 but is not attempted here.


### PR DESCRIPTION
## Summary

Adds a target-design spec at \`docs/specs/2026-04-25-evidence-factor-design.md\` for a new \`evidence()\` DSL verb, an \`EvidenceFactor\` Action IR entity, and a pluggable \`LikelihoodModel\` protocol. The proposal lets users hand Gaia a named statistical model (Binomial-against-diffuse-prior, Binomial-vs-Binomial, Gaussian measurement, etc.) instead of hand-computed scalars, and decouples observation reliability from Bayesian marginal so \`PRIORS\` and \`associate.prior_b\` stop competing for the same Claim field.

This is a **design document, not code** — posting as a PR rather than an issue because it's long and benefits from inline review / diff-style comments on individual sections.

## What the spec proposes

1. **New DSL verb** \`evidence(conclusion, data, model, assumptions, query, ...)\` following the Correlate-family convention (\`helper_kind = \"evidence\"\`).
2. **New IR Action** \`EvidenceFactor\` as a \`Correlate\` subclass, parallel to \`Associate\` and \`Infer\`.
3. **\`LikelihoodModel\` protocol** with initial library: \`ScalarBayesFactor\`, \`BinomialPointLikelihood\`, \`BinomialAgainstDiffusePrior\`, \`BinomialVsBinomial\`, \`GaussianMeasurementModel\`, \`PointwiseRatio\`, \`SymmetricScalarAssociation\`.
4. **BP lowering** where \`assumptions\` Claims multiplicatively gate the factor strength (\`g = ∏ posterior(assumption_i)\`).
5. **\`infer()\` and \`associate()\` retained as thin shorthands** over \`evidence()\` — full source compatibility, \`prior_*\` kwargs deprecated with a \`DeprecationWarning\`.
6. **Worked Mendel example** showing the current PR #482 workaround (\`probabilities.py\` + \`f2_dominant_count_specific\` intermediate node) dissolving when \`evidence(model=BinomialAgainstDiffusePrior(p=3/4))\` is used directly.
7. **Phased migration plan** (~1 week Phase A for landing the verb + models + tests; ~1 week Phase B for example migrations).

## Relation to existing tracks

- **Resolves #485** (narrow PRIORS ↔ \`associate.prior_b\` field collision) by making the \`prior_*\` kwargs unnecessary rather than renaming them.
- **Implements the statistical-evidence core of #448** (v6 proposal) without requiring #448's full language-surface rework. Positions \`evidence()\` as the v0.5-compatible subset of v6's \`EvidenceFactor\` direction.
- **Extends \`2026-04-24-gaia-composition-primitive-design.md\`** §1.3 / §11.4 — \`evidence()\` plays the same role in the Correlate family that \`compute()\` plays in the Support family.

## Feedback welcome on

- Section §5 (BP lowering): is \`g = ∏ posterior(assumption_i)\` the right default, or should it be noisy-AND from day one?
- Section §9.3 (unreliable reporter): should \`data.prior < 1\` act as an implicit gate, or do we require authors to lift reliability into an explicit \`Claim\` in \`assumptions\`?
- Section §9.2 (Gaussian continuous alternatives): analytic, numeric, or discretised? Choice to be made before Phase A lands.
- Section §10 acceptance criteria — any items to add / remove before this becomes actionable?

## Not in scope

- Actual implementation — this PR is spec-only. A follow-up PR under \`impl/evidence-factor\` will land the code once the spec is accepted.
- v6's \"remove probabilistic warrant\" rework, Strategy-IR restructure, and role-metadata-only Claim families (those remain in #448's wheelhouse).


Made with [Cursor](https://cursor.com)