### PR TITLE
docs(bayes): fix milestone A review issues

### DIFF
--- a/docs/plans/2026-05-05-bayes-milestone-a-distributions.md
+++ b/docs/plans/2026-05-05-bayes-milestone-a-distributions.md
@@ -458,12 +458,12 @@ def test_model_dump_serializes_concrete_params():
 def test_model_dump_skips_deferred_params(theta_deferred):
     """Deferred params are not JSON-serializable; model_dump must omit them
     or replace with a placeholder. We pick: only emit concrete params, and
-    add a parallel `deferred_params: list[str]` field so the IR side can
-    re-resolve them."""
+    add a parallel `deferred_params: dict[str, str]` field so the IR side can
+    re-resolve each parameter slot by Variable symbol."""
     d = _Dummy(params={"a": theta_deferred, "b": 0.5})
     dumped = d.model_dump()
     assert dumped["params"] == {"b": 0.5}
-    assert dumped["deferred_params"] == ["a"]
+    assert dumped["deferred_params"] == {"a": "theta"}
 ```
 
 - [ ] **Step 3: Run tests — verify failure**
@@ -490,7 +490,7 @@ This base class enforces:
 - _deferred_param_names() returns sorted parameter names whose values are
   deferred references
 - _resolved_params() returns {name: float} or raises UnresolvedParameterError
-- model_dump emits only concrete params and a parallel deferred_params list
+- model_dump emits only concrete params and a parallel deferred_params mapping
 """
 
 from __future__ import annotations
@@ -545,6 +545,14 @@ class _BaseDistribution(BaseModel):
             if _is_deferred_reference(value)
         )
 
+    def _deferred_param_symbols(self) -> dict[str, str]:
+        """Map deferred parameter names to the referenced Variable symbol."""
+        return {
+            name: value.symbol
+            for name, value in sorted(self.params.items())
+            if _is_deferred_reference(value)
+        }
+
     def _resolved_params(self) -> dict[str, float]:
         """Return concrete-numeric params, or raise UnresolvedParameterError.
 
@@ -556,23 +564,26 @@ class _BaseDistribution(BaseModel):
         return {name: float(value) for name, value in self.params.items()}
 
     def model_dump(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
-        """Override Pydantic dump: emit concrete params + deferred_params list.
+        """Override Pydantic dump: emit concrete params + deferred_params map.
 
         Deferred references are not JSON-serializable, so we strip them and
-        record their names in a parallel field. Milestone B's compiler reads
-        `deferred_params` to re-bind them before lowering.
+        record each parameter slot's Variable symbol in a parallel field.
+        Milestone B's compiler reads `deferred_params` to re-bind them before
+        lowering.
         """
-        deferred = self._deferred_param_names()
+        deferred = self._deferred_param_symbols()
         concrete = {
             name: value
             for name, value in self.params.items()
             if not _is_deferred_reference(value)
         }
