### PR TITLE
Port inquiry review loop to v0.5

### DIFF
--- a/gaia/cli/commands/check_core.py
+++ b/gaia/cli/commands/check_core.py
@@ -1,0 +1,121 @@
+"""Structured analyzers shared by `gaia check` and `gaia inquiry review`.
+
+This module is the single source of truth for graph-health / prior-hole /
+knowledge-breakdown analysis on a compiled Gaia IR. `gaia check` keeps
+emitting human-readable lines via the wrappers in ``check.py``; `gaia
+inquiry` consumes the structured dataclasses below directly.
+
+No detection logic is duplicated in ``gaia.inquiry``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from gaia.cli.commands._classify import KnowledgeClassification, classify_ir, node_role
+
+
+def get_prior(k: dict) -> float | None:
+    """Return the prior stored in a knowledge node's metadata, or None."""
+    meta = k.get("metadata") or {}
+    return meta.get("prior")
+
+
+@dataclass
+class HoleEntry:
+    """One independent claim, with or without a prior set."""
+
+    cid: str
+    label: str
+    content: str
+    prior: float | None
+    prior_justification: str = ""
+
+    @property
+    def is_hole(self) -> bool:
+        return self.prior is None
+
+
+@dataclass
+class KnowledgeBreakdown:
+    """Role-based breakdown of all knowledge nodes in an IR."""
+
+    settings: list[str] = field(default_factory=list)
+    questions: list[str] = field(default_factory=list)
+    independent: list[HoleEntry] = field(default_factory=list)
+    derived: list[str] = field(default_factory=list)
+    structural: list[str] = field(default_factory=list)
+    background_only: list[str] = field(default_factory=list)
+    orphaned: list[str] = field(default_factory=list)
+    classification: KnowledgeClassification = field(default_factory=KnowledgeClassification)
+
+    @property
+    def holes(self) -> list[HoleEntry]:
+        return [e for e in self.independent if e.is_hole]
+
+    @property
+    def covered(self) -> list[HoleEntry]:
+        return [e for e in self.independent if not e.is_hole]
+
+
+def analyze_knowledge_breakdown(ir: dict) -> KnowledgeBreakdown:
+    """Walk the IR once and classify every knowledge node by structural role."""
+    c = classify_ir(ir)
+    out = KnowledgeBreakdown(classification=c)
+
+    for k in ir.get("knowledges", []):
+        ktype = k.get("type")
+        kid = k["id"]
+        label = k.get("label", kid.split("::")[-1])
+        if ktype == "setting":
+            out.settings.append(label)
+            continue
+        if ktype == "question":
+            out.questions.append(label)
+            continue
+        if ktype != "claim":
+            continue
+        role = node_role(kid, "claim", c)
+        if role == "structural":
+            out.structural.append(label)
+        elif role == "derived":
+            out.derived.append(label)
+        elif role == "independent":
+            meta = k.get("metadata") or {}
+            out.independent.append(
+                HoleEntry(
+                    cid=kid,
+                    label=label,
+                    content=k.get("content", ""),
+                    prior=get_prior(k),
+                    prior_justification=meta.get("prior_justification", ""),
+                )
+            )
+        elif role == "background":
+            out.background_only.append(label)
+        else:
+            out.orphaned.append(label)
+    return out
+
+
+def find_possible_duplicate_claims(ir: dict) -> list[tuple[str, str]]:
+    """Heuristic: pairs of claims with identical normalized content.
+
+    Conservative — only exact-match after whitespace collapse. Per spec §8
+    `possible_duplicate_claims` is a graph-health hint, not an error.
+    """
+    claims = [k for k in ir.get("knowledges", []) if k.get("type") == "claim"]
+    by_norm: dict[str, list[str]] = {}
+    for k in claims:
+        content = " ".join((k.get("content") or "").split()).lower()
+        if not content:
+            continue
+        by_norm.setdefault(content, []).append(k.get("label", k["id"].split("::")[-1]))
+    pairs: list[tuple[str, str]] = []
+    for labels in by_norm.values():
+        if len(labels) < 2:
+            continue
+        for i in range(len(labels)):
+            for j in range(i + 1, len(labels)):
+                pairs.append((labels[i], labels[j]))
+    return pairs

--- a/gaia/cli/commands/check_core.py
+++ b/gaia/cli/commands/check_core.py
@@ -66,7 +66,7 @@ def analyze_knowledge_breakdown(ir: dict) -> KnowledgeBreakdown:
     for k in ir.get("knowledges", []):
         ktype = k.get("type")
         kid = k["id"]
-        label = k.get("label", kid.split("::")[-1])
+        label = k.get("label") or kid.split("::")[-1]
         if ktype == "setting":
             out.settings.append(label)
             continue

--- a/gaia/cli/commands/inquiry.py
+++ b/gaia/cli/commands/inquiry.py
@@ -1,0 +1,391 @@
+"""gaia inquiry — public CLI sub-app.
+
+Public commands per spec §G3:  focus, review.
+Additional ProofState-extension subcommands (Round A1) exposed under
+  inquiry obligation / hypothesis / reject / tactics
+to support Lean-like reasoning process tracking, all implemented via state.json
+only — no mutation of .py source / IR / priors / beliefs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from gaia.inquiry.review import (
+    publish_blockers,
+    render_markdown,
+    render_text,
+    resolve_graph,
+    run_review,
+)
+from gaia.inquiry.focus import resolve_focus_target
+from gaia.inquiry.state import (
+    VALID_OBLIGATION_KINDS,
+    SyntheticHypothesis,
+    SyntheticObligation,
+    SyntheticRejection,
+    append_tactic_event,
+    load_state,
+    mint_qid,
+    pop_focus_frame,
+    push_focus_frame,
+    save_state,
+)
+
+inquiry_app = typer.Typer(
+    name="inquiry",
+    help="Gaia Inquiry — semantic review loop.",
+    no_args_is_help=True,
+)
+
+obligation_app = typer.Typer(
+    name="obligation", help="Manage synthetic obligations.", no_args_is_help=True
+)
+hypothesis_app = typer.Typer(
+    name="hypothesis", help="Manage working hypotheses.", no_args_is_help=True
+)
+tactics_app = typer.Typer(
+    name="tactics", help="Inspect the inquiry tactic log.", no_args_is_help=True
+)
+
+inquiry_app.add_typer(obligation_app, name="obligation")
+inquiry_app.add_typer(hypothesis_app, name="hypothesis")
+inquiry_app.add_typer(tactics_app, name="tactics")
+
+
+# ---------------------------------------------------------------------------
+# focus
+# ---------------------------------------------------------------------------
+
+
+@inquiry_app.command("focus")
+def focus_command(
+    target: Optional[str] = typer.Argument(None, help="Focus target."),
+    clear: bool = typer.Option(False, "--clear", help="Clear current focus."),
+    push: bool = typer.Option(False, "--push", help="Push current focus and set new."),
+    pop: bool = typer.Option(False, "--pop", help="Pop saved focus off the stack."),
+    show_stack: bool = typer.Option(False, "--stack", help="Print focus stack."),
+    path: str = typer.Option(".", "--path", help="Package path."),
+) -> None:
+    flags_set = sum([bool(clear), bool(push), bool(pop), bool(show_stack)])
+    if flags_set > 1:
+        typer.echo("Error: --clear/--push/--pop/--stack are mutually exclusive.", err=True)
+        raise typer.Exit(2)
+
+    state = load_state(path)
+    graph = resolve_graph(path)
+
+    if clear:
+        push_focus_frame(state)  # preserve history — not required but cheap
+        state.focus_stack.pop()  # we actually don't want the frame on clear
+        state.focus = None
+        state.focus_kind = None
+        state.focus_resolved_id = None
+        save_state(path, state)
+        append_tactic_event(path, "focus_clear", {})
+        typer.echo("focus cleared")
+        return
+
+    if show_stack:
+        typer.echo(f"current: {state.focus or '(none)'}")
+        if not state.focus_stack:
+            typer.echo("stack: (empty)")
+            return
+        typer.echo("stack (top → bottom):")
+        for frame in reversed(state.focus_stack):
+            raw = frame.get("focus") or "(none)"
+            kind = frame.get("focus_kind") or "none"
+            typer.echo(f"  - {raw}  [{kind}]")
+        return
+
+    if pop:
+        if not state.focus_stack:
+            typer.echo("Error: focus stack is empty.", err=True)
+            raise typer.Exit(1)
+        old = pop_focus_frame(state)
+        save_state(path, state)
+        append_tactic_event(
+            path,
+            "focus_pop",
+            {"old": (old or {}).get("focus"), "restored": state.focus},
+        )
+        typer.echo(f"popped: {(old or {}).get('focus')} → {state.focus or '(none)'}")
+        return
+
+    if push:
+        if not target:
+            typer.echo("Error: --push requires a TARGET.", err=True)
+            raise typer.Exit(2)
+        push_focus_frame(state)
+        binding = resolve_focus_target(target, graph)
+        state.focus = binding.raw
+        state.focus_kind = binding.kind
+        state.focus_resolved_id = binding.resolved_id
+        save_state(path, state)
+        append_tactic_event(path, "focus_push", {"target": target})
+        typer.echo(f"focus pushed: {target}")
+        return
+
+    if target is None:
+        if state.focus is None:
+            typer.echo("focus: (none)")
+        else:
+            kind = state.focus_kind or "freeform"
+            rid = state.focus_resolved_id
+            suffix = f"; id={rid}" if rid else ""
+            typer.echo(f"focus: {state.focus}  [{kind}{suffix}]")
+        return
+
+    binding = resolve_focus_target(target, graph)
+    state.focus = binding.raw
+    state.focus_kind = binding.kind
+    state.focus_resolved_id = binding.resolved_id
+    save_state(path, state)
+    append_tactic_event(path, "focus_set", {"target": target, "kind": binding.kind})
+    typer.echo(f"focus set: {binding.raw}  [{binding.kind}]")
+
+
+# ---------------------------------------------------------------------------
+# obligation
+# ---------------------------------------------------------------------------
+
+
+@obligation_app.command("add")
+def obligation_add(
+    target_qid: str = typer.Argument(..., help="QID the obligation is about."),
+    content: str = typer.Option(..., "-c", "--content", help="What must be shown."),
+    kind: str = typer.Option("other", "--kind", help="Diagnostic kind."),
+    path: str = typer.Option(".", "--path", help="Package path."),
+) -> None:
+    if kind not in VALID_OBLIGATION_KINDS:
+        typer.echo(
+            f"Error: invalid --kind {kind!r}; allowed: {sorted(VALID_OBLIGATION_KINDS)}",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    state = load_state(path)
+    qid = mint_qid("oblig")
+    state.synthetic_obligations.append(
+        SyntheticObligation(qid=qid, target_qid=target_qid, content=content, diagnostic_kind=kind)
+    )
+    save_state(path, state)
+    append_tactic_event(
+        path,
+        "obligation_add",
+        {"qid": qid, "target_qid": target_qid, "kind": kind},
+    )
+    typer.echo(f"obligation added {qid}")
+
+
+@obligation_app.command("list")
+def obligation_list(
+    json_out: bool = typer.Option(False, "--json"),
+    path: str = typer.Option(".", "--path"),
+) -> None:
+    state = load_state(path)
+    rows = [
+        {
+            "qid": o.qid,
+            "target_qid": o.target_qid,
+            "content": o.content,
+            "diagnostic_kind": o.diagnostic_kind,
+            "created_at": o.created_at,
+        }
+        for o in state.synthetic_obligations
+    ]
+    if json_out:
+        typer.echo(json.dumps(rows, ensure_ascii=False, indent=2))
+        return
+    if not rows:
+        typer.echo("(no open obligations)")
+        return
+    for r in rows:
+        typer.echo(f"- [{r['diagnostic_kind']}] {r['qid']} → {r['target_qid']}: {r['content']}")
+
+
+@obligation_app.command("close")
+def obligation_close(
+    qid: str = typer.Argument(...),
+    path: str = typer.Option(".", "--path"),
+) -> None:
+    state = load_state(path)
+    before = len(state.synthetic_obligations)
+    state.synthetic_obligations = [o for o in state.synthetic_obligations if o.qid != qid]
+    if len(state.synthetic_obligations) == before:
+        typer.echo(f"Error: no obligation with qid {qid!r}.", err=True)
+        raise typer.Exit(1)
+    save_state(path, state)
+    append_tactic_event(path, "obligation_close", {"qid": qid})
+    typer.echo(f"obligation closed {qid}")
+
+
+# ---------------------------------------------------------------------------
+# hypothesis
+# ---------------------------------------------------------------------------
+
+
+@hypothesis_app.command("add")
+def hypothesis_add(
+    content: str = typer.Argument(..., help="Hypothesis content."),
+    scope: Optional[str] = typer.Option(None, "--scope", help="Scope QID."),
+    path: str = typer.Option(".", "--path"),
+) -> None:
+    state = load_state(path)
+    qid = mint_qid("hyp")
+    state.synthetic_hypotheses.append(
+        SyntheticHypothesis(qid=qid, content=content, scope_qid=scope)
+    )
+    save_state(path, state)
+    append_tactic_event(path, "hypothesis_add", {"qid": qid, "scope": scope})
+    typer.echo(f"hypothesis added {qid}")
+
+
+@hypothesis_app.command("list")
+def hypothesis_list(
+    json_out: bool = typer.Option(False, "--json"),
+    path: str = typer.Option(".", "--path"),
+) -> None:
+    state = load_state(path)
+    rows = [
+        {
+            "qid": h.qid,
+            "content": h.content,
+            "scope_qid": h.scope_qid,
+            "created_at": h.created_at,
+        }
+        for h in state.synthetic_hypotheses
+    ]
+    if json_out:
+        typer.echo(json.dumps(rows, ensure_ascii=False, indent=2))
+        return
+    if not rows:
+        typer.echo("(no hypotheses)")
+        return
+    for r in rows:
+        scope = f" @ {r['scope_qid']}" if r["scope_qid"] else ""
+        typer.echo(f"- {r['qid']}{scope}: {r['content']}")
+
+
+@hypothesis_app.command("remove")
+def hypothesis_remove(
+    qid: str = typer.Argument(...),
+    path: str = typer.Option(".", "--path"),
+) -> None:
+    state = load_state(path)
+    before = len(state.synthetic_hypotheses)
+    state.synthetic_hypotheses = [h for h in state.synthetic_hypotheses if h.qid != qid]
+    if len(state.synthetic_hypotheses) == before:
+        typer.echo(f"Error: no hypothesis with qid {qid!r}.", err=True)
+        raise typer.Exit(1)
+    save_state(path, state)
+    append_tactic_event(path, "hypothesis_remove", {"qid": qid})
+    typer.echo(f"hypothesis removed {qid}")
+
+
+# ---------------------------------------------------------------------------
+# reject
+# ---------------------------------------------------------------------------
+
+
+@inquiry_app.command("reject")
+def reject_command(
+    strategy: str = typer.Argument(..., help="Target strategy label/id."),
+    content: str = typer.Option(..., "-c", "--content", help="Reason."),
+    path: str = typer.Option(".", "--path"),
+) -> None:
+    state = load_state(path)
+    qid = mint_qid("rej")
+    state.synthetic_rejections.append(
+        SyntheticRejection(qid=qid, target_strategy=strategy, content=content)
+    )
+    save_state(path, state)
+    append_tactic_event(path, "reject", {"qid": qid, "strategy": strategy})
+    typer.echo(f"strategy rejected {qid} ({strategy})")
+
+
+# ---------------------------------------------------------------------------
+# tactics log
+# ---------------------------------------------------------------------------
+
+
+@tactics_app.command("log")
+def tactics_log(
+    json_out: bool = typer.Option(False, "--json"),
+    path: str = typer.Option(".", "--path"),
+) -> None:
+    from gaia.inquiry.state import read_tactic_log
+
+    rows = read_tactic_log(path)
+    if json_out:
+        typer.echo(json.dumps(rows, ensure_ascii=False, indent=2))
+        return
+    if not rows:
+        typer.echo("(no tactic log entries)")
+        return
+    for rec in rows:
+        ts = rec.get("timestamp", "")
+        ev = rec.get("event", "")
+        payload = rec.get("payload", {})
+        typer.echo(f"{ts}  {ev}  {json.dumps(payload, ensure_ascii=False)}")
+
+
+# ---------------------------------------------------------------------------
+# review
+# ---------------------------------------------------------------------------
+
+
+@inquiry_app.command("review")
+def review_command(
+    path: str = typer.Argument(".", help="Package path."),
+    focus_: Optional[str] = typer.Option(None, "--focus"),
+    mode: str = typer.Option("auto", "--mode"),
+    no_infer: bool = typer.Option(False, "--no-infer"),
+    depth: int = typer.Option(0, "--depth"),
+    since: Optional[str] = typer.Option(None, "--since"),
+    json_out: bool = typer.Option(False, "--json"),
+    markdown_out: bool = typer.Option(False, "--markdown"),
+    strict: bool = typer.Option(False, "--strict"),
+) -> None:
+    if mode not in {"auto", "formalize", "explore", "verify", "publish"}:
+        typer.echo(f"Error: invalid --mode {mode!r}.", err=True)
+        raise typer.Exit(2)
+    report = run_review(
+        path,
+        focus_override=focus_,
+        mode=mode,
+        no_infer=no_infer,
+        depth=depth,
+        since=since,
+        strict=strict,
+    )
+    append_tactic_event(
+        Path(path),
+        "review",
+        {"review_id": report.review_id, "mode": mode, "no_infer": no_infer},
+    )
+
+    if json_out and markdown_out:
+        typer.echo("Error: --json and --markdown are mutually exclusive.", err=True)
+        raise typer.Exit(2)
+    if json_out:
+        typer.echo(json.dumps(report.to_json_dict(), ensure_ascii=False, indent=2))
+    elif markdown_out:
+        typer.echo(render_markdown(report))
+    else:
+        typer.echo(render_text(report))
+
+    if report.graph_health.get("errors"):
+        raise typer.Exit(1)
+    if strict and mode == "publish":
+        blockers = publish_blockers(report)
+        if blockers:
+            for b in blockers:
+                typer.echo(f"[publish-strict] {b}", err=True)
+            raise typer.Exit(1)
+    elif strict and report.graph_health.get("warnings"):
+        raise typer.Exit(1)

--- a/gaia/cli/commands/inquiry.py
+++ b/gaia/cli/commands/inquiry.py
@@ -354,6 +354,10 @@ def review_command(
     if mode not in {"auto", "formalize", "explore", "verify", "publish"}:
         typer.echo(f"Error: invalid --mode {mode!r}.", err=True)
         raise typer.Exit(2)
+    if json_out and markdown_out:
+        typer.echo("Error: --json and --markdown are mutually exclusive.", err=True)
+        raise typer.Exit(2)
+
     report = run_review(
         path,
         focus_override=focus_,
@@ -369,9 +373,6 @@ def review_command(
         {"review_id": report.review_id, "mode": mode, "no_infer": no_infer},
     )
 
-    if json_out and markdown_out:
-        typer.echo("Error: --json and --markdown are mutually exclusive.", err=True)
-        raise typer.Exit(2)
     if json_out:
         typer.echo(json.dumps(report.to_json_dict(), ensure_ascii=False, indent=2))
     elif markdown_out:

--- a/gaia/cli/main.py
+++ b/gaia/cli/main.py
@@ -7,6 +7,7 @@ from gaia.cli.commands.check import check_command
 from gaia.cli.commands.compile import compile_command
 from gaia.cli.commands.infer import infer_command
 from gaia.cli.commands.init import init_command
+from gaia.cli.commands.inquiry import inquiry_app
 from gaia.cli.commands.register import register_command
 from gaia.cli.commands.render import render_command
 
@@ -29,3 +30,6 @@ app.command(name="infer")(infer_command)
 app.command(name="init")(init_command)
 app.command(name="register")(register_command)
 app.command(name="render")(render_command)
+
+app.add_typer(inquiry_app, name="inquiry")
+app.add_typer(inquiry_app, name="inquery", hidden=True)  # typo alias

--- a/gaia/inquiry/__init__.py
+++ b/gaia/inquiry/__init__.py
@@ -1,0 +1,86 @@
+"""gaia.inquiry — spec §10 public surface.
+
+Thin wrapper over Gaia. This module does not run its own compiler, validator,
+or inference engine; it composes the ones already in Gaia.
+"""
+
+from gaia.inquiry.anchor import SourceAnchor, find_anchors
+from gaia.inquiry.diagnostics import (
+    Diagnostic,
+    NextEdit,
+    format_diagnostics_as_next_edits,
+    format_diagnostics_as_structured_edits,
+    from_knowledge_breakdown,
+    from_validation,
+)
+from gaia.inquiry.diff import ClaimDelta, SemanticDiff, empty_diff
+from gaia.inquiry.focus import FocusBinding, resolve_focus_target
+from gaia.inquiry.proof_state import (
+    HypothesisView,
+    ObligationView,
+    ProofContext,
+    RejectionView,
+    build_proof_context,
+)
+from gaia.inquiry.render import render_json, render_markdown, to_json_dict
+from gaia.inquiry.review import ReviewReport, render_text, resolve_graph, run_review
+from gaia.inquiry.state import (
+    STATE_SCHEMA_VERSION,
+    VALID_MODES,
+    VALID_OBLIGATION_KINDS,
+    InquiryState,
+    SyntheticHypothesis,
+    SyntheticObligation,
+    SyntheticRejection,
+    append_tactic_event,
+    inquiry_dir,
+    load_state,
+    mint_qid,
+    pop_focus_frame,
+    push_focus_frame,
+    read_tactic_log,
+    save_state,
+)
+
+__all__ = [
+    "STATE_SCHEMA_VERSION",
+    "VALID_MODES",
+    "VALID_OBLIGATION_KINDS",
+    "ClaimDelta",
+    "Diagnostic",
+    "FocusBinding",
+    "HypothesisView",
+    "InquiryState",
+    "NextEdit",
+    "ObligationView",
+    "ProofContext",
+    "RejectionView",
+    "ReviewReport",
+    "SemanticDiff",
+    "SourceAnchor",
+    "SyntheticHypothesis",
+    "SyntheticObligation",
+    "SyntheticRejection",
+    "append_tactic_event",
+    "build_proof_context",
+    "empty_diff",
+    "find_anchors",
+    "format_diagnostics_as_next_edits",
+    "format_diagnostics_as_structured_edits",
+    "from_knowledge_breakdown",
+    "from_validation",
+    "inquiry_dir",
+    "render_json",
+    "render_markdown",
+    "load_state",
+    "mint_qid",
+    "pop_focus_frame",
+    "push_focus_frame",
+    "read_tactic_log",
+    "render_text",
+    "to_json_dict",
+    "resolve_focus_target",
+    "resolve_graph",
+    "run_review",
+    "save_state",
+]

--- a/gaia/inquiry/anchor.py
+++ b/gaia/inquiry/anchor.py
@@ -1,0 +1,116 @@
+"""Source anchor —— 把 IR 里的 label 反向解析回源代码 (file, line)。
+
+Gaia 的 Knowledge 只记录 ``module`` 名字，不记录行号。Inquiry 自己用
+``ast`` 扫描 package 源代码，定位 ``<name> = claim(...) / setting(...) /
+question(...) / support(...) / operator(...)`` 形式的顶层赋值，将变量名 (或
+显式 ``label="..."`` 关键字) 映射到 (文件路径, 行号, 列号)。
+
+只读：仅读取 .py 文件，不解析模块、不导入、不修改任何东西。
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+# Gaia DSL 顶层构造器；这些调用的赋值目标即为该节点 label 的默认值。
+_DSL_CALLABLES = {
+    "claim",
+    "setting",
+    "question",
+    "support",
+    "operator",
+    "noisy_and",
+}
+
+
+@dataclass(frozen=True)
+class SourceAnchor:
+    """指向 package 内某个 DSL 声明的源位置。"""
+
+    file: str  # 相对 package_root 的 POSIX 风格路径
+    line: int  # 1-based
+    column: int  # 0-based, 与 ast.AST.col_offset 一致
+
+    def to_dict(self) -> dict:
+        return {"file": self.file, "line": self.line, "column": self.column}
+
+
+def _label_from_call(node: ast.Call) -> str | None:
+    """优先用 ``label="..."`` 关键字, 缺省时由调用者用变量名兜底。"""
+    for kw in node.keywords:
+        if (
+            kw.arg == "label"
+            and isinstance(kw.value, ast.Constant)
+            and isinstance(kw.value.value, str)
+        ):
+            return kw.value.value
+    if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+        # 多数 DSL 把首个位置参数当作 content/label——claim() 是 content,
+        # 但变量名才是 label, 因此首位置参数不直接当 label。
+        return None
+    return None
+
+
+def _callable_name(func: ast.AST) -> str | None:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _scan_module(py_file: Path, rel_file: str) -> dict[str, SourceAnchor]:
+    out: dict[str, SourceAnchor] = {}
+    try:
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(py_file))
+    except (OSError, SyntaxError):
+        return out
+
+    for stmt in tree.body:
+        # 只看顶层赋值: x = claim(...) / x: T = claim(...)
+        if isinstance(stmt, ast.Assign):
+            targets = stmt.targets
+            value = stmt.value
+        elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+            targets = [stmt.target]
+            value = stmt.value
+        else:
+            continue
+        if not isinstance(value, ast.Call):
+            continue
+        name = _callable_name(value.func)
+        if name not in _DSL_CALLABLES:
+            continue
+        anchor = SourceAnchor(file=rel_file, line=stmt.lineno, column=stmt.col_offset)
+        explicit = _label_from_call(value)
+        if explicit:
+            out[explicit] = anchor
+        for tgt in targets:
+            if isinstance(tgt, ast.Name):
+                out.setdefault(tgt.id, anchor)
+    return out
+
+
+def find_anchors(pkg_path: str | Path) -> dict[str, SourceAnchor]:
+    """扫描 package 下所有 .py, 返回 label → SourceAnchor 映射。
+
+    重复 label 取首次出现; 排除 .gaia/ 与隐藏目录。
+    """
+    root = Path(pkg_path).resolve()
+    out: dict[str, SourceAnchor] = {}
+    if not root.is_dir():
+        return out
+    for py_file in sorted(root.rglob("*.py")):
+        # 跳过 .gaia/ / .venv / __pycache__ / 隐藏目录
+        if any(
+            part.startswith(".") or part == "__pycache__"
+            for part in py_file.relative_to(root).parts
+        ):
+            continue
+        rel = py_file.relative_to(root).as_posix()
+        for label, anchor in _scan_module(py_file, rel).items():
+            out.setdefault(label, anchor)
+    return out

