### PR TITLE
docs(specs): bayes — verified caveat on default exclusivity posterior compression

### DIFF
--- a/docs/specs/2026-05-04-bayes-module-design.md
+++ b/docs/specs/2026-05-04-bayes-module-design.md
@@ -317,6 +317,21 @@ posterior(H_a) / posterior(H_b)
 
 within Cromwell clamp. The default `pairwise_contradiction` mode is weaker ("at most one true") and can leave residual mass on "none of the above"; it preserves ordering among alternatives but is not a strict normalized model-comparison posterior. Authors who need posterior odds to equal Bayes-factor-weighted prior odds should use `exclusivity="exhaustive_pairwise_complement"` when the H set is exhaustive.
 
+**⚠️ Default exclusivity caveat — empirically verified.** Running BP on the Mendel example (logL_3:1 = −1.2, logL_null = −5.1, true BF ≈ 49) against the current `gaia.bp` engine yields:
+
+| `exclusivity` mode | posterior(H_3:1) | posterior(H_null) | posterior odds | matches BF? |
+|---|---|---|---|---|
+| `"pairwise_contradiction"` (default) | 0.666 | 0.040 | **≈ 16.9** | **No — compressed** |
+| `"exhaustive_pairwise_complement"` | 0.979 | 0.020 | **≈ 49.1** | **Yes — within Cromwell clamp** |
+
+The compression under the default mode is not a bug — "at most one true" leaves ~30% belief mass on "neither H explains the data", which bleeds off posterior from both H's in proportion. Textbook Bayes-factor posterior odds only recover when the H set is declared exhaustive.
+
+**Guidance for authors:**
+
+- If you are comparing a small number of point hypotheses and do **not** believe the set is exhaustive (the most scientifically cautious default), keep `"pairwise_contradiction"`. Report the posterior *ordering* among H's, not the numeric odds. The ordering is always faithful to the likelihood ratios.
+- If your H set is genuinely exhaustive (e.g., Mendel 3:1 vs 1:1 segregation under a binary-mechanism framing), pass `exclusivity="exhaustive_pairwise_complement"` explicitly. The spec intentionally requires this to be opt-in so authors do not accidentally misstate epistemic coverage.
+- The `gaia check` rule `bayes:hypothesis-prior-coherence` (§6.3) already enforces prior-sum invariants per mode; reviewers should treat a comparison with numeric-odds claims and no explicit `exclusivity=` as a finding.
+
 **Worked example (Mendel).** With logL_3:1 = −1.2 and logL_null = −5.1: logL_max = −1.2, LR_3:1 = 1.0, LR_null = exp(−3.9) ≈ 0.020. CPT entries: `p1_3:1 ≈ 1 − ε`, `p1_null ≈ 0.020`. Two `infer` strategies are emitted, both feeding cmp_result, with a shared `p0=0.5`. Under exhaustive two-H comparison, the posterior odds are ≈47.5 after Cromwell clamp (unclamped Bayes factor ≈49), which matches the intended likelihood-ratio semantics up to clamp.
 
 **Information loss caveats.**


### PR DESCRIPTION
Stacked on #509 (merged). Adds an empirically-verified caveat to §4.3 about how the default `exclusivity="pairwise_contradiction"` mode compresses posterior odds relative to textbook Bayes factors.

## What I verified

Built the Mendel factor graph (logL_3:1 = -1.2 vs logL_null = -5.1, true BF ≈ 49) and ran `gaia.bp.bp.BeliefPropagation` directly:

| `exclusivity` mode | posterior(H_3:1) | posterior(H_null) | posterior odds |
|---|---|---|---|
| `pairwise_contradiction` (default) | 0.666 | 0.040 | **≈ 16.9** |
| `exhaustive_pairwise_complement` | 0.979 | 0.020 | **≈ 49.1** |

The default mode is mathematically correct ("at most one true" leaves residual mass on "neither H explains the data") but the spec's worked example only cited the exhaustive number (~47.5). A reader could reasonably assume default mode reproduces textbook BF. It doesn't.

## What changes

§4.3 gains an explicit empirically-verified table + author guidance. **Default policy is unchanged** — cautious-by-default remains the right call because most scientific comparisons are not exhaustive.

- Authors wanting textbook-matching numeric odds must opt into `exhaustive_pairwise_complement`.
- `gaia check` should flag numeric-odds claims that lack explicit `exclusivity=` (hinted in §6.3).

## Verification

Reproducer in PR conversation. Spec-only change; no code touched.

🤖 Generated with Claude Code