### PR TITLE
Cover v0.5 role and decompose edge cases

### DIFF
--- a/tests/gaia/lang/test_decompose.py
+++ b/tests/gaia/lang/test_decompose.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gaia.lang import Claim, ClaimAtom, decompose, implies, land
+from gaia.lang import Claim, ClaimAtom, decompose, implies, land, lor
 from gaia.lang.compiler import compile_package_artifact
 from gaia.lang.runtime.action import Decompose, Structural
 from gaia.lang.runtime.package import CollectedPackage
@@ -108,3 +108,67 @@ def test_decompose_rejects_transitive_decomposition_cycle():
 
     with pytest.raises(ValueError, match="cycle"):
         decompose(c, parts=(a,), formula=ClaimAtom(a), label="c_as_a")
+
+
+def test_decompose_rejects_non_claim_whole():
+    a = Claim("Atomic A.")
+
+    with pytest.raises(TypeError, match="whole must be a Claim"):
+        decompose("not a claim", parts=(a,), formula=ClaimAtom(a))
+
+
+def test_decompose_rejects_empty_parts():
+    c = Claim("Composite claim.")
+
+    with pytest.raises(ValueError, match="at least one part"):
+        decompose(c, parts=(), formula=ClaimAtom(c))
+
+
+def test_decompose_rejects_non_claim_parts():
+    c = Claim("Composite claim.")
+    a = Claim("Atomic A.")
+
+    with pytest.raises(TypeError, match="parts must be Claims"):
+        decompose(c, parts=(a, "not a claim"), formula=ClaimAtom(a))
+
+
+def test_decompose_rejects_duplicate_parts():
+    c = Claim("Composite claim.")
+    a = Claim("Atomic A.")
+
+    with pytest.raises(ValueError, match="parts must be unique"):
+        decompose(c, parts=(a, a), formula=ClaimAtom(a))
+
+
+def test_decompose_rejects_non_formula():
+    c = Claim("Composite claim.")
+    a = Claim("Atomic A.")
+
+    with pytest.raises(TypeError, match="formula must be a Formula"):
+        decompose(c, parts=(a,), formula=a)
+
+
+def test_decompose_rejects_formula_that_references_whole():
+    c = Claim("Composite claim.")
+    a = Claim("Atomic A.")
+
+    with pytest.raises(ValueError, match="must not reference the whole claim"):
+        decompose(c, parts=(a,), formula=lor(ClaimAtom(a), ClaimAtom(c)))
+
+
+def test_decompose_rejects_unused_part():
+    c = Claim("Composite claim.")
+    a = Claim("Atomic A.")
+    b = Claim("Atomic B.")
+
+    with pytest.raises(ValueError, match="every decompose part"):
+        decompose(c, parts=(a, b), formula=ClaimAtom(a))
+
+
+def test_decompose_rejects_unlisted_formula_atom():
+    c = Claim("Composite claim.")
+    a = Claim("Atomic A.")
+    b = Claim("Atomic B.")
+
+    with pytest.raises(ValueError, match="only reference listed parts"):
+        decompose(c, parts=(a,), formula=land(ClaimAtom(a), ClaimAtom(b)))

--- a/tests/gaia/lang/test_roles.py
+++ b/tests/gaia/lang/test_roles.py
@@ -1,4 +1,17 @@
-from gaia.lang import Claim, equal, infer, observe
+from gaia.lang import Claim, ClaimAtom, associate, compute, decompose, derive, equal, infer, observe
+from gaia.lang.runtime.action import (
+    Associate,
+    Compose,
+    Compute,
+    Contradict,
+    Decompose,
+    DependsOn,
+    Derive,
+    Equal,
+    Exclusive,
+    Infer,
+    Support,
+)
 from gaia.lang.runtime.package import CollectedPackage
 from gaia.lang.runtime.roles import roles_for_claim, roles_for_package
 
@@ -34,3 +47,122 @@ def test_roles_for_package_indexes_multiple_structural_roles():
     assert _role_names(index[a]) == ["equivalent_claim"]
     assert _role_names(index[b]) == ["equivalent_claim"]
     assert _role_names(index[helper]) == ["equivalence_helper", "warrant"]