--- a/gaia/inquiry/anchor.py
+++ b/gaia/inquiry/anchor.py
@@ -1,9 +1,9 @@
 """Source anchor —— 把 IR 里的 label 反向解析回源代码 (file, line)。
 
 Gaia 的 Knowledge 只记录 ``module`` 名字，不记录行号。Inquiry 自己用
-``ast`` 扫描 package 源代码，定位 ``<name> = claim(...) / setting(...) /
-question(...) / support(...) / operator(...)`` 形式的顶层赋值，将变量名 (或
-显式 ``label="..."`` 关键字) 映射到 (文件路径, 行号, 列号)。
+``ast`` 扫描 package 源代码，定位 ``<name> = claim(...) / derive(...) /
+deduction(...)`` 等 DSL 顶层调用，将变量名 (或显式 ``label="..."`` 关键字)
+映射到 (文件路径, 行号, 列号)。
 
 只读：仅读取 .py 文件，不解析模块、不导入、不修改任何东西。
 """
@@ -16,12 +16,40 @@ from pathlib import Path
 
 # Gaia DSL 顶层构造器；这些调用的赋值目标即为该节点 label 的默认值。
 _DSL_CALLABLES = {
+    "abduction",
+    "analogy",
+    "associate",
+    "case_analysis",
     "claim",
-    "setting",
-    "question",
-    "support",
-    "operator",
+    "compare",
+    "composite",
+    "compose",
+    "composition",
+    "complement",
+    "contradict",
+    "contradiction",
+    "context",
+    "compute",
+    "deduction",
+    "depends_on",
+    "derive",
+    "disjunction",
+    "equal",
+    "elimination",
+    "equivalence",
+    "exclusive",
+    "extrapolation",
+    "fills",
+    "induction",
+    "infer",
+    "mathematical_induction",
+    "note",
     "noisy_and",
+    "observe",
+    "operator",
+    "question",
+    "setting",
+    "support",
 }
 
 
@@ -76,6 +104,9 @@ def _scan_module(py_file: Path, rel_file: str) -> dict[str, SourceAnchor]:
             value = stmt.value
         elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
             targets = [stmt.target]
+            value = stmt.value
+        elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            targets = []
             value = stmt.value
         else:
             continue

--- a/gaia/inquiry/diagnostics.py
+++ b/gaia/inquiry/diagnostics.py
@@ -1,0 +1,723 @@
+"""Spec §15 — Diagnostic layer over Gaia's existing detectors.
+
+Inquiry does NOT run its own graph analysis. It translates the outputs of
+``gaia.ir.validator.validate_local_graph`` and
+``gaia.cli.commands.check_core.analyze_knowledge_breakdown`` into a uniform
+``Diagnostic`` stream, which drives the `graph_health`, `prior_holes`, and
+`next_edits` sections of the review report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Literal
+
+from gaia.cli.commands.check_core import (
+    HoleEntry,
+    KnowledgeBreakdown,
+    find_possible_duplicate_claims,
+)
+from gaia.inquiry.anchor import SourceAnchor
+from gaia.inquiry.focus import FocusBinding
+
+Severity = Literal["error", "warning", "info"]
+DiagnosticKind = Literal[
+    "compile_error",
+    "validation_error",
+    "validation_warning",
+    "prior_hole",
+    "orphaned_claim",
+    "background_only_claim",
+    "possible_duplicate_claim",
+    "focus_weakness",
+    "structural_hole",
+    "support_weak",
+    "belief_regression",
+    "stale_artifact",
+    "focus_low_posterior",
+    "prior_without_justification",
+    "unreviewed_warrant",
+    "rejected_warrant",
+    "blocked_warrant_path",
+    "focus_unsupported",
+    "large_belief_drop",
+    "overstrong_strategy_without_provenance",
+    "claim_with_evidence_but_no_focus_connection",
+]
+
+
+@dataclass
+class Diagnostic:
+    """Spec §15 Diagnostic record. Uniform across all detection sources."""
+
+    severity: Severity
+    kind: DiagnosticKind
+    target: str
+    label: str
+    message: str
+    suggested_edit: str = ""
+    data: dict = field(default_factory=dict)
+    source_anchor: SourceAnchor | None = None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        if not d["data"]:
+            d.pop("data")
+        if d.get("source_anchor") is None:
+            d.pop("source_anchor", None)
+        return d
+
+
+@dataclass
+class NextEdit:
+    """Spec §8.8 / Round A2 — 结构化编辑建议。
+
+    ``text`` 是渲染给人看的 imperative 一行; ``source_anchor`` 在可定位时指向
+    需要修改的源位置。其余字段复制自产生该 edit 的 Diagnostic。
+    """
+
+    text: str
+    kind: str
+    severity: Severity
+    target: str
+    label: str
+    source_anchor: SourceAnchor | None = None
+
+    def to_dict(self) -> dict:
+        d = {
+            "text": self.text,
+            "kind": self.kind,
+            "severity": self.severity,
+            "target": self.target,
+            "label": self.label,
+        }
+        if self.source_anchor is not None:
+            d["source_anchor"] = self.source_anchor.to_dict()
+        return d
+
+
+def from_validation(warnings: list[str], errors: list[str]) -> list[Diagnostic]:
+    """Lift strings from ``ValidationResult`` into ``Diagnostic`` records."""
+    out: list[Diagnostic] = []
+    for msg in errors:
+        out.append(
+            Diagnostic(
+                severity="error",
+                kind="validation_error",
+                target="graph",
+                label="graph",
+                message=msg,
+            )
+        )
+    for msg in warnings:
+        out.append(
+            Diagnostic(
+                severity="warning",
+                kind="validation_warning",
+                target="graph",
+                label="graph",
+                message=msg,
+            )
+        )
+    return out
+
+
+def _attach_anchor(d: Diagnostic, anchors: dict[str, SourceAnchor] | None) -> Diagnostic:
+    if anchors and d.label in anchors:
+        d.source_anchor = anchors[d.label]
+    return d
+
+
+def from_knowledge_breakdown(
+    kb: KnowledgeBreakdown,
+    ir: dict,
+    focus: FocusBinding | None,
+    anchors: dict[str, SourceAnchor] | None = None,
+) -> list[Diagnostic]:
+    """Emit diagnostics for prior holes, orphans, background-only, duplicates."""
+    out: list[Diagnostic] = []
+    for entry in kb.holes:
+        out.append(_attach_anchor(_prior_hole_diag(entry), anchors))
+    for label in kb.orphaned:
+        out.append(
+            _attach_anchor(
+                Diagnostic(
+                    severity="warning",
+                    kind="orphaned_claim",
+                    target=label,
+                    label=label,
+                    message="Claim is not referenced by any strategy or operator.",
+                    suggested_edit=f"Either connect `{label}` to a strategy/operator, or remove it.",
+                ),
+                anchors,
+            )
+        )
+    for label in kb.background_only:
+        out.append(
+            _attach_anchor(
+                Diagnostic(
+                    severity="info",
+                    kind="background_only_claim",
+                    target=label,
+                    label=label,
+                    message="Claim appears only in strategy background; not part of the BP graph.",
+                    suggested_edit=(
+                        f"If `{label}` should affect beliefs, move it to premises; "
+                        "otherwise leave as background."
+                    ),
+                ),
+                anchors,
+            )
+        )
+    for a, b in find_possible_duplicate_claims(ir):
+        out.append(
+            Diagnostic(
+                severity="warning",
+                kind="possible_duplicate_claim",
+                target=f"{a}|{b}",
+                label=f"{a} / {b}",
+                message=f"Claims `{a}` and `{b}` have identical content.",
+                suggested_edit=f"Merge `{a}` and `{b}`, or differentiate their content.",
+            )
+        )
+    return out
+
+
+def _prior_hole_diag(entry: HoleEntry) -> Diagnostic:
+    preview = (entry.content[:72] + "...") if len(entry.content) > 75 else entry.content
+    return Diagnostic(
+        severity="warning",
+        kind="prior_hole",
+        target=entry.cid,
+        label=entry.label,
+        message=f"Independent claim `{entry.label}` has no prior set (defaults to 0.5).",
+        suggested_edit=(
+            f'Set a prior in priors.py: set_prior("{entry.label}", <value>, justification="...").'
+        ),
+        data={"content": preview},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch B emitters — additional diagnostic sources beyond validator/breakdown.
+# ---------------------------------------------------------------------------
+
+
+def detect_stale_artifact(
+    pkg_path,
+    current_ir_hash: str | None,
+) -> list[Diagnostic]:
+    """Compare in-memory ir_hash with on-disk .gaia/ir_hash file.
+
+    If the file exists and differs, the package state on disk was produced by
+    an earlier IR — typically because the agent edited Python after the last
+    review/build. Always non-fatal (warning).
+    """
+    from pathlib import Path as _P
+
+    out: list[Diagnostic] = []
+    if current_ir_hash is None:
+        return out
+    f = _P(pkg_path) / ".gaia" / "ir_hash"
+    if not f.exists():
+        return out
+    try:
+        recorded = f.read_text(encoding="utf-8").strip()
+    except OSError:
+        return out
+    if not recorded or recorded == current_ir_hash:
+        return out
+    out.append(
+        Diagnostic(
+            severity="warning",
+            kind="stale_artifact",
+            target=".gaia/ir_hash",
+            label=".gaia/ir_hash",
+            message=(
+                f"On-disk ir_hash ({recorded[:12]}...) does not match the freshly "
+                f"compiled graph ({current_ir_hash[:12]}...)."
+            ),
+            suggested_edit=(
+                "Re-run `gaia build` (or the package equivalent) to refresh "
+                "cached artifacts; otherwise downstream tools may read stale state."
+            ),
+            data={"recorded": recorded, "current": current_ir_hash},
+        )
+    )
+    return out
+
+
+def detect_focus_low_posterior(
+    belief_report: dict,
+    threshold: float = 0.3,
+) -> list[Diagnostic]:
+    """Emit when the focus claim's posterior is below ``threshold``.
+
+    Spec §15: low posterior on the focus signals that the supporting evidence
+    is currently insufficient. Threshold is conservative (0.3) to avoid noise.
+    """
+    out: list[Diagnostic] = []
+    foc = belief_report.get("focus") if isinstance(belief_report, dict) else None
+    if not foc:
+        return out
+    after = foc.get("after")
+    if after is None:
+        return out
+    try:
+        val = float(after)
+    except (TypeError, ValueError):
+        return out
+    if val >= threshold:
+        return out
+    label = foc.get("label", "")
+    target = foc.get("knowledge_id", label)
+    out.append(
+        Diagnostic(
+            severity="warning",
+            kind="focus_low_posterior",
+            target=target,
+            label=label,
+            message=(
+                f"Focus `{label}` posterior is {val:.3f}, below {threshold:.2f}; "
+                "evidence supporting it is currently weak."
+            ),
+            suggested_edit=(
+                f"Add a supporting strategy or premise for `{label}`, "
+                "or revise the claim if the evidence does not back it."
+            ),
+            data={"posterior": val, "threshold": threshold},
+        )
+    )
+    return out
+
+
+def detect_prior_without_justification(
+    kb,
+    anchors: dict | None = None,
+) -> list[Diagnostic]:
+    """For every covered (non-hole) prior, require a non-empty justification.
+
+    Reads from ``KnowledgeBreakdown.covered`` — entries with prior set but
+    empty ``prior_justification``. Severity is *info*: not blocking, but the
+    publish gate may surface it.
+    """
+    out: list[Diagnostic] = []
+    for entry in kb.covered:
+        just = (entry.prior_justification or "").strip()
+        if just:
+            continue
+        d = Diagnostic(
+            severity="info",
+            kind="prior_without_justification",
+            target=entry.cid,
+            label=entry.label,
+            message=(
+                f"Claim `{entry.label}` has prior={entry.prior} but no "
+                "`prior_justification` recorded."
+            ),
+            suggested_edit=(
+                f'Update priors.py: set_prior("{entry.label}", {entry.prior}, justification="...").'
+            ),
+            data={"prior": entry.prior},
+        )
+        out.append(_attach_anchor(d, anchors))
+    return out
+
+
+def detect_warrant_status(
+    graph,
+    rejected_strategy_targets: set[str] | None = None,
+    anchors: dict | None = None,
+) -> list[Diagnostic]:
+    """Walk graph.strategies and emit unreviewed/rejected warrants.
+
+    A strategy is *rejected* if its label or id appears in
+    ``rejected_strategy_targets`` (sourced from InquiryState.synthetic_rejections).
+    Otherwise it is *unreviewed* unless its metadata carries a non-empty
+    ``judgment`` key.
+    """
+    out: list[Diagnostic] = []
+    if graph is None:
+        return out
+    rejected = rejected_strategy_targets or set()
+    for s in getattr(graph, "strategies", []) or []:
+        sid = getattr(s, "id", "") or ""
+        label = sid.split("::")[-1] if sid else getattr(s, "label", "") or ""
+        meta = dict(getattr(s, "metadata", None) or {})
+        if sid in rejected or label in rejected:
+            d = Diagnostic(
+                severity="info",
+                kind="rejected_warrant",
+                target=sid or label,
+                label=label,
+                message=f"Strategy `{label}` is recorded as rejected.",
+                suggested_edit=(
+                    f"Either remove `{label}` from the package or replace it "
+                    "with a revised strategy."
+                ),
+            )
+            out.append(_attach_anchor(d, anchors))
+            continue
+        judgment = (meta.get("judgment") or "").strip()
+        if not judgment:
+            d = Diagnostic(
+                severity="info",
+                kind="unreviewed_warrant",
+                target=sid or label,
+                label=label,
+                message=f"Strategy `{label}` has no review judgment yet.",
+                suggested_edit=(
+                    f"Run a review pass on `{label}` and record a judgment "
+                    'in its metadata (e.g. metadata={"judgment": "accepted"}).'
+                ),
+            )
+            out.append(_attach_anchor(d, anchors))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Spec §15.2 — remaining diagnostic emitters
+#   blocked_warrant_path / focus_unsupported / large_belief_drop /
+#   overstrong_strategy_without_provenance /
+#   claim_with_evidence_but_no_focus_connection
+# ---------------------------------------------------------------------------
+
+
+def detect_blocked_warrant_path(
+    graph,
+    kb: KnowledgeBreakdown,
+    anchors: dict | None = None,
+) -> list[Diagnostic]:
+    """A strategy whose premises include unresolved prior holes.
+
+    Walks every strategy and reports it as a blocked warrant path when one or
+    more of its premises is a claim listed in ``kb.holes`` (independent claims
+    without a recorded prior). Severity is *warning*: the warrant cannot
+    propagate confidence until the upstream priors are filled.
+    """
+    out: list[Diagnostic] = []
+    if graph is None:
+        return out
+    hole_ids = {h.cid for h in kb.holes}
+    if not hole_ids:
+        return out
+    for s in getattr(graph, "strategies", []) or []:
+        sid = getattr(s, "id", "") or ""
+        label = sid.split("::")[-1] if sid else ""
+        premises = list(getattr(s, "premises", None) or [])
+        blocking = sorted(p for p in premises if p in hole_ids)
+        if not blocking:
+            continue
+        d = Diagnostic(
+            severity="warning",
+            kind="blocked_warrant_path",
+            target=sid or label,
+            label=label,
+            message=(f"Strategy `{label}` has unresolved prior holes in its premises: {blocking}."),
+            suggested_edit=(
+                f"Set priors in priors.py for {blocking} to unblock the warrant "
+                f"path leading to `{label}`."
+            ),
+            data={"blocking_premises": blocking, "strategy": sid},
+        )
+        out.append(_attach_anchor(d, anchors))
+    return out
+
+
+def detect_focus_unsupported(
+    graph,
+    focus: FocusBinding | None,
+    anchors: dict | None = None,
+) -> list[Diagnostic]:
+    """Focus claim is not referenced anywhere in the graph.
+
+    A focus is considered supported if it appears as a strategy's conclusion,
+    premise, or background, or as an operator's conclusion or variable. When
+    no such reference exists, the inquiry tree has no path leading to or from
+    the focus, and the agent cannot reason toward it.
+    """
+    if graph is None or focus is None:
+        return []
+    fid = focus.resolved_id
+    if not fid:
+        return []
+    for s in getattr(graph, "strategies", []) or []:
+        if getattr(s, "conclusion", None) == fid:
+            return []
+        if fid in (getattr(s, "premises", None) or []):
+            return []
+        if fid in (getattr(s, "background", None) or []):
+            return []
+    for o in getattr(graph, "operators", []) or []:
+        if getattr(o, "conclusion", None) == fid:
+            return []
+        if fid in (getattr(o, "variables", None) or []):
+            return []
+    label = fid.split("::")[-1] if fid else ""
+    d = Diagnostic(
+        severity="warning",
+        kind="focus_unsupported",
+        target=fid,
+        label=label,
+        message=(
+            f"Focus `{label}` is not referenced by any strategy or operator; "
+            "the inquiry tree has no edges touching it."
+        ),
+        suggested_edit=(
+            f"Add a strategy that concludes `{label}` (or include `{label}` "
+            "as a premise/background) so it is wired into the inquiry tree."
+        ),
+    )
+    return [_attach_anchor(d, anchors)]
+
+
+def detect_large_belief_drop(
+    belief_report: dict,
+    threshold: float = 0.3,
+) -> list[Diagnostic]:
+    """Posterior dropped meaningfully relative to the baseline snapshot.
+
+    Reads ``belief_report['largest_decreases']`` (populated only when a
+    baseline snapshot was found and inference ran) and emits one diagnostic
+    per claim whose ``delta <= -threshold``. Default threshold is conservative
+    (0.3) to avoid noise from small numerical fluctuations.
+    """
+    out: list[Diagnostic] = []
+    if not isinstance(belief_report, dict):
+        return out
+    decreases = belief_report.get("largest_decreases") or []
+    for entry in decreases:
+        delta = entry.get("delta")
+        try:
+            d_val = float(delta)
+        except (TypeError, ValueError):
+            continue
+        if d_val > -threshold:
+            continue
+        label = entry.get("label", "") or ""
+        before = entry.get("before")
+        after = entry.get("after")
+        out.append(
+            Diagnostic(
+                severity="warning",
+                kind="large_belief_drop",
+                target=label,
+                label=label,
+                message=(f"Belief for `{label}` dropped {d_val:+.3f} (from {before} to {after})."),
+                suggested_edit=(
+                    f"Investigate which evidence or strategy change pushed "
+                    f"`{label}` down by {-d_val:.2f}; revise the supporting "
+                    "structure or update the baseline if intentional."
+                ),
+                data={
+                    "before": before,
+                    "after": after,
+                    "delta": d_val,
+                    "threshold": threshold,
+                },
+            )
+        )
+    return out
+
+
+def detect_overstrong_strategy_without_provenance(
+    graph,
+    strength_threshold: float = 0.8,
+    anchors: dict | None = None,
+) -> list[Diagnostic]:
+    """Strategy has neither ``provenance`` nor ``justification`` metadata.
+
+    A strategy must record a non-empty ``provenance`` or ``justification``
+    field; otherwise its warrant is unsourced. When the strategy declares a
+    ``strength`` (or ``confidence``) at or above ``strength_threshold``,
+    severity is *warning* — the agent is leaning on an unjustified strong
+    claim. Otherwise severity is *info*.
+    """
+    out: list[Diagnostic] = []
+    if graph is None:
+        return out
+
+    def _nonempty(v) -> bool:
+        if v is None:
+            return False
+        if isinstance(v, str):
+            return bool(v.strip())
+        return True
+
+    for s in getattr(graph, "strategies", []) or []:
+        sid = getattr(s, "id", "") or ""
+        label = sid.split("::")[-1] if sid else ""
+        meta = dict(getattr(s, "metadata", None) or {})
+        if _nonempty(meta.get("provenance")) or _nonempty(meta.get("justification")):
+            continue
+
+        raw_strength = meta.get("strength", meta.get("confidence"))
+        try:
+            strength_val = float(raw_strength) if raw_strength is not None else None
+        except (TypeError, ValueError):
+            strength_val = None
+
+        if strength_val is not None and strength_val >= strength_threshold:
+            severity: Severity = "warning"
+            message = (
+                f"Strategy `{label}` declares strength {strength_val:.2f} "
+                "but has no `provenance` or `justification` recorded."
+            )
+        else:
+            severity = "info"
+            message = (
+                f"Strategy `{label}` has no `provenance` or `justification` "
+                "recorded in its metadata."
+            )
+        data: dict = {"strength_threshold": strength_threshold}
+        if strength_val is not None:
+            data["strength"] = strength_val
+        d = Diagnostic(
+            severity=severity,
+            kind="overstrong_strategy_without_provenance",
+            target=sid or label,
+            label=label,
+            message=message,
+            suggested_edit=(
+                f"Update `{label}`.metadata with a non-empty "
+                '"provenance" or "justification" field describing why this '
+                "warrant is taken to hold."
+            ),
+            data=data,
+        )
+        out.append(_attach_anchor(d, anchors))
+    return out
+
+
+def detect_claim_with_evidence_but_no_focus_connection(
+    graph,
+    focus: FocusBinding | None,
+    anchors: dict | None = None,
+) -> list[Diagnostic]:
+    """Claim cited as background but disconnected from the focus.
+
+    Builds an undirected adjacency over all strategy / operator co-occurrences
+    and BFS from the focus claim. A claim that appears only in some strategy's
+    ``background`` (i.e. cited as evidence but never as premise or conclusion)
+    yet is in a different connected component from the focus is reported.
+    Severity is *info* — it is rarely fatal but signals a stranded reference.
+    """
+    if graph is None or focus is None:
+        return []
+    fid = focus.resolved_id
+    if not fid:
+        return []
+
+    from collections import defaultdict, deque
+
+    adj: dict[str, set[str]] = defaultdict(set)
+
+    def _link_clique(nodes: list[str]) -> None:
+        nodes = [n for n in nodes if n]
+        for i, a in enumerate(nodes):
+            for b in nodes[i + 1 :]:
+                adj[a].add(b)
+                adj[b].add(a)
+
+    for s in getattr(graph, "strategies", []) or []:
+        clique: list[str] = []
+        if getattr(s, "conclusion", None):
+            clique.append(s.conclusion)
+        clique.extend(getattr(s, "premises", None) or [])
+        clique.extend(getattr(s, "background", None) or [])
+        _link_clique(clique)
+    for o in getattr(graph, "operators", []) or []:
+        clique = []
+        if getattr(o, "conclusion", None):
+            clique.append(o.conclusion)
+        clique.extend(getattr(o, "variables", None) or [])
+        _link_clique(clique)
+
+    visited: set[str] = {fid}
+    q: deque = deque([fid])
+    while q:
+        cur = q.popleft()
+        for nb in adj.get(cur, ()):
+            if nb not in visited:
+                visited.add(nb)
+                q.append(nb)
+
+    in_core: set[str] = set()
+    in_bg: set[str] = set()
+    for s in getattr(graph, "strategies", []) or []:
+        if getattr(s, "conclusion", None):
+            in_core.add(s.conclusion)
+        for p in getattr(s, "premises", None) or []:
+            in_core.add(p)
+        for b in getattr(s, "background", None) or []:
+            in_bg.add(b)
+    bg_only = in_bg - in_core
+
+    out: list[Diagnostic] = []
+    focus_label = fid.split("::")[-1] if fid else ""
+    for k in getattr(graph, "knowledges", []) or []:
+        kid = getattr(k, "id", "")
+        if kid not in bg_only or kid in visited:
+            continue
+        label = getattr(k, "label", "") or (kid.split("::")[-1] if kid else "")
+        d = Diagnostic(
+            severity="info",
+            kind="claim_with_evidence_but_no_focus_connection",
+            target=kid,
+            label=label,
+            message=(
+                f"Claim `{label}` is cited as background evidence but is in a "
+                f"different connected component than focus `{focus_label}`."
+            ),
+            suggested_edit=(
+                f"Either connect `{label}` into a strategy that touches the "
+                f"focus subgraph, or remove the dangling background reference."
+            ),
+        )
+        out.append(_attach_anchor(d, anchors))
+    return out
+
+
+_PRIO = {"error": 0, "warning": 1, "info": 2}
+
+
+def format_diagnostics_as_next_edits(diags: list[Diagnostic]) -> list[str]:
+    """Spec §8 `Next edits` — 文本形式 (向后兼容 Step 2 的 str 列表)。
+
+    若 diagnostic 带 ``source_anchor``, 追加 ``(file:line)`` 到末尾,
+    便于人眼直接定位源行。
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for d in sorted(diags, key=lambda d: _PRIO.get(d.severity, 9)):
+        edit = d.suggested_edit.strip()
+        if not edit or edit in seen:
+            continue
+        seen.add(edit)
+        if d.source_anchor is not None:
+            ordered.append(f"{edit} ({d.source_anchor.file}:{d.source_anchor.line})")
+        else:
+            ordered.append(edit)
+    return ordered
+
+
+def format_diagnostics_as_structured_edits(diags: list[Diagnostic]) -> list[NextEdit]:
+    """Round A2 — structured NextEdit 列表, 与文本版 dedup 语义一致。"""
+    seen: set[str] = set()
+    out: list[NextEdit] = []
+    for d in sorted(diags, key=lambda d: _PRIO.get(d.severity, 9)):
+        edit = d.suggested_edit.strip()
+        if not edit or edit in seen:
+            continue
+        seen.add(edit)
+        out.append(
+            NextEdit(
+                text=edit,
+                kind=d.kind,
+                severity=d.severity,
+                target=d.target,
+                label=d.label,
+                source_anchor=d.source_anchor,
+            )
+        )
+    return out

--- a/gaia/inquiry/diagnostics.py
+++ b/gaia/inquiry/diagnostics.py
@@ -17,6 +17,7 @@ from gaia.cli.commands.check_core import (
     KnowledgeBreakdown,
     find_possible_duplicate_claims,
 )
+from gaia.ir import ReviewManifest, ReviewStatus
 from gaia.inquiry.anchor import SourceAnchor
 from gaia.inquiry.focus import FocusBinding
 
@@ -98,6 +99,32 @@ class NextEdit:
 
 def _strategy_id(strategy) -> str:
     return getattr(strategy, "strategy_id", None) or getattr(strategy, "id", None) or ""
