### PR TITLE
feat(lang): complete formula migration cleanup

### DIFF
--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -203,25 +203,34 @@ If a step feels uncertain, first ask whether the uncertain part should become a 
 
 ## Operators (Deterministic Constraints)
 
-### Propositional expressions
+### Structured formula replacements
 
-Claims can be combined into helper claims with ordinary propositional structure:
-
-| Syntax | Function | Semantics | Review |
-|--------|----------|-----------|--------|
-| `~a` | `not_(a)` | NOT A | no |
-| `a & b` | `and_(a, b)` | A AND B | no |
-| OR shorthand | `or_(a, b)` | A OR B | no |
-
-The OR shorthand is `a | b`.
+For new packages, prefer explicit formula claims when you need a structural
+Boolean expression over existing claims. Wrap referenced claims in `ClaimAtom`
+so the compiler can connect the formula truth variable to the existing IR node.
 
 ```python
-not_classical = ~classical_prediction
-joint_case = evidence_a & evidence_b
-either_mechanism = mech_a | mech_b
+from gaia.lang import ClaimAtom, claim, land, lnot, lor
+
+not_classical = claim(
+    "The classical prediction does not hold.",
+    formula=lnot(ClaimAtom(classical_prediction)),
+)
+joint_case = claim(
+    "Both pieces of evidence hold.",
+    formula=land(ClaimAtom(evidence_a), ClaimAtom(evidence_b)),
+)
+either_mechanism = claim(
+    "At least one mechanism holds.",
+    formula=lor(ClaimAtom(mech_a), ClaimAtom(mech_b)),
+)
 ```
 
-These helpers are structural expression nodes. They do not create review warrants. Python keywords `not`, `and`, and `or` cannot be overloaded; use `~`, `&`, and `|` instead. `Claim` objects intentionally reject Python truth-value checks such as `if claim:`.
+The legacy shortcuts `~a`, `a & b`, `a | b`, `not_(a)`, `and_(...)`, and
+`or_(...)` still compile to structural helper claims, but they now emit
+`DeprecationWarning`. Python keywords `not`, `and`, and `or` still cannot be
+overloaded, and `Claim` objects intentionally reject truth-value checks such as
+`if claim:`.
 
 ### Propositional analysis
 
