### PR TITLE
[codex] Fix Gaia v0.4 authoring diagnostics

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -145,7 +145,16 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
     package_roots = [pkg_path, pkg_path / "src"]
     source_root = next((root for root in package_roots if (root / import_name).exists()), None)
     if source_root is None:
-        raise GaiaCliError(f"Error: package source directory '{import_name}/' not found.")
+        expected_paths = ", ".join(
+            f"{candidate.relative_to(pkg_path)}/"
+            for candidate in (root / import_name for root in package_roots)
+        )
+        raise GaiaCliError(
+            f"Error: package source directory '{import_name}/' not found.\n"
+            f"  Derived from [project] name {project_name!r}.\n"
+            '  Derivation: strip trailing "-gaia" when present, then convert hyphens to underscores.\n'
+            f"  Expected at one of: {expected_paths}"
+        )
 
     source_root_str = str(source_root)
     if source_root_str not in sys.path:
@@ -285,7 +294,10 @@ def apply_package_priors(loaded: LoadedGaiaPackage) -> None:
         if not isinstance(key, Knowledge):
             raise GaiaCliError(
                 f"Error: PRIORS key {key!r} is not a Knowledge object. "
-                "Keys must be claim/setting/question objects from the package."
+                "Keys must be claim/setting/question objects from the package.\n"
+                "  Hint: import the Knowledge object and use it directly, not its string label.\n"
+                "  Example: from . import my_claim\n"
+                '           PRIORS = {my_claim: (0.85, "reason")}'
             )
         if id(key) not in existing_knowledge_ids:
             raise GaiaCliError(

--- a/gaia/ir/knowledge.py
+++ b/gaia/ir/knowledge.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, model_validator
 
-_QID_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z0-9][a-z0-9_\-]*::[a-z_][a-z0-9_]*$")
+_QID_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z0-9][a-z0-9_\-]*::[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def make_qid(namespace: str, package_name: str, label: str) -> str:

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -80,11 +80,20 @@ def test_compile_not_knowledge_package(tmp_path):
 def test_compile_missing_source_dir(tmp_path):
     """Error when derived source directory does not exist."""
     (tmp_path / "pyproject.toml").write_text(
-        '[project]\nname = "missing-gaia"\nversion = "1.0.0"\n\n'
+        '[project]\nname = "missing-source-gaia"\nversion = "1.0.0"\n\n'
         '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
     )
+    wrong_src = tmp_path / "src" / "wrong_name"
+    wrong_src.mkdir(parents=True)
+    (wrong_src / "__init__.py").write_text("")
+
     result = runner.invoke(app, ["compile", str(tmp_path)])
     assert result.exit_code != 0
+    assert "package source directory 'missing_source/' not found" in result.output
+    assert "Derived from [project] name 'missing-source-gaia'." in result.output
+    assert 'strip trailing "-gaia"' in result.output
+    assert "convert hyphens to underscores" in result.output
+    assert "Expected at one of: missing_source/, src/missing_source/" in result.output
 
 
 def test_compile_fails_on_invalid_ir_validation(tmp_path):
@@ -1147,11 +1156,15 @@ def test_compile_priors_py_invalid_key_raises(tmp_path):
     (pkg_src / "__init__.py").write_text(
         'from gaia.lang import claim\n\nmy_claim = claim("A claim.")\n__all__ = ["my_claim"]\n'
     )
-    (pkg_src / "priors.py").write_text('PRIORS = {\n    "not_a_knowledge": (0.5, "invalid"),\n}\n')
+    (pkg_src / "priors.py").write_text('PRIORS = {\n    "my_claim": (0.5, "invalid"),\n}\n')
 
     result = runner.invoke(app, ["compile", str(pkg_dir)])
     assert result.exit_code != 0
-    assert "Knowledge" in result.output or "PRIORS" in result.output
+    assert "PRIORS key 'my_claim' is not a Knowledge object" in result.output
+    assert "import the Knowledge object and use it directly" in result.output
+    assert "not its string label" in result.output
+    assert "from . import my_claim" in result.output
+    assert 'PRIORS = {my_claim: (0.85, "reason")}' in result.output
 
 
 def test_compile_priors_py_new_knowledge_raises(tmp_path):

--- a/tests/ir/test_knowledge.py
+++ b/tests/ir/test_knowledge.py
@@ -26,6 +26,9 @@ class TestIsQid:
     def test_valid_generated_label(self):
         assert is_qid("github:test::__conjunction_result_a1b2c3d4")
 
+    def test_valid_uppercase_label(self):
+        assert is_qid("github:pkg::gcn_graphene_Vm")
+
     def test_invalid_gcn(self):
         assert not is_qid("gcn_abc123")
 
@@ -38,7 +41,7 @@ class TestIsQid:
     def test_invalid_empty(self):
         assert not is_qid("")
 
-    def test_invalid_uppercase(self):
+    def test_invalid_uppercase_namespace(self):
         assert not is_qid("Reg:pkg::label")
 
 

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -52,6 +52,11 @@ class TestKnowledgeValidation:
         r = validate_local_graph(g)
         assert r.valid
 
+    def test_valid_uppercase_label(self):
+        g = _local_graph(knowledges=[_claim("github:test::gcn_graphene_Vm")])
+        r = validate_local_graph(g)
+        assert r.valid
+
     def test_wrong_prefix_local(self):
         g = _local_graph(knowledges=[_claim("gcn_wrong")])
         r = validate_local_graph(g)


### PR DESCRIPTION
## Summary

This PR applies the small authoring/diagnostic fixes to `main`, which is the current v0.4 line.

- Allow uppercase ASCII letters in the QID label segment, e.g. `github:pkg::gcn_graphene_Vm`.
- Explain how a missing package source directory is derived from `[project].name`.
- Add a concrete hint when `priors.py` uses string keys instead of imported Knowledge objects.
- Add focused regressions for all three issue paths.

Fixes #495.
Fixes #496.
Fixes #497.

## Notes

The v0.5 PRs #499 and #500 were created before clarifying that `main` is the current v0.4 line. This PR should land first on `main`; then `main` can be merged into `v0.5` so v0.5 inherits the same fixes.

## Validation

- `uv run --project . --extra dev python -m pytest tests/cli/test_compile.py::test_compile_missing_source_dir tests/cli/test_compile.py::test_compile_priors_py_invalid_key_raises tests/ir/test_knowledge.py::TestIsQid tests/ir/test_validator.py::TestKnowledgeValidation::test_valid_uppercase_label`
- `uv run --project . --extra dev python -m pytest tests/cli/test_compile.py`
- `uv run --project . --extra dev python -m pytest tests/ir`
- `uv run --project . --extra dev ruff check gaia/cli/_packages.py gaia/ir/knowledge.py tests/cli/test_compile.py tests/ir/test_knowledge.py tests/ir/test_validator.py`
- `uv run --project . --extra dev ruff format --check .`