+
+
+def _action_label(metadata: dict | None) -> str | None:
+    label = (metadata or {}).get("action_label")
+    if not isinstance(label, str) or not label:
+        return None
+    if "::action::" in label:
+        return label.split("::action::", 1)[1]
+    return label
+
+
+def _strategy_label(strategy, sid: str, metadata: dict | None = None) -> str:
+    return (
+        _action_label(metadata)
+        or getattr(strategy, "label", None)
+        or (sid.split("::")[-1] if sid else "")
+    )
+
+
+def _manifest_status(
+    review_manifest: ReviewManifest | None,
+    target_id: str,
+) -> ReviewStatus | None:
+    if review_manifest is None or not target_id:
+        return None
+    return review_manifest.latest_status(target_id)
 
 
 def from_validation(warnings: list[str], errors: list[str]) -> list[Diagnostic]:
@@ -332,6 +359,7 @@ def detect_warrant_status(
     graph,
     rejected_strategy_targets: set[str] | None = None,
     anchors: dict | None = None,
+    review_manifest: ReviewManifest | None = None,
 ) -> list[Diagnostic]:
     """Walk graph.strategies and emit unreviewed/rejected warrants.
 
@@ -346,9 +374,12 @@ def detect_warrant_status(
     rejected = rejected_strategy_targets or set()
     for s in getattr(graph, "strategies", []) or []:
         sid = _strategy_id(s)
-        label = sid.split("::")[-1] if sid else getattr(s, "label", "") or ""
         meta = dict(getattr(s, "metadata", None) or {})
-        if sid in rejected or label in rejected:
+        label = _strategy_label(s, sid, meta)
+        status = _manifest_status(review_manifest, sid)
+        if status == ReviewStatus.ACCEPTED:
+            continue
+        if status == ReviewStatus.REJECTED or sid in rejected or label in rejected:
             d = Diagnostic(
                 severity="info",
                 kind="rejected_warrant",
@@ -362,8 +393,22 @@ def detect_warrant_status(
             )
             out.append(_attach_anchor(d, anchors))
             continue
+        if status == ReviewStatus.NEEDS_INPUTS:
+            d = Diagnostic(
+                severity="warning",
+                kind="unreviewed_warrant",
+                target=sid or label,
+                label=label,
+                message=f"Strategy `{label}` needs additional review inputs.",
+                suggested_edit=(
+                    f"Provide the missing review inputs for `{label}` and update "
+                    ".gaia/review_manifest.json."
+                ),
+            )
+            out.append(_attach_anchor(d, anchors))
+            continue
         judgment = (meta.get("judgment") or "").strip()
-        if not judgment:
+        if status == ReviewStatus.UNREVIEWED or (status is None and not judgment):
             d = Diagnostic(
                 severity="info",
                 kind="unreviewed_warrant",
@@ -407,7 +452,8 @@ def detect_blocked_warrant_path(
         return out
     for s in getattr(graph, "strategies", []) or []:
         sid = _strategy_id(s)
-        label = sid.split("::")[-1] if sid else ""
+        meta = dict(getattr(s, "metadata", None) or {})
+        label = _strategy_label(s, sid, meta)
         premises = list(getattr(s, "premises", None) or [])
         blocking = sorted(p for p in premises if p in hole_ids)
         if not blocking:
@@ -550,8 +596,8 @@ def detect_overstrong_strategy_without_provenance(
 
     for s in getattr(graph, "strategies", []) or []:
         sid = _strategy_id(s)
-        label = sid.split("::")[-1] if sid else ""
         meta = dict(getattr(s, "metadata", None) or {})
+        label = _strategy_label(s, sid, meta)
         if _nonempty(meta.get("provenance")) or _nonempty(meta.get("justification")):
             continue
 

--- a/gaia/inquiry/diagnostics.py
+++ b/gaia/inquiry/diagnostics.py
@@ -96,6 +96,10 @@ class NextEdit:
         return d
 
 
+def _strategy_id(strategy) -> str:
+    return getattr(strategy, "strategy_id", None) or getattr(strategy, "id", None) or ""
+
+
 def from_validation(warnings: list[str], errors: list[str]) -> list[Diagnostic]:
     """Lift strings from ``ValidationResult`` into ``Diagnostic`` records."""
     out: list[Diagnostic] = []
@@ -341,7 +345,7 @@ def detect_warrant_status(
         return out
     rejected = rejected_strategy_targets or set()
     for s in getattr(graph, "strategies", []) or []:
-        sid = getattr(s, "id", "") or ""
+        sid = _strategy_id(s)
         label = sid.split("::")[-1] if sid else getattr(s, "label", "") or ""
         meta = dict(getattr(s, "metadata", None) or {})
         if sid in rejected or label in rejected:
@@ -402,7 +406,7 @@ def detect_blocked_warrant_path(
     if not hole_ids:
         return out
     for s in getattr(graph, "strategies", []) or []:
-        sid = getattr(s, "id", "") or ""
+        sid = _strategy_id(s)
         label = sid.split("::")[-1] if sid else ""
         premises = list(getattr(s, "premises", None) or [])
         blocking = sorted(p for p in premises if p in hole_ids)
@@ -545,7 +549,7 @@ def detect_overstrong_strategy_without_provenance(
         return True
 
     for s in getattr(graph, "strategies", []) or []:
-        sid = getattr(s, "id", "") or ""
+        sid = _strategy_id(s)
         label = sid.split("::")[-1] if sid else ""
         meta = dict(getattr(s, "metadata", None) or {})
         if _nonempty(meta.get("provenance")) or _nonempty(meta.get("justification")):

--- a/gaia/inquiry/diff.py
+++ b/gaia/inquiry/diff.py
@@ -1,0 +1,297 @@
+"""Spec §14 semantic diff — compare current IR against a previous review snapshot.
+
+Implements all 16 categories listed in §14.2:
+
+    added/removed/changed_claims
+    added/removed_questions
+    added/removed_settings
+    added/removed/changed_strategies
+    added/removed/changed_operators
+    changed_priors
+    changed_exports
+
+Identity matching uses stable IR ids (§14.3); labels are kept only for human-
+readable display. The diff is report-only — it cannot be applied (Non-Goals §2).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+# --------------------------------------------------------------------------- #
+# Delta record                                                                #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ClaimDelta:
+    """Per-field change record for a knowledge / strategy / operator / prior."""
+
+    label: str
+    field: str  # see SemanticDiff field comments for the allowed values
+    before: str
+    after: str
+
+    def to_dict(self) -> dict:
+        return {
+            "label": self.label,
+            "field": self.field,
+            "before": self.before,
+            "after": self.after,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# SemanticDiff (spec §9.1, §14.2)                                             #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class SemanticDiff:
+    """Spec §9.1 semantic_diff object — covers all 16 §14.2 categories."""
+
+    baseline_review_id: str | None = None
+
+    # Knowledge — type=claim
+    added_claims: list[str] = field(default_factory=list)
+    removed_claims: list[str] = field(default_factory=list)
+    changed_claims: list[ClaimDelta] = field(default_factory=list)
+
+    # Knowledge — type=question (Non-Goals §2: questions are read-only DSL primitives,
+    # they appear only in added/removed because their identity is structural).
+    added_questions: list[str] = field(default_factory=list)
+    removed_questions: list[str] = field(default_factory=list)
+
+    # Knowledge — type=setting
+    added_settings: list[str] = field(default_factory=list)
+    removed_settings: list[str] = field(default_factory=list)
+
+    # Strategies (= warrants)
+    added_strategies: list[str] = field(default_factory=list)
+    removed_strategies: list[str] = field(default_factory=list)
+    changed_strategies: list[ClaimDelta] = field(default_factory=list)
+
+    # Operators
+    added_operators: list[str] = field(default_factory=list)
+    removed_operators: list[str] = field(default_factory=list)
+    changed_operators: list[ClaimDelta] = field(default_factory=list)
+
+    # Cross-cutting deltas
+    changed_priors: list[ClaimDelta] = field(default_factory=list)
+    changed_exports: list[ClaimDelta] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not any(
+            (
+                self.added_claims,
+                self.removed_claims,
+                self.changed_claims,
+                self.added_questions,
+                self.removed_questions,
+                self.added_settings,
+                self.removed_settings,
+                self.added_strategies,
+                self.removed_strategies,
+                self.changed_strategies,
+                self.added_operators,
+                self.removed_operators,
+                self.changed_operators,
+                self.changed_priors,
+                self.changed_exports,
+            )
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "baseline_review_id": self.baseline_review_id,
+            "added_claims": list(self.added_claims),
+            "removed_claims": list(self.removed_claims),
+            "changed_claims": [d.to_dict() for d in self.changed_claims],
+            "added_questions": list(self.added_questions),
+            "removed_questions": list(self.removed_questions),
+            "added_settings": list(self.added_settings),
+            "removed_settings": list(self.removed_settings),
+            "added_strategies": list(self.added_strategies),
+            "removed_strategies": list(self.removed_strategies),
+            "changed_strategies": [d.to_dict() for d in self.changed_strategies],
+            "added_operators": list(self.added_operators),
+            "removed_operators": list(self.removed_operators),
+            "changed_operators": [d.to_dict() for d in self.changed_operators],
+            "changed_priors": [d.to_dict() for d in self.changed_priors],
+            "changed_exports": [d.to_dict() for d in self.changed_exports],
+        }
+
+
+def empty_diff() -> SemanticDiff:
+    return SemanticDiff()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers — IR introspection                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _knowledges_by_type_id(ir: dict, kind: str) -> dict[str, dict]:
+    return {k["id"]: k for k in ir.get("knowledges", []) or [] if k.get("type") == kind}
+
+
+def _strategies_by_id(ir: dict) -> dict[str, dict]:
+    return {s["id"]: s for s in ir.get("strategies", []) or []}
+
+
+def _operators_by_id(ir: dict) -> dict[str, dict]:
+    return {o["id"]: o for o in ir.get("operators", []) or []}
+
+
+def _label(item: dict) -> str:
+    return item.get("label") or item.get("id", "").split("::")[-1]
+
+
+def _prior(k: dict):
+    meta = k.get("metadata") or {}
+    return meta.get("prior")
+
+
+def _exported(k: dict) -> bool:
+    if "exported" in k:
+        return bool(k["exported"])
+    meta = k.get("metadata") or {}
+    return bool(meta.get("exported", False))
+
+
+def _fmt(v) -> str:
+    return "∅" if v is None else str(v)
+
+
+# --------------------------------------------------------------------------- #
+# Computation                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def compute_semantic_diff(
+    current_ir: dict | None,
+    baseline_snapshot: dict | None,
+) -> SemanticDiff:
+    """Return all 16 §14.2 category deltas between two snapshots."""
+    if baseline_snapshot is None or current_ir is None:
+        d = SemanticDiff()
+        if baseline_snapshot is not None:
+            d.baseline_review_id = baseline_snapshot.get("review_id")
+        return d
+
+    diff = SemanticDiff(baseline_review_id=baseline_snapshot.get("review_id"))
+    base_ir = baseline_snapshot.get("ir") or {}
+
+    _diff_claims(diff, current_ir, base_ir)
+    _diff_questions(diff, current_ir, base_ir)
+    _diff_settings(diff, current_ir, base_ir)
+    _diff_strategies(diff, current_ir, base_ir)
+    _diff_operators(diff, current_ir, base_ir)
+    return diff
+
+
+# --------------------------------------------------------------------------- #
+# Per-category routines                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _diff_claims(diff: SemanticDiff, cur: dict, base: dict) -> None:
+    """added/removed/changed_claims + changed_priors + changed_exports."""
+    cur_c = _knowledges_by_type_id(cur, "claim")
+    base_c = _knowledges_by_type_id(base, "claim")
+
+    for cid in sorted(cur_c.keys() - base_c.keys()):
+        diff.added_claims.append(_label(cur_c[cid]))
+    for cid in sorted(base_c.keys() - cur_c.keys()):
+        diff.removed_claims.append(_label(base_c[cid]))
+
+    for cid in sorted(cur_c.keys() & base_c.keys()):
+        a, b = base_c[cid], cur_c[cid]
+        label = _label(b)
+
+        if (a.get("content") or "") != (b.get("content") or ""):
+            diff.changed_claims.append(
+                ClaimDelta(label, "content", a.get("content") or "", b.get("content") or "")
+            )
+        if (a.get("label") or "") != (b.get("label") or ""):
+            diff.changed_claims.append(
+                ClaimDelta(label, "label", a.get("label") or "", b.get("label") or "")
+            )
+
+        pa, pb = _prior(a), _prior(b)
+        if pa != pb:
+            diff.changed_priors.append(ClaimDelta(label, "prior", _fmt(pa), _fmt(pb)))
+
+        ea, eb = _exported(a), _exported(b)
+        if ea != eb:
+            diff.changed_exports.append(ClaimDelta(label, "exported", _fmt(ea), _fmt(eb)))
+
+
+def _diff_questions(diff: SemanticDiff, cur: dict, base: dict) -> None:
+    cur_q = _knowledges_by_type_id(cur, "question")
+    base_q = _knowledges_by_type_id(base, "question")
+    for qid in sorted(cur_q.keys() - base_q.keys()):
+        diff.added_questions.append(_label(cur_q[qid]))
+    for qid in sorted(base_q.keys() - cur_q.keys()):
+        diff.removed_questions.append(_label(base_q[qid]))
+
+
+def _diff_settings(diff: SemanticDiff, cur: dict, base: dict) -> None:
+    cur_s = _knowledges_by_type_id(cur, "setting")
+    base_s = _knowledges_by_type_id(base, "setting")
+    for sid in sorted(cur_s.keys() - base_s.keys()):
+        diff.added_settings.append(_label(cur_s[sid]))
+    for sid in sorted(base_s.keys() - cur_s.keys()):
+        diff.removed_settings.append(_label(base_s[sid]))
+
+
+def _diff_strategies(diff: SemanticDiff, cur: dict, base: dict) -> None:
+    cur_st = _strategies_by_id(cur)
+    base_st = _strategies_by_id(base)
+    for sid in sorted(cur_st.keys() - base_st.keys()):
+        diff.added_strategies.append(sid.split("::")[-1])
+    for sid in sorted(base_st.keys() - cur_st.keys()):
+        diff.removed_strategies.append(sid.split("::")[-1])
+    for sid in sorted(cur_st.keys() & base_st.keys()):
+        a, b = base_st[sid], cur_st[sid]
+        label = sid.split("::")[-1]
+        if a.get("conclusion") != b.get("conclusion"):
+            diff.changed_strategies.append(
+                ClaimDelta(
+                    label, "conclusion", _fmt(a.get("conclusion")), _fmt(b.get("conclusion"))
+                )
+            )
+        if list(a.get("premises") or []) != list(b.get("premises") or []):
+            diff.changed_strategies.append(
+                ClaimDelta(
+                    label,
+                    "premises",
+                    ",".join(a.get("premises") or []),
+                    ",".join(b.get("premises") or []),
+                )
+            )
+
+
+def _diff_operators(diff: SemanticDiff, cur: dict, base: dict) -> None:
+    cur_op = _operators_by_id(cur)
+    base_op = _operators_by_id(base)
+    for oid in sorted(cur_op.keys() - base_op.keys()):
+        diff.added_operators.append(oid.split("::")[-1])
+    for oid in sorted(base_op.keys() - cur_op.keys()):
+        diff.removed_operators.append(oid.split("::")[-1])
+    for oid in sorted(cur_op.keys() & base_op.keys()):
+        a, b = base_op[oid], cur_op[oid]
+        label = oid.split("::")[-1]
+        if a.get("conclusion") != b.get("conclusion"):
+            diff.changed_operators.append(
+                ClaimDelta(
+                    label, "conclusion", _fmt(a.get("conclusion")), _fmt(b.get("conclusion"))
+                )
+            )
+        va, vb = list(a.get("variables") or []), list(b.get("variables") or [])
+        if va != vb:
+            diff.changed_operators.append(
+                ClaimDelta(label, "variables", ",".join(va), ",".join(vb))
+            )

--- a/gaia/inquiry/focus.py
+++ b/gaia/inquiry/focus.py
@@ -1,0 +1,60 @@
+"""Focus resolution — look up TARGET against compiled IR and return binding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class FocusBinding:
+    raw: str | None
+    resolved_id: str | None = None
+    resolved_label: str | None = None
+    kind: str = "freeform"
+
+    def to_dict(self) -> dict:
+        return {
+            "raw": self.raw,
+            "resolved_id": self.resolved_id,
+            "resolved_label": self.resolved_label,
+            "kind": self.kind,
+        }
+
+
+def resolve_focus_target(target: str | None, graph) -> FocusBinding:
+    if target is None:
+        return FocusBinding(raw=None, kind="none")
+    t = str(target).strip()
+    if not t:
+        return FocusBinding(raw=None, kind="none")
+
+    if graph is None:
+        return FocusBinding(raw=t, kind="freeform")
+
+    knowledges = getattr(graph, "knowledges", None) or []
+    by_id: dict[str, object] = {}
+    by_label: dict[str, object] = {}
+    for k in knowledges:
+        kid = getattr(k, "id", None)
+        klabel = getattr(k, "label", None)
+        if kid:
+            by_id[kid] = k
+        if klabel:
+            by_label[klabel] = k
+
+    hit = by_id.get(t) or by_label.get(t)
+    if hit is None:
+        return FocusBinding(raw=t, kind="freeform")
+
+    ktype = getattr(hit, "type", None)
+    kind = "claim"
+    if str(ktype).endswith("question") or str(ktype) == "question":
+        kind = "question"
+    elif str(ktype).endswith("setting") or str(ktype) == "setting":
+        kind = "setting"
+    return FocusBinding(
+        raw=t,
+        resolved_id=getattr(hit, "id", None),
+        resolved_label=getattr(hit, "label", None),
+        kind=kind,
+    )

--- a/gaia/inquiry/proof_state.py
+++ b/gaia/inquiry/proof_state.py
@@ -1,0 +1,110 @@
+"""ProofContext — merged view of IR question()/setting() and synthetic state."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from gaia.inquiry.state import (
+    InquiryState,
+)
+
+
+@dataclass
+class ObligationView:
+    qid: str
+    target_qid: str | None
+    content: str
+    diagnostic_kind: str
+    origin: str  # "ir" | "synthetic"
+    anchor: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HypothesisView:
+    qid: str
+    content: str
+    scope_qid: str | None
+    origin: str  # "ir" | "synthetic"
+
+
+@dataclass
+class RejectionView:
+    qid: str
+    target_strategy: str
+    content: str
+
+
+@dataclass
+class ProofContext:
+    obligations: list[ObligationView] = field(default_factory=list)
+    hypotheses: list[HypothesisView] = field(default_factory=list)
+    rejections: list[RejectionView] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "obligations": [asdict(o) for o in self.obligations],
+            "hypotheses": [asdict(h) for h in self.hypotheses],
+            "rejections": [asdict(r) for r in self.rejections],
+        }
+
+
+def build_proof_context(graph, state: InquiryState) -> ProofContext:
+    ctx = ProofContext()
+
+    # IR side — question() becomes obligation view, setting() becomes hypothesis view.
+    if graph is not None:
+        for k in getattr(graph, "knowledges", []) or []:
+            ktype = str(getattr(k, "type", ""))
+            qid = getattr(k, "id", None) or getattr(k, "label", None) or ""
+            content = getattr(k, "content", "") or ""
+            if ktype.endswith("question") or ktype == "question":
+                ctx.obligations.append(
+                    ObligationView(
+                        qid=qid,
+                        target_qid=None,
+                        content=content,
+                        diagnostic_kind="other",
+                        origin="ir",
+                    )
+                )
+            elif ktype.endswith("setting") or ktype == "setting":
+                ctx.hypotheses.append(
+                    HypothesisView(
+                        qid=qid,
+                        content=content,
+                        scope_qid=None,
+                        origin="ir",
+                    )
+                )
+
+    # Synthetic state.
+    for o in state.synthetic_obligations:
+        ctx.obligations.append(
+            ObligationView(
+                qid=o.qid,
+                target_qid=o.target_qid,
+                content=o.content,
+                diagnostic_kind=o.diagnostic_kind,
+                origin="synthetic",
+                anchor=dict(o.anchor),
+            )
+        )
+    for h in state.synthetic_hypotheses:
+        ctx.hypotheses.append(
+            HypothesisView(
+                qid=h.qid,
+                content=h.content,
+                scope_qid=h.scope_qid,
+                origin="synthetic",
+            )
+        )
+    for r in state.synthetic_rejections:
+        ctx.rejections.append(
+            RejectionView(
+                qid=r.qid,
+                target_strategy=r.target_strategy,
+                content=r.content,
+            )
+        )
+    return ctx

--- a/gaia/inquiry/ranking.py
+++ b/gaia/inquiry/ranking.py
@@ -1,0 +1,178 @@
+"""Spec §7 mode-specific report ranking + §15.4 next-edit ordering.
+
+Each review mode reweights the **same** Diagnostic stream — there is no
+mode-specific detection logic, only ordering. This keeps inquiry's read-only
+contract (Non-Goals §2) while still letting agents see the most relevant
+edits first.
+
+The mapping in ``_MODE_RANK`` follows §7 verbatim:
+
+* auto      — compile/validation errors → structural holes → focus → priors → beliefs → graph health
+* formalize — provenance / explicit-vs-inferred / structural / prior holes
+* explore   — focus weakness, support gaps, possible counterexamples, alternatives
+* verify    — proof/computation/source citation, overconfident priors, weak supports
+* publish   — exports + complete chains + structural + missing priors + render readiness
+
+Mode is the *only* knob exposed to users. Diagnostic kinds that are not in a
+mode's ranking still appear, just at the end (sorted by severity). This is
+required so an unknown DiagnosticKind never silently drops off the report.
+"""
+
+from __future__ import annotations
+
+from gaia.inquiry.diagnostics import Diagnostic, NextEdit
+
+
+# Spec §7 — `kind` priority per mode. Lower number = higher priority.
+# `severity` is a tiebreaker (error < warning < info).
+_MODE_RANK: dict[str, dict[str, int]] = {
+    "auto": {
+        "compile_error": 0,
+        "validation_error": 1,
+        "validation_warning": 2,
+        "structural_hole": 3,
+        "focus_weakness": 4,
+        "prior_hole": 5,
+        "belief_regression": 6,
+        "support_weak": 7,
+        "orphaned_claim": 8,
+        "background_only_claim": 9,
+        "possible_duplicate_claim": 10,
+        "stale_artifact": 11,
+        "focus_low_posterior": 12,
+        "unreviewed_warrant": 13,
+        "prior_without_justification": 14,
+        "rejected_warrant": 15,
+        "blocked_warrant_path": 16,
+        "focus_unsupported": 17,
+        "large_belief_drop": 18,
+        "overstrong_strategy_without_provenance": 19,
+        "claim_with_evidence_but_no_focus_connection": 20,
+    },
+    "formalize": {
+        "compile_error": 0,
+        "validation_error": 1,
+        "validation_warning": 2,
+        "structural_hole": 3,
+        "prior_hole": 4,
+        "support_weak": 5,
+        "orphaned_claim": 6,
+        "background_only_claim": 7,
+        "possible_duplicate_claim": 8,
+        "focus_weakness": 9,
+        "belief_regression": 10,
+        "stale_artifact": 11,
+        "prior_without_justification": 12,
+        "unreviewed_warrant": 13,
+        "rejected_warrant": 14,
+        "focus_low_posterior": 15,
+        "blocked_warrant_path": 16,
+        "overstrong_strategy_without_provenance": 17,
+        "focus_unsupported": 18,
+        "large_belief_drop": 19,
+        "claim_with_evidence_but_no_focus_connection": 20,
+    },
+    "explore": {
+        "compile_error": 0,
+        "focus_weakness": 1,
+        "support_weak": 2,
+        "structural_hole": 3,
+        "validation_error": 4,
+        "validation_warning": 5,
+        "belief_regression": 6,
+        "possible_duplicate_claim": 7,
+        "orphaned_claim": 8,
+        "background_only_claim": 9,
+        "prior_hole": 10,
+        "focus_low_posterior": 11,
+        "rejected_warrant": 12,
+        "unreviewed_warrant": 13,
+        "stale_artifact": 14,
+        "prior_without_justification": 15,
+        "focus_unsupported": 16,
+        "claim_with_evidence_but_no_focus_connection": 17,
+        "blocked_warrant_path": 18,
+        "large_belief_drop": 19,
+        "overstrong_strategy_without_provenance": 20,
+    },
+    "verify": {
+        "compile_error": 0,
+        "validation_error": 1,
+        "support_weak": 2,
+        "prior_hole": 3,
+        "belief_regression": 4,
+        "validation_warning": 5,
+        "structural_hole": 6,
+        "focus_weakness": 7,
+        "possible_duplicate_claim": 8,
+        "orphaned_claim": 9,
+        "background_only_claim": 10,
+        "focus_low_posterior": 11,
+        "prior_without_justification": 12,
+        "stale_artifact": 13,
+        "rejected_warrant": 14,
+        "unreviewed_warrant": 15,
+        "overstrong_strategy_without_provenance": 16,
+        "large_belief_drop": 17,
+        "blocked_warrant_path": 18,
+        "focus_unsupported": 19,
+        "claim_with_evidence_but_no_focus_connection": 20,
+    },
+    "publish": {
+        "compile_error": 0,
+        "validation_error": 1,
+        "validation_warning": 2,
+        "structural_hole": 3,
+        "prior_hole": 4,
+        "orphaned_claim": 5,
+        "support_weak": 6,
+        "background_only_claim": 7,
+        "belief_regression": 8,
+        "focus_weakness": 9,
+        "possible_duplicate_claim": 10,
+        "stale_artifact": 11,
+        "prior_without_justification": 12,
+        "unreviewed_warrant": 13,
+        "rejected_warrant": 14,
+        "focus_low_posterior": 15,
+        "blocked_warrant_path": 16,
+        "overstrong_strategy_without_provenance": 17,
+        "focus_unsupported": 18,
+        "large_belief_drop": 19,
+        "claim_with_evidence_but_no_focus_connection": 20,
+    },
+}
+
+_SEVERITY_RANK = {"error": 0, "warning": 1, "info": 2}
+
+_UNKNOWN_KIND_RANK = 99  # appended after known kinds, sorted by severity only.
+
+
+def supported_modes() -> tuple[str, ...]:
+    return tuple(_MODE_RANK.keys())
+
+
+def _key(mode: str):
+    table = _MODE_RANK.get(mode, _MODE_RANK["auto"])
+
+    def _k(d: Diagnostic | NextEdit):
+        kind_rank = table.get(d.kind, _UNKNOWN_KIND_RANK)
+        sev_rank = _SEVERITY_RANK.get(d.severity, 9)
+        # Stable tiebreak on label so identical (kind, severity) sort deterministically.
+        return (kind_rank, sev_rank, d.label)
+
+    return _k
+
+
+def rank_diagnostics(diagnostics: list[Diagnostic], mode: str) -> list[Diagnostic]:
+    """Return a new list of diagnostics sorted by the mode's priority table.
+
+    Always returns a copy. Unknown kinds are appended after known ones and
+    sorted by severity only — they are never dropped.
+    """
+    return sorted(diagnostics, key=_key(mode))
+
+
+def rank_next_edits(edits: list[NextEdit], mode: str) -> list[NextEdit]:
+    """Same ranking applied to structured next-edits (kept in lock-step)."""
+    return sorted(edits, key=_key(mode))