@@ -268,7 +277,11 @@ one_of = exclusive(conventional_sc, unconventional_sc,
 
 ### v5 compatibility operators
 
-All operators take Knowledge inputs and optional `reason` + `prior` (must be paired: both or neither). Each returns a helper claim.
+The older operator functions remain for existing packages but emit
+`DeprecationWarning`. New packages should use relation verbs for reviewable
+semantic judgments, or formula claims for structural Boolean expressions. The
+compatibility functions take Knowledge inputs and optional `reason` + `prior`
+(must be paired: both or neither), then return a helper claim.
 
 | Function | Semantics | Meaning |
 |----------|-----------|---------|

--- a/docs/foundations/gaia-lang/dsl.md
+++ b/docs/foundations/gaia-lang/dsl.md
@@ -206,17 +206,25 @@ Decorates a Python function as a named action workflow. Calling the function ret
 
 Operators declare deterministic logical constraints between claims. Each function creates an `Operator` (auto-registered) and returns a helper claim usable in further reasoning. For formal definitions and truth tables, see [../gaia-ir/02-gaia-ir.md](../gaia-ir/02-gaia-ir.md), Section 2.
 
-### Propositional Expression Helpers
+### Structured Formula Replacements
 
-Use `~a`, `a & b`, and `a | b` for direct Boolean construction. These return structural helper claims and do not create review warrants.
+Use explicit formula claims for new structural Boolean construction. Referenced
+claims must be wrapped in `ClaimAtom`, which lets the compiler use the existing
+claim's IR node as the formula operand.
 
 ```python
-not_a = ~a          # same as not_(a)
-both = a & b        # same as and_(a, b)
-either = a | b      # same as or_(a, b)
+from gaia.lang import ClaimAtom, claim, land, lnot, lor
+
+not_a = claim("not A", formula=lnot(ClaimAtom(a)))
+both = claim("A and B", formula=land(ClaimAtom(a), ClaimAtom(b)))
+either = claim("A or B", formula=lor(ClaimAtom(a), ClaimAtom(b)))
 ```
 
-The explicit functions `not_(a)`, `and_(a, b, ...)`, and `or_(a, b, ...)` are also exported. Python keywords `not`, `and`, and `or` cannot be overloaded; `Claim.__bool__` raises to prevent accidental Python control-flow truth tests.
+The legacy shortcuts `~a`, `a & b`, `a | b`, `not_(a)`, `and_(a, b, ...)`, and
+`or_(a, b, ...)` remain exported for compatibility but emit
+`DeprecationWarning`. Python keywords `not`, `and`, and `or` cannot be
+overloaded; `Claim.__bool__` raises to prevent accidental Python control-flow
+truth tests.
 
 ### Propositional Analysis Helpers
 
@@ -243,7 +251,10 @@ Each relation returns a reviewable warrant helper claim and compiles to the corr
 
 ### v5 Compatibility Operators
 
-These functions remain for older packages. New v0.5 packages should prefer structural expressions (`~`, `&`, `|`) for direct Boolean construction and relation verbs (`equal`, `contradict`, `exclusive`) for reviewable semantic judgments.
+These functions remain for older packages but emit `DeprecationWarning`. New
+v0.5 packages should prefer formula claims for direct Boolean construction and
+relation verbs (`equal`, `contradict`, `exclusive`) for reviewable semantic
+judgments.
 
 ### `contradiction(a, b, *, reason="", prior=None)`
 

--- a/docs/specs/2026-05-04-claim-formula-schema-design.md
+++ b/docs/specs/2026-05-04-claim-formula-schema-design.md
@@ -454,36 +454,55 @@ This is what eliminates the duplicate-numbers pain: numbers live in Variable def
 
 ### 8.1 What must change
 
-Today's helper-creating DSL functions are subsumed by formula AST:
+Today's helper-creating DSL functions are subsumed by formula AST. When a
+formula refers to an existing claim, wrap the claim in `ClaimAtom(...)`; raw
+`Claim` objects are not formula leaves.
 
 | Today (v0.5) | Tomorrow (v0.6) |
 |---|---|
-| `helper = and_(P, Q)` | `claim(..., formula=land(P, Q))` |
-| `helper = or_(P, Q)` | `claim(..., formula=lor(P, Q))` |
-| `helper = not_(P)` | `claim(..., formula=lnot(P))` |
-| `helper = contradiction(P, Q, prior=0.99)` | `claim(..., formula=lnot(land(P, Q)), prior=0.99)` |
-| `helper = equivalence(P, Q, prior=0.99)` | `claim(..., formula=iff(P, Q), prior=0.99)` |
-| `helper = complement(P, Q)` | `claim(..., formula=lnot(iff(P, Q)))` (XOR) |
-| `helper = disjunction(P, Q, ...)` | `claim(..., formula=lor(P, Q, ...))` |
+| `helper = and_(P, Q)` | `claim(..., formula=land(ClaimAtom(P), ClaimAtom(Q)))` |
+| `helper = or_(P, Q)` | `claim(..., formula=lor(ClaimAtom(P), ClaimAtom(Q)))` |
+| `helper = not_(P)` | `claim(..., formula=lnot(ClaimAtom(P)))` |
+| `helper = contradiction(P, Q, prior=0.99)` | `claim(..., formula=lnot(land(ClaimAtom(P), ClaimAtom(Q))), prior=0.99)` |
+| `helper = equivalence(P, Q, prior=0.99)` | `claim(..., formula=iff(ClaimAtom(P), ClaimAtom(Q)), prior=0.99)` |
+| `helper = complement(P, Q)` | `claim(..., formula=lnot(iff(ClaimAtom(P), ClaimAtom(Q))))` (XOR) |
+| `helper = disjunction(P, Q, ...)` | `claim(..., formula=lor(ClaimAtom(P), ClaimAtom(Q), ...))` |
 
-The IR-level shape produced is **identical**. The migration is purely at the authoring surface.
+The formula replacements preserve the same rigid Boolean semantics, but they are
+not guaranteed to produce byte-for-byte identical IR topology. For example,
+`lnot(land(ClaimAtom(P), ClaimAtom(Q)))` can lower through explicit negation and
+conjunction operators, while the legacy `contradiction(P, Q)` helper still emits
+the old direct contradiction operator. During the deprecation window the legacy
+helpers preserve their old IR shape; new authoring should choose formula claims
+for structural expressions and relation verbs for reviewable semantic judgments.
 
 ### 8.2 Deprecation policy
 
-Recommend keeping the existing functions as deprecated aliases for **one minor version** (v0.6 ships both, v0.7 deletes the aliases):
+The existing functions stay available as deprecated aliases during the v0.5
+transition. They preserve the old IR shape but emit `DeprecationWarning`:
 
 ```python
 def and_(*claims, **kwargs):
-    warnings.warn("and_() is deprecated; use claim(formula=land(...))", DeprecationWarning)
-    # forward to the new lowering
+    warnings.warn(
+        "and_() is deprecated; use claim(formula=land(ClaimAtom(...), ...))",
+        DeprecationWarning,
+    )
+    # preserve legacy helper-claim behavior for compatibility
     ...
 ```
 
-This gives existing packages (Mendel, Galileo, Superconductivity, …) one release cycle to migrate. A migration codemod (AST-level rewrite) is in scope as a follow-up tool.
+This gives existing packages one release cycle to migrate. A migration codemod
+(AST-level rewrite) remains a follow-up tool because preserving custom helper
+labels, prose content, metadata, and review targets requires package-specific
+judgment.
 
 ### 8.3 Scope of migration in this design
 
-The migration codemod is a **separate** workstream. This design ships the new authoring surface and the deprecated aliases; package migration happens incrementally afterward.
+The migration codemod is a **separate** workstream. This design ships the new
+authoring surface and deprecated aliases; package migration happens
+incrementally. The first-party Mendel example now uses structured
+`observation(...)` for its F2 count so the duplicated count values are recorded
+as formula bindings on the source claim.
 
 ## 9. Implementation Milestones
 
@@ -510,8 +529,8 @@ Three independent PR slices, ordered by dependency:
 ### Milestone C — Migration tooling + deprecation
 
 - Wrap `and_/or_/not_/contradiction/equivalence/complement/disjunction` with `DeprecationWarning`
-- Codemod: `gaia migrate-formula <package>` rewrites old DSL calls to new formula form
-- Migrate first-party packages (Mendel, Galileo, Superconductivity) in separate PRs
+- Migrate first-party package surfaces where the formula sugar is lossless (Mendel F2 count observation)
+- Keep automatic codemod as follow-up tooling; do not rewrite helper labels/metadata blindly
 - Update gaia-lang docs
 
 Each milestone is independently shippable. Milestone A introduces no new author-facing surface; B is the user-visible feature; C is migration cleanup.

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
@@ -52,17 +52,32 @@ once the framework separates the ``reliability`` / ``marginal`` / ``belief``
 roles on a Claim. See issue #485 for the design discussion.
 """
 
-from gaia.lang import associate, claim, contradict, derive, equal, exclusive, note, observe
+from gaia.lang import (
+    Nat,
+    Variable,
+    associate,
+    claim,
+    contradict,
+    derive,
+    equal,
+    exclusive,
+    note,
+    observe,
+    observation,
+)
 
 from .probabilities import (
     DOMINANT_COUNT,
     RECESSIVE_COUNT,
+    TOTAL_COUNT,
     mendel_count_association_parameters,
 )
 
 
 association_parameters = mendel_count_association_parameters()
 
+f2_total_count = Variable(symbol="n_f2", domain=Nat, value=TOTAL_COUNT)
+f2_dominant_count = Variable(symbol="k_dominant", domain=Nat, value=DOMINANT_COUNT)
 
 monohybrid_cross_setup = note(
     "单因子杂交实验从两个稳定亲本品系开始：一个亲本稳定表现显性表型，"
@@ -120,9 +135,18 @@ f2_recessive_reappears_observation = observe(
     label="f2_recessive_reappears_observation",
 )
 
+_f2_count_observation_binding = observation(
+    n=f2_total_count,
+    k=f2_dominant_count,
+    describe=(
+        f"F2 计数为 {DOMINANT_COUNT} 个显性表型和 {RECESSIVE_COUNT} 个隐性表型，"
+        f"共 {TOTAL_COUNT} 个个体。"
+    ),
+    label="f2_count_observation",
+)
+
 f2_count_observation = observe(
-    f"F2 计数为 {DOMINANT_COUNT} 个显性表型和 {RECESSIVE_COUNT} 个隐性表型，"
-    f"共 {DOMINANT_COUNT + RECESSIVE_COUNT} 个个体。",
+    _f2_count_observation_binding,
     background=[monohybrid_cross_setup, f2_has_discrete_classes_observation],
     rationale="这是用于贝叶斯点似然比较的 F2 显性/隐性计数数据。",
     label="f2_count_observation",

--- a/gaia/lang/dsl/operators.py
+++ b/gaia/lang/dsl/operators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 from typing import Any
 
 from gaia.ir.parameterization import CROMWELL_EPS
@@ -42,10 +43,23 @@ def _helper_metadata(helper_kind: str, prior: float | None) -> dict:
     return meta
 
 
+def _warn_deprecated_operator(function_name: str, replacement: str) -> None:
+    warnings.warn(
+        f"{function_name}() is deprecated; use {replacement}",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 def contradiction(
     a: Knowledge, b: Knowledge, *, reason: str = "", prior: float | None = None
 ) -> Knowledge:
     """not(A and B). Creates Operator, returns helper claim."""
+    _warn_deprecated_operator(
+        "contradiction",
+        "contradict(a, b, rationale=...) for reviewable relations or "
+        "claim(formula=lnot(land(ClaimAtom(...), ...))) for structural formulas",
+    )
     _validate_reason_prior(reason, prior)
     helper = Knowledge(
         content=f"not_both_true({a.label or 'A'}, {b.label or 'B'})",
@@ -60,6 +74,11 @@ def equivalence(
     a: Knowledge, b: Knowledge, *, reason: str = "", prior: float | None = None
 ) -> Knowledge:
     """A = B. Creates Operator, returns helper claim."""
+    _warn_deprecated_operator(
+        "equivalence",
+        "equal(a, b, rationale=...) for reviewable relations or "
+        "claim(formula=iff(ClaimAtom(...), ClaimAtom(...))) for structural formulas",
+    )
     _validate_reason_prior(reason, prior)
     helper = Knowledge(
         content=f"same_truth({a.label or 'A'}, {b.label or 'B'})",
@@ -74,6 +93,11 @@ def complement(
     a: Knowledge, b: Knowledge, *, reason: str = "", prior: float | None = None
 ) -> Knowledge:
     """A != B (XOR). Creates Operator, returns helper claim."""
+    _warn_deprecated_operator(
+        "complement",
+        "exclusive(a, b, rationale=...) for reviewable relations or "
+        "claim(formula=lnot(iff(ClaimAtom(...), ClaimAtom(...)))) for structural formulas",
+    )
     _validate_reason_prior(reason, prior)
     helper = Knowledge(
         content=f"opposite_truth({a.label or 'A'}, {b.label or 'B'})",
@@ -86,6 +110,10 @@ def complement(
 
 def disjunction(*claims: Knowledge, reason: str = "", prior: float | None = None) -> Knowledge:
     """At least one true. Creates Operator, returns helper claim."""
+    _warn_deprecated_operator(
+        "disjunction",
+        "claim(formula=lor(ClaimAtom(...), ...)) for structural formulas",
+    )
     _validate_reason_prior(reason, prior)
     labels = ", ".join(c.label or f"C{i}" for i, c in enumerate(claims))
     helper = Knowledge(

--- a/gaia/lang/dsl/propositional.py
+++ b/gaia/lang/dsl/propositional.py
@@ -1,6 +1,8 @@
-"""Gaia Lang v6 propositional expression helpers."""
+"""Legacy propositional expression helpers."""
 
 from __future__ import annotations
+
+import warnings
 
 from gaia.lang.runtime.knowledge import Claim
 from gaia.lang.runtime.nodes import Operator
@@ -25,8 +27,17 @@ def _validate_claims(claims: tuple[Claim, ...], function_name: str) -> None:
             raise TypeError(f"{function_name}() arguments must be Claim objects")
 
 
+def _warn_deprecated_helper(function_name: str, replacement: str) -> None:
+    warnings.warn(
+        f"{function_name}() is deprecated; use {replacement} for structured formula claims",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 def not_(claim: Claim) -> Claim:
     """Construct the Boolean negation expression ``not claim``."""
+    _warn_deprecated_helper("not_", "claim(formula=lnot(ClaimAtom(...)))")
     _validate_claims((claim,), "not_")
     helper = _expression_helper(f"not({_claim_ref(claim)})", "negation_result")
     Operator(operator="negation", variables=[claim], conclusion=helper)
@@ -35,6 +46,7 @@ def not_(claim: Claim) -> Claim:
 
 def and_(*claims: Claim) -> Claim:
     """Construct a Boolean conjunction expression over two or more Claims."""
+    _warn_deprecated_helper("and_", "claim(formula=land(ClaimAtom(...), ...))")
     if len(claims) < 2:
         raise ValueError("and_() requires at least two claims")
     _validate_claims(claims, "and_")
@@ -46,6 +58,7 @@ def and_(*claims: Claim) -> Claim:
 
 def or_(*claims: Claim) -> Claim:
     """Construct a Boolean disjunction expression over two or more Claims."""
+    _warn_deprecated_helper("or_", "claim(formula=lor(ClaimAtom(...), ...))")
     if len(claims) < 2:
         raise ValueError("or_() requires at least two claims")
     _validate_claims(claims, "or_")

--- a/gaia/lang/runtime/knowledge.py
+++ b/gaia/lang/runtime/knowledge.py
@@ -151,8 +151,10 @@ class Claim(Knowledge):
 
     def __bool__(self) -> bool:
         raise TypeError(
-            "Claim objects do not have Python truth values. Use ~A, A & B, "
-            "or A | B to build Gaia logical expressions."
+            "Claim objects do not have Python truth values. Use claim(formula=...) "
+            "with ClaimAtom/land/lor/lnot to build structured formula claims; "
+            "legacy ~A, A & B, and A | B shortcuts still exist but emit "
+            "DeprecationWarning."
         )
 
     def __invert__(self) -> Claim:

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -104,6 +104,7 @@ def test_compile_missing_source_dir(tmp_path):
     assert "Expected at one of: missing_source/, src/missing_source/" in result.output
 
 
+@pytest.mark.filterwarnings("ignore:contradiction\\(\\) is deprecated:DeprecationWarning")
 def test_compile_fails_on_invalid_ir_validation(tmp_path):
     """Compile should fail before writing artifacts when IR validator rejects the graph."""
     pkg_dir = tmp_path / "invalid_pkg"

--- a/tests/gaia/lang/test_compiler.py
+++ b/tests/gaia/lang/test_compiler.py
@@ -295,7 +295,8 @@ def test_compile_operator():
         a.label = "a"
         b = claim("B.")
         b.label = "b"
-        c = contradiction(a, b, reason="they conflict", prior=0.9)
+        with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+            c = contradiction(a, b, reason="they conflict", prior=0.9)
         c.label = "a_vs_b"
     result = compile_package_artifact(pkg)
     assert len(result.graph.operators) == 1

--- a/tests/gaia/lang/test_formula_migration.py
+++ b/tests/gaia/lang/test_formula_migration.py
@@ -1,0 +1,88 @@
+"""Milestone C migration/deprecation tests for legacy helper APIs."""
+
+import pytest
+
+from gaia.lang import (
+    ClaimAtom,
+    and_,
+    claim,
+    complement,
+    contradiction,
+    disjunction,
+    equivalence,
+    land,
+    not_,
+    or_,
+)
+from gaia.lang.compiler.compile import compile_package_artifact
+from gaia.lang.runtime.package import CollectedPackage
+
+
+pytestmark = pytest.mark.legacy_dsl
+
+
+@pytest.mark.parametrize(
+    ("call_name", "factory", "helper_kind"),
+    [
+        ("not_", lambda a, b: not_(a), "negation_result"),
+        ("and_", lambda a, b: and_(a, b), "conjunction_result"),
+        ("or_", lambda a, b: or_(a, b), "disjunction_result"),
+    ],
+)
+def test_legacy_propositional_helpers_warn_but_preserve_behavior(
+    call_name,
+    factory,
+    helper_kind,
+):
+    a = claim("A.")
+    b = claim("B.")
+
+    with pytest.warns(DeprecationWarning, match=f"{call_name}\\(\\) is deprecated"):
+        helper = factory(a, b)
+
+    assert helper.metadata["helper_kind"] == helper_kind
+
+
+@pytest.mark.parametrize(
+    ("call_name", "factory", "helper_kind"),
+    [
+        ("contradiction", contradiction, "contradiction_result"),
+        ("equivalence", equivalence, "equivalence_result"),
+        ("complement", complement, "complement_result"),
+        ("disjunction", disjunction, "disjunction_result"),
+    ],
+)
+def test_legacy_relation_helpers_warn_but_preserve_behavior(
+    call_name,
+    factory,
+    helper_kind,
+):
+    a = claim("A.")
+    b = claim("B.")
+
+    with pytest.warns(DeprecationWarning, match=f"{call_name}\\(\\) is deprecated"):
+        helper = factory(a, b, reason="legacy compatibility", prior=0.9)
+
+    assert helper.metadata["helper_kind"] == helper_kind
+    assert helper.metadata["prior"] == 0.9
+
+
+def test_formula_claim_replacement_for_legacy_conjunction_compiles_to_same_operator_shape():
+    with CollectedPackage("formula_migration_pkg", namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        both = claim("A and B.", formula=land(ClaimAtom(a), ClaimAtom(b)))
+        both.label = "both"
+
+    artifact = compile_package_artifact(pkg)
+    op = next(
+        op
+        for op in artifact.graph.operators
+        if (op.metadata or {}).get("formula_lowering") == "connective"
+    )
+
+    assert op.operator == "conjunction"
+    assert op.variables == ["t:formula_migration_pkg::a", "t:formula_migration_pkg::b"]
+    assert op.conclusion == "t:formula_migration_pkg::both"

--- a/tests/gaia/lang/test_operators.py
+++ b/tests/gaia/lang/test_operators.py
@@ -4,20 +4,23 @@ import pytest
 
 from gaia.lang import claim, contradiction, complement, disjunction, equivalence, noisy_and
 
+pytestmark = pytest.mark.legacy_dsl
+
 
 def test_contradiction_creates_helper_claim():
     a = claim("A is true.")
     b = claim("B is true.")
-    helper = contradiction(a, b, reason="A and B cannot both be true", prior=0.95)
+    with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+        helper = contradiction(a, b, reason="A and B cannot both be true", prior=0.95)
     assert helper.type == "claim"
     assert "not_both_true" in helper.content
 
 
-@pytest.mark.legacy_dsl
 def test_contradiction_helper_usable_as_premise():
     a = claim("A.")
     b = claim("B.")
-    contra = contradiction(a, b, reason="conflict", prior=0.9)
+    with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+        contra = contradiction(a, b, reason="conflict", prior=0.9)
     c = claim("C.")
     with pytest.warns(DeprecationWarning, match="noisy_and\\(\\) is deprecated"):
         noisy_and([contra], c)
@@ -27,14 +30,16 @@ def test_contradiction_helper_usable_as_premise():
 def test_equivalence_creates_helper_claim():
     a = claim("Predicted obs.")
     b = claim("Actual obs.")
-    helper = equivalence(a, b, reason="Match", prior=0.9)
+    with pytest.warns(DeprecationWarning, match="equivalence\\(\\) is deprecated"):
+        helper = equivalence(a, b, reason="Match", prior=0.9)
     assert "same_truth" in helper.content
 
 
 def test_complement_creates_helper_claim():
     a = claim("Classical.")
     b = claim("Quantum.")
-    helper = complement(a, b, reason="Opposite", prior=0.9)
+    with pytest.warns(DeprecationWarning, match="complement\\(\\) is deprecated"):
+        helper = complement(a, b, reason="Opposite", prior=0.9)
     assert "opposite_truth" in helper.content
 
 
@@ -42,7 +47,8 @@ def test_disjunction_creates_helper_claim():
     a = claim("Mechanism A.")
     b = claim("Mechanism B.")
     c = claim("Mechanism C.")
-    helper = disjunction(a, b, c, reason="At least one", prior=0.9)
+    with pytest.warns(DeprecationWarning, match="disjunction\\(\\) is deprecated"):
+        helper = disjunction(a, b, c, reason="At least one", prior=0.9)
     assert "any_true" in helper.content
 
 
@@ -54,28 +60,32 @@ def test_disjunction_creates_helper_claim():
 def test_contradiction_prior_stored_in_metadata():
     a = claim("A.")
     b = claim("B.")
-    helper = contradiction(a, b, reason="incompatible", prior=0.95)
+    with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+        helper = contradiction(a, b, reason="incompatible", prior=0.95)
     assert helper.metadata["prior"] == 0.95
 
 
 def test_equivalence_prior_stored_in_metadata():
     a = claim("Predicted.")
     b = claim("Observed.")
-    helper = equivalence(a, b, reason="match", prior=0.9)
+    with pytest.warns(DeprecationWarning, match="equivalence\\(\\) is deprecated"):
+        helper = equivalence(a, b, reason="match", prior=0.9)
     assert helper.metadata["prior"] == 0.9
 
 
 def test_complement_prior_stored_in_metadata():
     a = claim("Classical.")
     b = claim("Quantum.")
-    helper = complement(a, b, reason="opposite", prior=0.85)
+    with pytest.warns(DeprecationWarning, match="complement\\(\\) is deprecated"):
+        helper = complement(a, b, reason="opposite", prior=0.85)
     assert helper.metadata["prior"] == 0.85
 
 
 def test_disjunction_prior_stored_in_metadata():
     a = claim("A.")
     b = claim("B.")
-    helper = disjunction(a, b, reason="at least one", prior=0.9)
+    with pytest.warns(DeprecationWarning, match="disjunction\\(\\) is deprecated"):
+        helper = disjunction(a, b, reason="at least one", prior=0.9)
     assert helper.metadata["prior"] == 0.9
 
 
@@ -85,8 +95,9 @@ def test_operator_reason_without_prior_raises():
 
     a = claim("A.")
     b = claim("B.")
-    with pytest.raises(ValueError, match="reason.*prior.*paired"):
-        contradiction(a, b, reason="incompatible")  # no prior!
+    with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+        with pytest.raises(ValueError, match="reason.*prior.*paired"):
+            contradiction(a, b, reason="incompatible")  # no prior!
 
 
 def test_operator_prior_without_reason_raises():
@@ -95,8 +106,9 @@ def test_operator_prior_without_reason_raises():
 
     a = claim("A.")
     b = claim("B.")
-    with pytest.raises(ValueError, match="reason.*prior.*paired"):
-        contradiction(a, b, prior=0.9)  # no reason!
+    with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+        with pytest.raises(ValueError, match="reason.*prior.*paired"):
+            contradiction(a, b, prior=0.9)  # no reason!
 
 
 def test_operator_prior_outside_cromwell_bounds_raises():
@@ -104,13 +116,15 @@ def test_operator_prior_outside_cromwell_bounds_raises():
 
     a = claim("A.")
     b = claim("B.")
-    with pytest.raises(ValueError, match="Cromwell bounds"):
-        contradiction(a, b, reason="invalid probability", prior=1.5)
+    with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+        with pytest.raises(ValueError, match="Cromwell bounds"):
+            contradiction(a, b, reason="invalid probability", prior=1.5)
 
 
 def test_operator_no_reason_no_prior_ok():
     """Neither reason nor prior is fine — uses defaults."""
     a = claim("A.")
     b = claim("B.")
-    helper = contradiction(a, b)
+    with pytest.warns(DeprecationWarning, match="contradiction\\(\\) is deprecated"):
+        helper = contradiction(a, b)
     assert "prior" not in helper.metadata

--- a/tests/gaia/lang/test_propositional.py
+++ b/tests/gaia/lang/test_propositional.py
@@ -7,7 +7,7 @@ from gaia.lang.runtime.package import CollectedPackage
 
 def test_claim_boolean_truth_value_is_not_allowed():
     a = Claim("A.")
-    with pytest.raises(TypeError, match="Gaia logical expressions"):
+    with pytest.raises(TypeError, match="structured formula claims"):
         bool(a)
 
 
@@ -15,9 +15,12 @@ def test_claim_logical_operator_overloads_create_expression_helpers():
     a = Claim("A.")
     b = Claim("B.")
 
-    not_a = ~a
-    both = a & b
-    either = a | b
+    with pytest.warns(DeprecationWarning, match="not_\\(\\) is deprecated"):
+        not_a = ~a
+    with pytest.warns(DeprecationWarning, match="and_\\(\\) is deprecated"):
+        both = a & b
+    with pytest.warns(DeprecationWarning, match="or_\\(\\) is deprecated"):
+        either = a | b
 
     assert not_a.metadata["helper_kind"] == "negation_result"
     assert both.metadata["helper_kind"] == "conjunction_result"
@@ -32,8 +35,10 @@ def test_explicit_and_or_functions_accept_multiple_claims():
     b = Claim("B.")
     c = Claim("C.")
 
-    both = and_(a, b, c)
-    either = or_(a, b, c)
+    with pytest.warns(DeprecationWarning, match="and_\\(\\) is deprecated"):
+        both = and_(a, b, c)
+    with pytest.warns(DeprecationWarning, match="or_\\(\\) is deprecated"):
+        either = or_(a, b, c)
 
     assert both.metadata["helper_kind"] == "conjunction_result"
     assert either.metadata["helper_kind"] == "disjunction_result"
@@ -41,10 +46,12 @@ def test_explicit_and_or_functions_accept_multiple_claims():
 
 def test_propositional_functions_reject_non_claim_inputs():
     a = Claim("A.")
-    with pytest.raises(TypeError, match="Claim"):
-        and_(a, object())
-    with pytest.raises(TypeError, match="Claim"):
-        or_(a, object())
+    with pytest.warns(DeprecationWarning, match="and_\\(\\) is deprecated"):
+        with pytest.raises(TypeError, match="Claim"):
+            and_(a, object())
+    with pytest.warns(DeprecationWarning, match="or_\\(\\) is deprecated"):
+        with pytest.raises(TypeError, match="Claim"):
+            or_(a, object())
 
 
 def test_compile_propositional_expression_helpers_to_nonreviewed_operators():
@@ -53,11 +60,14 @@ def test_compile_propositional_expression_helpers_to_nonreviewed_operators():
         a.label = "a"
         b = Claim("B.")
         b.label = "b"
-        not_a = ~a
+        with pytest.warns(DeprecationWarning, match="not_\\(\\) is deprecated"):
+            not_a = ~a
         not_a.label = "not_a"
-        both = a & b
+        with pytest.warns(DeprecationWarning, match="and_\\(\\) is deprecated"):
+            both = a & b
         both.label = "both"
-        either = a | b
+        with pytest.warns(DeprecationWarning, match="or_\\(\\) is deprecated"):
+            either = a | b
         either.label = "either"
 
     compiled = compile_package_artifact(pkg)

--- a/tests/test_mendel_v05_example.py
+++ b/tests/test_mendel_v05_example.py
@@ -74,6 +74,7 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     knowledge_by_label = {item["label"]: item for item in ir["knowledges"] if item.get("label")}
     strategy_types = {item["type"] for item in ir["strategies"]}
     association = knowledge_by_label["mendel_count_association"]
+    count_observation = knowledge_by_label["f2_count_observation"]
 
     # The package uses a single associate (Mendel ↔ count) and three qualitative
     # contradict edges against blending. It declares no `infer` strategy of its own.
@@ -130,6 +131,18 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
         association_parameters.p_count_given_mendelian
         > association_parameters.p_count_given_diffuse
     )
+
+    assert {
+        (param["name"], param["type"], param["value"]) for param in count_observation["parameters"]
+    } == {
+        ("n_f2", "Nat", 395),
+        ("k_dominant", "Nat", 295),
+    }
+    assert count_observation["metadata"]["formula_lowering"] == "binding_conjunction"
+    assert count_observation["metadata"]["formula_bindings"] == [
+        {"symbol": "n_f2", "domain": "Nat", "value": 395, "source": "formula"},
+        {"symbol": "k_dominant", "domain": "Nat", "value": 295, "source": "formula"},
+    ]
 
     _accept_all_reviews(package)
 


### PR DESCRIPTION
## Summary

Completes the Milestone C cleanup slice on top of the merged formula work:

- emits `DeprecationWarning` from legacy helper APIs: `not_`, `and_`, `or_`, `contradiction`, `equivalence`, `complement`, and `disjunction`
- keeps those helpers behavior-compatible for existing packages
- migrates the Mendel v0.5 F2 count observation to structured `observation(...)` bindings while preserving the `observe(...)` review/grounding action
- updates the user/foundation/spec docs to point new authors at `ClaimAtom` + formula claims and relation verbs
- adds migration/deprecation regression tests and extends the Mendel example regression to assert the compiled count bindings

The automatic codemod remains a follow-up rather than a blind rewrite here, because legacy helper calls can carry package-specific labels, prose content, metadata, and review-target intent.

## Tests

- `python -m pytest tests/gaia/lang -q`
- `python -m pytest tests/test_mendel_v05_example.py tests/cli/test_compile.py -q`
- `python -m pytest tests/cli/test_infer.py -q`
- `python -m pytest tests/test_lowering.py tests/test_bp_jaynes_contract.py -q`
- `python -m pytest tests/test_contraction.py -q`
- `ruff check .`
- `ruff format --check .`
- `git diff --check`

Also ran `python -m pytest tests -q`; the suite reached `1401 passed` with one local failure in `tests/gaia/test_stats.py::test_stats_module_does_not_import_scipy`. That failure is outside this diff (`gaia/stats.py`, `gaia/unit.py`, and that test are untouched) and appears tied to the local environment importing top-level `scipy` through `pint`; the targeted Milestone C coverage above is green.
