### PR TITLE
docs(specs): document binding-conjunction lowering for joint bindings

### DIFF
--- a/docs/specs/2026-05-04-claim-formula-schema-design.md
+++ b/docs/specs/2026-05-04-claim-formula-schema-design.md
@@ -339,6 +339,24 @@ A Claim with `formula=Equals(p, 0.75)` (parameter assertion):
   predicate so renderers and audits can recover the formula shape without
   executing Python.
 
+A Claim with `formula=land(Equals(n, 10), Equals(k, 3), ...)` (joint binding,
+the shape produced by `observation(n=n, k=k, ...)`):
+- Treat as a *binding conjunction*, not a propositional conjunction. The source
+  Claim's IR `Knowledge` remains the single truth variable; **no** orphan
+  formula-atom helpers and **no** `CONJUNCTION` operator are emitted.
+- Each `Equals(var, value)` operand contributes a binding to the source
+  `Knowledge.parameters` and to `metadata.formula_bindings`.
+- Tag `metadata.formula_lowering = "binding_conjunction"` so downstream tooling
+  can distinguish "this Land merely records joint bindings" from "this Land is
+  a propositional connective with truth-bearing operands".
+- Rationale: lowering this shape as a propositional `CONJUNCTION` would inject
+  rigid-operator factors that do not normalize over the source Claim's truth
+  variable, compressing its authored prior under BP. A multi-key
+  `observation(prior=0.95)` would then settle to a posterior strictly below
+  0.95 even with no evidence attached. Joint binding has no such factor —
+  the bindings are recorded as parameter metadata, and the source Claim's
+  prior survives unchanged.
+
 Compound formulas (e.g., `land(equals(...), implies(...))`) lower bottom-up —
 each non-atomic node emits a helper Knowledge plus the matching Operator.
 Atomic predicates nested inside a compound formula may be represented by


### PR DESCRIPTION
## Summary

- Adds §7.1 paragraph documenting the **binding-conjunction** lowering rule used by `observation(n=n, k=k, ...)` and any other top-level `Land(Equals, Equals, ...)` formula.
- Records *why* this shape lowers to bindings-on-source rather than to a propositional `CONJUNCTION`: the rigid CONJUNCTION factor would not normalize over the source Claim's truth variable, compressing its authored prior under BP.
- Closes a Milestone B documentation gap — the lowering itself shipped in #515 (`_is_binding_conjunction` path in `gaia/lang/compiler/lower_formula.py`); the spec just hadn't caught up.

## Test plan

- [ ] Read §7.1 — the new paragraph fits between the single-`Equals` parameter case and the existing "Compound formulas (e.g., `land(equals(...), implies(...))`) lower bottom-up" paragraph
- [ ] Confirm wording matches the runtime behavior verified during PR #515 review (single-binding ✅, multi-binding via `binding_conjunction` ✅)