### PR TITLE
[codex] Improve CLI diagnostics for package setup errors

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -145,7 +145,16 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
     package_roots = [pkg_path, pkg_path / "src"]
     source_root = next((root for root in package_roots if (root / import_name).exists()), None)
     if source_root is None:
-        raise GaiaCliError(f"Error: package source directory '{import_name}/' not found.")
+        expected_paths = ", ".join(
+            f"{candidate.relative_to(pkg_path)}/"
+            for candidate in (root / import_name for root in package_roots)
+        )
+        raise GaiaCliError(
+            f"Error: package source directory '{import_name}/' not found.\n"
+            f"  Derived from [project] name {project_name!r}.\n"
+            '  Derivation: strip trailing "-gaia" when present, then convert hyphens to underscores.\n'
+            f"  Expected at one of: {expected_paths}"
+        )
 
     source_root_str = str(source_root)
     if source_root_str not in sys.path:
@@ -285,7 +294,10 @@ def apply_package_priors(loaded: LoadedGaiaPackage) -> None:
         if not isinstance(key, Knowledge):
             raise GaiaCliError(
                 f"Error: PRIORS key {key!r} is not a Knowledge object. "
-                "Keys must be claim objects from the package."
+                "Keys must be claim objects from the package.\n"
+                "  Hint: import the claim object and use it directly, not its string label.\n"
+                "  Example: from . import my_claim\n"
+                '           PRIORS = {my_claim: (0.85, "reason")}'
             )
         if id(key) not in existing_knowledge_ids:
             raise GaiaCliError(

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -88,11 +88,20 @@ def test_compile_not_knowledge_package(tmp_path):
 def test_compile_missing_source_dir(tmp_path):
     """Error when derived source directory does not exist."""
     (tmp_path / "pyproject.toml").write_text(
-        '[project]\nname = "missing-gaia"\nversion = "1.0.0"\n\n'
+        '[project]\nname = "missing-source-gaia"\nversion = "1.0.0"\n\n'
         '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
     )
+    wrong_src = tmp_path / "src" / "wrong_name"
+    wrong_src.mkdir(parents=True)
+    (wrong_src / "__init__.py").write_text("")
+
     result = runner.invoke(app, ["compile", str(tmp_path)])
     assert result.exit_code != 0
+    assert "package source directory 'missing_source/' not found" in result.output
+    assert "Derived from [project] name 'missing-source-gaia'." in result.output
+    assert 'strip trailing "-gaia"' in result.output
+    assert "convert hyphens to underscores" in result.output
+    assert "Expected at one of: missing_source/, src/missing_source/" in result.output
 
 
 def test_compile_fails_on_invalid_ir_validation(tmp_path):
@@ -1161,11 +1170,15 @@ def test_compile_priors_py_invalid_key_raises(tmp_path):
     (pkg_src / "__init__.py").write_text(
         'from gaia.lang import claim\n\nmy_claim = claim("A claim.")\n__all__ = ["my_claim"]\n'
     )
-    (pkg_src / "priors.py").write_text('PRIORS = {\n    "not_a_knowledge": (0.5, "invalid"),\n}\n')
+    (pkg_src / "priors.py").write_text('PRIORS = {\n    "my_claim": (0.5, "invalid"),\n}\n')
 
     result = runner.invoke(app, ["compile", str(pkg_dir)])
     assert result.exit_code != 0
-    assert "Knowledge" in result.output or "PRIORS" in result.output
+    assert "PRIORS key 'my_claim' is not a Knowledge object" in result.output
+    assert "import the claim object and use it directly" in result.output
+    assert "not its string label" in result.output
+    assert "from . import my_claim" in result.output
+    assert 'PRIORS = {my_claim: (0.85, "reason")}' in result.output
 
 
 def test_compile_priors_py_note_key_raises(tmp_path):


### PR DESCRIPTION
## Summary

This PR improves two Gaia CLI diagnostics that were easy to understand in code but hard for users to fix from the terminal output.

- For missing package source directories, the error now explains how `[project].name` is converted into the expected import directory and lists the searched locations.
- For `priors.py` dictionaries that use string keys, the error now tells users to import and use the claim object directly, with a minimal example.
- Tightened compile CLI regression tests for both messages.

Fixes #496.
Fixes #497.

## Validation

- `uv run --project . --extra dev python -m pytest tests/cli/test_compile.py`
- `uv run --project . --extra dev ruff check gaia/cli/_packages.py tests/cli/test_compile.py`
- `uv run --project . --extra dev ruff format --check .`
