### PR TITLE
docs(specs): bayes module design — hypothesis-data inference subsystem

### DIFF
--- a/docs/plans/2026-05-05-bayes-milestone-a-distributions.md
+++ b/docs/plans/2026-05-05-bayes-milestone-a-distributions.md
@@ -1,0 +1,2119 @@
+# Bayes Module — Milestone A: Distributions Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land `gaia.lang.bayes.distributions` — a typed-value distribution layer (Binomial / Normal / Beta / Poisson / Exponential / LogNormal / StudentT / Cauchy / Gamma / ChiSquared) backed by `scipy.stats`, with Variable-aware parameter slots that defer resolution to Milestone B.
+
+**Architecture:** Each distribution is a Pydantic `BaseModel` carrying `kind: str` and `params: dict[str, DistParam]` where `DistParam = int | float | _DeferredRef`. `.logpmf / .logpdf / .support` delegate to a thin `scipy_backend` that constructs the matching `scipy.stats` frozen distribution at call time. Distributions raise `UnresolvedParameterError` when invoked with deferred params — Milestone B will resolve those before lowering. **No coupling to PR 505's Variable class** — we accept anything with a `.symbol` attribute via duck typing; the compiler in Milestone B replaces deferred slots with concrete numbers before `.logpmf` is ever called.
+
+**Tech Stack:** Python 3.12, Pydantic v2, scipy.stats, pytest, ruff.
+
+**Spec reference:** `docs/specs/2026-05-04-bayes-module-design.md` §3.1 (Distribution Lang-side typed value), §9 Milestone A (Distribution module + protocol).
+
+**Branch:** `feat/bayes-milestone-a-distributions` (off `feat/bayes-module-design`).
+
+---
+
+## File Structure
+
+```
+gaia/lang/bayes/
+├── __init__.py                       # public re-exports for `from gaia.lang import bayes`
+├── distributions/
+│   ├── __init__.py                   # re-exports Binomial, Normal, Beta, ...
+│   ├── protocol.py                   # Distribution Protocol + DistParam type alias + UnresolvedParameterError
+│   ├── base.py                       # _BaseDistribution Pydantic model (Variable-aware params, common validation)
+│   ├── discrete.py                   # Binomial, Poisson
+│   └── continuous.py                 # Normal, Beta, Exponential, LogNormal, StudentT, Cauchy, Gamma, ChiSquared
+└── adapters/
+    ├── __init__.py
+    └── scipy_backend.py              # _to_scipy_dist(distribution) -> scipy.stats frozen rv
+
+tests/gaia/lang/bayes/
+├── __init__.py
+├── conftest.py                       # shared fixtures: scipy reference, deferred-param helper
+├── test_protocol.py                  # Protocol contract — every distribution implements .logpmf/.logpdf/.support
+├── test_base.py                      # Variable-aware param storage; UnresolvedParameterError on call
+├── distributions/
+│   ├── __init__.py
+│   ├── test_binomial.py
+│   ├── test_normal.py
+│   ├── test_beta.py
+│   ├── test_poisson.py
+│   ├── test_exponential.py
+│   ├── test_lognormal.py
+│   ├── test_studentt.py
+│   ├── test_cauchy.py
+│   ├── test_gamma.py
+│   └── test_chisquared.py
+└── test_public_api.py                # `from gaia.lang.bayes import Binomial, ...` works
+```
+
+**Files NOT created in Milestone A** (defer to B/C):
+- `gaia/lang/bayes/verbs/predict.py`, `verbs/likelihood.py` — Milestone B
+- `gaia/lang/bayes/runtime/{prediction,comparison}.py` — Milestone B
+- `gaia/lang/bayes/compiler/lower.py` — Milestone B
+- `docs/foundations/gaia-lang/bayes.md` — Milestone C
+
+---
+
+## Chunk 1: Foundation
+
+Adds the scipy dependency, lays the package skeleton, and defines the Protocol + parameter-handling base class. **No distributions yet** — those land in Chunks 2–3 once the framework is in place.
+
+**Files this chunk creates:**
+- `gaia/lang/bayes/__init__.py`
+- `gaia/lang/bayes/distributions/__init__.py`
+- `gaia/lang/bayes/distributions/protocol.py`
+- `gaia/lang/bayes/distributions/base.py`
+- `gaia/lang/bayes/adapters/__init__.py`
+- `gaia/lang/bayes/adapters/scipy_backend.py`
+- `tests/gaia/lang/bayes/__init__.py`
+- `tests/gaia/lang/bayes/conftest.py`
+- `tests/gaia/lang/bayes/test_protocol.py`
+- `tests/gaia/lang/bayes/test_base.py`
+
+**Files this chunk modifies:**
+- `pyproject.toml` (add `scipy>=1.13` to `dependencies`)
+
+### Task 1.1: Add scipy as a direct runtime dependency
+
+**Files:**
+- Modify: `pyproject.toml:18-26`
+
+- [ ] **Step 1: Edit `pyproject.toml`** — add `scipy>=1.13` to the `dependencies` list, keeping alphabetical-ish placement next to `numpy`.
+
+```toml
+dependencies = [
+    "pydantic>=2.0",
+    "typer[all]>=0.12",
+    "numpy>=1.26,<2.4",  # numpy 2.4 breaks pytest-cov (double-import C extension)
+    "scipy>=1.13",
+    "opt-einsum>=3.3",
+    "httpx>=0.27",
+    "faiss-cpu>=1.7",
+]
+```
+
+- [ ] **Step 2: Re-lock**
+
+Run: `uv lock`
+Expected: `uv.lock` updated; scipy + transitive deps appear in the lock file.
+
+- [ ] **Step 3: Verify scipy importable**
+
+Run: `uv run --extra dev python -c "import scipy.stats; print(scipy.stats.binom.pmf(5, 10, 0.5))"`
+Expected: `0.24609375` (Binomial(10, 0.5) PMF at k=5).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "deps(bayes): add scipy>=1.13 as direct runtime dependency
+
+Required by gaia.lang.bayes.distributions for logpmf/logpdf evaluation.
+Spec §1.1: 'Single new hard dependency: scipy (must be added as a direct
+runtime dependency; do not rely on optional transitive dependencies).'"
+```
+
+---
+
+### Task 1.2: Create empty package skeleton
+
+**Files:**
+- Create: `gaia/lang/bayes/__init__.py` (empty for now — Chunk 4 fills it)
+- Create: `gaia/lang/bayes/distributions/__init__.py` (empty)
+- Create: `gaia/lang/bayes/adapters/__init__.py` (empty)
+- Create: `tests/gaia/lang/bayes/__init__.py` (empty)
+- Create: `tests/gaia/lang/bayes/distributions/__init__.py` (empty)
+
+- [ ] **Step 1: Create the five empty files**
+
+```bash
+mkdir -p gaia/lang/bayes/distributions gaia/lang/bayes/adapters
+mkdir -p tests/gaia/lang/bayes/distributions
+touch gaia/lang/bayes/__init__.py
+touch gaia/lang/bayes/distributions/__init__.py
+touch gaia/lang/bayes/adapters/__init__.py
+touch tests/gaia/lang/bayes/__init__.py
+touch tests/gaia/lang/bayes/distributions/__init__.py
+```
+
+- [ ] **Step 2: Verify import path resolves**
+
+Run: `uv run --extra dev python -c "import gaia.lang.bayes; import gaia.lang.bayes.distributions; import gaia.lang.bayes.adapters; print('ok')"`
+Expected: `ok` printed (no `ModuleNotFoundError`).
+
+- [ ] **Step 3: Add the new packages to setuptools include list**
+
+Modify `pyproject.toml`'s `[tool.setuptools.packages.find]` `include` list to include the new subpackages. Find the line:
+
+```toml
+include = ["gaia", "gaia.ir*", "gaia.lang*", "gaia.bp*", "gaia.cli*", "gaia.review*"]
+```
+
+The existing `gaia.lang*` glob already covers `gaia.lang.bayes.*`, so **no change needed**. Verify by:
+
+Run: `uv run --extra dev python -c "from importlib.resources import files; import gaia.lang.bayes; print(files(gaia.lang.bayes))"`
+Expected: prints a path under the workspace.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lang/bayes tests/gaia/lang/bayes
+git commit -m "feat(bayes): empty package skeleton for distributions module
+
+Placeholder __init__.py files so subsequent commits can land
+distributions, adapters, and tests incrementally without import errors."
+```
+
+---
+
+### Task 1.3: Distribution Protocol + DistParam + UnresolvedParameterError
+
+**Files:**
+- Create: `gaia/lang/bayes/distributions/protocol.py`
+- Test: `tests/gaia/lang/bayes/test_protocol.py`
+
+- [ ] **Step 1: Write the failing protocol contract test**
+
+Create `tests/gaia/lang/bayes/test_protocol.py`:
+
+```python
+"""Distribution Protocol contract tests.
+
+The Protocol itself has no behaviour to test, but importing it
+must succeed and DistParam / UnresolvedParameterError must be
+exposed at the protocol module level. Concrete distribution
+classes are checked individually in distributions/test_*.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.lang.bayes.distributions.protocol import (
+    DistParam,
+    Distribution,
+    UnresolvedParameterError,
+)
+
+
+def test_protocol_imports_resolve():
+    # Import side effects only — the protocol itself isn't instantiable.
+    assert Distribution is not None
+    assert DistParam is not None
+    assert issubclass(UnresolvedParameterError, ValueError)
+
+
+def test_dist_param_accepts_concrete_numbers():
+    """DistParam is a duck-typed alias; concrete int/float must satisfy it."""
+    # We don't enforce DistParam at runtime — this test documents the contract.
+    x: DistParam = 0.75
+    y: DistParam = 10
+    assert x == 0.75
+    assert y == 10
+
+
+def test_unresolved_parameter_error_is_value_error():
+    """ValueError subclass so existing 'except ValueError' handlers catch it."""
+    err = UnresolvedParameterError("test", deferred_params=["theta"])
+    assert isinstance(err, ValueError)
+    assert "theta" in str(err)
+
+
+def test_unresolved_parameter_error_carries_param_names():
+    err = UnresolvedParameterError("Binomial", deferred_params=["n", "p"])
+    assert err.distribution_kind == "Binomial"
+    assert err.deferred_params == ["n", "p"]
+```
+
+- [ ] **Step 2: Run test — verify it fails on import**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/test_protocol.py -v`
+Expected: collection error, `ModuleNotFoundError: No module named 'gaia.lang.bayes.distributions.protocol'`.
+
+- [ ] **Step 3: Implement `protocol.py`**
+
+Create `gaia/lang/bayes/distributions/protocol.py`:
+
+```python
+"""Distribution Protocol — structural type for bayes-module distribution literals.
+
+A Distribution is a typed value (NOT a Knowledge node) that:
+- carries `kind` (string discriminator) and `params` (dict of name → DistParam).
+- implements `.logpmf(x)` / `.logpdf(x)` / `.support()` via a scipy backend.
+- raises UnresolvedParameterError if any parameter is a deferred reference
+  (e.g., a PR 505 Variable that hasn't been bound yet) at evaluation time.
+
+Resolution of deferred parameters is the compiler's responsibility (Milestone B).
+This module only defines the structural contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+# DistParam is a structural alias. We do NOT enforce it at runtime —
+# Pydantic models in `base.py` perform per-distribution validation.
+# A DistParam is one of:
+#   - int / float (concrete numeric value)
+#   - object with a `.symbol: str` attribute (deferred — e.g., PR 505 Variable)
+DistParam = int | float | Any
+
+
+class UnresolvedParameterError(ValueError):
+    """Raised when a Distribution method is called with deferred parameters.
+
+    Milestone B's compiler resolves deferred parameters (e.g., PR 505 Variables
+    bound by PARAMETER claims) before any `.logpmf` / `.logpdf` call. If this
+    error escapes user code, it indicates a bug in the lowering path.
+    """
+
+    def __init__(self, distribution_kind: str, deferred_params: list[str]) -> None:
+        self.distribution_kind = distribution_kind
+        self.deferred_params = list(deferred_params)
+        names = ", ".join(deferred_params)
+        super().__init__(
+            f"{distribution_kind} has unresolved deferred parameter(s): {names}. "
+            f"Distributions must be fully bound to concrete numeric values before "
+            f"likelihood evaluation. This typically means a Variable was used as a "
+            f"parameter without a corresponding parameter() claim binding it."
+        )
+
+
+@runtime_checkable
+class Distribution(Protocol):
+    """Structural type every concrete distribution implements.
+
+    Implementors are Pydantic models in `discrete.py` / `continuous.py`,
+    sharing common machinery via `_BaseDistribution` in `base.py`.
+    """
+
+    kind: str
+    params: dict[str, DistParam]
+
+    def logpmf(self, x: int) -> float:
+        """Discrete log-probability mass. Continuous distributions raise TypeError."""
+        ...
+
+    def logpdf(self, x: float) -> float:
+        """Continuous log-probability density. Discrete distributions raise TypeError."""
+        ...
+
+    def support(self) -> tuple[float, float]:
+        """Closed interval (low, high) where the density / pmf is non-zero."""
+        ...
+```
+
+- [ ] **Step 4: Run test — verify pass**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/test_protocol.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Run ruff**
+
+Run: `uv run --extra dev ruff format gaia/lang/bayes/distributions/protocol.py tests/gaia/lang/bayes/test_protocol.py && uv run --extra dev ruff check gaia/lang/bayes tests/gaia/lang/bayes`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/lang/bayes/distributions/protocol.py tests/gaia/lang/bayes/test_protocol.py
+git commit -m "feat(bayes): Distribution Protocol + DistParam + UnresolvedParameterError
+
+Spec §3.1. Defines the structural contract every distribution literal
+implements (kind, params, logpmf/logpdf, support). DistParam is duck-typed
+to admit concrete numbers now and PR 505 Variables later without coupling.
+UnresolvedParameterError extends ValueError so existing handlers catch it."
+```
+
+---
+
+### Task 1.4: `_BaseDistribution` Pydantic model
+
+**Files:**
+- Create: `gaia/lang/bayes/distributions/base.py`
+- Create: `tests/gaia/lang/bayes/conftest.py`
+- Test: `tests/gaia/lang/bayes/test_base.py`
+
+- [ ] **Step 1: Write `conftest.py` with a deferred-param fixture**
+
+Create `tests/gaia/lang/bayes/conftest.py`:
+
+```python
+"""Shared fixtures for bayes distribution tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass(frozen=True)
+class _DeferredVariable:
+    """Stand-in for PR 505's Variable. Distributions accept it via duck typing
+    on `.symbol`. Resolution is Milestone B's job; in Milestone A tests we
+    only verify that distributions store the deferred reference and raise
+    UnresolvedParameterError at call time."""
+
+    symbol: str
+
+
+@pytest.fixture
+def theta_deferred() -> _DeferredVariable:
+    return _DeferredVariable(symbol="theta")
+
+
+@pytest.fixture
+def n_deferred() -> _DeferredVariable:
+    return _DeferredVariable(symbol="n")
+```
+
+- [ ] **Step 2: Write the failing base-class tests**
+
+Create `tests/gaia/lang/bayes/test_base.py`:
+
+```python
+"""_BaseDistribution behavior — Variable-aware param storage,
+deferred-parameter detection, and the kind/params shape contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.lang.bayes.distributions.base import _BaseDistribution
+from gaia.lang.bayes.distributions.protocol import UnresolvedParameterError
+
+
+class _Dummy(_BaseDistribution):
+    """Minimal concrete subclass for testing the base. Real distributions
+    live in discrete.py / continuous.py."""
+
+    kind: str = "dummy"
+
+
+def test_subclass_stores_concrete_params():
+    d = _Dummy(params={"a": 1.5, "b": 2})
+    assert d.kind == "dummy"
+    assert d.params == {"a": 1.5, "b": 2}
+
+
+def test_subclass_stores_deferred_params(theta_deferred):
+    d = _Dummy(params={"a": theta_deferred, "b": 0.5})
+    assert d.params["a"] is theta_deferred
+    assert d.params["b"] == 0.5
+
+
+def test_deferred_param_names_returns_only_deferred(theta_deferred):
+    d = _Dummy(params={"a": theta_deferred, "b": 0.5})
+    assert d._deferred_param_names() == ["a"]
+
+
+def test_deferred_param_names_returns_empty_when_all_concrete():
+    d = _Dummy(params={"a": 1.0, "b": 2})
+    assert d._deferred_param_names() == []
+
+
+def test_deferred_param_names_sorted_for_determinism(theta_deferred, n_deferred):
+    d = _Dummy(params={"p": theta_deferred, "n": n_deferred})
+    assert d._deferred_param_names() == ["n", "p"]
+
+
+def test_resolved_params_returns_concrete_floats():
+    d = _Dummy(params={"a": 1.5, "b": 2})
+    resolved = d._resolved_params()
+    assert resolved == {"a": 1.5, "b": 2}
+
+
+def test_resolved_params_raises_when_deferred(theta_deferred):
+    d = _Dummy(params={"a": theta_deferred, "b": 0.5})
+    with pytest.raises(UnresolvedParameterError) as excinfo:
+        d._resolved_params()
+    assert excinfo.value.distribution_kind == "dummy"
+    assert excinfo.value.deferred_params == ["a"]
+
+
+def test_param_must_be_number_or_have_symbol_attr():
+    """Strings, lists, etc. are rejected at construction."""
+    with pytest.raises(ValueError, match="parameter 'a' must be"):
+        _Dummy(params={"a": "not a number"})
+
+
+def test_bool_rejected_as_param_value():
+    """bool is a subclass of int in Python; reject it explicitly to avoid
+    silent True->1 / False->0 confusion in distribution params."""
+    with pytest.raises(ValueError, match="parameter 'a' must be"):
+        _Dummy(params={"a": True})
+
+
+def test_model_dump_serializes_concrete_params():
+    d = _Dummy(params={"a": 0.75, "b": 10})
+    dumped = d.model_dump()
+    assert dumped == {"kind": "dummy", "params": {"a": 0.75, "b": 10}}
+
+
+def test_model_dump_skips_deferred_params(theta_deferred):
+    """Deferred params are not JSON-serializable; model_dump must omit them
+    or replace with a placeholder. We pick: only emit concrete params, and
+    add a parallel `deferred_params: dict[str, str]` field so the IR side can
+    re-resolve each parameter slot by Variable symbol."""
+    d = _Dummy(params={"a": theta_deferred, "b": 0.5})
+    dumped = d.model_dump()
+    assert dumped["params"] == {"b": 0.5}
+    assert dumped["deferred_params"] == {"a": "theta"}
+```
+
+- [ ] **Step 3: Run tests — verify failure**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/test_base.py -v`
+Expected: collection error, `ModuleNotFoundError: No module named 'gaia.lang.bayes.distributions.base'`.
+
+- [ ] **Step 4: Implement `base.py`**
+
+Create `gaia/lang/bayes/distributions/base.py`:
+
+```python
+"""_BaseDistribution — common machinery for distribution Pydantic models.
+
+Each concrete distribution (Binomial, Normal, ...) subclasses this and adds:
+- `kind: Literal["binomial"]` (etc.) discriminator
+- a __init__ overload that accepts named keyword params (n=, p=, ...) and
+  packs them into the `params` dict
+- `logpmf` / `logpdf` / `support` implementations delegating to scipy_backend
+
+This base class enforces:
+- params values must be numeric (int / float, excluding bool) OR a deferred
+  reference (any object with a `.symbol` attribute, duck-typed for Variable)
+- _deferred_param_names() returns sorted parameter names whose values are
+  deferred references
+- _resolved_params() returns {name: float} or raises UnresolvedParameterError
+- model_dump emits only concrete params and a parallel deferred_params mapping
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from gaia.lang.bayes.distributions.protocol import UnresolvedParameterError
+
+
+def _is_concrete_number(value: Any) -> bool:
+    # Reject bool explicitly — `True/False` would silently become 1/0.
+    if isinstance(value, bool):
+        return False
+    return isinstance(value, (int, float))
+
+
+def _is_deferred_reference(value: Any) -> bool:
+    # Duck-typed: any object with a string `.symbol` attribute. Matches PR 505
+    # Variable without importing it (Milestone A is independent of PR 505).
+    symbol = getattr(value, "symbol", None)
+    return isinstance(symbol, str)
+
+
+class _BaseDistribution(BaseModel):
+    """Shared base for all distribution literals."""
+
+    # Pydantic v2 config: allow arbitrary types so deferred refs (which are
+    # not Pydantic models) can sit inside the params dict.
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    kind: str
+    params: dict[str, Any]
+
+    @model_validator(mode="after")
+    def _validate_params(self) -> _BaseDistribution:
+        for name, value in self.params.items():
+            if not _is_concrete_number(value) and not _is_deferred_reference(value):
+                raise ValueError(
+                    f"{self.kind} parameter {name!r} must be a number "
+                    f"(int/float, not bool) or a deferred reference with a "
+                    f"`.symbol` attribute; got {type(value).__name__}"
+                )
+        return self
+
+    def _deferred_param_names(self) -> list[str]:
+        """Sorted names of params whose values are deferred references."""
+        return sorted(
+            name
+            for name, value in self.params.items()
+            if _is_deferred_reference(value)
+        )
+
+    def _deferred_param_symbols(self) -> dict[str, str]:
+        """Map deferred parameter names to the referenced Variable symbol."""
+        return {
+            name: value.symbol
+            for name, value in sorted(self.params.items())
+            if _is_deferred_reference(value)
+        }
+
+    def _resolved_params(self) -> dict[str, float]:
+        """Return concrete-numeric params, or raise UnresolvedParameterError.
+
+        Used by logpmf / logpdf / support before delegating to scipy.
+        """
+        deferred = self._deferred_param_names()
+        if deferred:
+            raise UnresolvedParameterError(self.kind, deferred)
+        return {name: float(value) for name, value in self.params.items()}
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
+        """Override Pydantic dump: emit concrete params + deferred_params map.
+
+        Deferred references are not JSON-serializable, so we strip them and
+        record each parameter slot's Variable symbol in a parallel field.
+        Milestone B's compiler reads `deferred_params` to re-bind them before
+        lowering.
+        """
+        deferred = self._deferred_param_symbols()
+        concrete = {
+            name: value
+            for name, value in self.params.items()
+            if not _is_deferred_reference(value)
+        }
+        dumped = {
+            "kind": self.kind,
+            "params": concrete,
+        }
+        if deferred:
+            dumped["deferred_params"] = deferred
+        return dumped
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/test_base.py -v`
+Expected: 11 passed.
+
+- [ ] **Step 6: Run ruff**
+
+Run: `uv run --extra dev ruff format gaia/lang/bayes/distributions/base.py tests/gaia/lang/bayes/conftest.py tests/gaia/lang/bayes/test_base.py && uv run --extra dev ruff check gaia/lang/bayes tests/gaia/lang/bayes`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/lang/bayes/distributions/base.py tests/gaia/lang/bayes/conftest.py tests/gaia/lang/bayes/test_base.py
+git commit -m "feat(bayes): _BaseDistribution Pydantic model with Variable-aware params
+
+Concrete distributions subclass this. Accepts numeric params or deferred
+references (any object with .symbol: str — duck-typed PR 505 Variable).
+Raises UnresolvedParameterError when methods are called before deferred
+params resolve. model_dump serializes concrete + parallel deferred_params
+mapping so compiler (Milestone B) can re-bind each parameter slot."
+```
+
+---
+
+### Task 1.5: scipy backend skeleton
+
+**Files:**
+- Create: `gaia/lang/bayes/adapters/scipy_backend.py`
+
+This is a thin internal helper that constructs a scipy frozen distribution from a `_BaseDistribution`. It has **no public surface** in Milestone A — concrete distributions in Chunks 2–3 call it. Tests for this module land alongside each distribution (e.g., `test_binomial.py` indirectly exercises `_to_scipy_dist` via `Binomial(...).logpmf(...)`).
+
+- [ ] **Step 1: Implement `scipy_backend.py`**
+
+Create `gaia/lang/bayes/adapters/scipy_backend.py`:
+
+```python
+"""scipy.stats backend for distribution evaluation.
+
+Maps each distribution `kind` to a scipy.stats frozen rv. Concrete
+distributions in `gaia/lang/bayes/distributions/` call this from their
+.logpmf / .logpdf / .support methods.
+
+This module is internal — it is not part of the public bayes API. PyMC /
+Stan adapters in v2+ will sit alongside this module without changing the
+DSL contract (Spec §5.2).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import scipy.stats as stats
+
+# Each builder takes the distribution's resolved-params dict and returns a
+# scipy frozen rv (anything implementing .logpmf / .logpdf / .support).
+_BUILDERS: dict[str, Callable[[dict[str, float]], Any]] = {
+    "binomial": lambda p: stats.binom(n=int(p["n"]), p=p["p"]),
+    "normal": lambda p: stats.norm(loc=p["mu"], scale=p["sigma"]),
+    "beta": lambda p: stats.beta(a=p["alpha"], b=p["beta"]),
+    "poisson": lambda p: stats.poisson(mu=p["rate"]),
+    "exponential": lambda p: stats.expon(scale=1.0 / p["rate"]),
+    "lognormal": lambda p: stats.lognorm(s=p["sigma"], scale=__import__("math").exp(p["mu"])),
+    "studentt": lambda p: stats.t(df=p["df"], loc=p["mu"], scale=p["sigma"]),
+    "cauchy": lambda p: stats.cauchy(loc=p["mu"], scale=p["gamma"]),
+    "gamma": lambda p: stats.gamma(a=p["alpha"], scale=1.0 / p["rate"]),
+    "chisquared": lambda p: stats.chi2(df=p["df"]),
+}
+
+
+def _to_scipy_dist(kind: str, resolved_params: dict[str, float]) -> Any:
+    """Build a scipy.stats frozen distribution from a `kind` + resolved params.
+
+    Raises KeyError if `kind` has no registered builder — this is a developer
+    error (a new distribution class was added without registering it here),
+    not a user error, so we let the bare KeyError propagate.
+    """
+    return _BUILDERS[kind](resolved_params)
+```
+
+- [ ] **Step 2: Smoke test in REPL**
+
+Run:
+```bash
+uv run --extra dev python -c "
+from gaia.lang.bayes.adapters.scipy_backend import _to_scipy_dist
+d = _to_scipy_dist('binomial', {'n': 10, 'p': 0.5})
+print(d.logpmf(5))
+"
+```
+Expected: `-1.4023300224853388` (≈ ln(0.246)).
+
+- [ ] **Step 3: Run ruff**
+
+Run: `uv run --extra dev ruff format gaia/lang/bayes/adapters/scipy_backend.py && uv run --extra dev ruff check gaia/lang/bayes/adapters`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lang/bayes/adapters/scipy_backend.py
+git commit -m "feat(bayes): scipy.stats backend skeleton
+
+Internal _to_scipy_dist(kind, resolved_params) builds the matching
+scipy.stats frozen rv. Concrete distributions in Chunks 2-3 call this from
+their .logpmf / .logpdf / .support methods. Public PyMC/Stan adapter slots
+land in v2+ without touching the DSL surface (spec §5.2)."
+```
+
+---
+
+**Chunk 1 done.** Foundation in place: scipy dep added, package skeleton, Protocol + DistParam + UnresolvedParameterError, base class with Variable-aware param storage, scipy backend dispatch table. No distributions yet.
+
+---
+
+## Chunk 2: Reference distributions — Binomial (discrete) and Normal (continuous)
+
+These two land first as the **canonical TDD templates** every other distribution in Chunk 3 copies. Binomial exercises the discrete path (`.logpmf`, integer support, bounded domain). Normal exercises the continuous path (`.logpdf`, unbounded support). Each ships with parity tests against `scipy.stats` reference values and a deferred-parameter test using the `theta_deferred` fixture.
+
+**Files this chunk creates:**
+- `gaia/lang/bayes/distributions/discrete.py` (with `Binomial` only for now; Poisson added in Chunk 3)
+- `gaia/lang/bayes/distributions/continuous.py` (with `Normal` only for now; others in Chunk 3)
+- `tests/gaia/lang/bayes/distributions/test_binomial.py`
+- `tests/gaia/lang/bayes/distributions/test_normal.py`
+
+### Task 2.1: Binomial — failing test
+
+**Files:**
+- Test: `tests/gaia/lang/bayes/distributions/test_binomial.py`
+
+- [ ] **Step 1: Write the test file**
+
+Create `tests/gaia/lang/bayes/distributions/test_binomial.py`:
+
+```python
+"""Binomial distribution — discrete reference implementation.
+
+Parity with scipy.stats.binom at representative points; input validation
+(n >= 0, 0 <= p <= 1); deferred-parameter handling via theta_deferred fixture.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import scipy.stats as stats
+
+from gaia.lang.bayes.distributions.discrete import Binomial
+from gaia.lang.bayes.distributions.protocol import UnresolvedParameterError
+
+
+# ---- Construction & basic identity ------------------------------------------
+
+
+def test_binomial_stores_kind_and_params():
+    d = Binomial(n=10, p=0.3)
+    assert d.kind == "binomial"
+    assert d.params == {"n": 10, "p": 0.3}
+
+
+def test_binomial_keyword_only():
+    """n and p are keyword-only — positional call must fail."""
+    with pytest.raises(TypeError):
+        Binomial(10, 0.3)  # type: ignore[misc]
+
+
+def test_binomial_is_frozen():
+    """Pydantic frozen=True — attributes can't be reassigned post-construction."""
+    d = Binomial(n=10, p=0.3)
+    with pytest.raises(Exception):
+        d.params = {"n": 20, "p": 0.5}  # type: ignore[misc]
+
+
+# ---- Parameter validation ---------------------------------------------------
+
+
+@pytest.mark.parametrize("n", [0, 1, 10, 100, 10_000])
+def test_binomial_valid_n(n):
+    Binomial(n=n, p=0.5)  # no raise
+
+
+@pytest.mark.parametrize("bad_n", [-1, -100])
+def test_binomial_rejects_negative_n(bad_n):
+    with pytest.raises(ValueError, match=r"Binomial.*n.*>=.*0"):
+        Binomial(n=bad_n, p=0.5)
+
+
+def test_binomial_rejects_non_integer_n():
+    with pytest.raises(ValueError, match=r"Binomial.*n.*integer"):
+        Binomial(n=10.5, p=0.5)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("p", [0.0, 0.001, 0.5, 0.999, 1.0])
+def test_binomial_valid_p(p):
+    Binomial(n=10, p=p)  # no raise
+
+
+@pytest.mark.parametrize("bad_p", [-0.1, 1.1, -1e-9, 1.0 + 1e-9])
+def test_binomial_rejects_p_out_of_range(bad_p):
+    with pytest.raises(ValueError, match=r"Binomial.*p.*\[0, 1\]"):
+        Binomial(n=10, p=bad_p)
+
+
+# ---- logpmf parity with scipy.stats -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "n,p,k",
+    [
+        (10, 0.5, 5),
+        (10, 0.8, 8),
+        (10, 0.5, 0),
+        (10, 0.5, 10),
+        (395, 0.75, 295),  # Mendel reference
+        (1, 0.5, 1),
+    ],
+)
+def test_binomial_logpmf_matches_scipy(n, p, k):
+    d = Binomial(n=n, p=p)
+    expected = stats.binom.logpmf(k, n, p)
+    assert d.logpmf(k) == pytest.approx(expected, rel=1e-12, abs=1e-15)
+
+
+def test_binomial_logpmf_outside_support_is_neg_inf():
+    d = Binomial(n=10, p=0.5)
+    assert d.logpmf(-1) == -math.inf
+    assert d.logpmf(11) == -math.inf
+
+
+def test_binomial_logpmf_rejects_float_k():
+    """k must be an int — Binomial is discrete."""
+    d = Binomial(n=10, p=0.5)
+    with pytest.raises(TypeError, match=r"Binomial.*integer"):
+        d.logpmf(5.5)  # type: ignore[arg-type]
+
+
+def test_binomial_logpdf_raises():
+    """Discrete distributions have no pdf; calling logpdf is a type error."""
+    d = Binomial(n=10, p=0.5)
+    with pytest.raises(TypeError, match=r"discrete"):
+        d.logpdf(5.0)
+
+
+# ---- Support ----------------------------------------------------------------
+
+
+def test_binomial_support():
+    d = Binomial(n=10, p=0.5)
+    low, high = d.support()
+    assert (low, high) == (0, 10)
+
+
+def test_binomial_support_n_zero():
+    d = Binomial(n=0, p=0.5)
+    assert d.support() == (0, 0)
+
+
+# ---- Deferred parameters ----------------------------------------------------
+
+
+def test_binomial_accepts_deferred_p(theta_deferred):
+    d = Binomial(n=10, p=theta_deferred)
+    # Construction succeeds — resolution happens at .logpmf time.
+    assert d.params["p"] is theta_deferred
+
+
+def test_binomial_logpmf_with_deferred_p_raises(theta_deferred):
+    d = Binomial(n=10, p=theta_deferred)
+    with pytest.raises(UnresolvedParameterError) as excinfo:
+        d.logpmf(5)
+    assert excinfo.value.distribution_kind == "binomial"
+    assert excinfo.value.deferred_params == ["p"]
+
+
+def test_binomial_accepts_deferred_n_and_p(n_deferred, theta_deferred):
+    d = Binomial(n=n_deferred, p=theta_deferred)
+    assert d.params["n"] is n_deferred
+    assert d.params["p"] is theta_deferred
+
+
+def test_binomial_support_with_deferred_n_raises(n_deferred):
+    d = Binomial(n=n_deferred, p=0.5)
+    with pytest.raises(UnresolvedParameterError):
+        d.support()
+
+
+def test_binomial_model_dump_with_deferred_p(theta_deferred):
+    d = Binomial(n=10, p=theta_deferred)
+    dumped = d.model_dump()
+    assert dumped["kind"] == "binomial"
+    assert dumped["params"] == {"n": 10}
+    assert dumped["deferred_params"] == {"p": "theta"}
+```
+
+- [ ] **Step 2: Run — verify test fails at collection**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/distributions/test_binomial.py -v`
+Expected: collection error, `ModuleNotFoundError: gaia.lang.bayes.distributions.discrete`.
+
+---
+
+### Task 2.2: Binomial — minimal implementation
+
+**Files:**
+- Create: `gaia/lang/bayes/distributions/discrete.py`
+- Modify: `gaia/lang/bayes/adapters/scipy_backend.py` (already registers `binomial`; no change needed)
+
+- [ ] **Step 1: Implement `discrete.py` with Binomial only**
+
+Create `gaia/lang/bayes/distributions/discrete.py`:
+
+```python
+"""Discrete distributions for the bayes module.
+
+Milestone A ships Binomial + Poisson. Milestone B's compiler resolves
+deferred parameters (e.g., PR 505 Variables) before any .logpmf call;
+calls with unresolved deferred params raise UnresolvedParameterError.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from pydantic import model_validator
+
+from gaia.lang.bayes.adapters.scipy_backend import _to_scipy_dist
+from gaia.lang.bayes.distributions.base import _BaseDistribution, _is_concrete_number
+from gaia.lang.bayes.distributions.protocol import UnresolvedParameterError
+
+
+class Binomial(_BaseDistribution):
+    """Binomial(n, p): number of successes in n independent Bernoulli trials.
+
+    Parameters
+    ----------
+    n : int | DeferredRef
+        Number of trials. Must be a non-negative integer (or deferred).
+    p : float | DeferredRef
+        Success probability per trial. Must lie in [0, 1] (or deferred).
+    """
+
+    kind: str = "binomial"
+
+    def __init__(self, *, n: Any, p: Any) -> None:  # noqa: D417 — kwargs-only
+        # Pydantic v2: route through the generic params dict on BaseModel.
+        super().__init__(kind="binomial", params={"n": n, "p": p})
+
+    @model_validator(mode="after")
+    def _validate_binomial(self) -> "Binomial":
+        n = self.params["n"]
+        p = self.params["p"]
+        # Only validate concrete values; deferred references are validated
+        # post-resolution by the compiler.
+        if _is_concrete_number(n):
+            if isinstance(n, float) and not n.is_integer():
+                raise ValueError(f"Binomial n must be an integer, got {n!r}")
+            n_int = int(n)
+            if n_int < 0:
+                raise ValueError(f"Binomial n must be >= 0, got {n!r}")
+        if _is_concrete_number(p):
+            if not 0.0 <= float(p) <= 1.0:
+                raise ValueError(f"Binomial p must be in [0, 1], got {p!r}")
+        return self
+
+    def logpmf(self, k: int) -> float:
+        if not isinstance(k, int) or isinstance(k, bool):
+            raise TypeError(f"Binomial.logpmf(k): k must be integer, got {type(k).__name__}")
+        resolved = self._resolved_params()
+        n = int(resolved["n"])
+        if k < 0 or k > n:
+            return -math.inf
+        return float(_to_scipy_dist("binomial", resolved).logpmf(k))
+
+    def logpdf(self, x: float) -> float:  # noqa: ARG002
+        raise TypeError("Binomial is a discrete distribution; use .logpmf() not .logpdf()")
+
+    def support(self) -> tuple[int, int]:
+        resolved = self._resolved_params()
+        n = int(resolved["n"])
+        return (0, n)
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/distributions/test_binomial.py -v`
+Expected: all Binomial tests pass (roughly 25–30 assertions).
+
+- [ ] **Step 3: Re-run full bayes suite** — make sure nothing in Chunk 1 regressed.
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes -v`
+Expected: all tests pass.
+
+- [ ] **Step 4: Run ruff**
+
+Run: `uv run --extra dev ruff format gaia/lang/bayes tests/gaia/lang/bayes && uv run --extra dev ruff check gaia/lang/bayes tests/gaia/lang/bayes`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/lang/bayes/distributions/discrete.py tests/gaia/lang/bayes/distributions/test_binomial.py
+git commit -m "feat(bayes): Binomial distribution with scipy parity
+
+First concrete distribution — establishes the TDD pattern Chunk 3
+distributions will copy. Parity with scipy.stats.binom at representative
+points (including Mendel n=395 k=295); kwargs-only constructor; validates
+n >= 0 integer and p in [0, 1]; logpmf returns -inf outside support;
+logpdf raises TypeError (discrete); accepts deferred n/p and raises
+UnresolvedParameterError at call time."
+```
+
+---
+
+### Task 2.3: Normal — failing test
+
+**Files:**
+- Test: `tests/gaia/lang/bayes/distributions/test_normal.py`
+
+- [ ] **Step 1: Write the test file**
+
+Create `tests/gaia/lang/bayes/distributions/test_normal.py`:
+
+```python
+"""Normal distribution — continuous reference implementation.
+
+Parity with scipy.stats.norm at representative points; input validation
+(sigma > 0); deferred-parameter handling.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import scipy.stats as stats
+
+from gaia.lang.bayes.distributions.continuous import Normal
+from gaia.lang.bayes.distributions.protocol import UnresolvedParameterError
+
+
+# ---- Construction & basic identity ------------------------------------------
+
+
+def test_normal_stores_kind_and_params():
+    d = Normal(mu=0.0, sigma=1.0)
+    assert d.kind == "normal"
+    assert d.params == {"mu": 0.0, "sigma": 1.0}
+
+
+def test_normal_keyword_only():
+    with pytest.raises(TypeError):
+        Normal(0.0, 1.0)  # type: ignore[misc]
+
+
+def test_normal_is_frozen():
+    d = Normal(mu=0.0, sigma=1.0)
+    with pytest.raises(Exception):
+        d.params = {"mu": 1.0, "sigma": 2.0}  # type: ignore[misc]
+
+
+# ---- Parameter validation ---------------------------------------------------
+
+
+@pytest.mark.parametrize("mu", [-1e6, -1.5, 0.0, 1.5, 1e6])
+def test_normal_accepts_any_real_mu(mu):
+    Normal(mu=mu, sigma=1.0)  # no raise
+
+
+@pytest.mark.parametrize("sigma", [1e-9, 0.5, 1.0, 100.0])
+def test_normal_valid_sigma(sigma):
+    Normal(mu=0.0, sigma=sigma)  # no raise
+
+
+@pytest.mark.parametrize("bad_sigma", [0.0, -0.1, -1e-12])
+def test_normal_rejects_non_positive_sigma(bad_sigma):
+    with pytest.raises(ValueError, match=r"Normal.*sigma.*> 0"):
+        Normal(mu=0.0, sigma=bad_sigma)
+
+
+# ---- logpdf parity with scipy.stats -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mu,sigma,x",
+    [
+        (0.0, 1.0, 0.0),
+        (0.0, 1.0, 1.0),
+        (0.0, 1.0, -3.0),
+        (5.0, 2.0, 5.0),
+        (5.0, 2.0, 10.0),
+        (-1.0, 0.5, 0.0),
+    ],
+)
+def test_normal_logpdf_matches_scipy(mu, sigma, x):
+    d = Normal(mu=mu, sigma=sigma)
+    expected = stats.norm.logpdf(x, loc=mu, scale=sigma)
+    assert d.logpdf(x) == pytest.approx(expected, rel=1e-12, abs=1e-15)
+
+
+def test_normal_logpdf_at_extreme_tail_is_finite_negative():
+    """Float range, far from mean — logpdf should be a large negative float,
+    not -inf (Normal has infinite support)."""
+    d = Normal(mu=0.0, sigma=1.0)
+    val = d.logpdf(10.0)
+    assert math.isfinite(val)
+    assert val < -40
+
+
+def test_normal_logpmf_raises():
+    """Continuous distributions have no pmf."""
+    d = Normal(mu=0.0, sigma=1.0)
+    with pytest.raises(TypeError, match=r"continuous"):
+        d.logpmf(0)
+
+
+def test_normal_logpdf_accepts_int():
+    """Python ints are valid continuous inputs."""
+    d = Normal(mu=0.0, sigma=1.0)
+    expected = stats.norm.logpdf(0, loc=0.0, scale=1.0)
+    assert d.logpdf(0) == pytest.approx(expected)
+
+
+# ---- Support ----------------------------------------------------------------
+
+
+def test_normal_support_is_unbounded():
+    d = Normal(mu=0.0, sigma=1.0)
+    low, high = d.support()
+    assert low == -math.inf
+    assert high == math.inf
+
+
+def test_normal_support_independent_of_params():
+    """Normal support is (-inf, inf) regardless of mu/sigma."""
+    d = Normal(mu=100.0, sigma=0.001)
+    assert d.support() == (-math.inf, math.inf)
+
+
+# ---- Deferred parameters ----------------------------------------------------
+
+
+def test_normal_accepts_deferred_mu(theta_deferred):
+    d = Normal(mu=theta_deferred, sigma=1.0)
+    assert d.params["mu"] is theta_deferred
+
+
+def test_normal_logpdf_with_deferred_mu_raises(theta_deferred):
+    d = Normal(mu=theta_deferred, sigma=1.0)
+    with pytest.raises(UnresolvedParameterError) as excinfo:
+        d.logpdf(0.0)
+    assert excinfo.value.distribution_kind == "normal"
+    assert excinfo.value.deferred_params == ["mu"]
+
+
+def test_normal_support_with_deferred_params_still_unbounded(theta_deferred):
+    """Normal support doesn't depend on params, so support() should work
+    even with deferred mu/sigma."""
+    d = Normal(mu=theta_deferred, sigma=1.0)
+    assert d.support() == (-math.inf, math.inf)
+
+
+def test_normal_model_dump_with_deferred_mu(theta_deferred):
+    d = Normal(mu=theta_deferred, sigma=1.0)
+    dumped = d.model_dump()
+    assert dumped["kind"] == "normal"
+    assert dumped["params"] == {"sigma": 1.0}
+    assert dumped["deferred_params"] == {"mu": "theta"}
+```
+
+- [ ] **Step 2: Run — verify test fails at collection**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/distributions/test_normal.py -v`
+Expected: collection error, `ModuleNotFoundError: gaia.lang.bayes.distributions.continuous`.
+
+---
+
+### Task 2.4: Normal — minimal implementation
+
+**Files:**
+- Create: `gaia/lang/bayes/distributions/continuous.py`
+
+- [ ] **Step 1: Implement `continuous.py` with Normal only**
+
+Create `gaia/lang/bayes/distributions/continuous.py`:
+
+```python
+"""Continuous distributions for the bayes module.
+
+Milestone A ships Normal, Beta, Exponential, LogNormal, StudentT, Cauchy,
+Gamma, ChiSquared. Normal is the reference implementation landing first;
+the rest follow the same pattern in Chunk 3.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from pydantic import model_validator
+
+from gaia.lang.bayes.adapters.scipy_backend import _to_scipy_dist
+from gaia.lang.bayes.distributions.base import _BaseDistribution, _is_concrete_number
+
+
+class Normal(_BaseDistribution):
+    """Normal(mu, sigma): mean-mu, std-sigma Gaussian.
+
+    Parameters
+    ----------
+    mu : float | DeferredRef
+        Mean. Any real number (or deferred).
+    sigma : float | DeferredRef
+        Standard deviation. Must be > 0 (or deferred).
+
+    Support: (-inf, inf) regardless of params.
+    """
+
+    kind: str = "normal"
+
+    def __init__(self, *, mu: Any, sigma: Any) -> None:
+        super().__init__(kind="normal", params={"mu": mu, "sigma": sigma})
+
+    @model_validator(mode="after")
+    def _validate_normal(self) -> "Normal":
+        sigma = self.params["sigma"]
+        if _is_concrete_number(sigma):
+            if float(sigma) <= 0.0:
+                raise ValueError(f"Normal sigma must be > 0, got {sigma!r}")
+        # mu admits any real — no additional validation beyond _BaseDistribution.
+        return self
+
+    def logpdf(self, x: float) -> float:
+        resolved = self._resolved_params()
+        return float(_to_scipy_dist("normal", resolved).logpdf(float(x)))
+
+    def logpmf(self, k: int) -> float:  # noqa: ARG002
+        raise TypeError("Normal is a continuous distribution; use .logpdf() not .logpmf()")
+
+    def support(self) -> tuple[float, float]:
+        # Normal support is unbounded and independent of params; we skip
+        # _resolved_params() so support() works with deferred mu/sigma.
+        return (-math.inf, math.inf)
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/distributions/test_normal.py -v`
+Expected: all Normal tests pass.
+
+- [ ] **Step 3: Run full bayes suite**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes -v`
+Expected: all tests pass (Protocol + base + Binomial + Normal).
+
+- [ ] **Step 4: Run ruff**
+
+Run: `uv run --extra dev ruff format gaia/lang/bayes tests/gaia/lang/bayes && uv run --extra dev ruff check gaia/lang/bayes tests/gaia/lang/bayes`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/lang/bayes/distributions/continuous.py tests/gaia/lang/bayes/distributions/test_normal.py
+git commit -m "feat(bayes): Normal distribution with scipy parity
+
+Continuous reference — mirrors Binomial's discrete template. Parity with
+scipy.stats.norm; kwargs-only constructor; sigma > 0 validation;
+support = (-inf, inf) computed without resolving params (so deferred
+mu/sigma still give a usable support); logpmf raises TypeError (continuous)."
+```
+
+---
+
+**Chunk 2 done.** Two reference distributions — one discrete, one continuous — establish the pattern for Chunk 3. Per-distribution file layout: (1) kwargs-only constructor, (2) `@model_validator(mode="after")` for type/range checks on concrete values, (3) one delegation method (`logpmf` or `logpdf`) that resolves params then calls `_to_scipy_dist`, (4) the inapplicable method raises `TypeError`, (5) `support()` reads from resolved params unless support is param-independent (Normal).
+
+---
+
+## Chunk 3: Remaining 8 distributions
+
+Eight distributions sharing the Chunk 2 template: **Poisson** (discrete), **Beta / Exponential / LogNormal / StudentT / Cauchy / Gamma / ChiSquared** (continuous). Each task is a single TDD cycle (test → implementation → parity-with-scipy verification → commit). The file-level pattern is identical to Chunk 2's `Binomial` / `Normal`.
+
+### Shared testing template
+
+Every new distribution in this chunk copies these test sections from `test_binomial.py` / `test_normal.py`, adjusted for its own parameter names:
+
+1. **Construction** — `kind` + `params` storage, kwargs-only, Pydantic frozen immutability (3 tests).
+2. **Parameter validation** — valid range cases, invalid-range rejection with distribution-name in error message (4–8 tests, `@pytest.mark.parametrize`).
+3. **Parity with scipy.stats** — 5–8 representative (params, x) pairs via `@pytest.mark.parametrize`, assert `pytest.approx(scipy_reference, rel=1e-12, abs=1e-15)` (one parametrized test).
+4. **Outside support** — `-inf` return (discrete) or large-negative-finite (continuous bounded).
+5. **Wrong-path method raises** — discrete distributions' `.logpdf` → `TypeError("discrete")`; continuous' `.logpmf` → `TypeError("continuous")`.
+6. **Support** — `.support()` returns the expected closed interval.
+7. **Deferred params** — `theta_deferred` in each parameter slot (one test per slot), plus `.logpmf` / `.logpdf` raises `UnresolvedParameterError`, plus `model_dump` emits the `{slot: symbol}` entry.
+
+This keeps each test file at 30–60 assertions — same shape as Binomial/Normal.
+
+### Shared implementation template
+
+Each class in `discrete.py` / `continuous.py`:
+
+```python
+class <Name>(_BaseDistribution):
+    """<one-line docstring>
+
+    Parameters
+    ----------
+    <param1> : ...
+    <param2> : ...
+
+    Support: <interval>
+    """
+
+    kind: str = "<lowercase kind>"
+
+    def __init__(self, *, <param1>: Any, <param2>: Any, ...) -> None:
+        super().__init__(kind="<kind>", params={"<p1>": <p1>, ...})
+
+    @model_validator(mode="after")
+    def _validate_<name>(self) -> "<Name>":
+        # Only validate concrete values (`_is_concrete_number(x)`).
+        ...
+        return self
+
+    def logpmf(self, k: int) -> float:     # or logpdf for continuous
+        resolved = self._resolved_params()
+        return float(_to_scipy_dist("<kind>", resolved).logpmf(k))
+
+    def logpdf(self, x: float) -> float:   # raises for discrete
+        raise TypeError("<kind> is a discrete distribution; use .logpmf() not .logpdf()")
+
+    def support(self) -> tuple[float, float]:
+        ...
+```
+
+### Per-distribution task table
+
+| Task | Class | Param signature | Validation | Support | scipy backend (already in `_BUILDERS`) |
+|------|-------|------------------|------------|---------|--------------------------------|
+| 3.1 | `Poisson` | `rate: float > 0` | rate > 0 | `(0, +inf)` — returned as `(0, math.inf)` | `stats.poisson(mu=p["rate"])` |
+| 3.2 | `Beta` | `alpha: float > 0`, `beta: float > 0` | alpha > 0, beta > 0 | `(0.0, 1.0)` | `stats.beta(a=alpha, b=beta)` |
+| 3.3 | `Exponential` | `rate: float > 0` | rate > 0 | `(0.0, math.inf)` | `stats.expon(scale=1/rate)` |
+| 3.4 | `LogNormal` | `mu: float`, `sigma: float > 0` | sigma > 0 | `(0.0, math.inf)` | `stats.lognorm(s=sigma, scale=exp(mu))` |
+| 3.5 | `StudentT` | `df: float > 0`, `mu: float = 0.0`, `sigma: float > 0` | df > 0, sigma > 0 | `(-inf, inf)` | `stats.t(df, loc=mu, scale=sigma)` |
+| 3.6 | `Cauchy` | `mu: float`, `gamma: float > 0` | gamma > 0 | `(-inf, inf)` | `stats.cauchy(loc=mu, scale=gamma)` |
+| 3.7 | `Gamma` | `alpha: float > 0`, `rate: float > 0` | alpha > 0, rate > 0 | `(0.0, math.inf)` | `stats.gamma(a=alpha, scale=1/rate)` |
+| 3.8 | `ChiSquared` | `df: float > 0` | df > 0 | `(0.0, math.inf)` | `stats.chi2(df)` |
+
+All 8 scipy builders are already wired up in `scipy_backend._BUILDERS` from Task 1.5. No changes to `scipy_backend.py` are needed in Chunk 3.
+
+### Per-distribution task shape (applies to Tasks 3.1 – 3.8)
+
+**Files for task 3.N:**
+- Modify: `gaia/lang/bayes/distributions/discrete.py` **or** `gaia/lang/bayes/distributions/continuous.py`
+- Test: `tests/gaia/lang/bayes/distributions/test_<name>.py`
+
+- [ ] **Step 1: Write the failing test file**
+
+Copy the matching reference test file (`test_binomial.py` for Poisson, `test_normal.py` for all continuous distributions), rename classes, adjust parameter names and validation-message regex, and pick 5–8 `(params, x)` pairs for the scipy-parity parametrize. Use the **Shared testing template** above as the checklist (all 7 sections present).
+
+For continuous distributions whose support is bounded on one side (Beta, Exponential, LogNormal, Gamma, ChiSquared), replace Normal's "support unbounded" tests with:
+```python
+def test_<name>_support_bounded():
+    d = <Name>(...)
+    low, high = d.support()
+    assert low == <lower>
+    assert high == <upper>
+
+
+def test_<name>_logpdf_outside_support_is_neg_inf():
+    d = <Name>(...)
+    assert d.logpdf(<below-lower>) == -math.inf   # or math.isclose
+```
+
+For Poisson (discrete, unbounded upper support), replace Binomial's `support() == (0, n)` test with:
+```python
+def test_poisson_support():
+    d = Poisson(rate=3.0)
+    low, high = d.support()
+    assert low == 0
+    assert high == math.inf
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/distributions/test_<name>.py -v`
+Expected: `ImportError` or `AttributeError` for the missing class, or assertion failures if the file is already partially implemented from a prior step.
+
+- [ ] **Step 3: Implement the class**
+
+Append a class to `discrete.py` (Poisson) or `continuous.py` (the other 7), filling in the **Shared implementation template** fields from the per-distribution task table. Validation block only checks concrete values (`_is_concrete_number(x)` guard). Support interval is returned as shown in the table — for `math.inf` upper bounds import `math` at the top of the file if not already imported.
+
+- [ ] **Step 4: Run the new distribution's tests**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/distributions/test_<name>.py -v`
+Expected: all pass.
+
+- [ ] **Step 5: Run the full bayes suite**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes -v`
+Expected: no regressions; all distributions landed so far pass.
+
+- [ ] **Step 6: Run ruff**
+
+Run: `uv run --extra dev ruff format gaia/lang/bayes tests/gaia/lang/bayes && uv run --extra dev ruff check gaia/lang/bayes tests/gaia/lang/bayes`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/lang/bayes/distributions/<file>.py tests/gaia/lang/bayes/distributions/test_<name>.py
+git commit -m "feat(bayes): <Name> distribution with scipy parity
+
+<one-sentence parameters and support summary>. Follows the Binomial /
+Normal template established in Chunk 2."
+```
+
+### Concrete parametrize choices per distribution
+
+These are the reference `(params, x, expected_from_scipy)` values every `test_<name>_logpmf_matches_scipy` or `test_<name>_logpdf_matches_scipy` parametrization must cover. Pick at minimum these six per distribution; add your own edge cases if you like.
+
+**Poisson** — rate ∈ {0.5, 1.0, 3.0, 10.0}, k ∈ {0, 1, 3, 10, 20}. Include (rate=3.0, k=0) and (rate=3.0, k=3) as the mode check.
+
+**Beta** — (alpha, beta) ∈ {(2, 2), (0.5, 0.5), (5, 1), (1, 5), (2, 5)}, x ∈ {0.1, 0.5, 0.9}. Note `logpdf(0.0)` / `logpdf(1.0)` with alpha/beta < 1 is `+inf` — that's a scipy behaviour parity case worth one assertion.
+
+**Exponential** — rate ∈ {0.5, 1.0, 3.0}, x ∈ {0.0, 0.5, 1.0, 5.0}. Include `logpdf(0.0) == log(rate)`.
+
+**LogNormal** — (mu, sigma) ∈ {(0.0, 1.0), (1.0, 0.5), (-1.0, 2.0)}, x ∈ {0.1, 1.0, 10.0}. Test that `logpdf(0.0) == -math.inf`.
+
+**StudentT** — df ∈ {1, 2.5, 10, 100}, (mu, sigma) ∈ {(0, 1), (5, 2)}, x ∈ {-2, 0, 2}. df=1 is Cauchy-equivalent; cross-check against scipy only (not against `Cauchy` class).
+
+**Cauchy** — (mu, gamma) ∈ {(0, 1), (5, 2), (-1, 0.5)}, x ∈ {-3, 0, 5}.
+
+**Gamma** — (alpha, rate) ∈ {(1, 1), (2, 0.5), (5, 2), (0.5, 1)}, x ∈ {0.1, 1.0, 5.0}. alpha=1 is Exponential; cross-check parity against scipy only.
+
+**ChiSquared** — df ∈ {1, 2, 5, 10}, x ∈ {0.1, 1.0, 5.0, 20.0}.
+
+---
+
+**Chunk 3 done.** 10 concrete distributions total (Chunk 2 + Chunk 3): 2 discrete (Binomial, Poisson), 8 continuous (Normal, Beta, Exponential, LogNormal, StudentT, Cauchy, Gamma, ChiSquared). Each matches scipy.stats parity at 5–8 representative points with 1e-12 relative tolerance, validates input ranges with distribution-named error messages, handles deferred parameters via `theta_deferred` fixture, serializes correctly through `model_dump`.
+
+---
+
+## Chunk 4: Public API + smoke + docs
+
+Wire the distributions into the public `gaia.lang.bayes` namespace, add an end-to-end smoke test, and write the module README. Also lands a small **exact-inference fixture** so future Milestone B / C tests have a non-BP ground-truth source — closing the "reproducer-bug masquerading as engine bug" trap that hit twice during spec authoring.
+
+**Files this chunk creates:**
+- `gaia/lang/bayes/README.md`
+- `tests/gaia/lang/bayes/test_public_api.py`
+- `tests/gaia/lang/bayes/conftest.py` — extended with `exact_factor_marginals` fixture (modify, not create)
+
+**Files this chunk modifies:**
+- `gaia/lang/bayes/__init__.py` — public re-exports
+- `gaia/lang/bayes/distributions/__init__.py` — re-exports of all 10 distribution classes
+- `gaia/lang/__init__.py` — adds `bayes` namespace re-export
+
+### Task 4.1: Distribution package re-exports
+
+**Files:**
+- Modify: `gaia/lang/bayes/distributions/__init__.py`
+
+- [ ] **Step 1: Implement re-exports**
+
+Replace the empty `gaia/lang/bayes/distributions/__init__.py` with:
+
+```python
+"""Distribution literals for the bayes module.
+
+Public surface: 10 distribution classes + Distribution Protocol +
+UnresolvedParameterError. Backed by scipy.stats via the internal
+adapters/scipy_backend module.
+"""
+
+from __future__ import annotations
+
+from gaia.lang.bayes.distributions.continuous import (
+    Beta,
+    Cauchy,
+    ChiSquared,
+    Exponential,
+    Gamma,
+    LogNormal,
+    Normal,
+    StudentT,
+)
+from gaia.lang.bayes.distributions.discrete import Binomial, Poisson
+from gaia.lang.bayes.distributions.protocol import (
+    DistParam,
+    Distribution,
+    UnresolvedParameterError,
+)
+
+__all__ = [
+    # Discrete
+    "Binomial",
+    "Poisson",
+    # Continuous
+    "Beta",
+    "Cauchy",
+    "ChiSquared",
+    "Exponential",
+    "Gamma",
+    "LogNormal",
+    "Normal",
+    "StudentT",
+    # Protocol surface
+    "DistParam",
+    "Distribution",
+    "UnresolvedParameterError",
+]
+```
+
+- [ ] **Step 2: Verify re-exports**
+
+Run: `uv run --extra dev python -c "from gaia.lang.bayes.distributions import Binomial, Normal, Beta, Poisson, Exponential, LogNormal, StudentT, Cauchy, Gamma, ChiSquared, Distribution, UnresolvedParameterError; print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gaia/lang/bayes/distributions/__init__.py
+git commit -m "feat(bayes): public re-exports from gaia.lang.bayes.distributions"
+```
+
+---
+
+### Task 4.2: bayes module top-level re-exports
+
+**Files:**
+- Modify: `gaia/lang/bayes/__init__.py`
+
+- [ ] **Step 1: Implement top-level re-exports**
+
+Replace the empty `gaia/lang/bayes/__init__.py` with:
+
+```python
+"""gaia.lang.bayes — hypothesis-data inference subsystem.
+
+Milestone A surface: distribution literals only (Binomial / Normal / Beta /
+Poisson / Exponential / LogNormal / StudentT / Cauchy / Gamma / ChiSquared).
+Milestone B will add `predict()` and `likelihood()` verbs; Milestone C adds
+the migration tooling.
+
+Recommended import style:
+
+    from gaia.lang import bayes
+    bayes.Binomial(n=10, p=0.5)
+
+Flat imports also work:
+
+    from gaia.lang.bayes import Binomial, Normal
+"""
+
+from __future__ import annotations
+
+from gaia.lang.bayes.distributions import (
+    Beta,
+    Binomial,
+    Cauchy,
+    ChiSquared,
+    DistParam,
+    Distribution,
+    Exponential,
+    Gamma,
+    LogNormal,
+    Normal,
+    Poisson,
+    StudentT,
+    UnresolvedParameterError,
+)
+
+__all__ = [
+    # Discrete distributions
+    "Binomial",
+    "Poisson",
+    # Continuous distributions
+    "Beta",
+    "Cauchy",
+    "ChiSquared",
+    "Exponential",
+    "Gamma",
+    "LogNormal",
+    "Normal",
+    "StudentT",
+    # Protocol surface
+    "DistParam",
+    "Distribution",
+    "UnresolvedParameterError",
+]
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `uv run --extra dev python -c "from gaia.lang.bayes import Binomial, Normal; print(Binomial(n=5, p=0.5).logpmf(3))"`
+Expected: a numeric value ≈ `-2.0794` (scipy reference for `binom(5, 0.5).logpmf(3)`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gaia/lang/bayes/__init__.py
+git commit -m "feat(bayes): top-level public API for gaia.lang.bayes"
+```
+
+---
+
+### Task 4.3: gaia.lang re-export
+
+**Files:**
+- Modify: `gaia/lang/__init__.py`
+
+The spec (§2) prescribes `from gaia.lang import bayes` as the recommended import style. Since the current `gaia/lang/__init__.py` does NOT auto-import all submodules (it imports specific names via `from gaia.lang.dsl import ...`), `bayes` is **already** importable as `gaia.lang.bayes` because Python's import system resolves package members on demand. We add an explicit re-export for IDE autocompletion and `from gaia.lang import bayes` ergonomics.
+
+- [ ] **Step 1: Add import to `gaia/lang/__init__.py`**
+
+At the top of `gaia/lang/__init__.py`, after the existing `from gaia.lang.dsl import (` block, add:
+
+```python
+from gaia.lang import bayes  # noqa: F401 — namespace re-export
+```
+
+If `gaia/lang/__init__.py` has an `__all__` list, append `"bayes"` to it. (Inspect file before edit.)
+
+- [ ] **Step 2: Verify the spec-recommended idiom works**
+
+Run: `uv run --extra dev python -c "from gaia.lang import bayes; print(bayes.Binomial(n=5, p=0.5).logpmf(3))"`
+Expected: same numeric value as Task 4.2 Step 2.
+
+- [ ] **Step 3: Verify nothing else broke**
+
+Run: `uv run --extra dev pytest tests/gaia/lang -q`
+Expected: all existing lang tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lang/__init__.py
+git commit -m "feat(bayes): re-export bayes namespace from gaia.lang
+
+Spec §2: 'Recommended import style is namespace: from gaia.lang import bayes'."
+```
+
+---
+
+### Task 4.4: Public API smoke test
+
+**Files:**
+- Test: `tests/gaia/lang/bayes/test_public_api.py`
+
+- [ ] **Step 1: Write the smoke test**
+
+Create `tests/gaia/lang/bayes/test_public_api.py`:
+
+```python
+"""Public-API smoke tests — verifies the import paths advertised in the spec
+all resolve and return functioning distribution objects."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+def test_namespace_import_recommended_style():
+    """Spec §2: `from gaia.lang import bayes; bayes.Binomial(...)`."""
+    from gaia.lang import bayes
+
+    d = bayes.Binomial(n=10, p=0.5)
+    assert d.logpmf(5) == pytest.approx(math.log(252 / 1024))
+
+
+def test_flat_import_alternate_style():
+    """Spec §2: `from gaia.lang.bayes import Binomial`."""
+    from gaia.lang.bayes import Binomial, Normal
+
+    assert Binomial(n=10, p=0.5).logpmf(5) == pytest.approx(math.log(252 / 1024))
+    assert Normal(mu=0.0, sigma=1.0).logpdf(0.0) == pytest.approx(-0.5 * math.log(2 * math.pi))
+
+
+def test_all_ten_distributions_constructible():
+    """Every distribution class in the spec's v1 list constructs with valid params."""
+    from gaia.lang import bayes
+
+    bayes.Binomial(n=10, p=0.5)
+    bayes.Poisson(rate=3.0)
+    bayes.Normal(mu=0.0, sigma=1.0)
+    bayes.Beta(alpha=2.0, beta=2.0)
+    bayes.Exponential(rate=1.0)
+    bayes.LogNormal(mu=0.0, sigma=1.0)
+    bayes.StudentT(df=10.0, mu=0.0, sigma=1.0)
+    bayes.Cauchy(mu=0.0, gamma=1.0)
+    bayes.Gamma(alpha=2.0, rate=1.0)
+    bayes.ChiSquared(df=5.0)
+
+
+def test_protocol_surface_exposed():
+    """Distribution Protocol + UnresolvedParameterError reachable from public API."""
+    from gaia.lang.bayes import Distribution, UnresolvedParameterError
+
+    assert UnresolvedParameterError is not None
+    assert Distribution is not None
+
+
+def test_kind_field_consistent_across_distributions():
+    """Each distribution self-reports its kind matching its scipy backend key."""
+    from gaia.lang import bayes
+
+    expected_kinds = [
+        (bayes.Binomial(n=10, p=0.5), "binomial"),
+        (bayes.Poisson(rate=1.0), "poisson"),
+        (bayes.Normal(mu=0.0, sigma=1.0), "normal"),
+        (bayes.Beta(alpha=2.0, beta=2.0), "beta"),
+        (bayes.Exponential(rate=1.0), "exponential"),
+        (bayes.LogNormal(mu=0.0, sigma=1.0), "lognormal"),
+        (bayes.StudentT(df=5.0, mu=0.0, sigma=1.0), "studentt"),
+        (bayes.Cauchy(mu=0.0, gamma=1.0), "cauchy"),
+        (bayes.Gamma(alpha=2.0, rate=1.0), "gamma"),
+        (bayes.ChiSquared(df=5.0), "chisquared"),
+    ]
+    for dist, kind in expected_kinds:
+        assert dist.kind == kind
+
+
+def test_dunder_all_completeness():
+    """`from gaia.lang.bayes import *` exposes the documented surface."""
+    import gaia.lang.bayes as bayes_mod
+
+    expected = {
+        "Binomial",
+        "Poisson",
+        "Normal",
+        "Beta",
+        "Exponential",
+        "LogNormal",
+        "StudentT",
+        "Cauchy",
+        "Gamma",
+        "ChiSquared",
+        "Distribution",
+        "DistParam",
+        "UnresolvedParameterError",
+    }
+    assert expected.issubset(set(bayes_mod.__all__))
+```
+
+- [ ] **Step 2: Run**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/test_public_api.py -v`
+Expected: all 6 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/gaia/lang/bayes/test_public_api.py
+git commit -m "test(bayes): public API smoke — all 10 distributions importable
+
+Verifies both spec-recommended import idioms ('from gaia.lang import bayes'
+and 'from gaia.lang.bayes import Binomial') and confirms every distribution
+class in v1 self-reports a kind that matches its scipy_backend dispatch key."
+```
+
+---
+
+### Task 4.5: Exact-inference fixture for ground truth
+
+**Files:**
+- Modify: `tests/gaia/lang/bayes/conftest.py`
+- Test: `tests/gaia/lang/bayes/test_exact_inference.py`
+
+**Why this fixture exists.** During spec authoring, two numeric claims about BP behaviour turned out to be wrong because the *reproducer scripts* had bugs (forgot to add a CONTRADICTION factor). The fixture below performs **brute-force exact inference** on small Boolean factor graphs by enumerating all $2^N$ assignments — a slow but unimpeachable ground truth that future Milestone B / C tests can compare against without depending on BP convergence behaviour.
+
+This is **fixture infrastructure for Milestone B/C**. Milestone A doesn't strictly need it, but landing it now while attention is on the bayes test layout is cheaper than retrofitting.
+
+- [ ] **Step 1: Extend `conftest.py` with the exact-inference fixture**
+
+Add these imports near the existing imports at the top of `tests/gaia/lang/bayes/conftest.py`:
+
+```python
+from itertools import product
+from typing import Callable
+```
+
+Then append the fixture implementation below the existing deferred-variable fixtures:
+
+```python
+
+def _enumerate_marginals(
+    n_vars: int,
+    factor_weight: Callable[[tuple[int, ...]], float],
+) -> tuple[float, list[float]]:
+    """Brute-force exact marginals for a Boolean factor graph.
+
+    Parameters
+    ----------
+    n_vars : int
+        Number of Boolean variables (each ∈ {0, 1}).
+    factor_weight : callable
+        Function mapping an assignment tuple of length n_vars to a non-negative
+        joint factor weight (product of all factor potentials at that assignment).
+
+    Returns
+    -------
+    (Z, marginals) where Z is the partition function and marginals[i] is
+    P(var_i = 1) under the joint distribution defined by `factor_weight`.
+
+    Use this in tests as the ground-truth comparison for BP-based inference
+    on small (n_vars <= 10) graphs.
+    """
+    Z = 0.0
+    one_marg = [0.0] * n_vars
+    for assignment in product((0, 1), repeat=n_vars):
+        w = factor_weight(assignment)
+        Z += w
+        for i, v in enumerate(assignment):
+            if v == 1:
+                one_marg[i] += w
+    if Z == 0:
+        raise ValueError("Partition function Z = 0; factor graph has no satisfiable assignment")
+    return Z, [m / Z for m in one_marg]
+
+
+@pytest.fixture
+def exact_factor_marginals() -> Callable[..., tuple[float, list[float]]]:
+    """Return the brute-force enumerator for use in tests.
+
+    Example
+    -------
+    >>> def w(assn):
+    ...     a, b = assn
+    ...     return (0.6 if a == 1 else 0.4) * (0.7 if b == 1 else 0.3)
+    >>> Z, marg = exact_factor_marginals(2, w)
+    >>> marg  # P(a=1), P(b=1)
+    [0.6, 0.7]
+    """
+    return _enumerate_marginals
+```
+
+- [ ] **Step 2: Write a sanity test for the fixture**
+
+Create `tests/gaia/lang/bayes/test_exact_inference.py`:
+
+```python
+"""Sanity tests for the exact-inference fixture used as ground truth in
+Milestone B/C BP regression tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+def test_two_independent_variables(exact_factor_marginals):
+    """Two independent vars with priors 0.6 and 0.7 — marginals must equal priors."""
+
+    def weight(assn):
+        a, b = assn
+        return (0.6 if a == 1 else 0.4) * (0.7 if b == 1 else 0.3)
+
+    Z, marg = exact_factor_marginals(2, weight)
+    assert Z == pytest.approx(1.0)
+    assert marg[0] == pytest.approx(0.6)
+    assert marg[1] == pytest.approx(0.7)
+
+
+def test_contradiction_constraint(exact_factor_marginals):
+    """Two vars with priors 0.5 each, plus a CONTRADICTION (¬(A ∧ B)) factor —
+    posterior odds P(A=1) / P(A=0) must equal 1/3 (one of the four assignments
+    is ruled out, so 3 are equally likely; A=1 happens in 1 of those 3).
+    """
+    eps = 1e-12
+
+    def weight(assn):
+        a, b = assn
+        prior = 0.5 * 0.5  # uniform over four assignments before constraint
+        contradict = eps if (a == 1 and b == 1) else (1 - eps)
+        return prior * contradict
+
+    Z, marg = exact_factor_marginals(2, weight)
+    assert marg[0] == pytest.approx(1 / 3, abs=1e-9)
+    assert marg[1] == pytest.approx(1 / 3, abs=1e-9)
+
+
+def test_likelihood_factor_recovers_bayes_factor(exact_factor_marginals):
+    """Single H clamped via a likelihood factor with logL = -1.2 vs an alternate
+    H' with logL = -5.1, plus pairwise CONTRADICTION — exact posterior odds
+    must equal exp(3.9) ≈ 49.4 (the true Bayes factor) within tolerance.
+
+    This is the corrected ground-truth that PR #514 verified — the same
+    arithmetic that flushed out the spec §4.3 bug. Keeping it as a test
+    locks the invariant before Milestone B's lowering tries to reproduce it.
+    """
+    eps = 1e-3
+    p0 = 0.5
+    p1_a = max(eps, min(1 - eps, (1 - eps) * 1.0))  # H_3:1 (best)
+    p1_b = max(eps, min(1 - eps, (1 - eps) * math.exp(-3.9)))  # H_null
+    cmp_clamp = 1 - eps
+
+    def cond_factor(h_val, cmp_val, p1):
+        cpt = [p0, p1]
+        prob = max(eps, min(1 - eps, cpt[h_val]))
+        return prob if cmp_val == 1 else 1 - prob
+
+    def contradict_factor(a, b):
+        return eps if (a == 1 and b == 1) else 1 - eps
+
+    def weight(assn):
+        h_a, h_b, cmp_v, contradict_helper = assn
+        # Priors: 0.5 each on H_a/H_b; cmp clamped to 1; contradict helper clamped to 1
+        prior = 0.5 * 0.5
+        cmp_prior = cmp_clamp if cmp_v == 1 else 1 - cmp_clamp
+        contradict_prior = (1 - eps) if contradict_helper == 1 else eps
+        # Factors
+        f_a = cond_factor(h_a, cmp_v, p1_a)
+        f_b = cond_factor(h_b, cmp_v, p1_b)
+        # CONTRADICTION operator factor: helper = ¬(a ∧ b)
+        truth = not (h_a == 1 and h_b == 1)
+        f_contradict = (1 - eps) if (contradict_helper == 1) == truth else eps
+        return prior * cmp_prior * contradict_prior * f_a * f_b * f_contradict
+
+    Z, marg = exact_factor_marginals(4, weight)
+    odds = marg[0] / marg[1]
+    # True BF = exp(3.9) ≈ 49.4. Cromwell clamp tightens slightly.
+    assert odds == pytest.approx(49.3, rel=0.05)
+```
+
+- [ ] **Step 3: Run**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes/test_exact_inference.py -v`
+Expected: 3 tests pass; the third reproduces the corrected `≈ 49.3` posterior odds from PR #514.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/gaia/lang/bayes/conftest.py tests/gaia/lang/bayes/test_exact_inference.py
+git commit -m "test(bayes): exact-inference fixture for BP ground-truth comparisons
+
+Brute-force enumerator over Boolean factor graphs (n_vars <= 10).
+Designed for Milestone B/C tests to verify BP-based inference matches
+exact marginals — closes the 'reproducer-bug masquerades as engine-bug'
+trap that hit the spec exclusivity caveat (PR #514).
+
+Includes a regression test pinning the corrected Mendel posterior odds
+(~49.3, matching exp(3.9)) so future lowering changes can't silently
+break the worked example."
+```
+
+---
+
+### Task 4.6: Module README
+
+**Files:**
+- Create: `gaia/lang/bayes/README.md`
+
+- [ ] **Step 1: Write the README**
+
+Create `gaia/lang/bayes/README.md`:
+
+````markdown
+# `gaia.lang.bayes`
+
+Hypothesis–data inference subsystem for Gaia. Spec: [`docs/specs/2026-05-04-bayes-module-design.md`](../../../docs/specs/2026-05-04-bayes-module-design.md).
+
+## Status
+
+| Milestone | Surface | Status |
+|---|---|---|
+| **A** | Distribution literals (10 distributions, scipy backend) | **this commit set** |
+| B | `predict()` / `likelihood()` verbs + IR lowering | Milestone B (separate plan) |
+| C | `evidence()` deletion, migration tools, foundation docs | Milestone C |
+
+## Quick start
+
+```python
+from gaia.lang import bayes
+
+# Discrete: Binomial PMF parity with scipy.stats.binom
+b = bayes.Binomial(n=10, p=0.5)
+print(b.logpmf(5))    # -1.402  (≈ log(0.246))
+print(b.support())     # (0, 10)
+
+# Continuous: Normal PDF parity with scipy.stats.norm
+n = bayes.Normal(mu=0.0, sigma=1.0)
+print(n.logpdf(0.0))   # -0.919  (≈ log(1/sqrt(2π)))
+
+# Variable-aware (Milestone B will resolve at compile time)
+class _StubVar:
+    symbol = "theta"
+b_deferred = bayes.Binomial(n=10, p=_StubVar())
+b_deferred.logpmf(5)   # raises UnresolvedParameterError
+```
+
+## Architecture
+
+```
+gaia.lang.bayes
+├── distributions/
+│   ├── protocol.py      # Distribution Protocol, DistParam, UnresolvedParameterError
+│   ├── base.py          # _BaseDistribution Pydantic model with Variable-aware params
+│   ├── discrete.py      # Binomial, Poisson
+│   └── continuous.py    # Normal, Beta, Exponential, LogNormal, StudentT, Cauchy, Gamma, ChiSquared
+└── adapters/
+    └── scipy_backend.py # internal: kind → scipy.stats frozen rv dispatch
+```
+
+## Available distributions
+
+| Class | Family | Parameters | Support |
+|---|---|---|---|
+| `Binomial` | discrete | `n: int >= 0`, `p ∈ [0, 1]` | `[0, n]` |
+| `Poisson` | discrete | `rate > 0` | `[0, +∞)` |
+| `Normal` | continuous | `mu: real`, `sigma > 0` | `(-∞, +∞)` |
+| `Beta` | continuous | `alpha > 0`, `beta > 0` | `(0, 1)` |
+| `Exponential` | continuous | `rate > 0` | `[0, +∞)` |
+| `LogNormal` | continuous | `mu: real`, `sigma > 0` | `(0, +∞)` |
+| `StudentT` | continuous | `df > 0`, `mu: real`, `sigma > 0` | `(-∞, +∞)` |
+| `Cauchy` | continuous | `mu: real`, `gamma > 0` | `(-∞, +∞)` |
+| `Gamma` | continuous | `alpha > 0`, `rate > 0` | `(0, +∞)` |
+| `ChiSquared` | continuous | `df > 0` | `[0, +∞)` |
+
+## Variable-aware parameters
+
+Distributions accept **deferred references** in any parameter slot — anything with a string `.symbol` attribute. PR 505's `Variable` class is the intended reference type, but Milestone A is decoupled: any duck-typed object works.
+
+When a distribution method (`.logpmf` / `.logpdf` / `.support`) is called with unresolved deferred parameters, it raises `UnresolvedParameterError` listing the unresolved slot names. Milestone B's compiler resolves these before lowering (by reading bound values off `parameter()` claims).
+
+`model_dump()` emits two fields:
+- `params: dict[name, value]` — concrete numeric params only.
+- `deferred_params: dict[slot, symbol]` — present only if any param is deferred. Maps each parameter slot to the referenced Variable's symbol.
+
+This shape lets the IR side serialise distribution literals without losing the Variable references that Milestone B re-binds.
+
+## Backend
+
+The scipy.stats backend is internal (`adapters/scipy_backend.py`). Future PyMC / Stan / NumPyro adapters plug in by registering additional `kind → frozen rv` builders without touching the public DSL. See spec §5.2.
+
+## Out of scope (this milestone)
+
+- `predict()` and `likelihood()` verbs — Milestone B
+- IR lowering — Milestone B
+- `evidence()` deletion — Milestone C
+- `gaia.stats` deprecation — none planned (no public `gaia.stats` to deprecate; spec §8.2)
+````
+
+- [ ] **Step 2: Verify rendering** (visual smoke — no assertion)
+
+Run: `cat gaia/lang/bayes/README.md | head -80`
+Expected: well-formed Markdown, the table renders with aligned pipes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gaia/lang/bayes/README.md
+git commit -m "docs(bayes): module README for Milestone A
+
+Quick start, architecture map, distribution table, Variable-aware param
+explanation, and clear out-of-scope list pointing at Milestones B and C."
+```
+
+---
+
+### Task 4.7: Final integration check
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Full test sweep**
+
+Run: `uv run --extra dev pytest tests/gaia/lang/bayes -v`
+Expected: all bayes tests pass — Protocol + base + 10 distributions + public API + exact-inference fixture.
+
+- [ ] **Step 2: Lang-wide test sweep — verify no regression**
+
+Run: `uv run --extra dev pytest tests/gaia/lang -q`
+Expected: every test in `tests/gaia/lang/` passes.
+
+- [ ] **Step 3: Lint sweep**
+
+Run: `uv run --extra dev ruff format --check gaia/lang/bayes tests/gaia/lang/bayes && uv run --extra dev ruff check gaia/lang/bayes tests/gaia/lang/bayes`
+Expected: no errors.
+
+- [ ] **Step 4: Milestone A acceptance subset check (§11)**
+
+Run: `uv run --extra dev python -c "
+import gaia.lang.bayes as b
+# §11.1: from gaia.lang import bayes exposes 10 distribution classes
+required = {'Binomial', 'Normal', 'Beta', 'Poisson', 'Exponential', 'LogNormal', 'StudentT', 'Cauchy', 'Gamma', 'ChiSquared'}
+assert required.issubset(set(b.__all__)), f'Missing: {required - set(b.__all__)}'
+print('§11.1 distribution subset satisfied (predict/likelihood deferred to Milestone B)')
+# §11.6: no new FactorType
+from gaia.bp.factor_graph import FactorType
+expected_types = {'IMPLICATION', 'CONJUNCTION', 'DISJUNCTION', 'EQUIVALENCE', 'CONTRADICTION', 'COMPLEMENT', 'SOFT_ENTAILMENT', 'CONDITIONAL'}
+assert {ft.name for ft in FactorType} == expected_types, 'FactorType drift detected'
+print('§11.6 satisfied')
+# §11.7: no new OperatorType
+from gaia.ir.operator import OperatorType
+expected_ops = {'IMPLICATION', 'EQUIVALENCE', 'CONTRADICTION', 'COMPLEMENT', 'DISJUNCTION', 'CONJUNCTION'}
+assert {ot.name for ot in OperatorType} == expected_ops, 'OperatorType drift detected'
+print('§11.7 satisfied')
+print('Milestone A acceptance subset satisfied at code level')
+"`
+Expected: three "satisfied" lines plus the final summary.
+
+Note: the rest of §11.1 (`predict` / `likelihood`) plus §11 acceptance criteria 2 (Mendel pipeline test), 3 (PR #506 close), 4 (gaia check rules), 5 (foundation docs) are deferred to Milestone B / C — they require verbs and lowering not in scope here.
+
+- [ ] **Step 5: Final commit (if anything cosmetic was touched)**
+
+If steps 1–4 surfaced any small fix, commit it with:
+```bash
+git commit -am "chore(bayes): final lint/cleanup pass for Milestone A"
+```
+Otherwise no commit needed.
+
+---
+
+**Chunk 4 done.** Public API surface for Milestone A is complete: `from gaia.lang import bayes` and `from gaia.lang.bayes import <Class>` both resolve, all 10 distributions exposed, README in place, exact-inference fixture available for Milestone B/C ground-truth comparisons. The §11.1 distribution subset plus §11.6 and §11.7 are verifiably satisfied; `predict` / `likelihood` and criteria 2-5 are deferred to later milestones.
+
+---
+
+## Plan summary
+
+| Chunk | Scope | Files added | Files modified | Tests |
+|---|---|---|---|---|
+| 1 | Foundation: scipy dep, package skeleton, Protocol, base class, scipy backend | 9 | `pyproject.toml` | 15 |
+| 2 | Reference distributions: Binomial, Normal | 2 | — | ~50 |
+| 3 | Remaining 8 distributions | 8 | `discrete.py`, `continuous.py` | ~250 |
+| 4 | Public API, smoke, exact-inference fixture, README | 5 | `gaia/lang/__init__.py`, distribution `__init__.py`, conftest | ~25 |
+
+**Total:** 24 new files, 4 modifications, ~340 test assertions, ~16 commits across 4 chunks.
+
+**Zero coupling to PR 505** — the duck-typed `.symbol` interface for deferred parameters means Milestone A can ship before, after, or alongside any PR 505 milestone. Milestone B picks up the binding work when PR 505's `parameter()` / `observation()` are merged.

--- a/docs/specs/2026-05-04-bayes-module-design.md
+++ b/docs/specs/2026-05-04-bayes-module-design.md
@@ -1,0 +1,611 @@
+# Bayes Module Design — Hypothesis–Data Inference Subsystem
+
+> **Status:** Target design (proposal)
+> **Branch:** `feat/bayes-module-design` (off `main`)
+> **Target release:** v0.6 (built on v0.5 foundation + PR 505 lifted Lang)
+> **Date:** 2026-05-04
+> **Scope:** Replacement of the Correlate `evidence()` verb with a structured `gaia.lang.bayes` module exposing `predict / observe / likelihood`.
+> **Supersedes:** PR #506 (`evidence()` verb). PR #506 will be closed without merge.
+> **Depends on:** PR #505 (claim formula schema — Variable / Domain / Formula AST / `parameter()` / `observation()` sugar).
+
+---
+
+## 0. Background and Motivation
+
+### 0.1 What's wrong with `evidence()` (PR #506)
+
+`evidence(D, hypothesis=H, model=M, null_model=M0, observed=v)` collapses five distinct conceptual atoms of scientific reasoning into a single verb:
+
+1. The *internal structure* of the hypothesis (what parameter, what value)
+2. The *predictive model* connecting H to the observable
+3. The *observation* (measured value, noise model)
+4. The *likelihood* P(D|H) computation
+5. The *belief update* on H
+
+This collapse forces every variation of "use data to evaluate a hypothesis" to be a new verb (`evidence` for Binomial, future `model_compare` for multi-H, `gaussian_evidence` for measurement, …) and prevents `gaia review` from inspecting individual atoms. PR #506's review surfaces two soundness gaps as a direct consequence:
+
+- `model.kind / params.n` mismatch between `model` and `null_model` is silently accepted (likelihoods computed on different probability spaces).
+- IR consumer contract for `evidence`-emitted strategies is implicit and undocumented (only distinguished from `infer` by `metadata["pattern"]`).
+
+The deeper problem is that `evidence()` covers a narrow slice (point H vs point ¬H, Binomial-only) of what scientific papers actually do.
+
+### 0.2 What scientific writing actually decomposes into
+
+A Bayesian-flavoured paper section reads:
+
+> "We hypothesise that θ = 0.75 (Mendelian segregation). Under this hypothesis, the dominant phenotype count k follows Binomial(n=395, p=0.75). We observed k=295. The likelihood under the 3:1 model is 0.30, vs 0.04 under the null 1:1 model — a Bayes factor of ≈7."
+
+Five atoms, each independently expressible:
+
+| Atom | Authoring artifact | Knowledge node? |
+|---|---|---|
+| Hypothesis with internal structure | `parameter(theta, 0.75)` (PR 505) | yes — PARAMETER claim |
+| Predictive model | `predict(H, k, distribution=Binomial(n, p=theta))` | yes — PredictiveModel claim |
+| Observation with optional noise | `observation(k=295, noise=...)` (PR 505) | yes — OBSERVATION claim |
+| Likelihood computation | `likelihood(data, via=M)` | yes — ComparisonResult claim |
+| Belief update | (lowering produces BP factors) | no — structural |
+
+This spec defines a `gaia.lang.bayes` module with three new verbs (`predict`, `likelihood`, plus distribution literals), reusing PR 505's `parameter()` / `observation()` for the hypothesis/observation atoms.
+
+### 0.3 First-principles position
+
+| Principle | How it lands |
+|---|---|
+| **DSL surface mirrors paper narrative.** | `predict / observe / likelihood` is the standard three-step paper method. |
+| **Each atom is a structured Claim, reviewable in isolation.** | All four user-facing artifacts are Knowledge nodes carrying typed metadata. |
+| **Composite hypotheses, multi-H, parameter priors are special cases of the same framework, not new verbs.** | Composite H is a formula-shape change (PR 505 grounding pass). Multi-H = expanding the H set passed to `predict`. Parameter prior = backend extension on Distribution. |
+| **Mature ecosystems plug in via Distribution backend.** | scipy.stats is the v1 default backend; PyMC / Stan / NumPyro are v2+ adapter slots that extend `Distribution.logpmf/logpdf` without changing the DSL. |
+| **IR is grounded propositional. Bayes module is lifted.** | Variables (PR 505) carry parameter identity; bayes verbs lower to existing IR `infer` strategies + `CONTRADICTION` operators. **No new FactorType.** |
+
+---
+
+## 1. Architectural Position
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Gaia Lang  (lifted)                                              │
+│  ────────────                                                      │
+│  PR 505:  Variable, Domain, Formula AST, parameter()/observation() │
+│           ↑                                                        │
+│  NEW:     gaia.lang.bayes                                          │
+│             distributions/  (scipy-backed, Variable-aware)         │
+│             predict()       → PredictiveModel Knowledge            │
+│             likelihood()    → ComparisonResult Knowledge           │
+└──────────────────────────────────────┬───────────────────────────┘
+                                       │ Compiler (grounding pass)
+                                       ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Gaia IR  (grounded)                                              │
+│  ─────────                                                         │
+│  Knowledge atoms (PARAMETER / OBSERVATION / PredictiveModel /     │
+│                   ComparisonResult)                                │
+│  Operator:  CONTRADICTION (auto-generated for multi-H exclusion)  │
+│  Strategy:  infer (per H, with conditional_probabilities)         │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 1.1 Module boundary
+
+- **Replaces** `evidence()` from PR #506 (deleted, not deprecated; user count = 0).
+- **Coexists with** `infer()` (low-level escape hatch, hand-written CPT) and `associate()` (symmetric correlation — orthogonal problem).
+- **Depends on** PR 505's Variable / Formula AST / `parameter()` / `observation()`.
+- **Single new hard dependency:** `scipy` (already transitively in dep graph).
+- **No IR schema changes. No new FactorType.**
+
+### 1.2 New `metadata` well-known keys
+
+| Key | Carrier | Value |
+|---|---|---|
+| `metadata["bayes"]["role"]` | Knowledge | `"prediction" | "comparison"` |
+| `metadata["bayes"]["distribution"]` | PredictiveModel Knowledge | `{"kind": "binomial", "params": {...}}` (DistributionLiteral dump) |
+| `metadata["bayes"]["likelihoods"]` | ComparisonResult Knowledge | `{H_qid: log_likelihood}` |
+| `metadata["bayes"]["data"]` | ComparisonResult Knowledge | `[obs_qid, ...]` |
+| `metadata["bayes"]["model"]` | ComparisonResult Knowledge | `predictive_model_qid` |
+| `metadata["bayes"]["log_likelihood"]` | infer Strategy | scalar — for trace inspection |
+| `metadata["bayes"]["auto_generated_by"]` | CONTRADICTION Operator | `"likelihood:<cmp_result_qid>"` (audit trail for auto-added exclusion) |
+| `metadata["bayes"]["noise"]` | OBSERVATION Knowledge | DistributionLiteral dump (optional) |
+
+These ride existing `metadata: dict[str, Any]` channels; no Pydantic schema change.
+
+---
+
+## 2. Module Code Layout
+
+```
+gaia/lang/bayes/
+├── __init__.py              # public API: predict, likelihood, distributions
+├── verbs/
+│   ├── predict.py           # predict() DSL
+│   └── likelihood.py        # likelihood() DSL
+├── distributions/
+│   ├── __init__.py          # re-export Binomial, Normal, Beta, Poisson, ...
+│   ├── protocol.py          # Distribution Protocol (.logpmf / .logpdf / .support)
+│   ├── discrete.py
+│   └── continuous.py
+├── adapters/
+│   ├── scipy_backend.py     # v1 default
+│   └── README.md            # PyMC / Stan adapter contract (v2+)
+├── runtime/
+│   ├── prediction.py        # PredictiveModel Knowledge subclass
+│   └── comparison.py        # ComparisonResult Knowledge subclass
+├── compiler/
+│   └── lower.py             # Lang→IR lowering (per §4)
+└── README.md                # module overview & extension points
+
+# Re-exports for convenience (matches existing `from gaia.lang import claim` style):
+gaia/lang/__init__.py:
+   from gaia.lang.bayes import predict, likelihood, Binomial, Normal, ...
+```
+
+Recommended import style is **namespace**:
+
+```python
+from gaia.lang import bayes
+bayes.predict(...)
+bayes.likelihood(...)
+bayes.Binomial(n=n, p=theta)
+```
+
+`from gaia.lang import predict, likelihood` also works.
+
+### 2.1 Module boundaries with existing code
+
+| Existing | Action |
+|---|---|
+| `gaia.stats.DistributionLiteral / Binomial / Normal / ...` (PR 506) | Move to `gaia.lang.bayes.distributions`. `gaia.stats` becomes a deprecation shim for one minor version, then deleted. |
+| PR 505's `parameter()` / `observation()` sugar | Stay at `gaia.lang.dsl` root; bayes module imports and uses them. |
+| Correlate `infer` / `associate` | Stay. `infer` = "I hand-wrote the CPT"; `bayes.likelihood` = "I have a model and observed value, kernel computes the CPT". |
+| Correlate `evidence` (PR 506) | **Delete in same PR as bayes module.** PR #506 closes without merge. |
+
+---
+
+## 3. Core DSL
+
+### 3.1 `Distribution` (Lang-side typed value)
+
+Distributions are *recipes*, not propositions — they don't have truth values, so they are not Knowledge nodes. They are typed values that may reference Variables.
+
+```python
+from gaia.lang.bayes import Binomial, Normal, Beta, Poisson, ...
+
+n = variable("n", Nat, value=395)
+theta = variable("theta", Probability)
+
+Binomial(n=n, p=theta)         # n, p: Variable | DistributionParam
+Normal(mu=mu_h, sigma=0.5)     # mu_h: Variable, sigma: float
+```
+
+Internally backed by `scipy.stats`. Each distribution implements:
+
+```python
+class Distribution(Protocol):
+    kind: str
+    params: dict[str, Variable | float]
+
+    def logpmf(self, x: int) -> float: ...        # discrete
+    def logpdf(self, x: float) -> float: ...      # continuous
+    def support(self) -> tuple[float, float]: ...
+```
+
+For the v1 release, `Binomial / Normal / Beta / Poisson / Exponential / LogNormal / StudentT / Cauchy / Gamma / ChiSquared` are sufficient (covers ≥90% of cited scientific use).
+
+### 3.2 `predict()` — produce a PredictiveModel claim
+
+```python
+M = bayes.predict(
+    hypothesis,        # Claim or set[Claim]
+    observable,        # Variable
+    distribution,      # Distribution literal (may reference Variables)
+    background=None,
+    rationale="",
+    label=None,
+) -> Claim
+```
+
+Returns a Knowledge node with `metadata["bayes"]["role"] = "prediction"` and `metadata["bayes"]["distribution"]` carrying the serialized distribution literal. Semantically asserts: *"under each H_i in the hypothesis set, the observable variable follows this distribution."*
+
+The distribution literal's parameters that are Variables are resolved at compile time by reading each H_i's `formula` (PR 505's PARAMETER claim shape: `Equals(var, const)`).
+
+Multi-H syntax is **set** — `predict({H_3_1, H_null}, k, distribution=...)` indicates "alternative models for the same observable."
+
+### 3.3 Observation with optional noise — extends PR 505's `observation()`
+
+PR 505 already provides `observation(var=value, ...)` returning an OBSERVATION claim with `formula = Equals(var, value)`. The bayes module adds an optional `noise=` parameter:
+
+```python
+data = observation(
+    k=295,
+    prior=1.0,
+    noise=Normal(mu=0, sigma=2.5),   # NEW: optional measurement noise model
+    rationale="...",
+    label=None,
+)
+```
+
+`noise` is stored at `metadata["bayes"]["noise"]`. `likelihood()` reads it during likelihood computation (§4.5).
+
+`observe()` is **not** a new verb. The PR 505 `observation()` function gains a `noise=` kwarg.
+
+### 3.4 `likelihood()` — produce a ComparisonResult claim + connect BP factor
+
+```python
+result = bayes.likelihood(
+    data,                    # OBSERVATION claim or list (multi-data accumulation)
+    via,                     # PredictiveModel claim from predict()
+    background=None,
+    rationale="",
+    label=None,
+    exclusivity="pairwise_contradiction",  # | "none" | "exhaustive_pairwise_complement"
+    precomputed=None,        # escape hatch: dict[H_qid, log_likelihood] — bypasses scipy
+) -> Claim
+```
+
+Returns a Knowledge node with:
+
+- `prior = 1 - ε` (clamped to True — likelihood is tautologically observed once computed)
+- `metadata["bayes"]["role"] = "comparison"`
+- `metadata["bayes"]["likelihoods"] = {H_qid: log_likelihood}`
+- `metadata["bayes"]["data"] = [obs_qid, ...]`
+- `metadata["bayes"]["model"] = predictive_model_qid`
+
+This is the artifact upstream reasoning can cite: *"based on this comparison-result, we conclude…"*.
+
+---
+
+## 4. Compiler / Lowering
+
+### 4.1 Lower paths
+
+```
+predict()      → PredictiveModel Knowledge atom (no factor by itself)
+observation()  → PR 505's existing OBSERVATION lowering, plus noise metadata
+likelihood()   → ComparisonResult Knowledge atom
+                 + N IR `infer` strategies (one per H_i in the H set)
+                 + auto-generated CONTRADICTION operators (multi-H exclusivity)
+```
+
+**No new FactorType.** All factors land in existing `IMPLICATION / CONJUNCTION / DISJUNCTION / EQUIVALENCE / CONTRADICTION / COMPLEMENT / SOFT_ENTAILMENT / CONDITIONAL` — verified against `gaia/bp/factor_graph.py:26`.
+
+### 4.2 `likelihood()` lowering steps
+
+Inputs: `data` (one or more OBSERVATION claims), `via=M` (PredictiveModel containing H set `{H_1, ..., H_N}`, distribution `D`, observable variable `X`).
+
+```
+Step 1: For each H_i:
+    a. Read H_i.formula, extract Variable bindings (e.g. theta=0.75).
+    b. Apply bindings to D, yielding concrete distribution D_i.
+    c. logL_i = Σ_g D_i.logpmf(d_g) or Σ_g D_i.logpdf(d_g)
+       (for noise model, see §4.5)
+
+Step 2: Create ComparisonResult Knowledge:
+    prior = 1 - ε
+    metadata["bayes"]["likelihoods"] = {H_i.qid: logL_i}
+    formula = None
+
+Step 3: Normalise log-likelihoods into CPT entries:
+    logL_max = max_i(logL_i)
+    LR_i     = exp(logL_i - logL_max)              # ∈ (0, 1]
+    p1_i     = 0.5 + (0.5 - ε) · LR_i              # ∈ [0.5, 1-ε]
+
+Step 4: For each H_i, emit an IR `infer` strategy:
+    premises                  = [H_i.qid]
+    conclusion                = ComparisonResult.qid
+    conditional_probabilities = [0.5, p1_i]        # length 2 (k=1)
+    metadata["bayes"]["log_likelihood"] = logL_i
+
+Step 5: If |H| ≥ 2 and exclusivity == "pairwise_contradiction":
+    For each unordered pair (H_i, H_j):
+        if no existing contradict(H_i, H_j) operator: emit one
+        metadata["bayes"]["auto_generated_by"] = "likelihood:<cmp_qid>"
+```
+
+The CPT shape `[0.5, p1_i]` is read by existing `gaia/bp/lowering.py:317` (`StrategyType.INFER` branch), which emits a `CONDITIONAL` factor with this CPT. No new lowering code needed at the BP layer.
+
+### 4.3 Why `[0.5, p1_i]` is the right CPT
+
+- `cpt[0] = P(cmp_result=1 | H_i=0) = 0.5` — neutral. When H_i is false, the comparison-result has no opinion; other H_j drive belief in cmp_result.
+- `cpt[1] = P(cmp_result=1 | H_i=1) = p1_i` — H_i being true *predicts* the comparison-result is true with probability proportional to LR_i.
+
+With cmp_result clamped to True (its `prior = 1-ε` enters BP via `gaia/bp/factor_graph.py:63` `add_variable` with the Cromwell-bounded prior, equivalent to a soft hard-evidence delta — see `gaia/bp/factor_graph.py:66` `observe()` runtime path for reference), each H_i's posterior multiplies by `LR_i` (relative to the baseline H), preserving the relative likelihood ratios across the H set. The H with maximum logL recovers the strongest update; lesser H's tend to neutral.
+
+**Worked example (Mendel).** With logL_3:1 = −1.2 and logL_null = −5.1: logL_max = −1.2, LR_3:1 = 1.0, LR_null = exp(−3.9) ≈ 0.020. CPT entries: p1_3:1 ≈ 1 − ε, p1_null ≈ 0.510. Two `infer` strategies emitted, both feeding cmp_result. After BP, posterior(H_3:1) / posterior(H_null) ≈ exp(3.9) ≈ 49 — matches the Bayes factor.
+
+**Information loss caveats.**
+- This mapping preserves likelihood *ratios* across H but loses absolute likelihood scale. For v1 this is acceptable — the visible quantity in scientific writing is the Bayes factor (ratio), not the absolute likelihood. Authors needing absolute scale can read `metadata["bayes"]["likelihoods"]` directly off the ComparisonResult.
+- Setting `cpt[0] = 0.5` makes H_i=False contribute nothing to cmp_result. Strong absolute disconfirmation patterns ("under H_i, this data is essentially impossible") propagate only via competition with other H's (LR_i → 0 yields p1_i → 0.5, so H_i loses to its competitors). Authors comparing against an exhaustive null should use `exclusivity="exhaustive_pairwise_complement"` so that H_i's belief is pulled down by other H's gaining mass. v2+ may revisit by allowing per-H absolute disconfirmation factors.
+
+### 4.4 Multi-data accumulation
+
+`likelihood([d_A, d_B], via=M)` sums logL across data points (independence assumption). This is correct for genuinely independent observations. Authors needing joint likelihood (e.g., correlated A/B test) build the joint distribution into the `predict()` distribution — `likelihood()` does not attempt to model correlation.
+
+### 4.5 Noise model handling
+
+If the OBSERVATION carries `metadata["bayes"]["noise"] = Normal(0, σ)`, Step 1c becomes a convolution of D_i with the noise density:
+
+```
+continuous D_i:  P(observed | H_i) = ∫ D_i.pdf(x) · Normal(observed; x, σ).pdf dx
+                                   (scipy.integrate.quad over D_i.support())
+
+discrete D_i:    P(observed | H_i) = Σ_{x ∈ D_i.support()} D_i.pmf(x) · Normal(observed; x, σ).pdf
+                                   (finite sum — Binomial, Poisson all have bounded effective support)
+```
+
+For v1: only `Normal` additive noise is supported. For other noise shapes, authors use the `precomputed=` escape hatch on `likelihood()`:
+
+```python
+my_logL = {H_3_1.qid: -2.34, H_null.qid: -57.2}
+likelihood(data, via=M, precomputed=my_logL)   # bypasses scipy entirely
+```
+
+### 4.6 Auto-exclusivity policy
+
+`likelihood()` defaults to `exclusivity="pairwise_contradiction"`. Other values:
+
+| Value | Behaviour |
+|---|---|
+| `"pairwise_contradiction"` (default) | Auto-emit CONTRADICTION pairwise for |H| ≥ 2. "At most one true" — fits typical model-comparison semantics. |
+| `"exhaustive_pairwise_complement"` | Auto-emit COMPLEMENT for |H| = 2 (XOR — exactly one true). For |H| ≥ 3, emit pairwise CONTRADICTION + a DISJUNCTION clamped True. |
+| `"none"` | Emit no exclusivity factors. Author has full responsibility for inter-H constraints. |
+
+Auto-emitted operators carry `metadata["bayes"]["auto_generated_by"]` for reviewer traceability and for `gaia migrate-` tooling.
+
+If the author has already written `contradict(H_i, H_j)` (or `equal()`, etc.), the lowering deduplicates by pair-hash before emitting.
+
+---
+
+## 5. Extension Points (v2+)
+
+The following are **out of v1 scope** but the v1 architecture preserves clean extension slots for them:
+
+### 5.1 Composite (range) hypotheses
+
+PR 505's grounding pass already supports `forall(theta_i ∈ grid, body)`. v2 reuses it:
+
+```python
+H_range = claim(formula=And(theta > 0.5, theta < 0.9), grid=np.linspace(0.5, 0.9, 20))
+likelihood(data, via=predict({H_range, H_null}, ...))
+```
+
+The compiler grounds H_range into 20 atomic point hypotheses, each running through v1's path, then aggregates their belief via DISJUNCTION. **DSL surface unchanged.**
+
+v1 raises `NotYetSupportedError` if a non-PARAMETER `formula` is encountered, with a "this requires v2 grounding extension" hint.
+
+### 5.2 Posterior backends (PyMC / Stan / NumPyro)
+
+`gaia.lang.bayes.adapters/` is the slot. The Distribution Protocol's `.logpmf/.logpdf` is the swappable surface — a `pymc_backend` can override these to perform NUTS/HMC posterior integration internally. The DSL never sees the backend choice; it appears as `Distribution.backend` config.
+
+### 5.3 Custom noise models
+
+`observation(noise=...)` accepts arbitrary `Distribution` objects in v2. v1 only supports Normal additive; authors needing more route through `likelihood(precomputed=...)`.
+
+### 5.4 Hierarchical / latent-variable models
+
+PR 505's quantifier (`forall`) + Variable mechanism already expresses hierarchy at the lifted layer. v2 adds `predict(latent=...)` to mark variables as marginalisation targets; the grounding pass then expands them.
+
+### 5.5 Multi-observation accumulation across packages
+
+Already supported in v1 — author writes multiple `likelihood()` calls referencing the same H set, each producing a separate ComparisonResult. BP composes the evidence automatically.
+
+### 5.6 Out-of-scope in any release
+
+- Decision-theoretic primitives (utility, action selection)
+- Frequentist hypothesis testing (p-values, CIs, NHST) — Gaia is Bayesian-native
+- Causal interventions (do-calculus, counterfactuals) — PR 505 reserves `causes()` predicate; semantics in v0.6+
+
+---
+
+## 6. Error Handling and `gaia check` Integration
+
+### 6.1 Compile-time hard errors
+
+| Trigger | Error | Source |
+|---|---|---|
+| Distribution param Variable unbound under H | `BindingError: <var.symbol> is unbound under <H.qid>` | `predict.lower()` |
+| H's `formula` is not a PARAMETER shape (`Equals(var, const)`) | `HypothesisShapeError` | `likelihood.lower()` Step 1 |
+| `observation()` value type mismatches Variable domain | `DomainTypeError` | PR 505's existing type check |
+| Distribution param physically out of range (e.g. Binomial.p > 1) | `ValueError` | `Distribution.__init__` |
+| Empty H set passed to `predict()` or `likelihood()` | `ValueError: empty hypothesis set` | `predict.__init__` |
+
+### 6.2 Compile-time warnings (non-blocking)
+
+- `predict({H1, H2})` without explicit `contradict()`: warn + auto-emit (per §4.6).
+- `observation(noise=Normal(0, σ))` with σ ≫ predict's distribution scale: warn `"noise dominates signal — likelihood may be uninformative"`.
+- Some `logL_i = -inf`: warn + force `p1_i = 0.5` (neutral) so that H is not driven to zero by a degenerate model evaluation.
+
+### 6.3 New `gaia check` rules
+
+| Rule | Description |
+|---|---|
+| `bayes:dangling-prediction` | A `predict()` PredictiveModel never referenced by `likelihood()`. |
+| `bayes:unobserved-prediction-target` | `predict()` observable has no matching `observation()` and is not imported from another package. |
+| `bayes:hypothesis-prior-coherence` | Dispatch on `exclusivity` mode: for `pairwise_contradiction`, error if Σ prior(H_i) > 1; for `exhaustive_pairwise_complement`, error if Σ prior(H_i) ≠ 1 (within ε). |
+| `bayes:likelihood-without-data` | `likelihood()` references an OBSERVATION with no value bound. |
+
+Existing `gaia check` machinery (factor coherence, double-prior conflict) remains unchanged.
+
+### 6.4 Error message standard
+
+Every bayes-module error MUST include:
+
+1. The Knowledge label / qid involved.
+2. The Variable symbol involved (where applicable).
+3. A "fix hint" subclause naming the missing or conflicting construct.
+
+Example: `BindingError: Variable 'theta' (gaia.bayes:mendel::theta) is unbound under hypothesis 'gaia.bayes:mendel::H_3_1'. Fix: add 'parameter(theta, <value>)' before the predict() call.`
+
+---
+
+## 7. Testing Strategy
+
+### 7.1 Test layout
+
+```
+tests/gaia/lang/bayes/
+├── unit/
+│   ├── test_distributions.py      # logpmf/logpdf vs scipy.stats reference
+│   ├── test_predict.py            # PredictiveModel construction, binding resolution
+│   ├── test_observe.py            # OBSERVATION + noise metadata
+│   └── test_likelihood.py         # logL, CPT normalisation, exclusivity policies
+├── compiler/
+│   ├── test_lower_predict.py      # PredictiveModel → IR atom
+│   ├── test_lower_likelihood.py   # ComparisonResult + N infer strategies + auto-CONTRADICTION
+│   └── test_likelihood_to_bp.py   # IR → factor graph end-to-end
+├── integration/
+│   ├── test_mendel_3to1.py        # Canonical full-pipeline reference
+│   ├── test_galileo_lunar.py      # Normal(μ, σ) measurement scenario
+│   ├── test_multi_h.py            # 3+ H comparison, exclusivity enforced
+│   ├── test_ab_test.py            # Multi-data logL accumulation
+│   └── test_external_h_import.py  # Cross-package H reference
+└── check/
+    └── test_gaia_check_bayes.py   # Each §6.3 rule's positive/negative cases
+```
+
+### 7.2 Property-based invariants
+
+| Invariant | Verification |
+|---|---|
+| `argmax_i(posterior_i)` == `argmax_i(logL_i)` after BP | Random N H + random data, hypothesis library |
+| `likelihood([d_A]) + likelihood([d_B])` ≡ `likelihood([d_A, d_B])` (up to ε) | Two-path equivalence test |
+| All BP outputs ∈ (ε, 1-ε) (Cromwell) | Iterate over integration cases |
+| Posterior monotonic with iter count, eventually stable | BP convergence smoke test |
+
+### 7.3 What **not** to test
+
+- scipy.stats numerical correctness (not our concern).
+- Exact iteration counts for BP convergence (fragile).
+- Error message string contents (only error class).
+
+### 7.4 Mendel as the golden reference
+
+`test_mendel_3to1` is the canonical end-to-end test. Failing it = bayes module is broken. Doubles as the executable example in `docs/foundations/gaia-lang/bayes.md`.
+
+```python
+def test_mendel_full_pipeline():
+    pkg = build_mendel_package()
+    ir = compile(pkg)
+    fg = lower(ir)
+    beliefs = run_bp(fg)
+    assert beliefs[H_3_1.qid] > 0.99
+    assert beliefs[H_null.qid] < 0.01
+    assert beliefs[cmp_result.qid] > 0.99
+```
+
+### 7.5 Performance smoke
+
+- N=10 H, 10 data points: BP converges <100 ms on dev hardware.
+- 100 OBSERVATION claims, 10 H: full compile + BP <1 s.
+
+Not a benchmark, just regression detection for the auto-exclusivity O(N²) factor count.
+
+---
+
+## 8. Migration and Coexistence
+
+### 8.1 `evidence()` → deletion
+
+PR #506 has not merged and no first-party package consumes `evidence()`. **The bayes module PR includes evidence-verb deletion** — no deprecation alias.
+
+PR #506 will be closed with the disposition:
+
+> Superseded by `gaia.lang.bayes` module (spec: `docs/specs/2026-05-04-bayes-module-design.md`). The module subsumes `evidence()`'s role with a structurally cleaner `predict / likelihood` decomposition.
+
+### 8.2 `gaia.stats` → `gaia.lang.bayes.distributions`
+
+- v0.6: New canonical location is `gaia.lang.bayes.distributions`. `gaia.stats` import paths emit `DeprecationWarning`.
+- v0.7: Delete `gaia.stats`.
+
+Migration tool: `gaia migrate-bayes` rewrites `from gaia.stats import ...` to `from gaia.lang.bayes import ...`. Same framework as PR 505's `gaia migrate-formula`.
+
+### 8.3 Documentation migration
+
+| Doc | Action |
+|---|---|
+| `docs/foundations/gaia-lang/dsl.md` `evidence` / `infer` sections | Replace `evidence` text with bayes-module overview pointer; keep `infer` (low-level escape hatch). |
+| `docs/foundations/gaia-lang/bayes.md` | **NEW** — canonical foundation document for the bayes module. Mirrors §3–§4 of this spec, scaled to authoring tutorial. |
+| `docs/specs/2026-04-23-gaia-foundation-spec.md` §11.3 (evidence) | Mark `[superseded by bayes module]`, redirect to this spec. |
+| `docs/foundations/bp/potentials.md` | No change — BP layer untouched. |
+
+### 8.4 Coexistence with `infer` and `associate`
+
+`gaia check` adds a lint:
+
+> `bayes:infer-likelihood-overlap`: An (H, observable) pair has both an `infer()` strategy and a `bayes.likelihood()` factor. Pick one; they are not additive.
+
+`associate()` is orthogonal (symmetric correlation) and untouched.
+
+---
+
+## 9. Implementation Milestones
+
+Three independent PR slices, ordered by dependency. Each independently shippable.
+
+### Milestone A — Distribution module + protocol
+
+- Move `gaia/stats.py` → `gaia/lang/bayes/distributions/`.
+- Add `Distribution` Protocol + scipy backend.
+- `gaia.stats` becomes a deprecation shim.
+- Tests: distribution literals, logpmf/logpdf parity with scipy.
+
+### Milestone B — `predict()` + `likelihood()` + lowering
+
+- `gaia/lang/bayes/runtime/prediction.py`, `comparison.py` — Knowledge subclasses.
+- `gaia/lang/bayes/verbs/predict.py`, `likelihood.py` — DSL surface.
+- `gaia/lang/bayes/compiler/lower.py` — Lang→IR lowering per §4.
+- Extend `observation()` (PR 505) with `noise=` parameter.
+- Tests: §7.1 unit + compiler + integration.
+
+### Milestone C — `evidence()` deletion + docs + migration tool
+
+- Delete `gaia.lang.dsl.evidence_verb` and tests.
+- Close PR #506.
+- Add `gaia migrate-bayes` codemod (modelled on PR 505 §8.2).
+- Write `docs/foundations/gaia-lang/bayes.md`.
+- Update `docs/foundations/gaia-lang/dsl.md` evidence section.
+
+Each milestone goes through `writing-plans` skill independently for detailed task breakdown.
+
+**Cross-milestone reminder:** `gaia.stats` deprecation in Milestone A implies a v0.7 cleanup ticket to delete the shim. Track in the v0.7 release checklist; do not forget.
+
+---
+
+## 10. Open Questions
+
+These are not blocking the design but flagged for implementation discussion:
+
+1. **`likelihood(..., exclusivity=...)` parameter shape.** Should it accept a string enum (proposed) or be split into multiple kwargs (`exclusive=True`, `exhaustive=False`)? String is more compact; kwargs is more discoverable in IDEs.
+
+2. **Naming: `observation()` vs `observe()`.** PR 505 introduces `observation()` (noun). Some authors may prefer the verb `observe()`. Both can coexist as aliases; default in docs to be decided.
+
+3. **Cross-package PredictiveModel reuse.** A package can `import M from upstream_pkg` and write `likelihood(my_data, via=M)`. The Variable bindings on M's distribution come from upstream — needs a check that those bindings resolve in the consuming package's H set. v1 may be conservative (require all H to be local) and lift in v2.
+
+4. **`exclusivity="exhaustive"` for |H|=3+.** Pairwise CONTRADICTION + clamped DISJUNCTION is correct but emits `O(N²)` factors. A multi-variable "exactly-one" Operator would be cleaner but is a new IR primitive. Defer until N=10+ scenarios actually appear.
+
+5. **Backend selection ergonomics for v2+.** Per-Distribution `.backend = "pymc"` vs a global `gaia.bayes.set_backend("pymc")` config. Punt to v2.
+
+---
+
+## 11. Acceptance Criteria
+
+The design is implemented when:
+
+1. `from gaia.lang import bayes` exposes `predict / likelihood / Binomial / Normal / Beta / Poisson / ...`.
+2. The Mendel pipeline test (§7.4) passes with H_3_1 posterior > 0.99.
+3. PR #506 is closed and `gaia.lang.dsl.evidence_verb` is removed.
+4. `gaia check` reports each of the four `bayes:*` rules in `tests/gaia/lang/bayes/check/`.
+5. `docs/foundations/gaia-lang/bayes.md` exists and its code examples are exercised in CI.
+6. No new `FactorType` is added to `gaia/bp/factor_graph.py`.
+7. No new `OperatorType` is added to `gaia/ir/operator.py`.
+8. `gaia.stats` import emits `DeprecationWarning` and continues to function for one minor release.
+9. The property `argmax_i(posterior_i) == argmax_i(logL_i)` holds across the property-based test suite (random N H + random data).
+
+---
+
+## 12. References
+
+- PR 505 (claim formula schema design): `docs/specs/2026-05-04-claim-formula-schema-design.md`
+- PR 506 (evidence verb — superseded): `gaia/lang/dsl/evidence_verb.py` on branch `codex/evidence-verb`
+- BP factor types: `gaia/bp/factor_graph.py:26`
+- IR operators: `gaia/ir/operator.py:14`
+- IR strategies: `gaia/ir/strategy.py`
+- BP lowering: `gaia/bp/lowering.py`
+- Foundation spec: `docs/specs/2026-04-23-gaia-foundation-spec.md` §11

--- a/docs/specs/2026-05-04-bayes-module-design.md
+++ b/docs/specs/2026-05-04-bayes-module-design.md
@@ -315,7 +315,22 @@ posterior(H_a) / posterior(H_b)
   ≈ prior(H_a) / prior(H_b) · exp(logL_a - logL_b)
 ```
 
-within Cromwell clamp. The default `pairwise_contradiction` mode is weaker ("at most one true") and can leave residual mass on "none of the above"; it preserves ordering among alternatives but is not a strict normalized model-comparison posterior. Authors who need posterior odds to equal Bayes-factor-weighted prior odds should use `exclusivity="exhaustive_pairwise_complement"` when the H set is exhaustive.
+within Cromwell clamp. The default `pairwise_contradiction` mode is weaker ("at most one true") and can leave residual mass on "none of the above"; it preserves pairwise odds among the listed alternatives but is not a strict normalized model-comparison posterior over only those alternatives. Authors who need posterior marginals to sum over an exhaustive H set should use `exclusivity="exhaustive_pairwise_complement"` when the H set is exhaustive.
+
+**⚠️ Default exclusivity caveat — empirically verified.** Running the Mendel example (logL_3:1 = −1.2, logL_null = −5.1, true BF ≈ 49) against the current `gaia.bp` engine yields:
+
+| `exclusivity` mode | exact posterior(H_3:1) | exact posterior(H_null) | exact posterior odds | BF odds? |
+|---|---|---|---|---|
+| `"pairwise_contradiction"` (default) | 0.657 | 0.014 | **≈ 46.9** | **Yes — within Cromwell clamp** |
+| `"exhaustive_pairwise_complement"` | 0.978 | 0.021 | **≈ 46.9** | **Yes — within Cromwell clamp** |
+
+The difference under the default mode is in the marginal probabilities, not in the pairwise odds: "at most one true" leaves residual belief mass on "neither H explains the data", which lowers both H marginals while the shared `p0` factors cancel in their ratio. Textbook Bayes-factor posterior odds are still recovered up to Cromwell clamp; exhaustive mode is needed when the H set should consume the full posterior mass over the compared alternatives.
+
+**Guidance for authors:**
+
+- If you are comparing a small number of point hypotheses and do **not** believe the set is exhaustive (the most scientifically cautious default), keep `"pairwise_contradiction"`. Report pairwise odds or ordering among H's, but do not describe the listed H marginals as a normalized exhaustive posterior.
+- If your H set is genuinely exhaustive (e.g., Mendel 3:1 vs 1:1 segregation under a binary-mechanism framing), pass `exclusivity="exhaustive_pairwise_complement"` explicitly. The spec intentionally requires this to be opt-in so authors do not accidentally misstate epistemic coverage.
+- The `gaia check` rule `bayes:hypothesis-prior-coherence` (§6.3) already enforces prior-sum invariants per mode; reviewers should treat a comparison with normalized-posterior claims and no explicit `exclusivity=` as a finding.
 
 **Worked example (Mendel).** With logL_3:1 = −1.2 and logL_null = −5.1: logL_max = −1.2, LR_3:1 = 1.0, LR_null = exp(−3.9) ≈ 0.020. CPT entries: `p1_3:1 ≈ 1 − ε`, `p1_null ≈ 0.020`. Two `infer` strategies are emitted, both feeding cmp_result, with a shared `p0=0.5`. Under exhaustive two-H comparison, the posterior odds are ≈47.5 after Cromwell clamp (unclamped Bayes factor ≈49), which matches the intended likelihood-ratio semantics up to clamp.
 
@@ -494,8 +509,10 @@ def test_mendel_full_pipeline():
     ir = compile(pkg)
     fg = lower(ir)
     beliefs = run_bp(fg)
-    assert beliefs[H_3_1.qid] > 0.99
-    assert beliefs[H_null.qid] < 0.01
+    odds = beliefs[H_3_1.qid] / beliefs[H_null.qid]
+    assert odds == pytest.approx(49, rel=0.1)
+    assert beliefs[H_3_1.qid] > 0.95
+    assert beliefs[H_null.qid] < 0.03
     assert beliefs[cmp_result.qid] > 0.99
 ```
 
@@ -597,7 +614,7 @@ These are not blocking the design but flagged for implementation discussion:
 The design is implemented when:
 
 1. `from gaia.lang import bayes` exposes `predict / likelihood / Binomial / Normal / Beta / Poisson / ...`.
-2. The Mendel pipeline test (§7.4) passes with H_3_1 posterior > 0.99.
+2. The Mendel pipeline test (§7.4) passes with posterior odds matching the Bayes factor (≈49) and H_3_1 posterior in the corrected exhaustive range (>0.95, not the obsolete >0.99 threshold).
 3. PR #506 is closed and `gaia.lang.dsl.evidence_verb` is removed.
 4. `gaia check` reports each of the four `bayes:*` rules in `tests/gaia/lang/bayes/check/`.
 5. `docs/foundations/gaia-lang/bayes.md` exists and its code examples are exercised in CI.

--- a/docs/specs/2026-05-04-bayes-module-design.md
+++ b/docs/specs/2026-05-04-bayes-module-design.md
@@ -4,7 +4,7 @@
 > **Branch:** `feat/bayes-module-design` (off `main`)
 > **Target release:** v0.6 (built on v0.5 foundation + PR 505 lifted Lang)
 > **Date:** 2026-05-04
-> **Scope:** Replacement of the Correlate `evidence()` verb with a structured `gaia.lang.bayes` module exposing `predict / observe / likelihood`.
+> **Scope:** Replacement of the Correlate `evidence()` verb with a structured `gaia.lang.bayes` module exposing `predict / likelihood` plus distribution literals.
 > **Supersedes:** PR #506 (`evidence()` verb). PR #506 will be closed without merge.
 > **Depends on:** PR #505 (claim formula schema — Variable / Domain / Formula AST / `parameter()` / `observation()` sugar).
 
@@ -45,13 +45,13 @@ Five atoms, each independently expressible:
 | Likelihood computation | `likelihood(data, via=M)` | yes — ComparisonResult claim |
 | Belief update | (lowering produces BP factors) | no — structural |
 
-This spec defines a `gaia.lang.bayes` module with three new verbs (`predict`, `likelihood`, plus distribution literals), reusing PR 505's `parameter()` / `observation()` for the hypothesis/observation atoms.
+This spec defines a `gaia.lang.bayes` module with two new verbs (`predict`, `likelihood`) plus distribution literals, reusing PR 505's `parameter()` / `observation()` for the hypothesis/observation atoms.
 
 ### 0.3 First-principles position
 
 | Principle | How it lands |
 |---|---|
-| **DSL surface mirrors paper narrative.** | `predict / observe / likelihood` is the standard three-step paper method. |
+| **DSL surface mirrors paper narrative.** | `predict / observation / likelihood` is the standard three-step paper method. |
 | **Each atom is a structured Claim, reviewable in isolation.** | All four user-facing artifacts are Knowledge nodes carrying typed metadata. |
 | **Composite hypotheses, multi-H, parameter priors are special cases of the same framework, not new verbs.** | Composite H is a formula-shape change (PR 505 grounding pass). Multi-H = expanding the H set passed to `predict`. Parameter prior = backend extension on Distribution. |
 | **Mature ecosystems plug in via Distribution backend.** | scipy.stats is the v1 default backend; PyMC / Stan / NumPyro are v2+ adapter slots that extend `Distribution.logpmf/logpdf` without changing the DSL. |
@@ -89,7 +89,7 @@ This spec defines a `gaia.lang.bayes` module with three new verbs (`predict`, `l
 - **Replaces** `evidence()` from PR #506 (deleted, not deprecated; user count = 0).
 - **Coexists with** `infer()` (low-level escape hatch, hand-written CPT) and `associate()` (symmetric correlation — orthogonal problem).
 - **Depends on** PR 505's Variable / Formula AST / `parameter()` / `observation()`.
-- **Single new hard dependency:** `scipy` (already transitively in dep graph).
+- **Single new hard dependency:** `scipy` (must be added as a direct runtime dependency; do not rely on optional transitive dependencies).
 - **No IR schema changes. No new FactorType.**
 
 ### 1.2 New `metadata` well-known keys
@@ -152,7 +152,7 @@ bayes.Binomial(n=n, p=theta)
 
 | Existing | Action |
 |---|---|
-| `gaia.stats.DistributionLiteral / Binomial / Normal / ...` (PR 506) | Move to `gaia.lang.bayes.distributions`. `gaia.stats` becomes a deprecation shim for one minor version, then deleted. |
+| Distribution literals | Implement directly in `gaia.lang.bayes.distributions`. Do **not** add a `gaia.stats` compatibility shim: PR #506 is unmerged and current `main` has no public `gaia.stats` API to migrate. |
 | PR 505's `parameter()` / `observation()` sugar | Stay at `gaia.lang.dsl` root; bayes module imports and uses them. |
 | Correlate `infer` / `associate` | Stay. `infer` = "I hand-wrote the CPT"; `bayes.likelihood` = "I have a model and observed value, kernel computes the CPT". |
 | Correlate `evidence` (PR 506) | **Delete in same PR as bayes module.** PR #506 closes without merge. |
@@ -285,12 +285,13 @@ Step 2: Create ComparisonResult Knowledge:
 Step 3: Normalise log-likelihoods into CPT entries:
     logL_max = max_i(logL_i)
     LR_i     = exp(logL_i - logL_max)              # ∈ (0, 1]
-    p1_i     = 0.5 + (0.5 - ε) · LR_i              # ∈ [0.5, 1-ε]
+    p0_i     = 0.5                                 # shared neutral baseline
+    p1_i     = clamp((1 - ε) · LR_i)               # ∈ [ε, 1-ε]
 
-Step 4: For each H_i, emit an IR `infer` strategy:
+Step 4: For each H_i, emit an IR `infer` strategy plus its parameter record:
     premises                  = [H_i.qid]
     conclusion                = ComparisonResult.qid
-    conditional_probabilities = [0.5, p1_i]        # length 2 (k=1)
+    StrategyParamRecord.conditional_probabilities = [p0_i, p1_i]
     metadata["bayes"]["log_likelihood"] = logL_i
 
 Step 5: If |H| ≥ 2 and exclusivity == "pairwise_contradiction":
@@ -299,20 +300,28 @@ Step 5: If |H| ≥ 2 and exclusivity == "pairwise_contradiction":
         metadata["bayes"]["auto_generated_by"] = "likelihood:<cmp_qid>"
 ```
 
-The CPT shape `[0.5, p1_i]` is read by existing `gaia/bp/lowering.py:317` (`StrategyType.INFER` branch), which emits a `CONDITIONAL` factor with this CPT. No new lowering code needed at the BP layer.
+The CPT shape `[p0_i, p1_i]` is passed through the existing parameterization channel (`StrategyParamRecord.conditional_probabilities`, or the runtime `strategy_conditional_params` map) and is read by existing `gaia/bp/lowering.py:317` (`StrategyType.INFER` branch), which emits a `CONDITIONAL` factor with this CPT. Do not store this numeric CPT only in `Strategy.metadata`; current lowering does not read strategy metadata for infer parameters. No new lowering code is needed at the BP layer.
 
-### 4.3 Why `[0.5, p1_i]` is the right CPT
+### 4.3 Why `[p0_i, p1_i]` is the right CPT
 
-- `cpt[0] = P(cmp_result=1 | H_i=0) = 0.5` — neutral. When H_i is false, the comparison-result has no opinion; other H_j drive belief in cmp_result.
-- `cpt[1] = P(cmp_result=1 | H_i=1) = p1_i` — H_i being true *predicts* the comparison-result is true with probability proportional to LR_i.
+- `cpt[0] = P(cmp_result=1 | H_i=0) = p0_i = 0.5` — shared neutral baseline. When H_i is false, this factor contributes the same constant for every hypothesis.
+- `cpt[1] = P(cmp_result=1 | H_i=1) = p1_i` — proportional to `LR_i = exp(logL_i - logL_max)`, Cromwell-clamped.
 
-With cmp_result clamped to True (its `prior = 1-ε` enters BP via `gaia/bp/factor_graph.py:63` `add_variable` with the Cromwell-bounded prior, equivalent to a soft hard-evidence delta — see `gaia/bp/factor_graph.py:66` `observe()` runtime path for reference), each H_i's posterior multiplies by `LR_i` (relative to the baseline H), preserving the relative likelihood ratios across the H set. The H with maximum logL recovers the strongest update; lesser H's tend to neutral.
+With cmp_result clamped to True (its `prior = 1-ε` enters BP via `gaia/bp/factor_graph.py:63` `add_variable` with the Cromwell-bounded prior, equivalent to a soft hard-evidence delta — see `gaia/bp/factor_graph.py:66` `observe()` runtime path for reference), the shared `p0_i=0.5` terms cancel when comparing mutually exclusive alternatives. Under an exhaustive two-H comparison, posterior odds obey:
 
-**Worked example (Mendel).** With logL_3:1 = −1.2 and logL_null = −5.1: logL_max = −1.2, LR_3:1 = 1.0, LR_null = exp(−3.9) ≈ 0.020. CPT entries: p1_3:1 ≈ 1 − ε, p1_null ≈ 0.510. Two `infer` strategies emitted, both feeding cmp_result. After BP, posterior(H_3:1) / posterior(H_null) ≈ exp(3.9) ≈ 49 — matches the Bayes factor.
+```
+posterior(H_a) / posterior(H_b)
+  ≈ prior(H_a) / prior(H_b) · p1_a / p1_b
+  ≈ prior(H_a) / prior(H_b) · exp(logL_a - logL_b)
+```
+
+within Cromwell clamp. The default `pairwise_contradiction` mode is weaker ("at most one true") and can leave residual mass on "none of the above"; it preserves ordering among alternatives but is not a strict normalized model-comparison posterior. Authors who need posterior odds to equal Bayes-factor-weighted prior odds should use `exclusivity="exhaustive_pairwise_complement"` when the H set is exhaustive.
+
+**Worked example (Mendel).** With logL_3:1 = −1.2 and logL_null = −5.1: logL_max = −1.2, LR_3:1 = 1.0, LR_null = exp(−3.9) ≈ 0.020. CPT entries: `p1_3:1 ≈ 1 − ε`, `p1_null ≈ 0.020`. Two `infer` strategies are emitted, both feeding cmp_result, with a shared `p0=0.5`. Under exhaustive two-H comparison, the posterior odds are ≈47.5 after Cromwell clamp (unclamped Bayes factor ≈49), which matches the intended likelihood-ratio semantics up to clamp.
 
 **Information loss caveats.**
 - This mapping preserves likelihood *ratios* across H but loses absolute likelihood scale. For v1 this is acceptable — the visible quantity in scientific writing is the Bayes factor (ratio), not the absolute likelihood. Authors needing absolute scale can read `metadata["bayes"]["likelihoods"]` directly off the ComparisonResult.
-- Setting `cpt[0] = 0.5` makes H_i=False contribute nothing to cmp_result. Strong absolute disconfirmation patterns ("under H_i, this data is essentially impossible") propagate only via competition with other H's (LR_i → 0 yields p1_i → 0.5, so H_i loses to its competitors). Authors comparing against an exhaustive null should use `exclusivity="exhaustive_pairwise_complement"` so that H_i's belief is pulled down by other H's gaining mass. v2+ may revisit by allowing per-H absolute disconfirmation factors.
+- Cromwell clamp caps extreme Bayes factors at roughly `(1-ε)/ε` per comparison. The raw log-likelihoods remain available in metadata for trace inspection and future exact backends.
 
 ### 4.4 Multi-data accumulation
 
@@ -410,7 +419,7 @@ Already supported in v1 — author writes multiple `likelihood()` calls referenc
 
 - `predict({H1, H2})` without explicit `contradict()`: warn + auto-emit (per §4.6).
 - `observation(noise=Normal(0, σ))` with σ ≫ predict's distribution scale: warn `"noise dominates signal — likelihood may be uninformative"`.
-- Some `logL_i = -inf`: warn + force `p1_i = 0.5` (neutral) so that H is not driven to zero by a degenerate model evaluation.
+- Some `logL_i = -inf`: warn + force `p1_i = ε` after normalization. If all `logL_i = -inf`, raise a hard error because no model assigns support to the data.
 
 ### 6.3 New `gaia check` rules
 
@@ -445,10 +454,10 @@ tests/gaia/lang/bayes/
 │   ├── test_distributions.py      # logpmf/logpdf vs scipy.stats reference
 │   ├── test_predict.py            # PredictiveModel construction, binding resolution
 │   ├── test_observe.py            # OBSERVATION + noise metadata
-│   └── test_likelihood.py         # logL, CPT normalisation, exclusivity policies
+│   └── test_likelihood.py         # logL, StrategyParamRecord CPTs, exclusivity policies
 ├── compiler/
 │   ├── test_lower_predict.py      # PredictiveModel → IR atom
-│   ├── test_lower_likelihood.py   # ComparisonResult + N infer strategies + auto-CONTRADICTION
+│   ├── test_lower_likelihood.py   # ComparisonResult + N infer strategies/params + auto-CONTRADICTION
 │   └── test_likelihood_to_bp.py   # IR → factor graph end-to-end
 ├── integration/
 │   ├── test_mendel_3to1.py        # Canonical full-pipeline reference
@@ -464,7 +473,7 @@ tests/gaia/lang/bayes/
 
 | Invariant | Verification |
 |---|---|
-| `argmax_i(posterior_i)` == `argmax_i(logL_i)` after BP | Random N H + random data, hypothesis library |
+| With equal priors and exhaustive H, `argmax_i(posterior_i)` == `argmax_i(logL_i)` after BP | Random N H + random data, hypothesis library |
 | `likelihood([d_A]) + likelihood([d_B])` ≡ `likelihood([d_A, d_B])` (up to ε) | Two-path equivalence test |
 | All BP outputs ∈ (ε, 1-ε) (Cromwell) | Iterate over integration cases |
 | Posterior monotonic with iter count, eventually stable | BP convergence smoke test |
@@ -509,12 +518,12 @@ PR #506 will be closed with the disposition:
 
 > Superseded by `gaia.lang.bayes` module (spec: `docs/specs/2026-05-04-bayes-module-design.md`). The module subsumes `evidence()`'s role with a structurally cleaner `predict / likelihood` decomposition.
 
-### 8.2 `gaia.stats` → `gaia.lang.bayes.distributions`
+### 8.2 Distribution import path
 
-- v0.6: New canonical location is `gaia.lang.bayes.distributions`. `gaia.stats` import paths emit `DeprecationWarning`.
-- v0.7: Delete `gaia.stats`.
+- v0.6: New canonical location is `gaia.lang.bayes.distributions` and convenience re-exports from `gaia.lang.bayes`.
+- No `gaia.stats` shim is introduced. PR #506 is unmerged, current `main` has no `gaia.stats`, and the stated migration policy for `evidence()` is deletion without deprecation.
 
-Migration tool: `gaia migrate-bayes` rewrites `from gaia.stats import ...` to `from gaia.lang.bayes import ...`. Same framework as PR 505's `gaia migrate-formula`.
+No `gaia migrate-bayes` command is required for v1 unless a later release creates a public import path that actually needs migration.
 
 ### 8.3 Documentation migration
 
@@ -541,9 +550,9 @@ Three independent PR slices, ordered by dependency. Each independently shippable
 
 ### Milestone A — Distribution module + protocol
 
-- Move `gaia/stats.py` → `gaia/lang/bayes/distributions/`.
+- Add `gaia/lang/bayes/distributions/`.
 - Add `Distribution` Protocol + scipy backend.
-- `gaia.stats` becomes a deprecation shim.
+- Add `scipy` as a direct runtime dependency in `pyproject.toml`.
 - Tests: distribution literals, logpmf/logpdf parity with scipy.
 
 ### Milestone B — `predict()` + `likelihood()` + lowering
@@ -558,13 +567,12 @@ Three independent PR slices, ordered by dependency. Each independently shippable
 
 - Delete `gaia.lang.dsl.evidence_verb` and tests.
 - Close PR #506.
-- Add `gaia migrate-bayes` codemod (modelled on PR 505 §8.2).
 - Write `docs/foundations/gaia-lang/bayes.md`.
 - Update `docs/foundations/gaia-lang/dsl.md` evidence section.
 
 Each milestone goes through `writing-plans` skill independently for detailed task breakdown.
 
-**Cross-milestone reminder:** `gaia.stats` deprecation in Milestone A implies a v0.7 cleanup ticket to delete the shim. Track in the v0.7 release checklist; do not forget.
+**Cross-milestone reminder:** because no `gaia.stats` shim is created, there is no v0.7 cleanup ticket for that path. Keep migration work limited to actual public APIs.
 
 ---
 
@@ -595,8 +603,8 @@ The design is implemented when:
 5. `docs/foundations/gaia-lang/bayes.md` exists and its code examples are exercised in CI.
 6. No new `FactorType` is added to `gaia/bp/factor_graph.py`.
 7. No new `OperatorType` is added to `gaia/ir/operator.py`.
-8. `gaia.stats` import emits `DeprecationWarning` and continues to function for one minor release.
-9. The property `argmax_i(posterior_i) == argmax_i(logL_i)` holds across the property-based test suite (random N H + random data).
+8. `gaia.stats` is not introduced as a compatibility shim unless a real merged public API later requires it.
+9. With equal priors and exhaustive H, the property `argmax_i(posterior_i) == argmax_i(logL_i)` holds across the property-based test suite (random N H + random data).
 
 ---
 


### PR DESCRIPTION
## Summary

从第一性原理重新设计 Gaia 的"基于数据评价假设"模块。替代 PR #506 的 `evidence()` 动词，给出一个 `gaia.lang.bayes` 模块骨架（`predict` / `likelihood` + scipy-backed distributions），建在 PR #505 的 lifted Lang 基础上（Variable / Formula AST / `parameter()` / `observation()`）。

**核心设计决定：**

- **五个科学原子 → 三个正交动词**：`predict` / `observation()` / `likelihood`，每个是结构化 Claim，review pipeline 可逐步审
- **Distribution 是 Lang-side typed value**（不是 Knowledge 节点），引用 Variable 获得跨包复用。命题是"在 H 下 X 服从这个分布"，载体是 `predict()` 的输出节点
- **Lowering 只用现有 IR 原语**：`likelihood()` 产出 N 个现有 `infer` strategy（每 H 一个，CPT = `[0.5, p1_i]`）+ 自动生成 CONTRADICTION operator 处理多 H 互斥。**不新增 FactorType，不新增 OperatorType**
- **scipy.stats 是 v1 backend**；PyMC / Stan / NumPyro 是 v2+ 的 adapter slot——DSL 接口不改，只换 `Distribution.logpmf/logpdf` 实现
- **Extension space** 明确落点：composite hypotheses（PR 505 grounding pass）、参数先验后验（adapter backend）、hierarchical models（v2+）、多数据累积（v1 已支持）

**替代 PR #506：**

PR #506 用户量 = 0，`evidence()` 直接删，不走 deprecation alias。PR #506 关闭原因："superseded by bayes module"。

## Test plan

这是 spec PR，无代码改动。

- [ ] Reviewer 对每节决定（§3 DSL / §4 lowering / §4.3 CPT 换算公式 / §4.6 auto-exclusivity 策略 / §8.1 evidence 直接删）表态
- [ ] 确认 §4 的 lowering 路径（走 `StrategyType.INFER` → `CONDITIONAL` 因子）跟现有 `gaia/bp/lowering.py:317` 一致
- [ ] 确认 §6.3 的四条 `gaia check` 规则覆盖到位、无 gap
- [ ] 确认 §11 的 9 条 acceptance criteria 可机械验证
- [ ] §10 的 5 个 open questions 讨论处理意见

Spec 通过后，§9 的三个 milestone 分别走 writing-plans skill 拆成独立实施 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)