### PR TITLE
[codex] Allow uppercase QID labels

### DIFF
--- a/gaia/ir/knowledge.py
+++ b/gaia/ir/knowledge.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, model_validator
 
-_QID_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z0-9][a-z0-9_\-]*::[a-z_][a-z0-9_]*$")
+_QID_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z0-9][a-z0-9_\-]*::[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def make_qid(namespace: str, package_name: str, label: str) -> str:

--- a/tests/ir/test_knowledge.py
+++ b/tests/ir/test_knowledge.py
@@ -28,6 +28,9 @@ class TestIsQid:
     def test_valid_generated_label(self):
         assert is_qid("github:test::__conjunction_result_a1b2c3d4")
 
+    def test_valid_uppercase_label(self):
+        assert is_qid("github:pkg::gcn_graphene_Vm")
+
     def test_invalid_gcn(self):
         assert not is_qid("gcn_abc123")
 
@@ -40,7 +43,7 @@ class TestIsQid:
     def test_invalid_empty(self):
         assert not is_qid("")
 
-    def test_invalid_uppercase(self):
+    def test_invalid_uppercase_namespace(self):
         assert not is_qid("Reg:pkg::label")
 
 

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -100,6 +100,11 @@ class TestKnowledgeValidation:
         r = validate_local_graph(g)
         assert r.valid
 
+    def test_valid_uppercase_label(self):
+        g = _local_graph(knowledges=[_claim("github:test::gcn_graphene_Vm")])
+        r = validate_local_graph(g)
+        assert r.valid
+
     def test_wrong_prefix_local(self):
         g = _local_graph(knowledges=[_claim("gcn_wrong")])
         r = validate_local_graph(g)


### PR DESCRIPTION
## Summary

This PR fixes QID validation for imported labels that contain uppercase letters.

- Allows uppercase ASCII letters in the QID label segment, such as `github:pkg::gcn_graphene_Vm`.
- Keeps the existing lowercase namespace and package-name rules unchanged.
- Adds regression coverage for both direct `is_qid()` validation and `validate_local_graph()`.

Fixes #495.

## Validation

- `uv run --project . --extra dev python -m pytest tests/ir`
- `uv run --project . --extra dev ruff check gaia/ir/knowledge.py tests/ir/test_knowledge.py tests/ir/test_validator.py`
- `uv run --project . --extra dev ruff format --check .`
