### PR TITLE
fix(dsl): make deduction rigid — default prior=0.999, allow reason without prior

### DIFF
--- a/gaia/lang/dsl/strategies.py
+++ b/gaia/lang/dsl/strategies.py
@@ -9,7 +9,7 @@ from typing import Literal
 from gaia.lang.runtime import Knowledge, Step, Strategy
 from gaia.lang.runtime.nodes import ReasonInput
 from gaia.lang.runtime.nodes import _current_package
-from gaia.lang.dsl.operators import _validate_reason_prior
+from gaia.lang.dsl.operators import _validate_reason_prior, _validate_prior_range
 from gaia.lang.runtime.package import infer_package_from_callstack
 
 
@@ -301,23 +301,23 @@ def deduction(
     reason: ReasonInput = "",
     prior: float | None = None,
 ) -> Strategy:
-    """Deduction lowered via the canonical IR formalizer at compile time.
+    """Deduction — rigid implication; premises jointly entail the conclusion.
 
-    prior -> confidence for the implication warrant.
+    Default prior is 0.999 (Cromwell-bounded near-certainty). Reason is
+    always allowed — it documents the chain of reasoning without forcing
+    a manual prior. Explicit prior overrides the default.
     """
     if len(premises) < 1:
         raise ValueError("deduction() requires at least 1 premise")
-    _validate_reason_prior(reason, prior)
-    metadata: dict | None = None
-    if prior is not None:
-        metadata = {"prior": prior}
+    effective_prior = prior if prior is not None else 0.999
+    _validate_prior_range(effective_prior)
     return _named_strategy(
         "deduction",
         premises=premises,
         conclusion=conclusion,
         background=background,
         reason=reason,
-        metadata=metadata,
+        metadata={"prior": effective_prior},
     )
 
 

--- a/tests/ir/test_formalize.py
+++ b/tests/ir/test_formalize.py
@@ -525,7 +525,11 @@ class TestPriorPropagation:
         assert impl_helpers[0].metadata["prior"] == 0.9
 
     def test_deduction_no_prior_no_metadata_key(self):
-        """Without metadata['prior'], helper claim has no 'prior' key."""
+        """Without metadata['prior'], helper claim has no 'prior' key.
+
+        (The DSL-level deduction() defaults to prior=0.999, but the formalizer
+        alone only propagates what it receives.)
+        """
         result = formalize_named_strategy(
             scope="local",
             type_="deduction",
@@ -541,6 +545,25 @@ class TestPriorPropagation:
         ]
         assert len(impl_helpers) == 1
         assert "prior" not in impl_helpers[0].metadata
+
+    def test_deduction_explicit_prior(self):
+        """Explicit prior on deduction flows to helper claim metadata."""
+        result = formalize_named_strategy(
+            scope="local",
+            type_="deduction",
+            premises=["github:test::a"],
+            conclusion="github:test::b",
+            namespace="github",
+            package_name="test",
+            metadata={"prior": 0.95},
+        )
+        impl_helpers = [
+            k
+            for k in result.knowledges
+            if (k.metadata or {}).get("helper_kind") == "implication_result"
+        ]
+        assert len(impl_helpers) == 1
+        assert impl_helpers[0].metadata["prior"] == 0.95
 
     def test_support_propagates_prior(self):
         """Support: forward helper gets prior."""


### PR DESCRIPTION
## Summary

`deduction()` is semantically rigid (premises jointly entail the conclusion), but it was grouped with probabilistic strategies (`support`, `compare`) and enforced the "reason and prior must be paired" rule. This made it impossible to document the chain of reasoning without also manually supplying a prior.

## Changes

- `deduction()` no longer calls `_validate_reason_prior` — `reason` is always allowed
- Default `prior=0.999` (Cromwell upper bound) when not specified
- Explicit `prior` overrides the default
- Added `_validate_prior_range` import from operators (was missing)

## Behavior

| call | prior | reason |
|---|---|---|
| `deduction([a], b, reason="...")` | 0.999 (default) | ✅ |
| `deduction([a], b)` | 0.999 (default) | (empty) |
| `deduction([a], b, reason="...", prior=0.8)` | 0.8 | ✅ |

## Test plan

- [x] `TestPriorPropagation` — 6/6 passing
- [x] DSL-level smoke test: all three calling conventions produce correct prior values

🤖 Generated with [Claude Code](https://claude.com/claude-code)