+
+
+def test_roles_cover_authored_action_shapes_and_sources():
+    a = Claim("A.")
+    b = Claim("B.")
+    c = Claim("C.")
+    d = Claim("D.")
+    helper = Claim("Helper.")
+    bg = Claim("Background.")
+    warrant = Claim("Warrant.")
+    likelihood_param = Claim("Likelihood parameter.")
+
+    actions = (
+        Derive(label="derive_c", conclusion=c, given=(a,), background=[bg], warrants=[warrant]),
+        Compute(label="compute_d", conclusion=d, given=(c,)),
+        DependsOn(label="depends_d", conclusion=d, given=(b,)),
+        Infer(
+            label="infer_b",
+            hypothesis=a,
+            evidence=b,
+            given=(c,),
+            helper=helper,
+            p_e_given_h=likelihood_param,
+            p_e_given_not_h=0.2,
+        ),
+        Associate(label="assoc_ab", a=a, b=b, helper=helper),
+        Equal(label="eq_ab", a=a, b=b, helper=helper),
+        Contradict(label="contradict_ab", a=a, b=b, helper=helper),
+        Exclusive(label="exclusive_ab", a=a, b=b, helper=helper),
+        Decompose(label="split_c", whole=c, parts=(a, b), formula=ClaimAtom(a)),
+    )
+
+    index = roles_for_package(actions)
+
+    assert "premise" in _role_names(index[a])
+    assert "hypothesis" in _role_names(index[a])
+    assert "association_target" in _role_names(index[a])
+    assert "equivalent_claim" in _role_names(index[a])
+    assert "contradiction_target" in _role_names(index[a])
+    assert "exclusive_alternative" in _role_names(index[a])
+    assert "decomposition_part" in _role_names(index[a])
+    assert "dependency_target" in _role_names(index[d])
+    assert "computed_result" in _role_names(index[d])
+    assert "likelihood_helper" in _role_names(index[helper])
+    assert "association_helper" in _role_names(index[helper])
+    assert "equivalence_helper" in _role_names(index[helper])
+    assert "contradiction_helper" in _role_names(index[helper])
+    assert "exclusivity_helper" in _role_names(index[helper])
+    assert _role_names(index[likelihood_param]) == ["likelihood_parameter"]
+    assert _role_names(index[bg]) == ["background"]
+    assert index[bg][0].source == "background"
+    assert _role_names(index[warrant]) == ["warrant"]
+    assert index[warrant][0].source == "warrant"
+
+
+def test_roles_can_exclude_background_and_warrants():
+    claim = Claim("Claim.")
+    bg = Claim("Background.")
+    warrant = Claim("Warrant.")
+    action = Derive(
+        label="derive_claim",
+        conclusion=claim,
+        background=[bg],
+        warrants=[warrant],
+    )
+
+    assert roles_for_claim(bg, (action,), include_background=False) == ()
+    assert roles_for_claim(warrant, (action,), include_warrants=False) == ()
+
+
+def test_roles_traverse_composed_child_actions_with_path():
+    a = Claim("A.")
+    b = Claim("B.")
+    child = Derive(label="child_derive", conclusion=b, given=(a,))
+    composition = Compose(
+        label="workflow",
+        name="test:workflow",
+        version="1.0",
+        inputs=(a,),
+        actions=(child,),
+        conclusion=b,
+    )
+
+    roles = roles_for_claim(a, (composition,))
+
+    assert [occ.role for occ in roles] == ["composition_input", "premise"]
+    assert roles[1].path == ("child_derive",)
+
+
+def test_roles_falls_back_for_legacy_support_action():
+    premise = Claim("Premise.")
+    conclusion = Claim("Conclusion.")
+    action = Support(label="legacy_support", conclusion=conclusion, given=(premise,))
+
+    assert _role_names(roles_for_claim(conclusion, (action,))) == ["conclusion"]
+    assert _role_names(roles_for_claim(premise, (action,))) == ["premise"]
+
+
+def test_roles_for_package_accepts_collected_package_with_more_verbs():
+    with CollectedPackage("roles_more") as pkg:
+        a = Claim("A.")
+        b = Claim("B.")
+        c = derive("C.", given=a, label="derive_c")
+        observed = observe("Observed B.", given=b, label="observe_b")
+        computed = compute(Claim, fn=lambda _c: Claim("Computed."), given=c, label="compute_c")
+        assoc_helper = associate(
+            a,
+            b,
+            p_a_given_b=0.7,
+            p_b_given_a=0.3,
+            label="assoc_ab",
+        )
+        decompose(c, parts=(a,), formula=ClaimAtom(a), label="split_c")
+
+    index = roles_for_package(pkg)
+    assert "conclusion" in _role_names(index[c])
+    assert "observation" in _role_names(index[observed])
+    assert "computed_result" in _role_names(index[computed])
+    assert "association_helper" in _role_names(index[assoc_helper])


### PR DESCRIPTION
## Summary
- add decompose validation tests for type errors, empty/duplicate parts, self references, unused parts, and unlisted atoms
- add role projection coverage for support, structural, probabilistic, compose, background, and warrant paths

## Why
PR #524 merged with GitHub Actions green, but Codecov marked the merge commit red because patch coverage was 78.01% against an 80% target. This follow-up raises coverage for the newly added role/decompose surfaces.

## Verification
- python -m pytest tests/gaia/lang/test_decompose.py tests/gaia/lang/test_roles.py -q
- python -m pytest tests/gaia/lang/test_decompose.py tests/gaia/lang/test_roles.py --cov=gaia.lang.dsl.decompose --cov=gaia.lang.runtime.roles --cov-report=term-missing -q
- python -m pytest --cov=gaia --cov-report=xml --cov-report=term-missing tests -v -m "not integration_api"
- ruff check .
- ruff format --check .
- git diff --check