### PR TITLE
fix(lang): compile Claim prior into IR metadata

### DIFF
--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -167,6 +167,10 @@ def _metadata_to_ir(value: Any, knowledge_map: dict[int, str]) -> Any:
 
 def _knowledge_metadata(k: Knowledge, knowledge_map: dict[int, str]) -> dict[str, Any] | None:
     metadata = dict(k.metadata)
+    prior = getattr(k, "prior", None)
+    if prior is not None and "prior" not in metadata:
+        # priors.py writes metadata["prior"] before compilation; that parameterization wins.
+        metadata["prior"] = prior
     grounding = getattr(k, "grounding", None)
     if grounding is not None:
         metadata["grounding"] = asdict(grounding)

--- a/tests/gaia/lang/test_milestone_a_compile_smoke.py
+++ b/tests/gaia/lang/test_milestone_a_compile_smoke.py
@@ -7,6 +7,7 @@ but no `variable` or `domain` typed entries.
 """
 
 from gaia.lang.compiler.compile import compile_package_artifact
+from gaia.lang.dsl.knowledge import claim
 from gaia.lang.runtime.domain import Domain
 from gaia.lang.runtime.knowledge import Claim, _current_package
 from gaia.lang.runtime.package import CollectedPackage
@@ -42,3 +43,34 @@ def test_package_with_variables_and_domains_compiles_cleanly():
         f"Types in IR: {sorted(types)}"
     )
     assert any(str(k.type) == "claim" for k in knowledges), "no claim found in compiled artifact"
+
+
+def _compile_claim_metadata(make_claim):
+    pkg = CollectedPackage(name="t_prior_smoke", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        make_claim()
+    finally:
+        _current_package.reset(token)
+
+    artifact = compile_package_artifact(pkg)
+    claims = [k for k in artifact.graph.knowledges if str(k.type) == "claim"]
+    assert len(claims) == 1
+    return claims[0].metadata or {}
+
+
+def test_dsl_claim_prior_compiles_to_ir_metadata():
+    metadata = _compile_claim_metadata(lambda: claim("A prior-bearing claim.", prior=0.85))
+    assert metadata["prior"] == 0.85
+
+
+def test_runtime_claim_prior_compiles_to_ir_metadata():
+    metadata = _compile_claim_metadata(lambda: Claim("A prior-bearing claim.", prior=0.85))
+    assert metadata["prior"] == 0.85
+
+
+def test_existing_metadata_prior_overrides_runtime_claim_prior():
+    metadata = _compile_claim_metadata(
+        lambda: Claim("A prior-bearing claim.", prior=0.2, metadata={"prior": 0.85})
+    )
+    assert metadata["prior"] == 0.85


### PR DESCRIPTION
## Summary

Fixes the PR 505 follow-up regression where `claim(..., prior=...)` and `Claim(..., prior=...)` preserved the runtime `Claim.prior` field but no longer serialized that prior into compiled IR metadata.

The compiler now copies runtime `Claim.prior` into IR `metadata["prior"]` when no metadata prior is already present. Existing metadata priors still win, preserving the `priors.py` injection/parameterization path.

## Why

BP lowering reads compiled IR `metadata["prior"]`, not the runtime `Claim.prior` attribute. Without this bridge, author-facing `prior=` silently falls back to the default 0.5 after compilation.

## Tests

- `python -m pytest tests/gaia/lang/test_milestone_a_compile_smoke.py -q`
- `python -m pytest tests/gaia/lang/test_claim_dsl_forwarding.py tests/gaia/lang/test_milestone_a_compile_smoke.py tests/cli/test_compile.py::test_compile_priors_py_injects_metadata_prior tests/test_lowering.py::test_claim_metadata_prior_used_in_lowering -q`
- `python -m pytest tests/gaia/lang -q`
- `python -m pytest tests/cli/test_compile.py -q`
- `python -m pytest tests/test_lowering.py -q`
- `ruff check gaia/lang/compiler/compile.py tests/gaia/lang/test_milestone_a_compile_smoke.py`
- `ruff format --check .`
- `git diff --check origin/v0.5...HEAD`