--- a/gaia/inquiry/render.py
+++ b/gaia/inquiry/render.py
@@ -1,0 +1,400 @@
+"""Spec §8 text renderer + §9.1 JSON serializer for ReviewReport."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from gaia.inquiry.focus import FocusBinding
+from gaia.inquiry.proof_state import ProofContext
+
+
+def render_text(report: "ReviewReport") -> str:  # noqa: F821 - forward ref from review.py
+    lines: list[str] = []
+    lines.append("Gaia Inquiry Review")
+    lines.append("─" * 20)
+    lines.append("")
+
+    lines.append("## Focus")
+    f = report.focus
+    if f.resolved_id:
+        lines.append(f"  {f.resolved_label} ({f.kind}, id={f.resolved_id})")
+    elif f.raw:
+        lines.append(f"  (freeform) {f.raw}")
+    else:
+        lines.append("  (no focus set)")
+    lines.append(f"  mode: {report.mode}")
+    lines.append("")
+
+    lines.append("## Compile")
+    lines.append(f"  status: {report.compile_status}")
+    if report.ir_hash:
+        lines.append(f"  ir_hash: {report.ir_hash}")
+    for k, v in report.counts.items():
+        lines.append(f"  {k}: {v}")
+    lines.append("")
+
+    lines.append("## Semantic diff")
+    d = report.semantic_diff
+    if d.baseline_review_id is None:
+        lines.append("  (no baseline review — run `gaia inquiry review` again to diff)")
+    elif d.is_empty:
+        lines.append(f"  baseline: {d.baseline_review_id}")
+        lines.append("  (no semantic changes)")
+    else:
+        lines.append(f"  baseline: {d.baseline_review_id}")
+        # §14.2 — print every non-empty category with consistent +/- prefixes.
+        for tag, items in (
+            ("claims", d.added_claims),
+            ("questions", d.added_questions),
+            ("settings", d.added_settings),
+            ("strategies", d.added_strategies),
+            ("operators", d.added_operators),
+        ):
+            if items:
+                lines.append(f"  + {len(items)} {tag}")
+        for tag, items in (
+            ("claims", d.removed_claims),
+            ("questions", d.removed_questions),
+            ("settings", d.removed_settings),
+            ("strategies", d.removed_strategies),
+            ("operators", d.removed_operators),
+        ):
+            if items:
+                lines.append(f"  - {len(items)} {tag}")
+        if d.changed_claims:
+            lines.append(f"  ~ {len(d.changed_claims)} changed claims")
+        if d.changed_strategies:
+            lines.append(f"  ~ {len(d.changed_strategies)} changed strategies")
+        if d.changed_operators:
+            lines.append(f"  ~ {len(d.changed_operators)} changed operators")
+        if d.changed_priors:
+            lines.append("  changed priors:")
+            for delta in d.changed_priors:
+                lines.append(f"    - {delta.label}: {delta.before} → {delta.after}")
+        if d.changed_exports:
+            lines.append("  changed exports:")
+            for delta in d.changed_exports:
+                lines.append(f"    - {delta.label}: {delta.before} → {delta.after}")
+    lines.append("")
+
+    lines.append("## Graph health")
+    gh = report.graph_health
+    lines.append(f"  warnings: {len(gh['warnings'])}")
+    lines.append(f"  errors: {len(gh['errors'])}")
+    lines.append(f"  orphaned claims: {len(gh['orphaned_claims'])}")
+    lines.append(f"  background-only claims: {len(gh['background_only_claims'])}")
+    lines.append(f"  independent claims missing priors: {len(gh['prior_holes'])}")
+    lines.append(f"  possible duplicate claims: {len(gh['possible_duplicates'])}")
+    for msg in gh["errors"]:
+        lines.append(f"  ! {msg}")
+    for msg in gh["warnings"]:
+        lines.append(f"  · {msg}")
+    lines.append("")
+
+    lines.append("## Inquiry tree")
+    it = report.inquiry_tree
+    lines.append(f"  goals: {it['goals']}")
+    lines.append(f"  accepted warrants: {it['accepted_warrants']}")
+    lines.append(f"  unreviewed warrants: {it['unreviewed_warrants']}")
+    lines.append(f"  blocked paths: {it['blocked_paths']}")
+    lines.append(f"  structural holes: {len(it['structural_holes'])}")
+    lines.append("")
+
+    lines.append("## Prior holes")
+    if not report.prior_holes:
+        lines.append("  (all independent claims have priors set)")
+    else:
+        for h in report.prior_holes:
+            lines.append(f"  - {h['label']}")
+            preview = h.get("content", "")
+            if preview:
+                lines.append(f"    content: {preview}")
+            lines.append(f"    prior:   {h['prior']}")
+    lines.append("")
+
+    lines.append("## Belief report")
+    br = report.belief_report
+    if not br["ran_inference"]:
+        lines.append("  (inference skipped)")
+    else:
+        if br.get("focus"):
+            foc = br["focus"]
+            if foc.get("delta") is not None:
+                lines.append(
+                    f"  focus {foc['label']}: {foc['before']} → {foc['after']} "
+                    f"(Δ={foc['delta']:+.3f})"
+                )
+            else:
+                lines.append(f"  focus {foc['label']}: {foc['after']:.3f}")
+        lines.append(f"  total claims with beliefs: {len(br['beliefs'])}")
+        if br.get("largest_increases"):
+            lines.append("  largest increases:")
+            for item in br["largest_increases"]:
+                lines.append(f"    - {item['label']}: {item['before']} → {item['after']}")
+        if br.get("largest_decreases"):
+            lines.append("  largest decreases:")
+            for item in br["largest_decreases"]:
+                lines.append(f"    - {item['label']}: {item['before']} → {item['after']}")
+    lines.append("")
+
+    if report.proof_context is not None and (
+        report.proof_context.obligations
+        or report.proof_context.hypotheses
+        or report.proof_context.rejections
+    ):
+        pc = report.proof_context
+        lines.append("## Proof state")
+        lines.append(f"  obligations ({len(pc.obligations)}):")
+        for ob in pc.obligations:
+            lines.append(f"    - [{ob.diagnostic_kind}] {ob.content}")
+        if pc.hypotheses:
+            lines.append(f"  hypotheses ({len(pc.hypotheses)}):")
+            for hp in pc.hypotheses:
+                lines.append(f"    - {hp.content}")
+        if pc.rejections:
+            lines.append(f"  rejections ({len(pc.rejections)}):")
+            for rj in pc.rejections:
+                lines.append(f"    - {rj.target_strategy}: {rj.content}")
+        lines.append("")
+
+    lines.append("## Next edits")
+    if not report.next_edits:
+        lines.append("  (no suggested edits)")
+    else:
+        for i, edit in enumerate(report.next_edits, 1):
+            lines.append(f"  {i}. {edit}")
+
+    return "\n".join(lines)
+
+
+def to_json_dict(report: "ReviewReport") -> dict[str, Any]:  # noqa: F821
+    return {
+        "review_id": report.review_id,
+        "created_at": report.created_at,
+        "path": report.path,
+        "focus": _focus_to_dict(report.focus),
+        "mode": report.mode,
+        "compile": {
+            "status": report.compile_status,
+            "ir_hash": report.ir_hash,
+            "counts": dict(report.counts),
+        },
+        "semantic_diff": report.semantic_diff.to_dict(),
+        "graph_health": report.graph_health,
+        "inquiry_tree": report.inquiry_tree,
+        "prior_holes": list(report.prior_holes),
+        "belief_report": report.belief_report,
+        "diagnostics": [d.to_dict() for d in report.diagnostics],
+        "next_edits": list(report.next_edits),
+        "next_edits_structured": [e.to_dict() for e in report.next_edits_structured],
+        "proof_context": _proof_context_to_dict(report.proof_context),
+    }
+
+
+def _focus_to_dict(f: FocusBinding) -> dict[str, Any]:
+    return {
+        "raw": f.raw,
+        "resolved_id": f.resolved_id,
+        "resolved_label": f.resolved_label,
+        "kind": f.kind,
+    }
+
+
+def _proof_context_to_dict(pc: ProofContext | None) -> dict[str, Any]:
+    if pc is None:
+        return {"obligations": [], "hypotheses": [], "rejections": []}
+    return {
+        "obligations": [vars(o) for o in pc.obligations],
+        "hypotheses": [vars(h) for h in pc.hypotheses],
+        "rejections": [vars(r) for r in pc.rejections],
+    }
+
+
+def render_markdown(report) -> str:
+    """Spec §17.2 Markdown renderer.
+
+    Mirrors the eight-section text layout but uses Markdown headings, bullet
+    lists, and fenced code blocks for IDs/source anchors. The section names
+    match render_text exactly so agents can diff outputs.
+    """
+    md: list[str] = []
+    md.append("# Gaia Inquiry Review")
+    md.append("")
+    md.append(f"- **review_id**: `{report.review_id}`")
+    md.append(f"- **created_at**: `{report.created_at}`")
+    md.append(f"- **path**: `{report.path}`")
+    md.append("")
+
+    md.append("## Focus")
+    f = report.focus
+    if f.resolved_id:
+        md.append(f"- **target**: `{f.resolved_label}` (`{f.kind}`, id=`{f.resolved_id}`)")
+    elif f.raw:
+        md.append(f"- **freeform**: `{f.raw}`")
+    else:
+        md.append("- _no focus set_")
+    md.append(f"- **mode**: `{report.mode}`")
+    md.append("")
+
+    md.append("## Compile")
+    md.append(f"- status: `{report.compile_status}`")
+    if report.ir_hash:
+        md.append(f"- ir_hash: `{report.ir_hash}`")
+    for k, v in report.counts.items():
+        md.append(f"- {k}: {v}")
+    md.append("")
+
+    md.append("## Semantic diff")
+    d = report.semantic_diff
+    if d.baseline_review_id is None:
+        md.append("_no baseline review yet_")
+    elif d.is_empty:
+        md.append(f"baseline: `{d.baseline_review_id}` — no semantic changes")
+    else:
+        md.append(f"baseline: `{d.baseline_review_id}`")
+        md.append("")
+        for heading, items in (
+            ("Added claims", d.added_claims),
+            ("Removed claims", d.removed_claims),
+            ("Added questions", d.added_questions),
+            ("Removed questions", d.removed_questions),
+            ("Added settings", d.added_settings),
+            ("Removed settings", d.removed_settings),
+            ("Added strategies", d.added_strategies),
+            ("Removed strategies", d.removed_strategies),
+            ("Added operators", d.added_operators),
+            ("Removed operators", d.removed_operators),
+        ):
+            if items:
+                md.append(f"**{heading}** ({len(items)})")
+                for x in items:
+                    md.append(f"- `{x}`")
+                md.append("")
+        for heading, deltas in (
+            ("Changed claims", d.changed_claims),
+            ("Changed strategies", d.changed_strategies),
+            ("Changed operators", d.changed_operators),
+            ("Changed priors", d.changed_priors),
+            ("Changed exports", d.changed_exports),
+        ):
+            if deltas:
+                md.append(f"**{heading}** ({len(deltas)})")
+                for delta in deltas:
+                    md.append(
+                        f"- `{delta.label}` _{delta.field}_: `{delta.before}` → `{delta.after}`"
+                    )
+                md.append("")
+    md.append("")
+
+    md.append("## Graph health")
+    gh = report.graph_health
+    md.append(f"- warnings: {len(gh['warnings'])}")
+    md.append(f"- errors: {len(gh['errors'])}")
+    md.append(f"- orphaned claims: {len(gh['orphaned_claims'])}")
+    md.append(f"- background-only claims: {len(gh['background_only_claims'])}")
+    md.append(f"- prior holes: {len(gh['prior_holes'])}")
+    md.append(f"- possible duplicates: {len(gh['possible_duplicates'])}")
+    if gh["errors"]:
+        md.append("")
+        md.append("**Errors**")
+        for msg in gh["errors"]:
+            md.append(f"- {msg}")
+    if gh["warnings"]:
+        md.append("")
+        md.append("**Warnings**")
+        for msg in gh["warnings"]:
+            md.append(f"- {msg}")
+    md.append("")
+
+    md.append("## Inquiry tree")
+    it = report.inquiry_tree
+    md.append(f"- goals: {it['goals']}")
+    md.append(f"- accepted warrants: {it['accepted_warrants']}")
+    md.append(f"- unreviewed warrants: {it['unreviewed_warrants']}")
+    md.append(f"- blocked paths: {it['blocked_paths']}")
+    md.append(f"- structural holes: {len(it['structural_holes'])}")
+    md.append("")
+
+    md.append("## Prior holes")
+    if not report.prior_holes:
+        md.append("_all independent claims have priors set_")
+    else:
+        for h in report.prior_holes:
+            md.append(f"- **{h['label']}**")
+            preview = h.get("content", "")
+            if preview:
+                md.append(f"  - content: {preview}")
+            md.append(f"  - prior: `{h['prior']}`")
+    md.append("")
+
+    md.append("## Belief report")
+    br = report.belief_report
+    if not br["ran_inference"]:
+        md.append("_inference skipped_")
+    else:
+        if br.get("focus"):
+            foc = br["focus"]
+            if foc.get("delta") is not None:
+                md.append(
+                    f"- focus **{foc['label']}**: {foc['before']} → {foc['after']} "
+                    f"(Δ={foc['delta']:+.3f})"
+                )
+            else:
+                md.append(f"- focus **{foc['label']}**: {foc['after']:.3f}")
+        md.append(f"- claims with beliefs: {len(br['beliefs'])}")
+        if br.get("largest_increases"):
+            md.append("")
+            md.append("**Largest increases**")
+            for item in br["largest_increases"]:
+                md.append(f"- `{item['label']}`: {item['before']} → {item['after']}")
+        if br.get("largest_decreases"):
+            md.append("")
+            md.append("**Largest decreases**")
+            for item in br["largest_decreases"]:
+                md.append(f"- `{item['label']}`: {item['before']} → {item['after']}")
+    md.append("")
+
+    if report.proof_context is not None and (
+        report.proof_context.obligations
+        or report.proof_context.hypotheses
+        or report.proof_context.rejections
+    ):
+        pc = report.proof_context
+        md.append("## Proof state")
+        if pc.obligations:
+            md.append(f"**Obligations** ({len(pc.obligations)})")
+            for ob in pc.obligations:
+                md.append(f"- _[{ob.diagnostic_kind}]_ {ob.content}")
+        if pc.hypotheses:
+            md.append("")
+            md.append(f"**Hypotheses** ({len(pc.hypotheses)})")
+            for hp in pc.hypotheses:
+                md.append(f"- {hp.content}")
+        if pc.rejections:
+            md.append("")
+            md.append(f"**Rejections** ({len(pc.rejections)})")
+            for rj in pc.rejections:
+                md.append(f"- `{rj.target_strategy}`: {rj.content}")
+        md.append("")
+
+    md.append("## Next edits")
+    if not report.next_edits_structured and not report.next_edits:
+        md.append("_no suggested edits_")
+    else:
+        items = report.next_edits_structured or [None for _ in report.next_edits]
+        for i, edit in enumerate(report.next_edits_structured, 1):
+            anchor = ""
+            if edit.source_anchor is not None:
+                a = edit.source_anchor
+                anchor = f" — `{a.file}:{a.line}`"
+            md.append(f"{i}. _[{edit.kind}/{edit.severity}]_ {edit.text}{anchor}")
+        if not report.next_edits_structured:
+            for i, edit in enumerate(report.next_edits, 1):
+                md.append(f"{i}. {edit}")
+
+    return "\n".join(md)
+
+
+def render_json(report) -> str:
+    return json.dumps(to_json_dict(report), ensure_ascii=False, indent=2)

--- a/gaia/inquiry/review.py
+++ b/gaia/inquiry/review.py
@@ -1,0 +1,515 @@
+"""gaia inquiry review — orchestrator.
+
+This module is intentionally thin: it composes Gaia's existing compile,
+validate, classify, hole-analysis, and inference layers into the eight-section
+report defined by spec §8/§9. No detection logic lives here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from gaia.cli._packages import (
+    GaiaCliError,
+    apply_package_priors,
+    collect_foreign_node_priors,
+    compile_loaded_package_artifact,
+    ensure_package_env,
+    load_gaia_package,
+)
+from gaia.cli.commands.check_core import (
+    KnowledgeBreakdown,
+    analyze_knowledge_breakdown,
+    find_possible_duplicate_claims,
+)
+from gaia.ir.validator import validate_local_graph
+
+from gaia.inquiry.anchor import find_anchors
+from gaia.inquiry.diagnostics import (
+    Diagnostic,
+    NextEdit,
+    detect_blocked_warrant_path,
+    detect_claim_with_evidence_but_no_focus_connection,
+    detect_focus_low_posterior,
+    detect_focus_unsupported,
+    detect_large_belief_drop,
+    detect_overstrong_strategy_without_provenance,
+    detect_prior_without_justification,
+    detect_stale_artifact,
+    detect_warrant_status,
+    format_diagnostics_as_structured_edits,
+    from_knowledge_breakdown,
+    from_validation,
+)
+from gaia.inquiry.diff import SemanticDiff, compute_semantic_diff, empty_diff
+from gaia.inquiry.focus import FocusBinding, resolve_focus_target
+from gaia.inquiry.proof_state import ProofContext, build_proof_context
+from gaia.inquiry.ranking import rank_diagnostics, rank_next_edits
+from gaia.inquiry.render import render_markdown as _render_markdown
+from gaia.inquiry.render import render_text as _render_text
+from gaia.inquiry.render import to_json_dict as _to_json_dict
+from gaia.inquiry.snapshot import (
+    load_snapshot,
+    mint_review_id,
+    resolve_baseline,
+    save_snapshot,
+)
+from gaia.inquiry.state import load_state, save_state
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+# --------------------------------------------------------------------------- #
+# Report dataclass — passive container, all fields filled by run_review.      #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ReviewReport:
+    review_id: str
+    created_at: str
+    path: str
+    focus: FocusBinding
+    mode: str
+
+    # §8.2 Compile
+    compile_status: str
+    ir_hash: str | None
+    counts: dict[str, int]
+
+    # §8.3 Semantic diff
+    semantic_diff: SemanticDiff = field(default_factory=empty_diff)
+
+    # §8.4 Graph health (sourced from validate_local_graph + check_core)
+    graph_health: dict[str, Any] = field(default_factory=dict)
+
+    # §8.5 Inquiry tree
+    inquiry_tree: dict[str, Any] = field(default_factory=dict)
+
+    # §8.6 Prior holes — list of {label, cid, content, prior}
+    prior_holes: list[dict[str, Any]] = field(default_factory=list)
+
+    # §8.7 Belief report
+    belief_report: dict[str, Any] = field(default_factory=dict)
+
+    # §15 Diagnostic stream — drives §8.8 next_edits.
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+    next_edits: list[str] = field(default_factory=list)
+    next_edits_structured: list[NextEdit] = field(default_factory=list)
+
+    # ProofState (Round A1 extension)
+    proof_context: ProofContext | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return _to_json_dict(self)
+
+
+# --------------------------------------------------------------------------- #
+# Public helpers                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def resolve_graph(path: str | Path):
+    """Compile a package and return its LocalCanonicalGraph (or None on failure)."""
+    try:
+        ensure_package_env(Path(path).resolve())
+        loaded = load_gaia_package(str(path))
+        apply_package_priors(loaded)
+        compiled = compile_loaded_package_artifact(loaded)
+    except GaiaCliError:
+        return None
+    except Exception:
+        return None
+    return compiled.graph
+
+
+def render_text(report: ReviewReport) -> str:
+    """Spec §8 eight-section text renderer."""
+    return _render_text(report)
+
+
+def render_markdown(report: ReviewReport) -> str:
+    """Spec §17.2 Markdown renderer."""
+    return _render_markdown(report)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def run_review(
+    path: str | Path,
+    *,
+    focus_override: str | None = None,
+    mode: str = "auto",
+    no_infer: bool = False,
+    depth: int = 0,
+    since: str | None = None,
+    strict: bool = False,
+) -> ReviewReport:
+    pkg_path = Path(path).resolve()
+    state = load_state(pkg_path)
+    focus_raw = focus_override if focus_override is not None else state.focus
+
+    warnings: list[str] = []
+    errors: list[str] = []
+    graph = None
+    compile_status = "error"
+    ir_hash: str | None = None
+    counts = {"knowledge": 0, "strategies": 0, "operators": 0}
+
+    # Step 1: compile via Gaia.
+    try:
+        ensure_package_env(pkg_path)
+        loaded = load_gaia_package(str(pkg_path))
+        apply_package_priors(loaded)
+        compiled = compile_loaded_package_artifact(loaded)
+        graph = compiled.graph
+        compile_status = "ok"
+    except GaiaCliError as exc:
+        errors.append(f"compile: {exc}")
+    except Exception as exc:  # surfaced as report error, not raised
+        errors.append(f"compile: {exc}")
+
+    if graph is not None:
+        counts["knowledge"] = len(getattr(graph, "knowledges", []) or [])
+        counts["strategies"] = len(getattr(graph, "strategies", []) or [])
+        counts["operators"] = len(getattr(graph, "operators", []) or [])
+        ir_hash = getattr(graph, "ir_hash", None)
+
+        # Step 2: validate via Gaia.
+        validation = validate_local_graph(graph)
+        warnings.extend(validation.warnings)
+        errors.extend(validation.errors)
+
+    focus = resolve_focus_target(focus_raw, graph)
+
+    # Step 3: knowledge breakdown via check_core (single source of truth).
+    ir_dict = _graph_to_ir_dict(graph)
+    if ir_dict is not None:
+        kb = analyze_knowledge_breakdown(ir_dict)
+    else:
+        kb = KnowledgeBreakdown()
+
+    graph_health = _build_graph_health(kb, ir_dict, warnings, errors)
+    prior_holes = _build_prior_holes(kb)
+    inquiry_tree = _build_inquiry_tree(kb, graph)
+
+    # Step 4: semantic diff against baseline snapshot.
+    baseline_id = resolve_baseline(pkg_path, since, state.last_review_id)
+    baseline_snap = load_snapshot(pkg_path, baseline_id) if baseline_id else None
+    semantic_diff = compute_semantic_diff(ir_dict, baseline_snap)
+
+    # Step 5: inference via gaia.bp; enrich with baseline belief deltas.
+    belief_report = _build_belief_report(graph, pkg_path, no_infer, errors, focus)
+    if belief_report["ran_inference"] and baseline_snap is not None:
+        _annotate_belief_deltas(belief_report, baseline_snap)
+
+    # Step 6: diagnostics — translate validator + breakdown into one stream.
+    anchors = find_anchors(pkg_path)
+    diagnostics: list[Diagnostic] = []
+    diagnostics.extend(from_validation(warnings, errors))
+    if ir_dict is not None:
+        diagnostics.extend(from_knowledge_breakdown(kb, ir_dict, focus, anchors))
+        diagnostics.extend(detect_prior_without_justification(kb, anchors))
+    diagnostics.extend(detect_stale_artifact(pkg_path, ir_hash))
+    diagnostics.extend(detect_focus_low_posterior(belief_report))
+    rejected_targets = {r.target_strategy for r in getattr(state, "synthetic_rejections", []) or []}
+    diagnostics.extend(detect_warrant_status(graph, rejected_targets, anchors))
+    if graph is not None:
+        if ir_dict is not None:
+            diagnostics.extend(detect_blocked_warrant_path(graph, kb, anchors))
+        diagnostics.extend(detect_focus_unsupported(graph, focus, anchors))
+        diagnostics.extend(detect_overstrong_strategy_without_provenance(graph, anchors=anchors))
+        diagnostics.extend(
+            detect_claim_with_evidence_but_no_focus_connection(graph, focus, anchors)
+        )
+    diagnostics.extend(detect_large_belief_drop(belief_report))
+    diagnostics = rank_diagnostics(diagnostics, mode)
+    next_edits_structured = rank_next_edits(
+        format_diagnostics_as_structured_edits(diagnostics), mode
+    )
+    next_edits = [
+        f"{e.text} ({e.source_anchor.file}:{e.source_anchor.line})"
+        if e.source_anchor is not None
+        else e.text
+        for e in next_edits_structured
+    ]
+
+    # Step 7: ProofContext (Round A1).
+    proof_ctx = build_proof_context(graph, state)
+
+    review_id = mint_review_id(ir_hash, mode)
+    created_at = _utcnow_iso()
+    report = ReviewReport(
+        review_id=review_id,
+        created_at=created_at,
+        path=str(pkg_path),
+        focus=focus,
+        mode=mode,
+        compile_status=compile_status,
+        ir_hash=ir_hash,
+        counts=counts,
+        semantic_diff=semantic_diff,
+        graph_health=graph_health,
+        inquiry_tree=inquiry_tree,
+        prior_holes=prior_holes,
+        belief_report=belief_report,
+        diagnostics=diagnostics,
+        next_edits=next_edits,
+        next_edits_structured=next_edits_structured,
+        proof_context=proof_ctx,
+    )
+
+    # Persist snapshot for future diffs.
+    save_snapshot(
+        pkg_path,
+        review_id=review_id,
+        created_at=created_at,
+        ir_hash=ir_hash,
+        ir_dict=ir_dict,
+        beliefs=belief_report.get("beliefs", []),
+    )
+
+    state.last_review_id = review_id
+    if state.baseline_review_id is None:
+        state.baseline_review_id = review_id
+    state.mode = mode
+    save_state(pkg_path, state)
+
+    return report
+
+
+def _annotate_belief_deltas(belief_report: dict, baseline_snap: dict) -> None:
+    """Compute per-claim belief deltas vs baseline; fill focus/largest_*."""
+    base_by_id = {b["knowledge_id"]: b["belief"] for b in baseline_snap.get("beliefs", [])}
+    deltas: list[tuple[str, str, float, float, float]] = []
+    for entry in belief_report["beliefs"]:
+        kid = entry["knowledge_id"]
+        if kid not in base_by_id:
+            continue
+        before = base_by_id[kid]
+        after = entry["belief"]
+        try:
+            delta = float(after) - float(before)
+        except (TypeError, ValueError):
+            continue
+        deltas.append((kid, entry["label"], before, after, delta))
+
+    if belief_report.get("focus"):
+        foc = belief_report["focus"]
+        for kid, _label, before, after, delta in deltas:
+            if kid == foc.get("knowledge_id"):
+                foc["before"] = before
+                foc["after"] = after
+                foc["delta"] = delta
+                break
+
+    deltas.sort(key=lambda t: t[4], reverse=True)
+    belief_report["largest_increases"] = [
+        {"label": lbl, "before": b, "after": a, "delta": d}
+        for _kid, lbl, b, a, d in deltas[:3]
+        if d > 0
+    ]
+    belief_report["largest_decreases"] = [
+        {"label": lbl, "before": b, "after": a, "delta": d}
+        for _kid, lbl, b, a, d in sorted(deltas, key=lambda t: t[4])[:3]
+        if d < 0
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Section assemblers — pure, no detection logic.                              #
+# --------------------------------------------------------------------------- #
+
+
+def _graph_to_ir_dict(graph) -> dict | None:
+    """Convert a LocalCanonicalGraph to the dict shape consumed by check_core.
+
+    check_core was written against the JSON IR shape. The compiled graph holds
+    the same data on dataclasses; this adapter is the only translation layer.
+    """
+    if graph is None:
+        return None
+    knowledges = []
+    for k in getattr(graph, "knowledges", []) or []:
+        knowledges.append(
+            {
+                "id": getattr(k, "id", ""),
+                "label": getattr(k, "label", ""),
+                "type": _normalize_type(getattr(k, "type", "")),
+                "content": getattr(k, "content", "") or "",
+                "metadata": dict(getattr(k, "metadata", {}) or {}),
+                "exported": bool(getattr(k, "exported", False)),
+            }
+        )
+    strategies = []
+    for s in getattr(graph, "strategies", []) or []:
+        strategies.append(
+            {
+                "id": getattr(s, "id", ""),
+                "conclusion": getattr(s, "conclusion", None),
+                "premises": list(getattr(s, "premises", []) or []),
+                "background": list(getattr(s, "background", []) or []),
+            }
+        )
+    operators = []
+    for o in getattr(graph, "operators", []) or []:
+        operators.append(
+            {
+                "id": getattr(o, "id", ""),
+                "conclusion": getattr(o, "conclusion", None),
+                "variables": list(getattr(o, "variables", []) or []),
+            }
+        )
+    return {"knowledges": knowledges, "strategies": strategies, "operators": operators}
+
+
+def _normalize_type(t: Any) -> str:
+    s = str(t)
+    if "." in s:
+        s = s.rsplit(".", 1)[-1]
+    return s.lower()
+
+
+def _build_graph_health(
+    kb: KnowledgeBreakdown,
+    ir_dict: dict | None,
+    warnings: list[str],
+    errors: list[str],
+) -> dict[str, Any]:
+    duplicates = find_possible_duplicate_claims(ir_dict) if ir_dict else []
+    return {
+        "warnings": list(warnings),
+        "errors": list(errors),
+        "orphaned_claims": list(kb.orphaned),
+        "background_only_claims": list(kb.background_only),
+        "prior_holes": [h.label for h in kb.holes],
+        "possible_duplicates": [{"a": a, "b": b} for a, b in duplicates],
+    }
+
+
+def _build_prior_holes(kb: KnowledgeBreakdown) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for h in kb.holes:
+        preview = (h.content[:72] + "...") if len(h.content) > 75 else h.content
+        out.append(
+            {
+                "label": h.label,
+                "cid": h.cid,
+                "content": preview,
+                "prior": "NOT SET (defaults to 0.5)",
+            }
+        )
+    return out
+
+
+def _build_inquiry_tree(kb: KnowledgeBreakdown, graph) -> dict[str, Any]:
+    n_strategies = len(getattr(graph, "strategies", []) or []) if graph else 0
+    hole_ids = {h.cid for h in kb.holes}
+    blocked_paths = 0
+    if graph is not None and hole_ids:
+        for s in getattr(graph, "strategies", []) or []:
+            premises = list(getattr(s, "premises", None) or [])
+            if any(p in hole_ids for p in premises):
+                blocked_paths += 1
+    return {
+        "goals": len(kb.questions),
+        "accepted_warrants": 0,
+        "unreviewed_warrants": n_strategies,
+        "blocked_paths": blocked_paths,
+        "structural_holes": list(kb.orphaned),
+    }
+
+
+def _build_belief_report(
+    graph,
+    pkg_path: Path,
+    no_infer: bool,
+    errors: list[str],
+    focus: FocusBinding,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "ran_inference": False,
+        "beliefs": [],
+        "focus": None,
+        "largest_increases": [],
+        "largest_decreases": [],
+    }
+    if graph is None or no_infer:
+        return out
+    if errors:
+        return out
+    try:
+        from gaia.bp import lower_local_graph
+        from gaia.bp.engine import InferenceEngine
+
+        foreign = collect_foreign_node_priors(graph, pkg_path)
+        fg = lower_local_graph(graph, node_priors=foreign or None)
+        fg_errs = fg.validate()
+        if fg_errs:
+            errors.extend(fg_errs)
+            return out
+        engine = InferenceEngine()
+        result = engine.run(fg)
+    except Exception as exc:  # pragma: no cover
+        errors.append(f"infer: {exc}")
+        return out
+
+    out["ran_inference"] = True
+    kbyid = {k.id: k for k in graph.knowledges}
+    for kid, belief in sorted(result.bp_result.beliefs.items()):
+        if kid in kbyid:
+            out["beliefs"].append(
+                {"knowledge_id": kid, "label": kbyid[kid].label, "belief": belief}
+            )
+
+    if focus.resolved_id:
+        for entry in out["beliefs"]:
+            if entry["knowledge_id"] == focus.resolved_id:
+                out["focus"] = {
+                    "knowledge_id": focus.resolved_id,
+                    "label": entry["label"],
+                    "before": None,
+                    "after": entry["belief"],
+                    "delta": None,
+                }
+                break
+
+    return out
+
+
+def publish_blockers(report: ReviewReport) -> list[str]:
+    """Spec §12 publish-readiness — return non-empty list iff strict mode should fail.
+
+    The publish gate fails if *any* of these hold:
+    - graph_health.errors is non-empty
+    - graph_health.warnings is non-empty
+    - any prior_hole, unreviewed_warrant, prior_without_justification, or
+      stale_artifact diagnostic remains
+    """
+    blockers: list[str] = []
+    health = report.graph_health or {}
+    for e in health.get("errors", []) or []:
+        blockers.append(f"graph error: {e}")
+    for w in health.get("warnings", []) or []:
+        blockers.append(f"graph warning: {w}")
+    blocking_kinds = {
+        "prior_hole",
+        "unreviewed_warrant",
+        "prior_without_justification",
+        "stale_artifact",
+        "blocked_warrant_path",
+        "focus_unsupported",
+        "overstrong_strategy_without_provenance",
+    }
+    for d in report.diagnostics:
+        if d.kind in blocking_kinds:
+            blockers.append(f"{d.kind}: {d.label} — {d.message}")
+    return blockers

--- a/gaia/inquiry/review.py
+++ b/gaia/inquiry/review.py
@@ -27,6 +27,7 @@ from gaia.cli.commands.check_core import (
     analyze_knowledge_breakdown,
     find_possible_duplicate_claims,
 )
+from gaia.ir import ReviewManifest, ReviewStatus
 from gaia.ir.validator import validate_local_graph
 
 from gaia.inquiry.anchor import find_anchors
@@ -164,6 +165,7 @@ def run_review(
     graph = None
     loaded = None
     compiled = None
+    review_manifest: ReviewManifest | None = None
     compile_status = "error"
     ir_hash: str | None = None
     counts = {"knowledge": 0, "strategies": 0, "operators": 0}
@@ -192,6 +194,12 @@ def run_review(
         warnings.extend(validation.warnings)
         errors.extend(validation.errors)
 
+    if loaded is not None and compiled is not None:
+        try:
+            review_manifest = load_or_generate_review_manifest(loaded.pkg_path, compiled)
+        except GaiaCliError as exc:
+            errors.append(f"review_manifest: {exc}")
+
     focus = resolve_focus_target(focus_raw, graph)
 
     # Step 3: knowledge breakdown via check_core (single source of truth).
@@ -201,9 +209,8 @@ def run_review(
     else:
         kb = KnowledgeBreakdown()
 
-    graph_health = _build_graph_health(kb, ir_dict, warnings, errors)
     prior_holes = _build_prior_holes(kb)
-    inquiry_tree = _build_inquiry_tree(kb, graph)
+    inquiry_tree = _build_inquiry_tree(kb, graph, review_manifest)
 
     # Step 4: semantic diff against baseline snapshot.
     baseline_id = resolve_baseline(pkg_path, since, state.last_review_id)
@@ -219,10 +226,13 @@ def run_review(
         focus,
         loaded=loaded,
         compiled=compiled,
+        review_manifest=review_manifest,
         depth=depth,
     )
     if belief_report["ran_inference"] and baseline_snap is not None:
         _annotate_belief_deltas(belief_report, baseline_snap)
+
+    graph_health = _build_graph_health(kb, ir_dict, warnings, errors)
 
     # Step 6: diagnostics — translate validator + breakdown into one stream.
     anchors = find_anchors(pkg_path)
@@ -234,7 +244,14 @@ def run_review(
     diagnostics.extend(detect_stale_artifact(pkg_path, ir_hash))
     diagnostics.extend(detect_focus_low_posterior(belief_report))
     rejected_targets = {r.target_strategy for r in getattr(state, "synthetic_rejections", []) or []}
-    diagnostics.extend(detect_warrant_status(graph, rejected_targets, anchors))
+    diagnostics.extend(
+        detect_warrant_status(
+            graph,
+            rejected_targets,
+            anchors,
+            review_manifest=review_manifest,
+        )
+    )
     if graph is not None:
         if ir_dict is not None:
             diagnostics.extend(detect_blocked_warrant_path(graph, kb, anchors))
@@ -359,7 +376,7 @@ def _graph_to_ir_dict(graph) -> dict | None:
         knowledges.append(
             {
                 "id": getattr(k, "id", ""),
-                "label": getattr(k, "label", ""),
+                "label": getattr(k, "label", None) or "",
                 "type": _normalize_type(getattr(k, "type", "")),
                 "content": getattr(k, "content", "") or "",
                 "metadata": dict(getattr(k, "metadata", {}) or {}),
@@ -435,8 +452,33 @@ def _build_prior_holes(kb: KnowledgeBreakdown) -> list[dict[str, Any]]:
     return out
 
 
-def _build_inquiry_tree(kb: KnowledgeBreakdown, graph) -> dict[str, Any]:
-    n_strategies = len(getattr(graph, "strategies", []) or []) if graph else 0
+def _strategy_review_status(
+    strategy,
+    review_manifest: ReviewManifest | None,
+) -> ReviewStatus | None:
+    sid = _strategy_id(strategy)
+    if review_manifest is None or not sid:
+        return None
+    return review_manifest.latest_status(sid)
+
+
+def _build_inquiry_tree(
+    kb: KnowledgeBreakdown,
+    graph,
+    review_manifest: ReviewManifest | None = None,
+) -> dict[str, Any]:
+    accepted_warrants = 0
+    rejected_warrants = 0
+    unreviewed_warrants = 0
+    if graph is not None:
+        for s in getattr(graph, "strategies", []) or []:
+            status = _strategy_review_status(s, review_manifest)
+            if status == ReviewStatus.ACCEPTED:
+                accepted_warrants += 1
+            elif status == ReviewStatus.REJECTED:
+                rejected_warrants += 1
+            else:
+                unreviewed_warrants += 1
     hole_ids = {h.cid for h in kb.holes}
     blocked_paths = 0
     if graph is not None and hole_ids:
@@ -446,8 +488,9 @@ def _build_inquiry_tree(kb: KnowledgeBreakdown, graph) -> dict[str, Any]:
                 blocked_paths += 1
     return {
         "goals": len(kb.questions),
-        "accepted_warrants": 0,
-        "unreviewed_warrants": n_strategies,
+        "accepted_warrants": accepted_warrants,
+        "unreviewed_warrants": unreviewed_warrants,
+        "rejected_warrants": rejected_warrants,
         "blocked_paths": blocked_paths,
         "structural_holes": list(kb.orphaned),
     }
@@ -462,6 +505,7 @@ def _build_belief_report(
     *,
     loaded=None,
     compiled=None,
+    review_manifest: ReviewManifest | None = None,
     depth: int = 0,
 ) -> dict[str, Any]:
     out: dict[str, Any] = {
@@ -481,7 +525,6 @@ def _build_belief_report(
         from gaia.bp import FactorGraph, lower_local_graph, merge_factor_graphs
         from gaia.bp.engine import InferenceEngine
 
-        review_manifest = load_or_generate_review_manifest(loaded.pkg_path, compiled)
         if depth != 0:
             dep_compiled = load_dependency_compiled_graphs(loaded.project_config, depth=depth)
             dep_factor_graphs: list[tuple[str, FactorGraph, str]] = []

--- a/gaia/inquiry/review.py
+++ b/gaia/inquiry/review.py
@@ -18,8 +18,10 @@ from gaia.cli._packages import (
     collect_foreign_node_priors,
     compile_loaded_package_artifact,
     ensure_package_env,
+    load_dependency_compiled_graphs,
     load_gaia_package,
 )
+from gaia.cli.commands._review_manifest import load_or_generate_review_manifest
 from gaia.cli.commands.check_core import (
     KnowledgeBreakdown,
     analyze_knowledge_breakdown,
@@ -160,6 +162,8 @@ def run_review(
     warnings: list[str] = []
     errors: list[str] = []
     graph = None
+    loaded = None
+    compiled = None
     compile_status = "error"
     ir_hash: str | None = None
     counts = {"knowledge": 0, "strategies": 0, "operators": 0}
@@ -207,7 +211,16 @@ def run_review(
     semantic_diff = compute_semantic_diff(ir_dict, baseline_snap)
 
     # Step 5: inference via gaia.bp; enrich with baseline belief deltas.
-    belief_report = _build_belief_report(graph, pkg_path, no_infer, errors, focus)
+    belief_report = _build_belief_report(
+        graph,
+        pkg_path,
+        no_infer,
+        errors,
+        focus,
+        loaded=loaded,
+        compiled=compiled,
+        depth=depth,
+    )
     if belief_report["ran_inference"] and baseline_snap is not None:
         _annotate_belief_deltas(belief_report, baseline_snap)
 
@@ -268,7 +281,7 @@ def run_review(
     )
 
     # Persist snapshot for future diffs.
-    save_snapshot(
+    snapshot_path = save_snapshot(
         pkg_path,
         review_id=review_id,
         created_at=created_at,
@@ -276,6 +289,10 @@ def run_review(
         ir_dict=ir_dict,
         beliefs=belief_report.get("beliefs", []),
     )
+    actual_review_id = snapshot_path.stem
+    if actual_review_id != review_id:
+        review_id = actual_review_id
+        report.review_id = actual_review_id
 
     state.last_review_id = review_id
     if state.baseline_review_id is None:
@@ -353,7 +370,7 @@ def _graph_to_ir_dict(graph) -> dict | None:
     for s in getattr(graph, "strategies", []) or []:
         strategies.append(
             {
-                "id": getattr(s, "id", ""),
+                "id": _strategy_id(s),
                 "conclusion": getattr(s, "conclusion", None),
                 "premises": list(getattr(s, "premises", []) or []),
                 "background": list(getattr(s, "background", []) or []),
@@ -363,12 +380,20 @@ def _graph_to_ir_dict(graph) -> dict | None:
     for o in getattr(graph, "operators", []) or []:
         operators.append(
             {
-                "id": getattr(o, "id", ""),
+                "id": _operator_id(o),
                 "conclusion": getattr(o, "conclusion", None),
                 "variables": list(getattr(o, "variables", []) or []),
             }
         )
     return {"knowledges": knowledges, "strategies": strategies, "operators": operators}
+
+
+def _strategy_id(strategy) -> str:
+    return getattr(strategy, "strategy_id", None) or getattr(strategy, "id", None) or ""
+
+
+def _operator_id(operator) -> str:
+    return getattr(operator, "operator_id", None) or getattr(operator, "id", None) or ""
 
 
 def _normalize_type(t: Any) -> str:
@@ -434,6 +459,10 @@ def _build_belief_report(
     no_infer: bool,
     errors: list[str],
     focus: FocusBinding,
+    *,
+    loaded=None,
+    compiled=None,
+    depth: int = 0,
 ) -> dict[str, Any]:
     out: dict[str, Any] = {
         "ran_inference": False,
@@ -444,14 +473,38 @@ def _build_belief_report(
     }
     if graph is None or no_infer:
         return out
+    if loaded is None or compiled is None:
+        return out
     if errors:
         return out
     try:
-        from gaia.bp import lower_local_graph
+        from gaia.bp import FactorGraph, lower_local_graph, merge_factor_graphs
         from gaia.bp.engine import InferenceEngine
 
-        foreign = collect_foreign_node_priors(graph, pkg_path)
-        fg = lower_local_graph(graph, node_priors=foreign or None)
+        review_manifest = load_or_generate_review_manifest(loaded.pkg_path, compiled)
+        if depth != 0:
+            dep_compiled = load_dependency_compiled_graphs(loaded.project_config, depth=depth)
+            dep_factor_graphs: list[tuple[str, FactorGraph, str]] = []
+            for dep in dep_compiled:
+                dep_review_manifest = load_or_generate_review_manifest(dep.root, dep)
+                dep_fg = lower_local_graph(dep.graph, review_manifest=dep_review_manifest)
+                dep_prefix = f"{dep.graph.namespace}:{dep.graph.package_name}::"
+                dep_factor_graphs.append((dep.import_name, dep_fg, dep_prefix))
+
+            local_fg = lower_local_graph(graph, review_manifest=review_manifest)
+            local_prefix = f"{graph.namespace}:{graph.package_name}::"
+            fg = (
+                merge_factor_graphs(local_fg, dep_factor_graphs, local_prefix=local_prefix)
+                if dep_factor_graphs
+                else local_fg
+            )
+        else:
+            foreign = collect_foreign_node_priors(graph, pkg_path)
+            fg = lower_local_graph(
+                graph,
+                node_priors=foreign or None,
+                review_manifest=review_manifest,
+            )
         fg_errs = fg.validate()
         if fg_errs:
             errors.extend(fg_errs)

--- a/gaia/inquiry/snapshot.py
+++ b/gaia/inquiry/snapshot.py
@@ -1,0 +1,111 @@
+"""Review snapshot persistence — `.gaia/inquiry/reviews/<review_id>.json`.
+
+Snapshots are the *only* durable IR footprint inquiry creates. They carry
+exactly the fields needed by ``compute_semantic_diff``: a minimal IR dict plus
+beliefs. This is the input spec §6 diffing rides on.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from gaia.inquiry.state import inquiry_dir
+
+_SAFE_MODE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def reviews_dir(pkg_path: str | Path) -> Path:
+    d = inquiry_dir(pkg_path) / "reviews"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def mint_review_id(ir_hash: str | None, mode: str) -> str:
+    """Round A3 — ``<iso-time>_<ir_hash[:8]>_<mode>``, filesystem-safe.
+
+    Colons in the ISO timestamp are replaced with dashes so the id is usable
+    as a path component on every platform.
+    """
+    ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    raw = ir_hash or "nohash"
+    if ":" in raw:
+        raw = raw.split(":", 1)[1]
+    short = _SAFE_MODE.sub("", raw)[:8] or "nohash"
+    safe_mode = _SAFE_MODE.sub("", mode) or "auto"
+    return f"{ts}_{short}_{safe_mode}"
+
+
+def save_snapshot(
+    pkg_path: str | Path,
+    *,
+    review_id: str,
+    created_at: str,
+    ir_hash: str | None,
+    ir_dict: dict | None,
+    beliefs: list[dict[str, Any]],
+) -> Path:
+    """Persist the minimal snapshot needed to diff future reviews."""
+    base_dir = reviews_dir(pkg_path)
+    path = base_dir / f"{review_id}.json"
+    # 同秒且 ir_hash 不变会产生相同 review_id；追加递增后缀避免覆盖之前的 snapshot。
+    if path.exists():
+        n = 2
+        while (base_dir / f"{review_id}-{n}.json").exists():
+            n += 1
+        review_id = f"{review_id}-{n}"
+        path = base_dir / f"{review_id}.json"
+    payload = {
+        "review_id": review_id,
+        "created_at": created_at,
+        "ir_hash": ir_hash,
+        "ir": ir_dict or {"knowledges": [], "strategies": [], "operators": []},
+        "beliefs": list(beliefs),
+    }
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def load_snapshot(pkg_path: str | Path, review_id: str) -> dict | None:
+    path = reviews_dir(pkg_path) / f"{review_id}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def list_snapshots(pkg_path: str | Path) -> list[str]:
+    """All review ids present on disk, newest first by filename."""
+    d = reviews_dir(pkg_path)
+    ids = [p.stem for p in d.glob("*.json")]
+    ids.sort(reverse=True)
+    return ids
+
+
+def resolve_baseline(
+    pkg_path: str | Path, since: str | None, state_last_id: str | None
+) -> str | None:
+    """Pick a baseline review id based on the --since selector.
+
+    - None / "last" → most recent prior snapshot (excluding the current one)
+    - "none" → no baseline
+    - explicit id → that id (if snapshot file exists)
+    """
+    if since == "none":
+        return None
+    if since and since not in (None, "last"):
+        snap = load_snapshot(pkg_path, since)
+        return since if snap is not None else None
+    if state_last_id:
+        snap = load_snapshot(pkg_path, state_last_id)
+        if snap is not None:
+            return state_last_id
+    ids = list_snapshots(pkg_path)
+    return ids[0] if ids else None

--- a/gaia/inquiry/state.py
+++ b/gaia/inquiry/state.py
@@ -1,0 +1,219 @@
+"""Inquiry state — Lean-ProofState-style reasoning process state.
+
+This module owns the only mutable artifact of gaia.inquiry: .gaia/inquiry/state.json
+plus an append-only tactic log at .gaia/inquiry/tactics.jsonl.
+
+Per spec §2 Non-Goals, none of this touches .py source / IR / priors / beliefs.
+The dataclasses here mirror a Lean proof state:
+  - focus + focus_stack  ≈ goal stack
+  - synthetic_obligations ≈ unresolved goals that the agent wants to track
+                            separately from IR-level question()
+  - synthetic_hypotheses  ≈ local context / working assumptions (≈ setting())
+  - synthetic_rejections  ≈ closed strategy branches
+  - tactic log            ≈ append-only audit of inquiry commands
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATE_SCHEMA_VERSION = 2
+
+VALID_MODES = {"auto", "formalize", "explore", "verify", "publish"}
+
+VALID_OBLIGATION_KINDS = {
+    "prior_hole",
+    "structural_hole",
+    "support_weak",
+    "focus_weakness",
+    "other",
+}
+
+
+def _utcnow() -> str:
+    return datetime.now(tz=timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def mint_qid(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@dataclass
+class SyntheticObligation:
+    qid: str
+    target_qid: str
+    content: str
+    diagnostic_kind: str = "other"
+    anchor: dict[str, Any] = field(default_factory=dict)
+    created_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.created_at is None:
+            self.created_at = _utcnow()
+        if self.diagnostic_kind not in VALID_OBLIGATION_KINDS:
+            raise ValueError(
+                f"invalid obligation kind {self.diagnostic_kind!r}; "
+                f"allowed: {sorted(VALID_OBLIGATION_KINDS)}"
+            )
+
+
+@dataclass
+class SyntheticHypothesis:
+    qid: str
+    content: str
+    scope_qid: str | None = None
+    created_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.created_at is None:
+            self.created_at = _utcnow()
+
+
+@dataclass
+class SyntheticRejection:
+    qid: str
+    target_strategy: str
+    content: str
+    created_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.created_at is None:
+            self.created_at = _utcnow()
+
+
+@dataclass
+class InquiryState:
+    version: int = STATE_SCHEMA_VERSION
+    focus: str | None = None
+    focus_kind: str | None = None
+    focus_resolved_id: str | None = None
+    mode: str = "auto"
+    last_review_id: str | None = None
+    baseline_review_id: str | None = None
+    focus_stack: list[dict[str, Any]] = field(default_factory=list)
+    synthetic_obligations: list[SyntheticObligation] = field(default_factory=list)
+    synthetic_hypotheses: list[SyntheticHypothesis] = field(default_factory=list)
+    synthetic_rejections: list[SyntheticRejection] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "focus": self.focus,
+            "focus_kind": self.focus_kind,
+            "focus_resolved_id": self.focus_resolved_id,
+            "mode": self.mode,
+            "last_review_id": self.last_review_id,
+            "baseline_review_id": self.baseline_review_id,
+            "focus_stack": list(self.focus_stack),
+            "synthetic_obligations": [asdict(o) for o in self.synthetic_obligations],
+            "synthetic_hypotheses": [asdict(h) for h in self.synthetic_hypotheses],
+            "synthetic_rejections": [asdict(r) for r in self.synthetic_rejections],
+        }
+
+
+def inquiry_dir(pkg_path: str | Path) -> Path:
+    d = Path(pkg_path).resolve() / ".gaia" / "inquiry"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _state_path(pkg_path: str | Path) -> Path:
+    return inquiry_dir(pkg_path) / "state.json"
+
+
+def _tactics_path(pkg_path: str | Path) -> Path:
+    return inquiry_dir(pkg_path) / "tactics.jsonl"
+
+
+def load_state(pkg_path: str | Path) -> InquiryState:
+    p = _state_path(pkg_path)
+    if not p.exists():
+        return InquiryState()
+    raw = json.loads(p.read_text(encoding="utf-8"))
+    version = int(raw.get("version", 1))
+    if version > STATE_SCHEMA_VERSION:
+        raise ValueError(
+            f"state.json version {version} is newer than supported {STATE_SCHEMA_VERSION}"
+        )
+    mode = raw.get("mode", "auto")
+    if mode not in VALID_MODES:
+        raise ValueError(f"invalid mode {mode!r}; allowed: {sorted(VALID_MODES)}")
+    obligations = [SyntheticObligation(**o) for o in raw.get("synthetic_obligations", [])]
+    hypotheses = [SyntheticHypothesis(**h) for h in raw.get("synthetic_hypotheses", [])]
+    rejections = [SyntheticRejection(**r) for r in raw.get("synthetic_rejections", [])]
+    return InquiryState(
+        version=STATE_SCHEMA_VERSION,
+        focus=raw.get("focus"),
+        focus_kind=raw.get("focus_kind"),
+        focus_resolved_id=raw.get("focus_resolved_id"),
+        mode=mode,
+        last_review_id=raw.get("last_review_id"),
+        baseline_review_id=raw.get("baseline_review_id"),
+        focus_stack=list(raw.get("focus_stack", [])),
+        synthetic_obligations=obligations,
+        synthetic_hypotheses=hypotheses,
+        synthetic_rejections=rejections,
+    )
+
+
+def save_state(pkg_path: str | Path, state: InquiryState) -> None:
+    p = _state_path(pkg_path)
+    payload = state.to_dict()
+    p.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def append_tactic_event(
+    pkg_path: str | Path, event: str, payload: dict[str, Any] | None = None
+) -> None:
+    rec = {
+        "timestamp": _utcnow(),
+        "event": event,
+        "payload": payload or {},
+    }
+    p = _tactics_path(pkg_path)
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def read_tactic_log(pkg_path: str | Path) -> list[dict[str, Any]]:
+    p = _tactics_path(pkg_path)
+    if not p.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(json.loads(line))
+    return out
+
+
+def push_focus_frame(state: InquiryState) -> None:
+    """Push current focus onto focus_stack. Caller sets the new focus after."""
+    frame = {
+        "focus": state.focus,
+        "focus_kind": state.focus_kind,
+        "focus_resolved_id": state.focus_resolved_id,
+    }
+    state.focus_stack.append(frame)
+
+
+def pop_focus_frame(state: InquiryState) -> dict[str, Any] | None:
+    """Pop the top frame and restore it. Returns old current frame for logging."""
+    if not state.focus_stack:
+        return None
+    old = {
+        "focus": state.focus,
+        "focus_kind": state.focus_kind,
+        "focus_resolved_id": state.focus_resolved_id,
+    }
+    restored = state.focus_stack.pop()
+    state.focus = restored.get("focus")
+    state.focus_kind = restored.get("focus_kind")
+    state.focus_resolved_id = restored.get("focus_resolved_id")
+    return old

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["gaia", "gaia.ir*", "gaia.lang*", "gaia.logic*", "gaia.bp*", "gaia.cli*"]
+include = ["gaia", "gaia.ir*", "gaia.lang*", "gaia.logic*", "gaia.bp*", "gaia.cli*", "gaia.inquiry*"]
 
 [tool.setuptools.package-data]
 "gaia.cli.templates.pages" = ["**/*"]

--- a/tests/inquiry/conftest.py
+++ b/tests/inquiry/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures for inquiry tests — build minimal real Gaia packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_simple_pkg(pkg_dir: Path, name: str = "simple_pkg") -> Path:
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg_dir / name
+    src.mkdir(exist_ok=True)
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, setting, question\n"
+        'main_claim = claim("main hypothesis", metadata={"prior": 0.5})\n'
+        'iid_setting = setting("data is i.i.d.")\n'
+        'rq = question("does the result generalize?")\n'
+        '__all__ = ["main_claim", "iid_setting", "rq"]\n',
+        encoding="utf-8",
+    )
+    return pkg_dir
+
+
+@pytest.fixture
+def simple_pkg(tmp_path: Path) -> Path:
+    return _write_simple_pkg(tmp_path / "p")
+
+
+@pytest.fixture
+def simple_pkg_factory(tmp_path: Path):
+    def _make(name: str = "simple_pkg") -> Path:
+        return _write_simple_pkg(tmp_path / name, name=name)
+
+    return _make

--- a/tests/inquiry/test_batch_b_diagnostics.py
+++ b/tests/inquiry/test_batch_b_diagnostics.py
@@ -1,0 +1,239 @@
+"""Tests for Batch B Inquiry diagnostics:
+stale_artifact / focus_low_posterior / prior_without_justification /
+unreviewed_warrant / rejected_warrant + publish_blockers strict gate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+from gaia.cli.commands.check_core import HoleEntry, KnowledgeBreakdown
+from gaia.inquiry.diagnostics import (
+    Diagnostic,
+    detect_focus_low_posterior,
+    detect_prior_without_justification,
+    detect_stale_artifact,
+    detect_warrant_status,
+)
+from gaia.inquiry.ranking import rank_diagnostics, supported_modes
+from gaia.inquiry.review import publish_blockers, run_review
+
+
+# --------------------------------------------------------------------------- #
+# stale_artifact
+# --------------------------------------------------------------------------- #
+
+
+def test_stale_artifact_emits_when_hash_differs(tmp_path: Path) -> None:
+    (tmp_path / ".gaia").mkdir()
+    (tmp_path / ".gaia" / "ir_hash").write_text("abc123old")
+    diags = detect_stale_artifact(tmp_path, current_ir_hash="def456new")
+    assert len(diags) == 1
+    assert diags[0].kind == "stale_artifact"
+    assert diags[0].severity == "warning"
+    assert "abc123" in diags[0].message
+    assert "def456" in diags[0].message
+
+
+def test_stale_artifact_silent_when_hash_matches(tmp_path: Path) -> None:
+    (tmp_path / ".gaia").mkdir()
+    (tmp_path / ".gaia" / "ir_hash").write_text("samehash")
+    assert detect_stale_artifact(tmp_path, current_ir_hash="samehash") == []
+
+
+def test_stale_artifact_silent_when_no_recorded_file(tmp_path: Path) -> None:
+    assert detect_stale_artifact(tmp_path, current_ir_hash="anyhash") == []
+
+
+def test_stale_artifact_silent_when_no_current_hash(tmp_path: Path) -> None:
+    (tmp_path / ".gaia").mkdir()
+    (tmp_path / ".gaia" / "ir_hash").write_text("recorded")
+    assert detect_stale_artifact(tmp_path, current_ir_hash=None) == []
+
+
+# --------------------------------------------------------------------------- #
+# focus_low_posterior
+# --------------------------------------------------------------------------- #
+
+
+def test_focus_low_posterior_emits_below_threshold() -> None:
+    belief_report = {"focus": {"knowledge_id": "k::x", "label": "x", "after": 0.1, "before": 0.5}}
+    diags = detect_focus_low_posterior(belief_report, threshold=0.3)
+    assert len(diags) == 1
+    assert diags[0].kind == "focus_low_posterior"
+    assert diags[0].label == "x"
+    assert diags[0].data["posterior"] == 0.1
+
+
+def test_focus_low_posterior_silent_above_threshold() -> None:
+    belief_report = {"focus": {"knowledge_id": "k::y", "label": "y", "after": 0.9}}
+    assert detect_focus_low_posterior(belief_report, threshold=0.3) == []
+
+
+def test_focus_low_posterior_silent_when_no_focus() -> None:
+    assert detect_focus_low_posterior({"focus": None}) == []
+    assert detect_focus_low_posterior({}) == []
+
+
+# --------------------------------------------------------------------------- #
+# prior_without_justification
+# --------------------------------------------------------------------------- #
+
+
+def test_prior_without_justification_emits_for_empty_justification() -> None:
+    kb = KnowledgeBreakdown()
+    kb.independent.append(
+        HoleEntry(cid="c::a", label="a", content="ca", prior=0.7, prior_justification="")
+    )
+    kb.independent.append(
+        HoleEntry(cid="c::b", label="b", content="cb", prior=0.3, prior_justification="ok")
+    )
+    kb.independent.append(
+        HoleEntry(cid="c::c", label="c", content="cc", prior=None, prior_justification="")
+    )
+    diags = detect_prior_without_justification(kb)
+    labels = {d.label for d in diags}
+    assert labels == {"a"}
+    assert diags[0].kind == "prior_without_justification"
+    assert diags[0].severity == "info"
+
+
+# --------------------------------------------------------------------------- #
+# warrant_status
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _S:
+    id: str
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class _G:
+    strategies: list = field(default_factory=list)
+
+
+def test_warrant_status_unreviewed_for_no_judgment() -> None:
+    g = _G(strategies=[_S(id="s::s1"), _S(id="s::s2", metadata={"judgment": "accepted"})])
+    diags = detect_warrant_status(g, rejected_strategy_targets=set())
+    kinds = [(d.kind, d.label) for d in diags]
+    assert ("unreviewed_warrant", "s1") in kinds
+    assert all(d.label != "s2" for d in diags)
+
+
+def test_warrant_status_rejected_takes_priority() -> None:
+    g = _G(strategies=[_S(id="s::s1")])
+    diags = detect_warrant_status(g, rejected_strategy_targets={"s1"})
+    assert len(diags) == 1
+    assert diags[0].kind == "rejected_warrant"
+    assert diags[0].label == "s1"
+
+
+def test_warrant_status_handles_missing_graph() -> None:
+    assert detect_warrant_status(None, set()) == []
+
+
+# --------------------------------------------------------------------------- #
+# Ranking — new kinds appear in every mode (no kind silently rank=99).
+# --------------------------------------------------------------------------- #
+
+
+def test_ranking_includes_all_new_kinds_for_every_mode() -> None:
+    new_kinds = [
+        "stale_artifact",
+        "focus_low_posterior",
+        "prior_without_justification",
+        "unreviewed_warrant",
+        "rejected_warrant",
+    ]
+    for mode in supported_modes():
+        diags = [
+            Diagnostic(severity="warning", kind=k, target=k, label=k, message=k) for k in new_kinds
+        ]
+        ranked = rank_diagnostics(diags, mode)
+        # All present (no drop), and kind-rank lookup must be < 99.
+        from gaia.inquiry.ranking import _MODE_RANK, _UNKNOWN_KIND_RANK
+
+        table = _MODE_RANK[mode]
+        for d in ranked:
+            assert table.get(d.kind, _UNKNOWN_KIND_RANK) < _UNKNOWN_KIND_RANK, (
+                f"{d.kind} not ranked for mode={mode}"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# publish_blockers
+# --------------------------------------------------------------------------- #
+
+
+def _empty_report():
+    from gaia.inquiry.focus import FocusBinding
+    from gaia.inquiry.review import ReviewReport
+
+    return ReviewReport(
+        review_id="r",
+        created_at="t",
+        path="p",
+        focus=FocusBinding(raw=None, kind="none", resolved_id=None),
+        mode="publish",
+        compile_status="ok",
+        ir_hash="h",
+        counts={"knowledge": 0, "strategies": 0, "operators": 0},
+    )
+
+
+def test_publish_blockers_empty_for_clean_report() -> None:
+    report = _empty_report()
+    assert publish_blockers(report) == []
+
+
+def test_publish_blockers_flags_prior_hole_diagnostic() -> None:
+    report = _empty_report()
+    report.diagnostics = [
+        Diagnostic(
+            severity="warning", kind="prior_hole", target="c::a", label="a", message="missing prior"
+        )
+    ]
+    blockers = publish_blockers(report)
+    assert len(blockers) == 1
+    assert "prior_hole" in blockers[0]
+    assert "a" in blockers[0]
+
+
+def test_publish_blockers_flags_graph_warnings_and_errors() -> None:
+    report = _empty_report()
+    report.graph_health = {"errors": ["bad node"], "warnings": ["weird ref"]}
+    blockers = publish_blockers(report)
+    assert any("graph error" in b for b in blockers)
+    assert any("graph warning" in b for b in blockers)
+
+
+def test_publish_blockers_ignores_non_blocking_kinds() -> None:
+    report = _empty_report()
+    report.diagnostics = [
+        Diagnostic(
+            severity="info", kind="rejected_warrant", target="s::s1", label="s1", message="rejected"
+        ),
+        Diagnostic(
+            severity="info", kind="background_only", target="c::b", label="b", message="bg only"
+        ),
+    ]
+    assert publish_blockers(report) == []
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end via run_review on simple_pkg fixture (no rejections, no judgments).
+# --------------------------------------------------------------------------- #
+
+
+def test_run_review_in_publish_mode_runs_clean(simple_pkg):
+    report = run_review(str(simple_pkg), mode="publish")
+    # simple_pkg compiles, and the new diagnostic emitters must integrate
+    # cleanly into the run pipeline.
+    assert report.compile_status == "ok"
+    kinds = {d.kind for d in report.diagnostics}
+    assert "orphaned_claim" in kinds
+    publish_blockers(report)  # must not raise

--- a/tests/inquiry/test_cli_proof.py
+++ b/tests/inquiry/test_cli_proof.py
@@ -1,0 +1,265 @@
+"""Tests for the ProofState-extended gaia inquiry CLI (Round A1)."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+runner = CliRunner()
+
+
+def _simple_pkg(pkg_dir, name: str = "proof_pkg") -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg_dir / name
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim\n"
+        'main_claim = claim("main hypothesis", metadata={"prior": 0.5})\n'
+        '__all__ = ["main_claim"]\n',
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# focus push / pop / stack
+# ---------------------------------------------------------------------------
+
+
+def test_focus_push_then_stack_then_pop(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    runner.invoke(app, ["inquiry", "focus", "a", "--path", str(pkg)])
+    r = runner.invoke(app, ["inquiry", "focus", "b", "--push", "--path", str(pkg)])
+    assert r.exit_code == 0
+    assert "focus pushed: b" in r.output
+
+    r2 = runner.invoke(app, ["inquiry", "focus", "--stack", "--path", str(pkg)])
+    assert r2.exit_code == 0
+    assert "current: b" in r2.output
+    assert "a" in r2.output
+
+    r3 = runner.invoke(app, ["inquiry", "focus", "--pop", "--path", str(pkg)])
+    assert r3.exit_code == 0
+    assert "popped" in r3.output
+    assert "a" in r3.output
+
+
+def test_focus_push_without_target_rejected(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(app, ["inquiry", "focus", "--push", "--path", str(pkg)])
+    assert r.exit_code == 2
+
+
+def test_focus_multiple_flags_rejected(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(app, ["inquiry", "focus", "--push", "--pop", "--path", str(pkg)])
+    assert r.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# obligation add / list / close
+# ---------------------------------------------------------------------------
+
+
+def test_obligation_add_and_list(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(
+        app,
+        [
+            "inquiry",
+            "obligation",
+            "add",
+            "github:proof_pkg::main_claim",
+            "-c",
+            "需要独立 prior",
+            "--kind",
+            "prior_hole",
+            "--path",
+            str(pkg),
+        ],
+    )
+    assert r.exit_code == 0, r.output
+    assert "obligation added" in r.output
+
+    r2 = runner.invoke(app, ["inquiry", "obligation", "list", "--json", "--path", str(pkg)])
+    assert r2.exit_code == 0
+    rows = json.loads(r2.output)
+    assert len(rows) == 1
+    assert rows[0]["diagnostic_kind"] == "prior_hole"
+    assert rows[0]["target_qid"] == "github:proof_pkg::main_claim"
+
+
+def test_obligation_close(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(
+        app,
+        [
+            "inquiry",
+            "obligation",
+            "add",
+            "X",
+            "-c",
+            "a",
+            "--kind",
+            "prior_hole",
+            "--path",
+            str(pkg),
+        ],
+    )
+    assert r.exit_code == 0
+    qid = r.output.strip().split()[2]
+
+    r2 = runner.invoke(app, ["inquiry", "obligation", "close", qid, "--path", str(pkg)])
+    assert r2.exit_code == 0
+    assert "closed" in r2.output
+
+    r3 = runner.invoke(app, ["inquiry", "obligation", "list", "--path", str(pkg)])
+    assert "(no open obligations)" in r3.output
+
+
+def test_obligation_close_nonexistent_fails(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(app, ["inquiry", "obligation", "close", "no_such", "--path", str(pkg)])
+    assert r.exit_code == 1
+
+
+def test_obligation_bad_kind_rejected(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(
+        app,
+        ["inquiry", "obligation", "add", "X", "-c", "a", "--kind", "bogus", "--path", str(pkg)],
+    )
+    assert r.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# hypothesis
+# ---------------------------------------------------------------------------
+
+
+def test_hypothesis_add_list_remove(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(
+        app,
+        [
+            "inquiry",
+            "hypothesis",
+            "add",
+            "训练数据 i.i.d.",
+            "--scope",
+            "github:proof_pkg::main_claim",
+            "--path",
+            str(pkg),
+        ],
+    )
+    assert r.exit_code == 0
+    qid = r.output.strip().split()[2]
+
+    r2 = runner.invoke(app, ["inquiry", "hypothesis", "list", "--json", "--path", str(pkg)])
+    rows = json.loads(r2.output)
+    assert len(rows) == 1
+    assert rows[0]["content"] == "训练数据 i.i.d."
+    assert rows[0]["scope_qid"] == "github:proof_pkg::main_claim"
+
+    r3 = runner.invoke(app, ["inquiry", "hypothesis", "remove", qid, "--path", str(pkg)])
+    assert r3.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# reject
+# ---------------------------------------------------------------------------
+
+
+def test_reject_strategy(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(app, ["inquiry", "reject", "lcs_bad_s3", "-c", "loop", "--path", str(pkg)])
+    assert r.exit_code == 0
+    assert "rejected" in r.output
+
+
+# ---------------------------------------------------------------------------
+# tactics log
+# ---------------------------------------------------------------------------
+
+
+def test_tactics_log_captures_events(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    runner.invoke(app, ["inquiry", "focus", "a", "--path", str(pkg)])
+    runner.invoke(
+        app,
+        ["inquiry", "obligation", "add", "X", "-c", "a", "--kind", "other", "--path", str(pkg)],
+    )
+    r = runner.invoke(app, ["inquiry", "tactics", "log", "--json", "--path", str(pkg)])
+    assert r.exit_code == 0
+    rows = json.loads(r.output)
+    events = {row["event"] for row in rows}
+    assert "focus_set" in events
+    assert "obligation_add" in events
+
+
+def test_tactics_log_empty(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    r = runner.invoke(app, ["inquiry", "tactics", "log", "--path", str(pkg)])
+    assert r.exit_code == 0
+    assert "(no tactic log entries)" in r.output
+
+
+# ---------------------------------------------------------------------------
+# review includes proof state
+# ---------------------------------------------------------------------------
+
+
+def test_review_renders_proof_state_section(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    runner.invoke(
+        app,
+        [
+            "inquiry",
+            "obligation",
+            "add",
+            "github:proof_pkg::main_claim",
+            "-c",
+            "need prior",
+            "--kind",
+            "prior_hole",
+            "--path",
+            str(pkg),
+        ],
+    )
+    r = runner.invoke(app, ["inquiry", "review", str(pkg)])
+    assert r.exit_code == 0, r.output
+    assert "## Proof state" in r.output
+    assert "obligations (1)" in r.output
+
+
+def test_review_json_includes_proof_context(tmp_path):
+    pkg = tmp_path / "p"
+    _simple_pkg(pkg)
+    runner.invoke(
+        app,
+        ["inquiry", "hypothesis", "add", "iid", "--path", str(pkg)],
+    )
+    r = runner.invoke(app, ["inquiry", "review", str(pkg), "--json"])
+    assert r.exit_code == 0
+    parsed = json.loads(r.output)
+    assert "proof_context" in parsed
+    assert len(parsed["proof_context"]["hypotheses"]) == 1

--- a/tests/inquiry/test_focus.py
+++ b/tests/inquiry/test_focus.py
@@ -1,0 +1,59 @@
+"""Tests for focus resolution and CLI focus command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+from gaia.inquiry.focus import FocusBinding, resolve_focus_target
+from gaia.inquiry.state import load_state
+
+runner = CliRunner()
+
+
+def test_resolve_freeform_without_graph():
+    b = resolve_focus_target("any text", None)
+    assert isinstance(b, FocusBinding)
+    assert b.raw == "any text"
+    assert b.kind == "freeform"
+
+
+def test_resolve_none():
+    b = resolve_focus_target(None, None)
+    assert b.kind == "none"
+    assert b.raw is None
+
+
+def test_cli_focus_set_and_show(simple_pkg: Path):
+    r = runner.invoke(app, ["inquiry", "focus", "main_claim", "--path", str(simple_pkg)])
+    assert r.exit_code == 0, r.output
+    assert "focus set" in r.output
+
+    r2 = runner.invoke(app, ["inquiry", "focus", "--path", str(simple_pkg)])
+    assert r2.exit_code == 0
+    assert "main_claim" in r2.output
+
+    state = load_state(simple_pkg)
+    assert state.focus == "main_claim"
+
+
+def test_cli_focus_freeform_then_clear(simple_pkg: Path):
+    r = runner.invoke(
+        app, ["inquiry", "focus", "arbitrary research goal", "--path", str(simple_pkg)]
+    )
+    assert r.exit_code == 0
+
+    r2 = runner.invoke(app, ["inquiry", "focus", "--clear", "--path", str(simple_pkg)])
+    assert r2.exit_code == 0
+    assert "cleared" in r2.output
+    assert load_state(simple_pkg).focus is None
+
+
+def test_cli_focus_resolves_claim_to_question_kind(simple_pkg: Path):
+    r = runner.invoke(app, ["inquiry", "focus", "rq", "--path", str(simple_pkg)])
+    assert r.exit_code == 0
+    # show should report it with resolved kind (question or freeform fallback)
+    r2 = runner.invoke(app, ["inquiry", "focus", "--path", str(simple_pkg)])
+    assert r2.exit_code == 0
+    assert "rq" in r2.output

--- a/tests/inquiry/test_modes_diff_markdown.py
+++ b/tests/inquiry/test_modes_diff_markdown.py
@@ -1,0 +1,286 @@
+"""Step 6/7/8 — mode ranking, extended diff (16 categories), markdown renderer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gaia.inquiry.diagnostics import Diagnostic, NextEdit
+from gaia.inquiry.diff import (
+    SemanticDiff,
+    compute_semantic_diff,
+)
+from gaia.inquiry.ranking import (
+    rank_diagnostics,
+    rank_next_edits,
+    supported_modes,
+)
+from gaia.inquiry.review import render_markdown, run_review
+
+
+# --------------------------------------------------------------------------- #
+# §14.2 — extended diff categories                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _baseline_snapshot(ir: dict, review_id: str = "base-id") -> dict:
+    return {"review_id": review_id, "ir": ir, "beliefs": []}
+
+
+def _claim(cid: str, label: str, content: str = "", prior=None, exported: bool = False) -> dict:
+    md: dict = {}
+    if prior is not None:
+        md["prior"] = prior
+    return {
+        "id": cid,
+        "label": label,
+        "type": "claim",
+        "content": content,
+        "metadata": md,
+        "exported": exported,
+    }
+
+
+def _question(qid: str, label: str) -> dict:
+    return {"id": qid, "label": label, "type": "question", "content": "", "metadata": {}}
+
+
+def _setting(sid: str, label: str) -> dict:
+    return {"id": sid, "label": label, "type": "setting", "content": "", "metadata": {}}
+
+
+def _strategy(sid: str, conclusion: str, premises: list[str]) -> dict:
+    return {
+        "id": sid,
+        "conclusion": conclusion,
+        "premises": list(premises),
+        "background": [],
+    }
+
+
+def _operator(oid: str, conclusion: str, variables: list[str]) -> dict:
+    return {"id": oid, "conclusion": conclusion, "variables": list(variables)}
+
+
+def test_diff_added_removed_questions():
+    base_ir = {"knowledges": [_question("q::a", "qa")], "strategies": [], "operators": []}
+    cur_ir = {"knowledges": [_question("q::b", "qb")], "strategies": [], "operators": []}
+    d = compute_semantic_diff(cur_ir, _baseline_snapshot(base_ir))
+    assert d.added_questions == ["qb"]
+    assert d.removed_questions == ["qa"]
+
+
+def test_diff_added_removed_settings():
+    base_ir = {"knowledges": [_setting("s::a", "sa")], "strategies": [], "operators": []}
+    cur_ir = {
+        "knowledges": [_setting("s::b", "sb"), _setting("s::a", "sa")],
+        "strategies": [],
+        "operators": [],
+    }
+    d = compute_semantic_diff(cur_ir, _baseline_snapshot(base_ir))
+    assert d.added_settings == ["sb"]
+    assert d.removed_settings == []
+
+
+def test_diff_added_removed_changed_operators():
+    base_ir = {
+        "knowledges": [],
+        "strategies": [],
+        "operators": [_operator("op::keep", "y=Ax", ["x"]), _operator("op::gone", "z=0", [])],
+    }
+    cur_ir = {
+        "knowledges": [],
+        "strategies": [],
+        "operators": [
+            _operator("op::keep", "y=Bx", ["x", "b"]),
+            _operator("op::new", "u=v", ["v"]),
+        ],
+    }
+    d = compute_semantic_diff(cur_ir, _baseline_snapshot(base_ir))
+    assert d.added_operators == ["new"]
+    assert d.removed_operators == ["gone"]
+    fields = sorted(c.field for c in d.changed_operators)
+    assert fields == ["conclusion", "variables"]
+
+
+def test_diff_changed_exports():
+    base_ir = {
+        "knowledges": [_claim("c::a", "ca", exported=False)],
+        "strategies": [],
+        "operators": [],
+    }
+    cur_ir = {
+        "knowledges": [_claim("c::a", "ca", exported=True)],
+        "strategies": [],
+        "operators": [],
+    }
+    d = compute_semantic_diff(cur_ir, _baseline_snapshot(base_ir))
+    assert len(d.changed_exports) == 1
+    assert d.changed_exports[0].label == "ca"
+    assert d.changed_exports[0].before == "False"
+    assert d.changed_exports[0].after == "True"
+
+
+def test_diff_to_dict_has_all_16_keys():
+    d = SemanticDiff()
+    keys = set(d.to_dict().keys()) - {"baseline_review_id"}
+    assert keys == {
+        "added_claims",
+        "removed_claims",
+        "changed_claims",
+        "added_questions",
+        "removed_questions",
+        "added_settings",
+        "removed_settings",
+        "added_strategies",
+        "removed_strategies",
+        "changed_strategies",
+        "added_operators",
+        "removed_operators",
+        "changed_operators",
+        "changed_priors",
+        "changed_exports",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# §7 / §15.4 — mode-specific ranking                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _diag(kind: str, severity: str = "warning", label: str = "x") -> Diagnostic:
+    return Diagnostic(
+        severity=severity,
+        kind=kind,
+        target=label,
+        label=label,
+        message=f"{kind} for {label}",
+        suggested_edit=f"fix {label}",
+    )
+
+
+def test_supported_modes_match_spec():
+    assert set(supported_modes()) == {"auto", "formalize", "explore", "verify", "publish"}
+
+
+def test_rank_explore_promotes_focus_weakness():
+    ds = [
+        _diag("prior_hole", "warning", "ph"),
+        _diag("focus_weakness", "warning", "fw"),
+        _diag("validation_warning", "warning", "vw"),
+    ]
+    ranked = rank_diagnostics(ds, "explore")
+    assert ranked[0].kind == "focus_weakness"
+    # prior_hole drops to last since it has rank 10 in explore.
+    assert ranked[-1].kind == "prior_hole"
+
+
+def test_rank_formalize_promotes_prior_holes_and_structural_holes():
+    ds = [
+        _diag("focus_weakness", "warning", "fw"),
+        _diag("prior_hole", "warning", "ph"),
+        _diag("structural_hole", "warning", "sh"),
+    ]
+    ranked = rank_diagnostics(ds, "formalize")
+    kinds = [d.kind for d in ranked]
+    assert (
+        kinds.index("structural_hole") < kinds.index("prior_hole") < kinds.index("focus_weakness")
+    )
+
+
+def test_rank_publish_keeps_compile_errors_first():
+    ds = [
+        _diag("background_only_claim", "info", "bg"),
+        _diag("compile_error", "error", "ce"),
+        _diag("prior_hole", "warning", "ph"),
+    ]
+    ranked = rank_diagnostics(ds, "publish")
+    assert ranked[0].kind == "compile_error"
+
+
+def test_rank_unknown_kind_does_not_drop():
+    ds = [
+        _diag("prior_hole", "warning", "ph"),
+        Diagnostic(
+            severity="warning",
+            kind="future_unknown_kind",  # type: ignore[arg-type]
+            target="z",
+            label="z",
+            message="future",
+            suggested_edit="fix z",
+        ),
+    ]
+    ranked = rank_diagnostics(ds, "auto")
+    assert len(ranked) == 2
+    assert {d.kind for d in ranked} == {"prior_hole", "future_unknown_kind"}
+
+
+def test_rank_next_edits_severity_tiebreak():
+    edits = [
+        NextEdit(text="A", kind="prior_hole", severity="info", target="a", label="a"),
+        NextEdit(text="B", kind="prior_hole", severity="error", target="b", label="b"),
+        NextEdit(text="C", kind="prior_hole", severity="warning", target="c", label="c"),
+    ]
+    ranked = rank_next_edits(edits, "auto")
+    assert [e.severity for e in ranked] == ["error", "warning", "info"]
+
+
+# --------------------------------------------------------------------------- #
+# §17.2 — markdown renderer                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_render_markdown_has_all_eight_sections(simple_pkg: Path):
+    report = run_review(simple_pkg, no_infer=True)
+    md = render_markdown(report)
+    for heading in (
+        "# Gaia Inquiry Review",
+        "## Focus",
+        "## Compile",
+        "## Semantic diff",
+        "## Graph health",
+        "## Inquiry tree",
+        "## Prior holes",
+        "## Belief report",
+        "## Next edits",
+    ):
+        assert heading in md, f"missing section: {heading}\n---\n{md}"
+
+
+def test_render_markdown_includes_review_id(simple_pkg: Path):
+    report = run_review(simple_pkg, no_infer=True)
+    md = render_markdown(report)
+    assert f"`{report.review_id}`" in md
+
+
+def test_render_markdown_diff_section_lists_added_categories(tmp_path: Path):
+    pkg = tmp_path / "p"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "diffmd-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg / "diffmd"
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, question\n"
+        'a = claim("a")\n'
+        'q = question("q")\n'
+        '__all__ = ["a", "q"]\n',
+        encoding="utf-8",
+    )
+    r1 = run_review(pkg, no_infer=True)
+
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, question\n"
+        'a = claim("a")\n'
+        'b = claim("b")\n'
+        'q = question("q")\n'
+        'q2 = question("q2")\n'
+        '__all__ = ["a", "b", "q", "q2"]\n',
+        encoding="utf-8",
+    )
+    r2 = run_review(pkg, no_infer=True, since=r1.review_id)
+    md = render_markdown(r2)
+    assert "Added claims" in md
+    assert "Added questions" in md

--- a/tests/inquiry/test_remaining_diagnostics.py
+++ b/tests/inquiry/test_remaining_diagnostics.py
@@ -1,0 +1,401 @@
+"""Tests for the remaining 5 §15.2 diagnostic kinds:
+
+blocked_warrant_path / focus_unsupported / large_belief_drop /
+overstrong_strategy_without_provenance /
+claim_with_evidence_but_no_focus_connection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from gaia.cli.commands.check_core import HoleEntry, KnowledgeBreakdown
+from gaia.inquiry.diagnostics import (
+    Diagnostic,
+    detect_blocked_warrant_path,
+    detect_claim_with_evidence_but_no_focus_connection,
+    detect_focus_unsupported,
+    detect_large_belief_drop,
+    detect_overstrong_strategy_without_provenance,
+)
+from gaia.inquiry.focus import FocusBinding
+from gaia.inquiry.ranking import _MODE_RANK, _UNKNOWN_KIND_RANK, supported_modes
+from gaia.inquiry.review import publish_blockers, run_review
+
+
+# --------------------------------------------------------------------------- #
+# Lightweight graph stubs                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _K:
+    id: str
+    label: str = ""
+
+
+@dataclass
+class _S:
+    id: str
+    conclusion: str | None = None
+    premises: list = field(default_factory=list)
+    background: list = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class _O:
+    id: str
+    conclusion: str | None = None
+    variables: list = field(default_factory=list)
+
+
+@dataclass
+class _G:
+    knowledges: list = field(default_factory=list)
+    strategies: list = field(default_factory=list)
+    operators: list = field(default_factory=list)
+
+
+def _focus(target_id: str | None) -> FocusBinding:
+    return FocusBinding(raw=target_id, kind="claim", resolved_id=target_id)
+
+
+# --------------------------------------------------------------------------- #
+# blocked_warrant_path                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_blocked_warrant_path_emits_when_premise_is_hole() -> None:
+    kb = KnowledgeBreakdown()
+    kb.independent.append(HoleEntry(cid="c::a", label="a", content="ca", prior=None))
+    g = _G(
+        strategies=[
+            _S(id="s::s1", conclusion="c::z", premises=["c::a", "c::b"]),
+            _S(id="s::s2", conclusion="c::y", premises=["c::b"]),
+        ]
+    )
+    diags = detect_blocked_warrant_path(g, kb)
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.kind == "blocked_warrant_path"
+    assert d.label == "s1"
+    assert d.severity == "warning"
+    assert d.data["blocking_premises"] == ["c::a"]
+
+
+def test_blocked_warrant_path_silent_when_no_holes() -> None:
+    kb = KnowledgeBreakdown()
+    g = _G(strategies=[_S(id="s::s1", conclusion="c::z", premises=["c::a"])])
+    assert detect_blocked_warrant_path(g, kb) == []
+
+
+def test_blocked_warrant_path_silent_when_graph_missing() -> None:
+    kb = KnowledgeBreakdown()
+    kb.holes.append(HoleEntry(cid="c::a", label="a", content="", prior=None))
+    assert detect_blocked_warrant_path(None, kb) == []
+
+
+# --------------------------------------------------------------------------- #
+# focus_unsupported                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_focus_unsupported_emits_when_no_reference() -> None:
+    g = _G(
+        knowledges=[_K(id="c::main", label="main")],
+        strategies=[_S(id="s::s1", conclusion="c::other", premises=["c::p"])],
+    )
+    diags = detect_focus_unsupported(g, _focus("c::main"))
+    assert len(diags) == 1
+    assert diags[0].kind == "focus_unsupported"
+    assert diags[0].label == "main"
+    assert diags[0].severity == "warning"
+
+
+def test_focus_unsupported_silent_when_strategy_concludes_focus() -> None:
+    g = _G(strategies=[_S(id="s::s1", conclusion="c::main")])
+    assert detect_focus_unsupported(g, _focus("c::main")) == []
+
+
+def test_focus_unsupported_silent_when_used_as_premise() -> None:
+    g = _G(strategies=[_S(id="s::s1", conclusion="c::z", premises=["c::main"])])
+    assert detect_focus_unsupported(g, _focus("c::main")) == []
+
+
+def test_focus_unsupported_silent_when_referenced_by_operator() -> None:
+    g = _G(operators=[_O(id="o::o1", variables=["c::main"])])
+    assert detect_focus_unsupported(g, _focus("c::main")) == []
+
+
+def test_focus_unsupported_silent_when_no_focus() -> None:
+    g = _G(strategies=[_S(id="s::s1")])
+    assert detect_focus_unsupported(g, None) == []
+    assert detect_focus_unsupported(g, _focus(None)) == []
+
+
+# --------------------------------------------------------------------------- #
+# large_belief_drop                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_large_belief_drop_emits_at_or_below_threshold() -> None:
+    report = {
+        "largest_decreases": [
+            {"label": "x", "before": 0.8, "after": 0.4, "delta": -0.4},
+            {"label": "y", "before": 0.6, "after": 0.5, "delta": -0.1},
+        ]
+    }
+    diags = detect_large_belief_drop(report, threshold=0.3)
+    assert len(diags) == 1
+    assert diags[0].label == "x"
+    assert diags[0].kind == "large_belief_drop"
+    assert diags[0].severity == "warning"
+    assert diags[0].data["delta"] == pytest.approx(-0.4)
+
+
+def test_large_belief_drop_silent_when_below_threshold() -> None:
+    report = {"largest_decreases": [{"label": "y", "before": 0.6, "after": 0.5, "delta": -0.1}]}
+    assert detect_large_belief_drop(report, threshold=0.3) == []
+
+
+def test_large_belief_drop_silent_with_no_baseline() -> None:
+    assert detect_large_belief_drop({"largest_decreases": []}) == []
+    assert detect_large_belief_drop({}) == []
+
+
+def test_large_belief_drop_handles_malformed_delta() -> None:
+    report = {"largest_decreases": [{"label": "z", "delta": None}]}
+    assert detect_large_belief_drop(report) == []
+
+
+# --------------------------------------------------------------------------- #
+# overstrong_strategy_without_provenance                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_overstrong_warning_when_high_strength_no_provenance() -> None:
+    g = _G(strategies=[_S(id="s::s1", metadata={"strength": 0.9})])
+    diags = detect_overstrong_strategy_without_provenance(g, strength_threshold=0.8)
+    assert len(diags) == 1
+    assert diags[0].severity == "warning"
+    assert diags[0].kind == "overstrong_strategy_without_provenance"
+    assert diags[0].data["strength"] == pytest.approx(0.9)
+
+
+def test_overstrong_silent_when_provenance_present() -> None:
+    g = _G(
+        strategies=[
+            _S(id="s::s1", metadata={"strength": 0.9, "provenance": "lemma 3.4"}),
+        ]
+    )
+    assert detect_overstrong_strategy_without_provenance(g) == []
+
+
+def test_overstrong_silent_when_justification_present() -> None:
+    g = _G(strategies=[_S(id="s::s1", metadata={"justification": "matches paper §2"})])
+    assert detect_overstrong_strategy_without_provenance(g) == []
+
+
+def test_overstrong_info_when_no_strength_field() -> None:
+    g = _G(strategies=[_S(id="s::s1", metadata={})])
+    diags = detect_overstrong_strategy_without_provenance(g)
+    assert len(diags) == 1
+    assert diags[0].severity == "info"
+
+
+def test_overstrong_uses_confidence_as_fallback() -> None:
+    g = _G(strategies=[_S(id="s::s1", metadata={"confidence": 0.95})])
+    diags = detect_overstrong_strategy_without_provenance(g, strength_threshold=0.8)
+    assert len(diags) == 1
+    assert diags[0].severity == "warning"
+
+
+# --------------------------------------------------------------------------- #
+# claim_with_evidence_but_no_focus_connection                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_claim_evidence_disconnected_emits() -> None:
+    g = _G(
+        knowledges=[
+            _K(id="c::main", label="main"),
+            _K(id="c::p", label="p"),
+            _K(id="c::orphan_bg", label="orphan_bg"),
+            _K(id="c::q", label="q"),
+        ],
+        strategies=[
+            _S(id="s::s1", conclusion="c::main", premises=["c::p"]),
+            _S(
+                id="s::s2",
+                conclusion="c::q",
+                premises=[],
+                background=["c::orphan_bg"],
+            ),
+        ],
+    )
+    diags = detect_claim_with_evidence_but_no_focus_connection(g, _focus("c::main"))
+    labels = {d.label for d in diags}
+    assert labels == {"orphan_bg"}
+    assert diags[0].kind == "claim_with_evidence_but_no_focus_connection"
+    assert diags[0].severity == "info"
+
+
+def test_claim_evidence_silent_when_connected() -> None:
+    g = _G(
+        knowledges=[
+            _K(id="c::main", label="main"),
+            _K(id="c::ev", label="ev"),
+        ],
+        strategies=[
+            _S(id="s::s1", conclusion="c::main", premises=[], background=["c::ev"]),
+        ],
+    )
+    # ev 在 s::s1.background, c::main 是同一 strategy 的 conclusion → 同连通分量, 不报。
+    assert detect_claim_with_evidence_but_no_focus_connection(g, _focus("c::main")) == []
+
+
+def test_claim_evidence_silent_with_no_focus() -> None:
+    g = _G()
+    assert detect_claim_with_evidence_but_no_focus_connection(g, None) == []
+
+
+def test_claim_evidence_silent_when_claim_in_premises() -> None:
+    g = _G(
+        knowledges=[
+            _K(id="c::main", label="main"),
+            _K(id="c::ev", label="ev"),
+            _K(id="c::other", label="other"),
+        ],
+        strategies=[
+            _S(id="s::s1", conclusion="c::main", premises=[]),
+            _S(
+                id="s::s2",
+                conclusion="c::other",
+                premises=["c::ev"],
+                background=["c::ev"],
+            ),
+        ],
+    )
+    # ev 在 in_bg ∩ in_core → 不属于 bg_only, 不报。
+    assert detect_claim_with_evidence_but_no_focus_connection(g, _focus("c::main")) == []
+
+
+# --------------------------------------------------------------------------- #
+# Ranking — every new kind is ranked in every mode (no rank=99 fallback).     #
+# --------------------------------------------------------------------------- #
+
+
+def test_ranking_includes_all_remaining_kinds_for_every_mode() -> None:
+    new_kinds = [
+        "blocked_warrant_path",
+        "focus_unsupported",
+        "large_belief_drop",
+        "overstrong_strategy_without_provenance",
+        "claim_with_evidence_but_no_focus_connection",
+    ]
+    for mode in supported_modes():
+        table = _MODE_RANK[mode]
+        for k in new_kinds:
+            assert table.get(k, _UNKNOWN_KIND_RANK) < _UNKNOWN_KIND_RANK, (
+                f"{k} not ranked for mode={mode}"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# publish_blockers — new blocking kinds                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _empty_report():
+    from gaia.inquiry.review import ReviewReport
+
+    return ReviewReport(
+        review_id="r",
+        created_at="t",
+        path="p",
+        focus=FocusBinding(raw=None, kind="none", resolved_id=None),
+        mode="publish",
+        compile_status="ok",
+        ir_hash="h",
+        counts={"knowledge": 0, "strategies": 0, "operators": 0},
+    )
+
+
+def test_publish_blockers_flags_blocked_warrant_path() -> None:
+    report = _empty_report()
+    report.diagnostics = [
+        Diagnostic(
+            severity="warning",
+            kind="blocked_warrant_path",
+            target="s::s1",
+            label="s1",
+            message="blocked",
+        )
+    ]
+    blockers = publish_blockers(report)
+    assert any("blocked_warrant_path" in b for b in blockers)
+
+
+def test_publish_blockers_flags_focus_unsupported() -> None:
+    report = _empty_report()
+    report.diagnostics = [
+        Diagnostic(
+            severity="warning",
+            kind="focus_unsupported",
+            target="c::m",
+            label="m",
+            message="no ref",
+        )
+    ]
+    assert any("focus_unsupported" in b for b in publish_blockers(report))
+
+
+def test_publish_blockers_flags_overstrong_without_provenance() -> None:
+    report = _empty_report()
+    report.diagnostics = [
+        Diagnostic(
+            severity="info",
+            kind="overstrong_strategy_without_provenance",
+            target="s::s1",
+            label="s1",
+            message="no provenance",
+        )
+    ]
+    assert any("overstrong" in b for b in publish_blockers(report))
+
+
+def test_publish_blockers_ignores_large_belief_drop_and_no_focus_connection() -> None:
+    report = _empty_report()
+    report.diagnostics = [
+        Diagnostic(
+            severity="warning",
+            kind="large_belief_drop",
+            target="x",
+            label="x",
+            message="dropped",
+        ),
+        Diagnostic(
+            severity="info",
+            kind="claim_with_evidence_but_no_focus_connection",
+            target="c::y",
+            label="y",
+            message="dangling",
+        ),
+    ]
+    assert publish_blockers(report) == []
+
+
+# --------------------------------------------------------------------------- #
+# Integration: run_review on simple_pkg fixture; the new emitters compose.   #
+# --------------------------------------------------------------------------- #
+
+
+def test_run_review_integrates_new_diagnostics(simple_pkg) -> None:
+    report = run_review(str(simple_pkg), mode="publish")
+    assert report.compile_status == "ok"
+    legal_kinds = set(_MODE_RANK["publish"].keys())
+    for d in report.diagnostics:
+        assert d.kind in legal_kinds, f"unknown diag kind leaked: {d.kind}"

--- a/tests/inquiry/test_review.py
+++ b/tests/inquiry/test_review.py
@@ -1,0 +1,236 @@
+"""Step 2 — eight-section review + JSON schema + diagnostics composition."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+from gaia.inquiry.diagnostics import (
+    Diagnostic,
+    format_diagnostics_as_next_edits,
+    from_validation,
+)
+from gaia.inquiry.review import run_review
+
+runner = CliRunner()
+
+
+def _pkg_with_holes(pkg_dir: Path, name: str = "review_pkg") -> None:
+    """Build a package with: 1 prior-set claim, 1 hole, 1 setting, 1 question."""
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg_dir / name
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, setting, question, support\n"
+        'covered = claim("covered hypothesis", metadata={"prior": 0.7})\n'
+        'hole = claim("hypothesis with no prior")\n'
+        'derived_claim = claim("derived conclusion")\n'
+        "sup = support(premises=[hole, covered], conclusion=derived_claim)\n"
+        'iid = setting("data is i.i.d.")\n'
+        'rq = question("does it generalize?")\n'
+        '__all__ = ["covered", "hole", "derived_claim", "sup", "iid", "rq"]\n',
+        encoding="utf-8",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Diagnostics — pure function tests                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_from_validation_lifts_warnings_and_errors():
+    diags = from_validation(["w1", "w2"], ["e1"])
+    kinds = [d.kind for d in diags]
+    sevs = [d.severity for d in diags]
+    assert "validation_error" in kinds
+    assert "validation_warning" in kinds
+    assert "error" in sevs and "warning" in sevs
+
+
+def test_next_edits_dedup_and_severity_order():
+    diags = [
+        Diagnostic("info", "background_only_claim", "x", "x", "msg", "edit B"),
+        Diagnostic("error", "validation_error", "g", "g", "msg", "edit A"),
+        Diagnostic("warning", "prior_hole", "y", "y", "msg", "edit A"),
+    ]
+    edits = format_diagnostics_as_next_edits(diags)
+    assert edits == ["edit A", "edit B"]
+
+
+# --------------------------------------------------------------------------- #
+# Report shape                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_review_report_has_all_eight_sections(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    d = report.to_json_dict()
+    for key in (
+        "focus",
+        "compile",
+        "semantic_diff",
+        "graph_health",
+        "inquiry_tree",
+        "prior_holes",
+        "belief_report",
+        "diagnostics",
+        "next_edits",
+    ):
+        assert key in d, f"missing JSON section: {key}"
+
+
+def test_review_compile_section(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    assert report.compile_status == "ok"
+    assert report.counts["knowledge"] >= 4
+    assert report.counts["strategies"] >= 1
+
+
+def test_review_prior_holes_detect_missing_prior(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    labels = [h["label"] for h in report.prior_holes]
+    assert "hole" in labels
+    assert "covered" not in labels
+
+
+def test_review_graph_health_reports_orphans_and_holes(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    gh = report.graph_health
+    assert "hole" in gh["prior_holes"]
+    assert "covered" not in gh["prior_holes"]
+
+
+def test_review_inquiry_tree_counts_questions_as_goals(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    assert report.inquiry_tree["goals"] == 1
+    assert report.inquiry_tree["unreviewed_warrants"] >= 1
+
+
+def test_review_diagnostics_include_prior_hole_and_orphan(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    kinds = {d.kind for d in report.diagnostics}
+    assert "prior_hole" in kinds
+    assert "orphaned_claim" in kinds
+
+
+def test_review_next_edits_nonempty_when_holes_exist(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    assert any('set_prior("hole"' in e for e in report.next_edits)
+
+
+def test_review_semantic_diff_empty_on_first_run(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    report = run_review(pkg, no_infer=True)
+    assert report.semantic_diff.is_empty
+    assert report.semantic_diff.baseline_review_id is None
+
+
+# --------------------------------------------------------------------------- #
+# Text rendering — eight ## headers                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_text_render_has_all_eight_section_headers(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    r = runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer"])
+    assert r.exit_code == 0, r.output
+    for h in (
+        "## Focus",
+        "## Compile",
+        "## Semantic diff",
+        "## Graph health",
+        "## Inquiry tree",
+        "## Prior holes",
+        "## Belief report",
+        "## Next edits",
+    ):
+        assert h in r.output, f"text output missing header: {h}\n{r.output}"
+
+
+def test_text_render_lists_holes(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    r = runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer"])
+    assert "- hole" in r.output
+
+
+# --------------------------------------------------------------------------- #
+# JSON output — schema fidelity                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_json_output_well_formed_and_schema_v1(tmp_path):
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    r = runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert data["compile"]["status"] == "ok"
+    assert isinstance(data["graph_health"]["prior_holes"], list)
+    assert isinstance(data["diagnostics"], list)
+    assert any(d["kind"] == "prior_hole" for d in data["diagnostics"])
+    assert isinstance(data["next_edits"], list)
+    assert data["semantic_diff"]["baseline_review_id"] is None
+
+
+def test_strict_no_warnings_no_exit(tmp_path):
+    """Strict mode must NOT exit non-zero when only info-level diagnostics exist."""
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    # First review: validation may warn; we just check exit-code path is reachable.
+    r = runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer", "--mode", "publish"])
+    assert r.exit_code in (0, 1)  # depends on validator output for empty-strategy pkg
+
+
+# --------------------------------------------------------------------------- #
+# Composition contract — must use check_core, not duplicate logic             #
+# --------------------------------------------------------------------------- #
+
+
+def test_review_uses_check_core_breakdown(tmp_path):
+    """Sanity: prior_holes from review must match check_core directly."""
+    pkg = tmp_path / "p"
+    _pkg_with_holes(pkg)
+    from gaia.cli._packages import (
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        ensure_package_env,
+        load_gaia_package,
+    )
+    from gaia.cli.commands.check_core import analyze_knowledge_breakdown
+    from gaia.inquiry.review import _graph_to_ir_dict
+
+    ensure_package_env(pkg)
+    loaded = load_gaia_package(str(pkg))
+    apply_package_priors(loaded)
+    graph = compile_loaded_package_artifact(loaded).graph
+    kb = analyze_knowledge_breakdown(_graph_to_ir_dict(graph))
+    expected = sorted(h.label for h in kb.holes)
+
+    report = run_review(pkg, no_infer=True)
+    actual = sorted(h["label"] for h in report.prior_holes)
+    assert actual == expected

--- a/tests/inquiry/test_review.py
+++ b/tests/inquiry/test_review.py
@@ -13,7 +13,7 @@ from gaia.inquiry.diagnostics import (
     format_diagnostics_as_next_edits,
     from_validation,
 )
-from gaia.inquiry.review import run_review
+from gaia.inquiry.review import publish_blockers, run_review
 
 runner = CliRunner()
 
@@ -347,3 +347,84 @@ def test_review_depth_uses_joint_dependency_graphs(tmp_path, monkeypatch):
     assert joint.compile_status == "ok"
     assert upstream_id in joint_beliefs
     assert joint_beliefs[upstream_id] != flat_beliefs.get(upstream_id, 0.5)
+
+
+def test_review_depth_inference_errors_surface_in_graph_health(tmp_path):
+    pkg = tmp_path / "missing_dep_pkg"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "missing-dep-pkg-gaia"\nversion = "1.0.0"\n'
+        'dependencies = ["missing-upstream-gaia"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg / "missing_dep_pkg"
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim\n"
+        'local_obs = claim("Local observation.", metadata={"prior": 0.6})\n'
+        '__all__ = ["local_obs"]\n',
+        encoding="utf-8",
+    )
+
+    report = run_review(pkg, depth=1)
+
+    assert not report.belief_report["ran_inference"]
+    assert any("missing_upstream" in err for err in report.graph_health["errors"])
+
+    result = runner.invoke(app, ["inquiry", "review", str(pkg), "--depth", "1"])
+    assert result.exit_code == 1
+    assert "errors: 1" in result.output
+    assert "missing_upstream" in result.output
+
+
+def test_review_manifest_accepted_strategy_is_not_unreviewed(tmp_path):
+    pkg = tmp_path / "reviewed_pkg"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "reviewed-pkg-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg / "reviewed_pkg"
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, derive\n"
+        'a = claim("A.", metadata={"prior": 0.7})\n'
+        'c = derive("C.", given=a, rationale="A implies C.", label="derive_c")\n'
+        '__all__ = ["c"]\n',
+        encoding="utf-8",
+    )
+
+    from gaia.cli._packages import (
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        ensure_package_env,
+        load_gaia_package,
+    )
+    from gaia.ir import ReviewManifest, ReviewStatus
+
+    ensure_package_env(pkg)
+    loaded = load_gaia_package(str(pkg))
+    apply_package_priors(loaded)
+    compiled = compile_loaded_package_artifact(loaded)
+    generated = compiled.review
+    assert generated is not None
+    assert len(generated.reviews) == 1
+    accepted = generated.reviews[0].model_copy(update={"status": ReviewStatus.ACCEPTED, "round": 2})
+    review_path = pkg / ".gaia" / "review_manifest.json"
+    review_path.parent.mkdir()
+    review_path.write_text(
+        json.dumps(ReviewManifest(reviews=[accepted]).model_dump(mode="json"), indent=2),
+        encoding="utf-8",
+    )
+
+    report = run_review(pkg, no_infer=True, mode="publish")
+
+    assert report.inquiry_tree["accepted_warrants"] == 1
+    assert report.inquiry_tree["unreviewed_warrants"] == 0
+    assert not any(
+        d.kind == "unreviewed_warrant" and d.target == accepted.target_id
+        for d in report.diagnostics
+    )
+    assert not any("unreviewed_warrant" in blocker for blocker in publish_blockers(report))

--- a/tests/inquiry/test_review.py
+++ b/tests/inquiry/test_review.py
@@ -234,3 +234,116 @@ def test_review_uses_check_core_breakdown(tmp_path):
     report = run_review(pkg, no_infer=True)
     actual = sorted(h["label"] for h in report.prior_holes)
     assert actual == expected
+
+
+def test_review_adapter_preserves_strategy_and_operator_ids(tmp_path):
+    pkg = tmp_path / "p"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "id-review-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg / "id_review"
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, contradiction, support\n"
+        'a = claim("A", metadata={"prior": 0.7})\n'
+        'b = claim("B", metadata={"prior": 0.4})\n'
+        'c = claim("C")\n'
+        "sup = support(premises=[a], conclusion=c)\n"
+        "conflict = contradiction(a, b)\n"
+        '__all__ = ["a", "b", "c", "sup", "conflict"]\n',
+        encoding="utf-8",
+    )
+
+    from gaia.cli._packages import (
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        ensure_package_env,
+        load_gaia_package,
+    )
+    from gaia.inquiry.review import _graph_to_ir_dict
+
+    ensure_package_env(pkg)
+    loaded = load_gaia_package(str(pkg))
+    apply_package_priors(loaded)
+    graph = compile_loaded_package_artifact(loaded).graph
+    ir = _graph_to_ir_dict(graph)
+
+    assert ir["strategies"][0]["id"].startswith("lcs_")
+    assert ir["operators"][0]["id"].startswith("lco_")
+
+    report = run_review(pkg, no_infer=True)
+    unreviewed = [d for d in report.diagnostics if d.kind == "unreviewed_warrant"]
+    assert unreviewed
+    assert all(d.target.startswith("lcs_") for d in unreviewed)
+
+
+def _write_dep_package(dep_dir: Path, *, name: str, monkeypatch) -> None:
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    import_name = name.replace("-", "_")
+    src = dep_dir / import_name
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n"
+        'evidence = claim("Strong upstream evidence.", title="evidence")\n'
+        'upstream_conclusion = claim("Upstream conclusion.", title="conclusion")\n'
+        "deduction(premises=[evidence], conclusion=upstream_conclusion, "
+        "reason='evidence supports conclusion', prior=0.9)\n"
+        '__all__ = ["evidence", "upstream_conclusion"]\n',
+        encoding="utf-8",
+    )
+    (src / "priors.py").write_text(
+        'from . import evidence\n\nPRIORS = {evidence: (0.85, "Strong evidence")}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(dep_dir))
+
+
+def test_review_depth_uses_joint_dependency_graphs(tmp_path, monkeypatch):
+    from unittest.mock import patch
+
+    dep_dir = tmp_path / "upstream_dep"
+    _write_dep_package(dep_dir, name="upstream_dep", monkeypatch=monkeypatch)
+    compile_dep = runner.invoke(app, ["compile", str(dep_dir)])
+    assert compile_dep.exit_code == 0, compile_dep.output
+
+    pkg = tmp_path / "local_pkg"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "local-pkg-gaia"\nversion = "1.0.0"\n'
+        'dependencies = ["upstream-dep-gaia"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg / "local_pkg"
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import claim, deduction\n"
+        "from upstream_dep import upstream_conclusion\n"
+        'local_obs = claim("Local observation.")\n'
+        "local_result = claim('Local result.')\n"
+        "deduction(premises=[upstream_conclusion, local_obs], conclusion=local_result, "
+        "reason='apply upstream', prior=0.9)\n"
+        '__all__ = ["local_obs", "local_result"]\n',
+        encoding="utf-8",
+    )
+
+    flat = run_review(pkg, depth=0)
+    with patch("gaia.cli._packages._locate_dependency_manifest_root", return_value=dep_dir):
+        joint = run_review(pkg, depth=1)
+
+    upstream_id = "github:upstream_dep::upstream_conclusion"
+    flat_beliefs = {b["knowledge_id"]: b["belief"] for b in flat.belief_report["beliefs"]}
+    joint_beliefs = {b["knowledge_id"]: b["belief"] for b in joint.belief_report["beliefs"]}
+
+    assert flat.compile_status == "ok"
+    assert joint.compile_status == "ok"
+    assert upstream_id in joint_beliefs
+    assert joint_beliefs[upstream_id] != flat_beliefs.get(upstream_id, 0.5)

--- a/tests/inquiry/test_snapshot_diff.py
+++ b/tests/inquiry/test_snapshot_diff.py
@@ -1,0 +1,258 @@
+"""Step 4 — snapshot persistence + semantic diff + Round A3 review_id."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+from gaia.inquiry.diff import compute_semantic_diff
+from gaia.inquiry.review import run_review
+from gaia.inquiry.snapshot import (
+    list_snapshots,
+    mint_review_id,
+    resolve_baseline,
+    reviews_dir,
+)
+from gaia.inquiry.state import inquiry_dir
+
+runner = CliRunner()
+
+REVIEW_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z_[a-zA-Z0-9]+_[A-Za-z0-9._-]+$")
+
+
+def _write_pkg(
+    pkg_dir: Path,
+    name: str = "diff_pkg",
+    *,
+    extra_claim: str | None = None,
+    prior: float = 0.7,
+) -> None:
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg_dir / name
+    src.mkdir(exist_ok=True)
+    body = (
+        "from gaia.lang import claim, support\n"
+        f'main = claim("main hypothesis", metadata={{"prior": {prior}}})\n'
+        'evidence = claim("supporting evidence", metadata={"prior": 0.6})\n'
+        "sup = support(premises=[evidence], conclusion=main)\n"
+    )
+    if extra_claim:
+        body += f'extra = claim("{extra_claim}")\n'
+        body += '__all__ = ["main", "evidence", "sup", "extra"]\n'
+    else:
+        body += '__all__ = ["main", "evidence", "sup"]\n'
+    (src / "__init__.py").write_text(body, encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# review_id format (Round A3)                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_mint_review_id_format():
+    rid = mint_review_id("7c1a9f23bc", "auto")
+    assert REVIEW_ID_RE.match(rid), rid
+    assert "_7c1a9f23_auto" in rid
+
+
+def test_mint_review_id_no_hash_fallback():
+    rid = mint_review_id(None, "publish")
+    assert "_nohash_publish" in rid
+
+
+def test_mint_review_id_sanitizes_mode():
+    rid = mint_review_id("abcd1234", "weird/mode")
+    assert "/" not in rid
+    assert rid.endswith("_weirdmode")
+
+
+def test_run_review_uses_round_a3_id(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    report = run_review(pkg, no_infer=True)
+    assert REVIEW_ID_RE.match(report.review_id), report.review_id
+
+
+# --------------------------------------------------------------------------- #
+# Snapshot persistence                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_snapshot_written_after_review(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    report = run_review(pkg, no_infer=True)
+    path = reviews_dir(pkg) / f"{report.review_id}.json"
+    assert path.exists()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["review_id"] == report.review_id
+    assert payload["ir_hash"] == report.ir_hash
+    assert "knowledges" in payload["ir"]
+
+
+def test_list_snapshots_returns_newest_first(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    r1 = run_review(pkg, no_infer=True)
+    # Mutate package so ir_hash differs and id collision is avoided.
+    _write_pkg(pkg, extra_claim="another claim")
+    r2 = run_review(pkg, no_infer=True)
+    ids = list_snapshots(pkg)
+    assert r1.review_id in ids and r2.review_id in ids
+    assert ids[0] >= ids[-1]  # sorted newest-first
+
+
+def test_state_remembers_last_review_id(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    report = run_review(pkg, no_infer=True)
+    state_file = inquiry_dir(pkg) / "state.json"
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["last_review_id"] == report.review_id
+
+
+# --------------------------------------------------------------------------- #
+# Baseline resolution                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_baseline_none(tmp_path):
+    assert resolve_baseline(tmp_path, "none", "anything") is None
+
+
+def test_resolve_baseline_last_uses_state(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    r = run_review(pkg, no_infer=True)
+    assert resolve_baseline(pkg, "last", r.review_id) == r.review_id
+
+
+def test_resolve_baseline_explicit_missing(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    run_review(pkg, no_infer=True)
+    assert resolve_baseline(pkg, "no_such_id", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Semantic diff (compute_semantic_diff is the unit under test)                #
+# --------------------------------------------------------------------------- #
+
+
+def test_diff_first_review_is_empty(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    r = run_review(pkg, no_infer=True)
+    assert r.semantic_diff.is_empty
+    assert r.semantic_diff.baseline_review_id is None
+
+
+def test_diff_added_claim_detected(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    run_review(pkg, no_infer=True)  # baseline
+    _write_pkg(pkg, extra_claim="brand new claim")
+    r2 = run_review(pkg, no_infer=True)
+    assert "extra" in r2.semantic_diff.added_claims
+    assert r2.semantic_diff.baseline_review_id is not None
+
+
+def test_diff_prior_change_detected(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg, prior=0.7)
+    run_review(pkg, no_infer=True)
+    _write_pkg(pkg, prior=0.95)
+    r2 = run_review(pkg, no_infer=True)
+    priors = {d.label: (d.before, d.after) for d in r2.semantic_diff.changed_priors}
+    assert "main" in priors
+    assert priors["main"] == ("0.7", "0.95")
+
+
+def test_diff_removed_claim_detected(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg, extra_claim="will be removed")
+    run_review(pkg, no_infer=True)
+    _write_pkg(pkg)  # extra dropped
+    r2 = run_review(pkg, no_infer=True)
+    assert "extra" in r2.semantic_diff.removed_claims
+
+
+def test_diff_unit_compute_against_synthetic_snapshot():
+    cur = {
+        "knowledges": [
+            {
+                "id": "p::a",
+                "type": "claim",
+                "label": "a",
+                "content": "X",
+                "metadata": {"prior": 0.5},
+            },
+            {"id": "p::b", "type": "claim", "label": "b", "content": "new", "metadata": {}},
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    base_snap = {
+        "review_id": "r-base",
+        "ir": {
+            "knowledges": [
+                {
+                    "id": "p::a",
+                    "type": "claim",
+                    "label": "a",
+                    "content": "X",
+                    "metadata": {"prior": 0.3},
+                },
+                {"id": "p::c", "type": "claim", "label": "c", "content": "gone", "metadata": {}},
+            ],
+            "strategies": [],
+        },
+    }
+    d = compute_semantic_diff(cur, base_snap)
+    assert d.baseline_review_id == "r-base"
+    assert "b" in d.added_claims
+    assert "c" in d.removed_claims
+    priors = {x.label: (x.before, x.after) for x in d.changed_priors}
+    assert priors["a"] == ("0.3", "0.5")
+
+
+# --------------------------------------------------------------------------- #
+# CLI integration                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_review_emits_diff_section_after_second_run(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    r1 = runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer"])
+    assert r1.exit_code == 0
+    _write_pkg(pkg, extra_claim="cli extra")
+    r2 = runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer", "--json"])
+    assert r2.exit_code == 0
+    data = json.loads(r2.output)
+    assert "extra" in data["semantic_diff"]["added_claims"]
+    assert data["semantic_diff"]["baseline_review_id"] is not None
+
+
+def test_cli_since_none_disables_baseline(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer"])
+    _write_pkg(pkg, extra_claim="ignored")
+    r = runner.invoke(
+        app,
+        ["inquiry", "review", str(pkg), "--no-infer", "--since", "none", "--json"],
+    )
+    assert r.exit_code == 0
+    data = json.loads(r.output)
+    assert data["semantic_diff"]["baseline_review_id"] is None
+    assert data["semantic_diff"]["added_claims"] == []

--- a/tests/inquiry/test_snapshot_diff.py
+++ b/tests/inquiry/test_snapshot_diff.py
@@ -120,6 +120,24 @@ def test_state_remembers_last_review_id(tmp_path):
     assert state["last_review_id"] == report.review_id
 
 
+def test_review_id_collision_updates_report_and_state(tmp_path, monkeypatch):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    monkeypatch.setattr("gaia.inquiry.review.mint_review_id", lambda _hash, _mode: "fixed-id")
+
+    first = run_review(pkg, no_infer=True)
+    second = run_review(pkg, no_infer=True)
+
+    assert first.review_id == "fixed-id"
+    assert second.review_id == "fixed-id-2"
+    second_path = reviews_dir(pkg) / "fixed-id-2.json"
+    assert second_path.exists()
+    assert json.loads(second_path.read_text(encoding="utf-8"))["review_id"] == "fixed-id-2"
+
+    state = json.loads((inquiry_dir(pkg) / "state.json").read_text(encoding="utf-8"))
+    assert state["last_review_id"] == "fixed-id-2"
+
+
 # --------------------------------------------------------------------------- #
 # Baseline resolution                                                         #
 # --------------------------------------------------------------------------- #
@@ -256,3 +274,17 @@ def test_cli_since_none_disables_baseline(tmp_path):
     data = json.loads(r.output)
     assert data["semantic_diff"]["baseline_review_id"] is None
     assert data["semantic_diff"]["added_claims"] == []
+
+
+def test_cli_rejects_conflicting_output_flags_without_state(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+
+    result = runner.invoke(
+        app,
+        ["inquiry", "review", str(pkg), "--no-infer", "--json", "--markdown"],
+    )
+
+    assert result.exit_code == 2
+    assert "--json and --markdown are mutually exclusive" in result.output
+    assert not (pkg / ".gaia" / "inquiry").exists()

--- a/tests/inquiry/test_source_anchor.py
+++ b/tests/inquiry/test_source_anchor.py
@@ -1,0 +1,220 @@
+"""Step 5 — source anchor + structured NextEdit (Round A2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+from gaia.inquiry.anchor import SourceAnchor, find_anchors
+from gaia.inquiry.diagnostics import (
+    Diagnostic,
+    NextEdit,
+    format_diagnostics_as_next_edits,
+    format_diagnostics_as_structured_edits,
+)
+from gaia.inquiry.review import run_review
+
+runner = CliRunner()
+
+
+def _write_pkg(pkg_dir: Path, name: str = "anchor_pkg") -> None:
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg_dir / name
+    src.mkdir(exist_ok=True)
+    body = (
+        "from gaia.lang import claim, support\n"
+        "\n"
+        "# a prior hole (no prior set) — should be anchored\n"
+        'hypothesis = claim("unverified hypothesis")\n'
+        'evidence = claim("evidence", metadata={"prior": 0.7})\n'
+        "\n"
+        "conclusion = claim(\n"
+        '    "conclusion from above"\n'
+        ")\n"
+        "sup = support(premises=[hypothesis, evidence], conclusion=conclusion)\n"
+        '__all__ = ["hypothesis", "evidence", "conclusion", "sup"]\n'
+    )
+    (src / "__init__.py").write_text(body, encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# anchor.find_anchors — pure AST scan                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_find_anchors_locates_claims(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    anchors = find_anchors(pkg)
+    assert "hypothesis" in anchors
+    assert "evidence" in anchors
+    assert "conclusion" in anchors
+    assert "sup" in anchors
+    ha = anchors["hypothesis"]
+    assert isinstance(ha, SourceAnchor)
+    assert ha.file.endswith("__init__.py")
+    # hypothesis 赋值在第 4 行 (from; 空行; 注释; hypothesis=...)
+    assert ha.line == 4
+
+
+def test_find_anchors_multiline_call(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    anchors = find_anchors(pkg)
+    # conclusion = claim("conclusion from above") 跨两行, ast 取起始行
+    assert anchors["conclusion"].line == 7
+
+
+def test_find_anchors_handles_syntax_error(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    (pkg / "anchor_pkg" / "broken.py").write_text("def oops(\n", encoding="utf-8")
+    anchors = find_anchors(pkg)
+    # 坏文件被跳过, 正常文件仍被解析
+    assert "hypothesis" in anchors
+
+
+def test_find_anchors_ignores_hidden_dirs(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    hidden = pkg / ".gaia" / "cache"
+    hidden.mkdir(parents=True)
+    (hidden / "leak.py").write_text(
+        'from gaia.lang import claim\nleak = claim("x")\n', encoding="utf-8"
+    )
+    anchors = find_anchors(pkg)
+    assert "leak" not in anchors
+
+
+def test_find_anchors_returns_empty_for_nonexistent(tmp_path):
+    assert find_anchors(tmp_path / "does_not_exist") == {}
+
+
+# --------------------------------------------------------------------------- #
+# Diagnostic now carries source_anchor                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_review_diagnostics_carry_anchor(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    report = run_review(pkg, no_infer=True)
+    hole_diags = [d for d in report.diagnostics if d.kind == "prior_hole"]
+    assert hole_diags, "expected at least one prior_hole diagnostic"
+    for d in hole_diags:
+        assert d.source_anchor is not None
+        assert d.source_anchor.file.endswith("__init__.py")
+        assert d.source_anchor.line >= 1
+
+
+def test_diagnostic_to_dict_omits_anchor_when_missing():
+    d = Diagnostic(
+        severity="warning",
+        kind="validation_warning",
+        target="graph",
+        label="graph",
+        message="m",
+    )
+    payload = d.to_dict()
+    assert "source_anchor" not in payload
+
+
+def test_diagnostic_to_dict_includes_anchor():
+    d = Diagnostic(
+        severity="warning",
+        kind="prior_hole",
+        target="t",
+        label="lbl",
+        message="m",
+        suggested_edit="fix it",
+        source_anchor=SourceAnchor(file="mod.py", line=3, column=0),
+    )
+    payload = d.to_dict()
+    assert payload["source_anchor"] == {"file": "mod.py", "line": 3, "column": 0}
+
+
+# --------------------------------------------------------------------------- #
+# NextEdit structured                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_text_next_edit_contains_file_line(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    report = run_review(pkg, no_infer=True)
+    assert any("__init__.py:" in edit for edit in report.next_edits), report.next_edits
+
+
+def test_structured_next_edits_have_anchor(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    report = run_review(pkg, no_infer=True)
+    assert report.next_edits_structured
+    assert len(report.next_edits_structured) == len(report.next_edits)
+    for e in report.next_edits_structured:
+        assert isinstance(e, NextEdit)
+        assert e.text
+        assert e.kind
+        assert e.severity in ("error", "warning", "info")
+    assert any(e.source_anchor is not None for e in report.next_edits_structured)
+
+
+def test_structured_next_edits_dedup_matches_text():
+    diags = [
+        Diagnostic(
+            severity="warning",
+            kind="prior_hole",
+            target="a",
+            label="a",
+            message="m1",
+            suggested_edit="same edit",
+        ),
+        Diagnostic(
+            severity="warning",
+            kind="orphaned_claim",
+            target="b",
+            label="b",
+            message="m2",
+            suggested_edit="same edit",
+        ),
+        Diagnostic(
+            severity="error",
+            kind="validation_error",
+            target="graph",
+            label="graph",
+            message="m3",
+            suggested_edit="fix error",
+        ),
+    ]
+    text = format_diagnostics_as_next_edits(diags)
+    struct = format_diagnostics_as_structured_edits(diags)
+    assert len(text) == len(struct) == 2
+    # error 排在 warning 前
+    assert struct[0].severity == "error"
+    assert struct[0].text == "fix error"
+    assert struct[1].text == "same edit"
+
+
+# --------------------------------------------------------------------------- #
+# CLI JSON 输出 schema                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_json_contains_next_edits_structured(tmp_path):
+    pkg = tmp_path / "p"
+    _write_pkg(pkg)
+    r = runner.invoke(app, ["inquiry", "review", str(pkg), "--no-infer", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.output)
+    assert "next_edits_structured" in data
+    assert data["next_edits_structured"]
+    first = data["next_edits_structured"][0]
+    assert {"text", "kind", "severity", "target", "label"} <= set(first)

--- a/tests/inquiry/test_source_anchor.py
+++ b/tests/inquiry/test_source_anchor.py
@@ -98,6 +98,43 @@ def test_find_anchors_returns_empty_for_nonexistent(tmp_path):
     assert find_anchors(tmp_path / "does_not_exist") == {}
 
 
+def test_find_anchors_locates_v05_dsl_constructors(tmp_path):
+    pkg = tmp_path / "p"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "anchor-v05-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n',
+        encoding="utf-8",
+    )
+    src = pkg / "anchor_v05"
+    src.mkdir()
+    (src / "__init__.py").write_text(
+        "from gaia.lang import associate, claim, contradiction, deduction, depends_on, derive\n"
+        'a = claim("A.")\n'
+        'b = claim("B.")\n'
+        'c = claim("C.")\n'
+        'derived = derive("Derived.", given=a, rationale="A implies it.", label="derive_c")\n'
+        "proof = deduction(premises=[a], conclusion=c)\n"
+        "assoc = associate(a, b, p_a_given_b=0.7, p_b_given_a=0.6, label='assoc_ab')\n"
+        "conflict = contradiction(a, b)\n"
+        "depends_on(c, given=(a,), rationale='scaffold', label='c_depends_on_a')\n"
+        '__all__ = ["a", "b", "c", "derived", "proof", "assoc", "conflict"]\n',
+        encoding="utf-8",
+    )
+
+    anchors = find_anchors(pkg)
+
+    for label in (
+        "derive_c",
+        "proof",
+        "assoc_ab",
+        "assoc",
+        "conflict",
+        "c_depends_on_a",
+    ):
+        assert label in anchors
+
+
 # --------------------------------------------------------------------------- #
 # Diagnostic now carries source_anchor                                        #
 # --------------------------------------------------------------------------- #

--- a/tests/inquiry/test_state.py
+++ b/tests/inquiry/test_state.py
@@ -1,0 +1,113 @@
+"""Unit tests for gaia.inquiry.state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaia.inquiry.state import (
+    STATE_SCHEMA_VERSION,
+    InquiryState,
+    SyntheticHypothesis,
+    SyntheticObligation,
+    SyntheticRejection,
+    append_tactic_event,
+    inquiry_dir,
+    load_state,
+    mint_qid,
+    pop_focus_frame,
+    push_focus_frame,
+    read_tactic_log,
+    save_state,
+)
+
+
+def test_empty_state_roundtrip(tmp_path: Path):
+    state = load_state(tmp_path)
+    assert state.version == STATE_SCHEMA_VERSION
+    assert state.focus is None
+    assert state.synthetic_obligations == []
+    save_state(tmp_path, state)
+    again = load_state(tmp_path)
+    assert again.to_dict() == state.to_dict()
+
+
+def test_state_persists_focus_and_obligations(tmp_path: Path):
+    s = InquiryState()
+    s.focus = "main_claim"
+    s.focus_kind = "claim"
+    s.synthetic_obligations.append(
+        SyntheticObligation(
+            qid=mint_qid("oblig"),
+            target_qid="github:p::main_claim",
+            content="needs prior",
+            diagnostic_kind="prior_hole",
+        )
+    )
+    save_state(tmp_path, s)
+
+    raw = json.loads((inquiry_dir(tmp_path) / "state.json").read_text("utf-8"))
+    assert raw["version"] == STATE_SCHEMA_VERSION
+    assert raw["focus"] == "main_claim"
+    assert raw["synthetic_obligations"][0]["diagnostic_kind"] == "prior_hole"
+
+    reloaded = load_state(tmp_path)
+    assert reloaded.focus == "main_claim"
+    assert len(reloaded.synthetic_obligations) == 1
+
+
+def test_future_version_rejected(tmp_path: Path):
+    inquiry_dir(tmp_path).joinpath("state.json").write_text(
+        json.dumps({"version": STATE_SCHEMA_VERSION + 5, "focus": None}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_state(tmp_path)
+
+
+def test_invalid_mode_rejected(tmp_path: Path):
+    inquiry_dir(tmp_path).joinpath("state.json").write_text(
+        json.dumps({"version": STATE_SCHEMA_VERSION, "mode": "bogus"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_state(tmp_path)
+
+
+def test_invalid_obligation_kind_rejected():
+    with pytest.raises(ValueError):
+        SyntheticObligation(qid="x", target_qid="t", content="c", diagnostic_kind="bogus")
+
+
+def test_focus_push_and_pop_roundtrip(tmp_path: Path):
+    s = InquiryState()
+    s.focus = "a"
+    push_focus_frame(s)
+    s.focus = "b"
+    assert s.focus_stack and s.focus_stack[-1]["focus"] == "a"
+
+    old = pop_focus_frame(s)
+    assert old == {"focus": "b", "focus_kind": None, "focus_resolved_id": None}
+    assert s.focus == "a"
+    assert s.focus_stack == []
+
+
+def test_pop_empty_stack_returns_none():
+    s = InquiryState()
+    assert pop_focus_frame(s) is None
+
+
+def test_tactic_log_append_and_read(tmp_path: Path):
+    append_tactic_event(tmp_path, "focus_set", {"target": "a"})
+    append_tactic_event(tmp_path, "obligation_add", {"qid": "x"})
+    log = read_tactic_log(tmp_path)
+    assert [r["event"] for r in log] == ["focus_set", "obligation_add"]
+    assert log[0]["payload"]["target"] == "a"
+
+
+def test_synthetic_hypothesis_and_rejection_dataclasses():
+    h = SyntheticHypothesis(qid="h1", content="iid", scope_qid="c1")
+    r = SyntheticRejection(qid="r1", target_strategy="s", content="loop")
+    assert h.created_at and r.created_at


### PR DESCRIPTION
## Summary
- Port the public `gaia.inquiry` review loop from `main` onto `v0.5`.
- Add `gaia inquiry` / hidden `gaia inquery` CLI entry points.
- Add shared `check_core` analyzers used by inquiry without disturbing the existing v0.5 `_inquiry.py` / quality-gate path.
- Include the main-branch inquiry test suite and package `gaia.inquiry*` in setuptools discovery.

## Verification
- `uv run --project . --extra dev python -m pytest tests/inquiry -q`
- `uv run --project . --extra dev python -m pytest tests/cli/test_inquiry.py tests/cli/test_quality_gate.py tests/cli/test_check.py -q`
- `uv run --project . --extra dev python -m pytest -q`
- `uv run --project . --extra dev ruff check .`
- `uv run --project . --extra dev ruff format --check .`