-        return {
+        dumped = {
             "kind": self.kind,
             "params": concrete,
-            "deferred_params": deferred,
         }
+        if deferred:
+            dumped["deferred_params"] = deferred
+        return dumped
 ```
 
 - [ ] **Step 5: Run tests**
@@ -595,7 +606,7 @@ Concrete distributions subclass this. Accepts numeric params or deferred
 references (any object with .symbol: str — duck-typed PR 505 Variable).
 Raises UnresolvedParameterError when methods are called before deferred
 params resolve. model_dump serializes concrete + parallel deferred_params
-list so compiler (Milestone B) can re-bind."
+mapping so compiler (Milestone B) can re-bind each parameter slot."
 ```
 
 ---
@@ -687,4 +698,3 @@ land in v2+ without touching the DSL surface (spec §5.2)."
 ---
 
 **Chunk 1 done.** Foundation in place: scipy dep added, package skeleton, Protocol + DistParam + UnresolvedParameterError, base class with Variable-aware param storage, scipy backend dispatch table. No distributions yet.
-

--- a/docs/specs/2026-05-04-bayes-module-design.md
+++ b/docs/specs/2026-05-04-bayes-module-design.md
@@ -315,22 +315,22 @@ posterior(H_a) / posterior(H_b)
   ≈ prior(H_a) / prior(H_b) · exp(logL_a - logL_b)
 ```
 
-within Cromwell clamp. The default `pairwise_contradiction` mode is weaker ("at most one true") and can leave residual mass on "none of the above"; it preserves ordering among alternatives but is not a strict normalized model-comparison posterior. Authors who need posterior odds to equal Bayes-factor-weighted prior odds should use `exclusivity="exhaustive_pairwise_complement"` when the H set is exhaustive.
+within Cromwell clamp. The default `pairwise_contradiction` mode is weaker ("at most one true") and can leave residual mass on "none of the above"; it preserves pairwise odds among the listed alternatives but is not a strict normalized model-comparison posterior over only those alternatives. Authors who need posterior marginals to sum over an exhaustive H set should use `exclusivity="exhaustive_pairwise_complement"` when the H set is exhaustive.
 
-**⚠️ Default exclusivity caveat — empirically verified.** Running BP on the Mendel example (logL_3:1 = −1.2, logL_null = −5.1, true BF ≈ 49) against the current `gaia.bp` engine yields:
+**⚠️ Default exclusivity caveat — empirically verified.** Running the Mendel example (logL_3:1 = −1.2, logL_null = −5.1, true BF ≈ 49) against the current `gaia.bp` engine yields:
 
-| `exclusivity` mode | posterior(H_3:1) | posterior(H_null) | posterior odds | matches BF? |
+| `exclusivity` mode | exact posterior(H_3:1) | exact posterior(H_null) | exact posterior odds | BF odds? |
 |---|---|---|---|---|
-| `"pairwise_contradiction"` (default) | 0.666 | 0.040 | **≈ 16.9** | **No — compressed** |
-| `"exhaustive_pairwise_complement"` | 0.979 | 0.020 | **≈ 49.1** | **Yes — within Cromwell clamp** |
+| `"pairwise_contradiction"` (default) | 0.657 | 0.014 | **≈ 46.9** | **Yes — within Cromwell clamp** |
+| `"exhaustive_pairwise_complement"` | 0.978 | 0.021 | **≈ 46.9** | **Yes — within Cromwell clamp** |
 
-The compression under the default mode is not a bug — "at most one true" leaves ~30% belief mass on "neither H explains the data", which bleeds off posterior from both H's in proportion. Textbook Bayes-factor posterior odds only recover when the H set is declared exhaustive.
+The difference under the default mode is in the marginal probabilities, not in the pairwise odds: "at most one true" leaves residual belief mass on "neither H explains the data", which lowers both H marginals while the shared `p0` factors cancel in their ratio. Textbook Bayes-factor posterior odds are still recovered up to Cromwell clamp; exhaustive mode is needed when the H set should consume the full posterior mass over the compared alternatives.
 
 **Guidance for authors:**
 
-- If you are comparing a small number of point hypotheses and do **not** believe the set is exhaustive (the most scientifically cautious default), keep `"pairwise_contradiction"`. Report the posterior *ordering* among H's, not the numeric odds. The ordering is always faithful to the likelihood ratios.
+- If you are comparing a small number of point hypotheses and do **not** believe the set is exhaustive (the most scientifically cautious default), keep `"pairwise_contradiction"`. Report pairwise odds or ordering among H's, but do not describe the listed H marginals as a normalized exhaustive posterior.
 - If your H set is genuinely exhaustive (e.g., Mendel 3:1 vs 1:1 segregation under a binary-mechanism framing), pass `exclusivity="exhaustive_pairwise_complement"` explicitly. The spec intentionally requires this to be opt-in so authors do not accidentally misstate epistemic coverage.
-- The `gaia check` rule `bayes:hypothesis-prior-coherence` (§6.3) already enforces prior-sum invariants per mode; reviewers should treat a comparison with numeric-odds claims and no explicit `exclusivity=` as a finding.
+- The `gaia check` rule `bayes:hypothesis-prior-coherence` (§6.3) already enforces prior-sum invariants per mode; reviewers should treat a comparison with normalized-posterior claims and no explicit `exclusivity=` as a finding.
 
 **Worked example (Mendel).** With logL_3:1 = −1.2 and logL_null = −5.1: logL_max = −1.2, LR_3:1 = 1.0, LR_null = exp(−3.9) ≈ 0.020. CPT entries: `p1_3:1 ≈ 1 − ε`, `p1_null ≈ 0.020`. Two `infer` strategies are emitted, both feeding cmp_result, with a shared `p0=0.5`. Under exhaustive two-H comparison, the posterior odds are ≈47.5 after Cromwell clamp (unclamped Bayes factor ≈49), which matches the intended likelihood-ratio semantics up to clamp.
 


### PR DESCRIPTION
## Summary
- correct the Bayes exclusivity caveat with exact current-engine posterior numbers
- clarify that pairwise contradiction preserves pairwise odds but not exhaustive marginal mass
- serialize deferred distribution params as param-to-symbol mappings and omit empty deferred_params
- remove the trailing blank EOF line from the milestone plan

## Verification
- git diff --check
- python exact-inference smoke for Mendel pairwise contradiction/complement odds