### PR TITLE
[codex] Refresh causal design for latest v0.5

### DIFF
--- a/docs/specs/2026-05-05-causal-reasoning-design.md
+++ b/docs/specs/2026-05-05-causal-reasoning-design.md
@@ -1,189 +1,70 @@
-# Minimal Causal Reasoning Design
+# Minimal Causal Mechanism Design
 
 > **Status:** Replacement proposal for the causal design draft
 > **Branch:** `codex/v05-causal-docs-refresh` (off `v0.5`)
-> **Target release:** v0.6
+> **Target release:** v0.6 design discussion
 > **Date:** 2026-05-06
-> **Scope:** Define the smallest causal contract built on v0.5 Claims, formulas,
-> Actions, and IR lowering: causal Claims as source of truth, CausalDAG as a
-> derived view, and y0 as the first symbolic identification backend.
-> **Non-goals:** `mechanism(...)` actions, `is_causal` flags on existing actions,
-> causal discovery, DoWhy integration, data-driven effect estimation,
-> counterfactuals, and a full CPD family.
+> **Scope:** Promote causal mechanisms to a first-class Gaia `Knowledge` type,
+> project those mechanism nodes into `CausalDAG`, and use y0 as the first
+> symbolic identification backend.
+> **Non-goals:** Encoding mechanisms as `Claim(kind=CAUSAL)`, `is_causal`
+> flags on existing actions, DoWhy integration, causal discovery, data-driven
+> effect estimation, counterfactuals, and a full CPD family.
 
 ---
 
-## 0. Design Summary
+## 0. Core Decision
 
-The causal layer should be small enough to explain in one sentence:
+The causal layer should not model a mechanism as a Claim plus metadata. A
+mechanism is a piece of world structure:
 
-> `causal(...)` creates a truth-bearing causal Claim; `build_causal_dag(...)`
-> projects those causal Claims into a DAG; y0 identifies symbolic do-query
-> formulas from that DAG.
+```text
+X causes Y
+Y is generated from its causal parents
+```
 
-Everything else stays in its current layer:
+That is not the same kind of object as a proposition, and it is not a reasoning
+step. Therefore v0.6 should introduce:
 
-- `infer`, `support`, and `derive` support or attack Claims. They do not create
-  causal edges.
-- `implies(...)` and ordinary support relations are truth/evidence relations.
-  They are not causal mechanisms.
-- Gaia BP / FactorGraph remains the probability-computation backend for ordinary
-  probabilistic reasoning. A CausalDAG by itself does not compute probabilities.
-- DoWhy is intentionally deferred until Gaia has a data-binding and estimator
-  contract.
+```python
+CausalMechanism(Knowledge)
+```
 
-The minimum contract is:
+The minimal contract becomes:
 
 ```text
 Gaia IR
   Claim A
   Claim B
-  Claim C = causal(A, B, prior=0.9)
+  CausalMechanism M = mechanism(A, B)
 
 Derived views
   CausalDAG:
     node: A
     node: B
-    edge: A -> B, witnessed_by=C
+    edge: A -> B, source=M
 
   FactorGraph:
     ordinary BP lowering of Claims and Actions
+    later: causal factors lowered from CausalMechanism nodes when CPDs exist
 ```
 
-The CausalDAG is not a new source of truth. It is a typed projection over causal
-Claims in Gaia IR.
+The CausalDAG is a typed projection over `CausalMechanism` Knowledge nodes. It is
+not built from causal Claim metadata, and it is not a new source of truth.
 
 ---
 
-## 1. Current v0.5 Starting Point
+## 1. First-Principles Semantics
 
-v0.5 already has the right foundation:
+Gaia needs three different object kinds:
 
-- `Claim.formula` stores a typed formula AST.
-- `Claim.kind == ClaimKind.CAUSAL` marks a Claim whose top-level formula is a
-  causal predicate.
-- `Causes(cause, effect)` and `causes(cause, effect)` exist in the formula
-  layer.
-- `causal(cause, effect, prior=...)` exists as public authoring sugar for
-  current `Causes(...)` endpoints and returns
-  `Claim(formula=Causes(...), kind=ClaimKind.CAUSAL, prior=...)`.
-- Formula lowering already emits `metadata.causal = {"cause": ..., "effect": ...}`
-  for top-level `Causes(...)` Claims.
+| Kind | Meaning | Examples |
+|---|---|---|
+| `Claim` | A truth-bearing proposition | "It is raining"; "the field study is reliable" |
+| `Action` | A reasoning/review step connecting knowledge | `infer`, `derive`, `support`, `decompose` |
+| `CausalMechanism` | A structural causal relation in the modeled world | "rain causes wet ground"; "CO2 drives temperature" |
 
-The missing piece is not a second causal action system. The missing piece is a
-small projection layer that reads these causal Claims as candidate DAG edges.
-
----
-
-## 2. Public Authoring Surface
-
-### 2.1 Common path: Claim-to-Claim causality
-
-Most users should not need to write formula AST nodes directly:
-
-```python
-from gaia.lang import causal, claim, infer
-
-rain = claim("It rains", prior=0.3)
-wet = claim("The ground is wet", prior=0.2)
-
-rain_causes_wet = causal(
-    rain,
-    wet,
-    prior=0.9,
-    describe="Rain causes the ground to become wet.",
-)
-```
-
-`causal(rain, wet, ...)` normalizes internally to:
-
-```python
-Claim(
-    formula=Causes(ClaimAtom(rain), ClaimAtom(wet)),
-    kind=ClaimKind.CAUSAL,
-    prior=0.9,
-)
-```
-
-This requires one small v0.6 widening: `Causes` endpoint validation should accept
-`Term | ClaimAtom`. The current v0.5 term-only variable path stays valid.
-
-The resulting causal relation is a normal Claim. It can be supported, attacked,
-reviewed, imported, exported, and assigned a prior like any other Claim.
-
-```python
-field_study = claim("In the field study, rain events precede wet ground events.")
-
-infer(
-    field_study,
-    hypothesis=rain_causes_wet,
-    p_e_given_h=0.8,
-    p_e_given_not_h=0.2,
-)
-```
-
-This `infer(...)` supports the causal Claim. It does not create a separate
-causal edge.
-
-### 2.2 Existing path: variable-level causality
-
-The current v0.5 style remains valid:
-
-```python
-from gaia.lang import Real, Variable, causal
-
-co2 = Variable(symbol="co2", domain=Real)
-temp = Variable(symbol="temp", domain=Real)
-
-co2_causes_temp = causal(
-    co2,
-    temp,
-    prior=0.85,
-    describe="Atmospheric CO2 concentration causes mean temperature change.",
-)
-```
-
-This keeps the existing formula/Variable capability without forcing users into a
-new graph API.
-
-### 2.3 Explicit formula path
-
-Advanced users can still write the normalized formula directly:
-
-```python
-from gaia.lang import ClaimKind, ClaimAtom, Causes, claim
-
-edge = claim(
-    "Rain causes wet ground.",
-    formula=Causes(ClaimAtom(rain), ClaimAtom(wet)),
-    kind=ClaimKind.CAUSAL,
-    prior=0.9,
-)
-```
-
-The public rule is:
-
-```text
-causal(...) is the Pythonic surface.
-Causes(...) is the normalized formula representation.
-```
-
-### 2.4 What is not added
-
-Do not add:
-
-- `mechanism(...)`
-- `cause(...)`
-- `is_causal=True` on `infer`, `support`, `derive`, or `implies`
-- a separate action type whose only purpose is to create causal edges
-
-The edge exists because there is a causal Claim.
-
----
-
-## 3. Core Semantics
-
-### 3.1 Three relations that must stay separate
+This keeps three relations separate:
 
 ```text
 implication:
@@ -196,101 +77,243 @@ causation:
   Under intervention do(A=a), the generating process for B changes.
 ```
 
-Therefore:
+Consequences:
 
 - `implies(A, B)` is not a causal edge.
 - `infer(evidence=E, hypothesis=H)` is not a causal edge.
-- `infer(evidence=E, hypothesis=causal(A, B))` supports the edge Claim.
-- `causal(A, B)` is the only authoring surface that contributes an edge to
-  CausalDAG.
+- `CausalMechanism(A, B)` is the object that contributes edge `A -> B` to
+  `CausalDAG`.
+- Claims and Actions may support, challenge, justify, review, or decompose the
+  evidence for a mechanism, but they are not the mechanism itself.
 
-### 3.2 Prior means belief in the edge, not effect strength
+---
 
-For a causal Claim:
+## 2. Why Not `Claim(kind=CAUSAL)` as the Edge
+
+v0.5 introduced `Causes(X, Y)` as a formula marker inside a Claim. That remains
+useful for natural-language propositions, migration, and compatibility, but it
+should not be the long-term source of causal structure.
+
+The failure mode is semantic drift:
 
 ```python
 edge = causal(A, B, prior=0.9)
 ```
 
-`prior=0.9` means:
+If `edge` is a Claim, then `prior=0.9` means:
 
 ```text
 P("A causes B" is true) = 0.9
 ```
 
-It does not mean:
+But a causal mechanism needs different fields:
 
 ```text
-P(B | A) = 0.9
-P(B | do(A)) = 0.9
+source endpoint
+target endpoint
+optional structural parameters / CPD
+review state or support/challenge actions
 ```
 
-This distinction is non-negotiable. Edge belief and mechanism strength are
-different quantities.
+Reusing `Claim.prior` as an "edge existence prior" makes Gaia explain away a
+type mismatch with documentation. The minimal design avoids that mismatch:
 
-### 3.3 CausalDAG does not compute probabilities
+- `Claim.prior` stays a proposition prior.
+- `CausalMechanism` has no `prior` / `exists_prior` field.
+- Mechanism status is handled by causal review/support/challenge actions and
+  package review policy.
+- CPDs, when present, belong to the mechanism node.
 
-A DAG such as:
-
-```text
-Z -> X
-Z -> Y
-X -> Y
-```
-
-can answer structural questions:
-
-- Is the graph acyclic?
-- Is a do-query structurally meaningful?
-- Which variables are ancestors or descendants?
-- Which adjustment sets identify `P(Y | do(X))`?
-
-It cannot answer numeric questions by itself:
-
-- `P(Y=1 | do(X=1)) = ?`
-- `ATE(X -> Y) = ?`
-
-Numeric answers require CPDs, observational distributions, Gaia BP beliefs, or
-data estimators. The minimal v0.6 causal layer only promises symbolic
-identification, not numeric effect estimation.
+This is closer to Pearl's SCM split between variables and structural functions:
+the mechanism is part of the modeled world's structure, not just a proposition
+about the world.
 
 ---
 
-## 4. IR and Metadata Contract
+## 3. Public Authoring Surface
 
-### 4.1 Source of truth
+### 3.1 Primary API
 
-The source of truth is the compiled causal Claim:
+Use `mechanism(...)` as the Pythonic factory for a `CausalMechanism` Knowledge
+node:
+
+```python
+from gaia.lang import claim, mechanism
+
+rain = claim("It rains", prior=0.3)
+wet = claim("The ground is wet", prior=0.2)
+
+rain_wets_ground = mechanism(
+    rain,
+    wet,
+    label="rain_wets_ground",
+    describe="Rain is a causal mechanism for wet ground.",
+)
+```
+
+`mechanism(...)` returns `CausalMechanism`, not `Claim` and not `Action`.
+
+### 3.2 Variable endpoint path
+
+Mechanisms may also point at formula Variables, preserving the useful part of
+the current v0.5 `Causes(...)` work:
+
+```python
+from gaia.lang import Real, Variable, mechanism
+
+co2 = Variable(symbol="co2", domain=Real)
+temp = Variable(symbol="temp", domain=Real)
+
+co2_drives_temp = mechanism(
+    co2,
+    temp,
+    label="co2_drives_temp",
+)
+```
+
+Claim endpoints compile to QIDs. Variable endpoints compile to stable CNIDs
+because `Variable` is Lang-only and does not enter the IR Knowledge map.
+
+### 3.3 Optional CPD
+
+The first symbolic causal release does not need CPDs. CPDs are only needed for
+later numeric `do()` or SCM simulation.
+
+If preserved in v0.6, support exactly one minimal CPD type:
+
+```python
+from gaia.lang import BinaryCPD, mechanism
+
+m = mechanism(
+    rain,
+    wet,
+    cpd=BinaryCPD(
+        p_effect_given_cause=0.8,
+        p_effect_given_not_cause=0.1,
+    ),
+)
+```
+
+The CPD is a structural parameter of the mechanism. It is not a Claim prior, not
+an Action score, and not Bayes evidence.
+
+Out of scope for the first release:
+
+- noisy-OR
+- arbitrary multi-parent CPT authoring
+- learned CPDs
+- stochastic/policy interventions
+
+### 3.4 Causal evidence and review actions
+
+Because `CausalMechanism` has no `exists_prior`, Gaia needs actions that record
+why a mechanism should be trusted or challenged. The minimal design can start
+with qualitative actions:
+
+```python
+from gaia.lang import support_mechanism, challenge_mechanism
+
+study = claim("Rain events reliably precede wet ground in the field study.")
+
+support_mechanism(
+    [study],
+    rain_wets_ground,
+    reason="Temporal order and intervention evidence support the mechanism.",
+)
+```
+
+These actions do not create DAG edges. They explain and review an existing
+mechanism node. A registry/review policy can later decide whether a mechanism is
+accepted for a published package, but the mechanism object itself does not store
+probabilistic existence belief.
+
+For v0.6, `build_causal_dag(...)` uses authored mechanisms by default. A stricter
+review-gated policy can be added after Gaia's review manifest has an explicit
+mechanism target status.
+
+### 3.5 Compatibility with `causal(...)` and `Causes(...)`
+
+Existing v0.5 APIs should not disappear abruptly:
+
+- `Causes(...)` remains a formula predicate.
+- `causal(...)` may remain a compatibility helper that creates a causal Claim.
+- Causal Claims are not the canonical source for new CausalDAG edges.
+
+Migration rule:
+
+```text
+New packages:
+  use mechanism(...)
+
+Old packages:
+  compile existing Claim(kind=CAUSAL, formula=Causes(...)) as legacy causal
+  propositions; optionally migrate them into CausalMechanism nodes.
+```
+
+This keeps old packages readable while preventing the new causal layer from
+depending on Claim metadata as its primary structure.
+
+---
+
+## 4. Runtime and IR Contract
+
+### 4.1 Runtime object
+
+Minimal runtime shape:
+
+```python
+@dataclass(init=False, eq=False)
+class CausalMechanism(Knowledge):
+    cause: Knowledge | Variable
+    effect: Knowledge | Variable
+    cpd: BinaryCPD | None = None
+```
+
+Rules:
+
+- It subclasses `Knowledge`, not `Claim`.
+- It cannot carry `prior`.
+- It does not participate in BP as a Boolean variable by default.
+- Its endpoints are typed references to Claims or Variables.
+- Its `metadata` may carry display/provenance information, but not causal edge
+  identity; the object itself is the edge identity.
+
+### 4.2 IR knowledge type
+
+Add a first-class IR type:
+
+```python
+class KnowledgeType(StrEnum):
+    CLAIM = "claim"
+    NOTE = "note"
+    COMPOSITION = "composition"
+    CAUSAL_MECHANISM = "causal_mechanism"
+```
+
+Minimal serialized shape:
 
 ```python
 {
-    "id": "pkg::rain_causes_wet",
-    "type": "claim",
+    "id": "pkg::rain_wets_ground",
+    "type": "causal_mechanism",
+    "content": "Rain is a causal mechanism for wet ground.",
     "metadata": {
-        "prior": 0.9,
-        "formula_atom": {"kind": "causes"},
-        "causal": {
-            "cause": {"kind": "claim", "qid": "pkg::rain"},
-            "effect": {"kind": "claim", "qid": "pkg::wet"},
-        },
+        "cause": {"kind": "claim", "qid": "pkg::rain"},
+        "effect": {"kind": "claim", "qid": "pkg::wet"},
+        "cpd": null,
     },
 }
 ```
 
-The exact metadata shape can preserve the current v0.5 flat form:
+Validation:
 
-```python
-metadata["causal"] = {"cause": ..., "effect": ...}
-```
+- `metadata.prior` is invalid for `causal_mechanism`.
+- `cause` and `effect` must normalize to QID or CNID endpoints.
+- If `cpd` is present, its values must satisfy the normal Cromwell bounds.
 
-No `metadata.causal_mechanism` key is introduced.
+### 4.3 Endpoint descriptors
 
-### 4.2 Endpoint descriptors
-
-`metadata.causal.cause` and `metadata.causal.effect` describe nodes in the
-derived CausalDAG.
-
-Supported in the minimal design:
+Supported endpoint descriptors:
 
 ```python
 {"kind": "claim", "qid": "<compiled Claim QID>"}
@@ -300,50 +323,10 @@ Supported in the minimal design:
 Rules:
 
 - Claim endpoints use QIDs.
-- Variable endpoints use stable CNIDs because `Variable` is Lang-only and does
-  not enter the IR Knowledge map.
+- Variable endpoints use stable CNIDs.
 - Cross-package variables use the declaring package when known; otherwise the
-  current package namespace is used as a fallback.
-- Quantified causal formulas are allowed as Claims, but the minimal DAG builder
-  only includes endpoints that can be normalized to concrete QIDs or CNIDs.
-
-### 4.3 Optional CPD metadata
-
-CPD support is not required for symbolic identification. It is optional metadata
-for later numeric intervention work:
-
-```python
-edge = causal(
-    A,
-    B,
-    prior=0.9,
-    cpd=BinaryCPD(
-        p_effect_given_cause=0.8,
-        p_effect_given_not_cause=0.1,
-    ),
-)
-```
-
-Compiled metadata:
-
-```python
-metadata["causal"]["cpd"] = {
-    "kind": "binary",
-    "p_effect_given_cause": 0.8,
-    "p_effect_given_not_cause": 0.1,
-}
-```
-
-Only one CPD shape is in scope for the minimal spec:
-
-```python
-BinaryCPD(p_effect_given_cause: float, p_effect_given_not_cause: float)
-```
-
-No noisy-OR, no arbitrary multi-parent CPT, no estimator registry. If an effect
-has multiple causal parents and numeric intervention is required, v0.6 may report
-that numeric lowering is not implemented for that graph. y0 symbolic
-identification can still run because it only needs structure.
+  using package namespace is the fallback.
+- Quantified mechanisms are out of scope for the first release.
 
 ---
 
@@ -362,7 +345,7 @@ Minimal data model:
 ```python
 @dataclass(frozen=True)
 class CausalNode:
-    id: str                 # QID or CNID
+    id: str
     kind: Literal["claim", "variable"]
     label: str | None = None
 
@@ -371,8 +354,7 @@ class CausalNode:
 class CausalEdge:
     cause_id: str
     effect_id: str
-    witness_claim_qid: str
-    belief: float | None = None
+    mechanism_qid: str
     cpd: BinaryCPD | None = None
 
 
@@ -382,45 +364,48 @@ class CausalDAG:
     edges: tuple[CausalEdge, ...]
 ```
 
+No `belief` field appears on `CausalEdge`. Belief/review status belongs to
+actions or review manifests, not the structural edge.
+
 ### 5.2 Projection rule
 
-`build_causal_dag(graph)` scans compiled knowledges and includes a Claim when all
-of these are true:
+`build_causal_dag(graph)` scans compiled knowledges and includes a node when:
 
-1. The knowledge is a Claim.
-2. It has a top-level causal formula marker. In compiled IR this is
-   `metadata.formula_atom.kind == "causes"` plus `metadata.causal`; in runtime
-   objects it may also be visible as `Claim.kind == ClaimKind.CAUSAL`.
-3. `metadata.causal.cause` and `metadata.causal.effect` can be normalized to QID
-   or CNID endpoints.
-4. The resulting graph remains acyclic.
+1. `knowledge.type == "causal_mechanism"`.
+2. Its cause/effect descriptors normalize to QID or CNID endpoints.
+3. The resulting graph remains acyclic.
 
 The edge is:
 
 ```text
 cause_id -> effect_id
-witnessed_by = causal Claim QID
-belief = causal Claim prior, if present
+mechanism_qid = CausalMechanism QID
+cpd = mechanism.cpd, if present
 ```
 
-The default projection is structural: it includes authored causal Claims without
-thresholding on prior. Applications can filter low-belief edges before calling
-`build_causal_dag`, but the core API does not guess a MAP structure.
+The default projection is structural: it includes authored mechanisms. Review
+gating can be added later as a policy layer:
+
+```python
+build_causal_dag(graph, review_manifest=manifest, policy="accepted")
+```
+
+That policy is not part of the minimal implementation.
 
 ### 5.3 Validation failures
 
 Hard errors:
 
 - endpoint cannot be normalized
-- duplicate contradictory endpoint descriptors for the same causal Claim
 - cycle in the projected CausalDAG
+- duplicate mechanism labels/QIDs
 - `do(X)` requested for a node that is not in the CausalDAG
 
 Warnings:
 
-- causal Claim has no prior
-- causal Claim has no CPD and user requested numeric intervention
-- quantified causal Claim has not been grounded
+- mechanism has no CPD and user requested numeric intervention
+- legacy causal Claim was found but no migrated `CausalMechanism` exists
+- causal support/challenge actions target an unknown mechanism
 
 ---
 
@@ -466,7 +451,7 @@ CausalDAG -> y0 graph/expression -> IdentificationResult
 ```
 
 This keeps Gaia's schema stable and lets future adapters coexist without
-rewriting causal Claims.
+rewriting mechanism Knowledge nodes.
 
 ### 6.3 Why DoWhy is deferred
 
@@ -494,14 +479,14 @@ That is the y0-shaped problem.
 
 ---
 
-## 7. Relationship to BP and `do()`
+## 7. Relationship to BP and Numeric `do()`
 
 ### 7.1 Minimal v0.6
 
 The first deliverable does not need numeric `do()`:
 
 ```text
-causal Claims -> CausalDAG -> y0 symbolic identification
+CausalMechanism Knowledge -> CausalDAG -> y0 symbolic identification
 ```
 
 This is enough to answer:
@@ -519,91 +504,119 @@ Numeric intervention requires more than the DAG:
 CausalDAG + CPDs or observational distribution + BP/data backend
 ```
 
-When numeric `do()` is added, the rule should be:
+When numeric `do()` is added:
 
 1. Validate the treatment node exists in CausalDAG.
-2. Use CausalDAG to identify which causal incoming edge factors to remove.
-3. Use CPD metadata or an observational estimand to build a numeric query.
-4. Reuse Gaia BP when the query can be represented as a FactorGraph.
+2. Lower CPD-bearing `CausalMechanism` nodes into causal factors.
+3. Record factor source as `source_type="causal_mechanism"` and
+   `source_id=<mechanism_qid>`.
+4. `mutilate()` removes factors sourced from incoming mechanisms to the
+   intervened node.
+5. Reuse Gaia BP when the resulting query is representable as a FactorGraph.
 
-This later work must not infer CPDs from causal Claim priors.
+This does not require a generic `Factor.metadata["modality"] = "causal"` tag.
+The factor's source type is the mechanism Knowledge type.
 
 ---
 
 ## 8. Implementation Plan
 
-### D1. Normalize causal authoring
+### D0. Gaia IR design discussion
 
-- Keep `causal(cause, effect, ...)` as the primary public API.
-- Extend it to accept Claim endpoints by wrapping them in `ClaimAtom`.
-- Widen `Causes` endpoint validation to accept `Term | ClaimAtom`.
-- Keep Variable/Term endpoints working as they do today.
-- Keep explicit `Claim(formula=Causes(...), kind=CAUSAL)` valid.
-- Do not add `mechanism(...)` or `is_causal`.
+This proposal changes the IR schema. It should not be smuggled in as a docs-only
+cleanup. Open an explicit design discussion before implementation:
 
-### D2. Compile causal endpoint descriptors
-
-- Preserve the current `metadata.causal = {"cause": ..., "effect": ...}` shape.
-- Add descriptor support for ClaimAtom endpoints:
-
-```python
-{"kind": "claim", "qid": "..."}
+```text
+Promote causal mechanisms to first-class Knowledge?
 ```
 
-- Add stable CNIDs for Variable endpoints:
+The discussion should cover:
 
-```python
-{"kind": "variable", "symbol": "x", "domain": "Real", "cnid": "..."}
-```
+- `KnowledgeType.CAUSAL_MECHANISM`
+- runtime `CausalMechanism`
+- storage/index impact
+- renderer/review impact
+- migration from v0.5 `causal()` Claims
 
-### D3. Add `gaia.causal.dag`
+### D1. Runtime and DSL
+
+- Add runtime `CausalMechanism(Knowledge)`.
+- Add `mechanism(cause, effect, *, cpd=None, label=None, describe=None)`.
+- Ensure `mechanism(...)` returns Knowledge, not Claim and not Action.
+- Keep `causal(...)` as compatibility Claim helper or deprecate it after a
+  migration period.
+- Add minimal `BinaryCPD` only if numeric parameters must be preserved.
+
+### D2. IR lowering
+
+- Add `KnowledgeType.CAUSAL_MECHANISM`.
+- Compile runtime `CausalMechanism` into an IR Knowledge node.
+- Normalize endpoint descriptors to QID/CNID.
+- Reject `metadata.prior` on mechanism Knowledge.
+- Preserve legacy causal Claim metadata for migration and rendering, but do not
+  use it as the canonical DAG source.
+
+### D3. Causal actions/review hooks
+
+- Add minimal mechanism-targeted actions, such as `support_mechanism(...)` and
+  `challenge_mechanism(...)`, or extend review manifests to target mechanism
+  QIDs directly.
+- Do not make these actions create edges.
+- Use them only for justification, review, and future accepted/rejected policy.
+
+### D4. CausalDAG
 
 - Implement `CausalNode`, `CausalEdge`, `CausalDAG`.
-- Implement `build_causal_dag(graph)`.
-- Validate acyclicity.
-- Expose structural helpers only if needed by y0 adapter.
+- Implement `build_causal_dag(graph)` over `KnowledgeType.CAUSAL_MECHANISM`.
+- Validate acyclicity and endpoint normalization.
 
-### D4. Add y0 adapter
+### D5. y0 adapter
 
 - Add `gaia.causal.identify_effect(...)`.
-- Add runtime conversion from `CausalDAG` to y0.
+- Convert `CausalDAG` to y0 at runtime.
 - Return Gaia-owned `IdentificationResult`.
 - Lazy-import y0 or place it behind a small optional extra.
 
-### D5. Defer numeric intervention
+### D6. Defer numeric intervention
 
-Do not implement full numeric `do()` until after D1-D4 are stable. Add only the
-minimal `BinaryCPD` payload if needed to preserve authored parameters.
+Do not implement full numeric `do()` until mechanism Knowledge, DAG projection,
+and y0 identification are stable.
 
 ---
 
 ## 9. Open Questions
 
-Only two questions remain open for the minimal spec:
+1. **What is the exact action/review surface for mechanism status?**
 
-1. **Should y0 be a hard dependency or optional extra?**
+   Recommendation: start with mechanism-targeted support/challenge actions or
+   review-manifest statuses. Do not put `exists_prior` on the mechanism.
 
-   Recommendation: first-party API, lazy-import backend. User experience is
-   built-in; Gaia IR does not depend on y0 object types.
+2. **Should `mechanism(...)` replace or coexist with `causal(...)`?**
 
-2. **Should quantified causal Claims be grounded in v0.6?**
+   Recommendation: use `mechanism(...)` for new structural causal knowledge.
+   Keep `causal(...)` as a legacy Claim factory for one release.
 
-   Recommendation: not in the first causal PR. Store and render quantified
-   causal Claims, but require concrete QID/CNID endpoints for CausalDAG
-   projection.
+3. **Should y0 be a hard dependency or optional extra?**
 
-Everything else is intentionally out of scope for the minimal release.
+   Recommendation: first-party Gaia API with lazy-import y0 backend. User
+   experience is built in; IR does not depend on y0 object types.
+
+4. **How much storage/index work is required?**
+
+   Recommendation: treat this as an IR/storage-impacting design PR, not a
+   local lowering-only change.
 
 ---
 
 ## 10. Non-Goals Recap
 
-- No `mechanism` action.
+- No `Claim(kind=CAUSAL)` as the canonical DAG source.
+- No `exists_prior` on `CausalMechanism`.
 - No `is_causal` boolean flag.
 - No DoWhy in the first causal release.
 - No data-driven estimation.
 - No causal discovery.
 - No counterfactuals.
 - No full CPD taxonomy.
-- No attempt to recover causal structure from ordinary `infer` or
-  `implies` relations.
+- No attempt to recover causal structure from ordinary `infer` or `implies`
+  relations.

--- a/docs/specs/2026-05-05-causal-reasoning-design.md
+++ b/docs/specs/2026-05-05-causal-reasoning-design.md
@@ -1,1121 +1,609 @@
-# Causal Reasoning Design — Predicate Claims + Mechanism Actions + Intervention
+# Minimal Causal Reasoning Design
 
-> **Status:** Target design (proposal)
+> **Status:** Replacement proposal for the causal design draft
 > **Branch:** `codex/v05-causal-docs-refresh` (off `v0.5`)
-> **Target release:** v0.6 (built on the v0.5 lifted Lang, role/decompose, and Bayes foundations)
-> **Date:** 2026-05-05
-> **Scope:** Separate predicate-level causal propositions from action-level causal mechanisms, then add DAG semantics, d-separation, `do(X=x)` interventions, numeric answers via existing Gaia BP, and optional symbolic do-calculus identification via y0.
-> **Depends on:** PR #505 (Variable / Domain / Formula AST with `Causes` predicate), PR #510 (formula metadata lowering), PR #524 (current Action families + `decompose`), and PR #523/#526 (Bayes distribution/action surface).
-> **Non-goals:** Counterfactual reasoning (Pearl level 3); structure learning from data; data-driven effect estimation.
+> **Target release:** v0.6
+> **Date:** 2026-05-06
+> **Scope:** Define the smallest causal contract built on v0.5 Claims, formulas,
+> Actions, and IR lowering: causal Claims as source of truth, CausalDAG as a
+> derived view, and y0 as the first symbolic identification backend.
+> **Non-goals:** `mechanism(...)` actions, `is_causal` flags on existing actions,
+> causal discovery, DoWhy integration, data-driven effect estimation,
+> counterfactuals, and a full CPD family.
 
 ---
 
-## 0. Background and Motivation
+## 0. Design Summary
 
-### 0.1 Where v0.5 left `Causes`
+The causal layer should be small enough to explain in one sentence:
 
-PR #505 introduced `Causes(X, Y)` as a **marker predicate** in the formula AST (`gaia/lang/formula/predicate.py:129`) and added `Claim.formula` / `Claim.kind`. PR #510 then lowered atomic formulas into IR metadata: a fresh-compiled `Claim(formula=Causes(...), kind=CAUSAL)` now carries `metadata.causal = {"cause": ..., "effect": ...}`.
+> `causal(...)` creates a truth-bearing causal Claim; `build_causal_dag(...)`
+> projects those causal Claims into a DAG; y0 identifies symbolic do-query
+> formulas from that DAG.
 
-Today this marker is still **structurally inert**: compiled artifacts have the authored cause/effect descriptors, but no compiled mechanism record, nothing reads `metadata.causal` as an interventional edge, nothing enforces acyclicity, nothing distinguishes `Causes(X, Y)` from `Causes(Y, X)` structurally, and there is no DSL for asking a causal question.
+Everything else stays in its current layer:
 
-### 0.2 What v0.6 needs to deliver
+- `infer`, `support`, and `derive` support or attack Claims. They do not create
+  causal edges.
+- `implies(...)` and ordinary support relations are truth/evidence relations.
+  They are not causal mechanisms.
+- Gaia BP / FactorGraph remains the probability-computation backend for ordinary
+  probabilistic reasoning. A CausalDAG by itself does not compute probabilities.
+- DoWhy is intentionally deferred until Gaia has a data-binding and estimator
+  contract.
 
-Four concrete capabilities, ordered by dependency:
+The minimum contract is:
 
-1. **Causal propositions** — keep `Causes(X, Y)` as a formula predicate inside an ordinary truth-bearing `Claim`. A causal proposition can be reviewed, supported, contradicted, quantified, or used as a warrant, but by itself it is not a BP factor and not an intervention target.
-2. **Causal mechanisms** — add an action-level declaration that promotes a causal proposition into an interventional mechanism edge with CPD parameters. This is the only authoring surface that creates DAG edges.
-3. **Interventions** — a `do(X=x)` query primitive that produces a numeric answer `P(Y | do(X=x))` using Gaia's existing BP engine. This is the primitive that distinguishes causal reasoning from conditional probability.
-4. **Symbolic identification** (optional extra) — `identify(P(Y | do(X)))` returns either an identifiable expression (back-door / front-door / ID algorithm) or "not identifiable from observational data" — delegated to [y0](https://pypi.org/project/y0/), lazy-imported from an optional adapter.
+```text
+Gaia IR
+  Claim A
+  Claim B
+  Claim C = causal(A, B, prior=0.9)
 
-This spec covers all four. Counterfactual reasoning (Pearl level 3) is **out of scope** — see §11.
+Derived views
+  CausalDAG:
+    node: A
+    node: B
+    edge: A -> B, witnessed_by=C
 
-### 0.3 First-principles position
+  FactorGraph:
+    ordinary BP lowering of Claims and Actions
+```
 
-We adopt the `gaia.stats` / `gaia.lang.bayes` pattern:
+The CausalDAG is not a new source of truth. It is a typed projection over causal
+Claims in Gaia IR.
 
-- **Kernel layers declare what; they do not compute heavy statistics.** Lang/IR represent causal structure as metadata + schema; they never import scientific computing libraries.
-- **Adapters live outside the kernel.** Heavy or narrow-use dependencies ship in `project.optional-dependencies`.
-- **Gaia's own BP engine is the default numeric backend.** If the answer can be produced by a graph rewrite plus existing BP, we do that rather than bolting on a second inference library.
+---
 
-Concretely:
+## 1. Current v0.5 Starting Point
 
-| Layer | What it owns | Dependencies |
-|---|---|---|
-| `gaia.lang.formula.predicate.Causes` | Predicate-level AST marker inside a `Claim.formula` (exists today via PR #505) | none |
-| existing `gaia.lang.dsl.sugar.causal` re-exported by `gaia.lang` / `gaia.lang.dsl` | Claim helper for authoring a causal proposition. It returns `Claim(formula=Causes(...), kind=CAUSAL)` and does **not** declare a mechanism edge. | none |
-| `gaia.lang.dsl.causal.mechanism` (NEW) | Action-level mechanism declaration. This is the surface that owns CPD parameters and creates DAG edges. | none |
-| `gaia.causal.dag` (NEW, kernel) | `CausalDAG` view over a `CollectedPackage` | `networkx` |
-| `gaia.causal.intervene` (NEW, kernel) | `do(X=x)` rewrite + `.query(Y)` | reuses `gaia.bp` |
-| `gaia.causal.adapters.y0` (NEW, extra) | Symbolic do-calculus identification | `y0` (extra: `gaia[causal-do]`) |
+v0.5 already has the right foundation:
 
-`networkx` is promoted to a kernel dependency (pure Python, ~3MB, no native extensions, widely trusted). `y0` is not — its base install pulls pandas + scikit-learn + statsmodels, which violates the "kernel stays light" rule, and Gaia only uses its symbolic identifier, not its data-driven parts.
+- `Claim.formula` stores a typed formula AST.
+- `Claim.kind == ClaimKind.CAUSAL` marks a Claim whose top-level formula is a
+  causal predicate.
+- `Causes(cause, effect)` and `causes(cause, effect)` exist in the formula
+  layer.
+- `causal(cause, effect, prior=...)` exists as public authoring sugar for
+  current `Causes(...)` endpoints and returns
+  `Claim(formula=Causes(...), kind=ClaimKind.CAUSAL, prior=...)`.
+- Formula lowering already emits `metadata.causal = {"cause": ..., "effect": ...}`
+  for top-level `Causes(...)` Claims.
 
-The current v0.5 Action hierarchy is `Support`, `Structural`, `Probabilistic`, `Scaffold`, and `Compose`. Causal mechanisms should not be smuggled into formula metadata or reintroduce the older `Relate` / `Correlate` taxonomy. `causal()` stays a Claim/formula authoring helper; v0.6 adds a distinct `Mechanism` action family with its own lowering contract.
+The missing piece is not a second causal action system. The missing piece is a
+small projection layer that reads these causal Claims as candidate DAG edges.
 
-### 0.4 Layering and naming convention
+---
 
-This spec keeps the existing formula surface intact and adds a separate action helper. The names are deliberately layered:
+## 2. Public Authoring Surface
+
+### 2.1 Common path: Claim-to-Claim causality
+
+Most users should not need to write formula AST nodes directly:
 
 ```python
-from gaia.lang import Causes, causes, causal, mechanism
+from gaia.lang import causal, claim, infer
 
-f1 = Causes(X, Y)                         # formula AST dataclass
-f2 = causes(X, Y)                         # existing formula helper
-c  = causal(cause=X, effect=Y, prior=0.8) # causal proposition Claim
-m  = mechanism(                           # action-level mechanism edge
-    cause=X,
-    effect=Y,
-    backing_claim=c,
-    p_effect_given_cause=0.85,
-    p_effect_given_not_cause=0.05,
+rain = claim("It rains", prior=0.3)
+wet = claim("The ground is wet", prior=0.2)
+
+rain_causes_wet = causal(
+    rain,
+    wet,
+    prior=0.9,
+    describe="Rain causes the ground to become wet.",
 )
 ```
 
-`Causes(...)` and `causes(...)` are formula-layer constructs: they express the causal predicate but do not carry CPD parameters. `causal(...)` is claim sugar: it creates the underlying `Claim(formula=Causes(...), kind=CAUSAL, prior=...)` and is the object reviewers argue about. `mechanism(...)` is the propositional/action-layer declaration: it creates the interventional edge and carries the CPD parameters needed by D₂. No public `cause()` helper is introduced; `causes()` remains exported from `gaia.lang` and `gaia.lang.dsl` for compatibility.
+`causal(rain, wet, ...)` normalizes internally to:
 
-The compiler must not infer a mechanism from a bare `CAUSAL` claim. Promotion is explicit: no `mechanism(...)`, no DAG edge, no BP causal factor, and no valid `do()` target.
+```python
+Claim(
+    formula=Causes(ClaimAtom(rain), ClaimAtom(wet)),
+    kind=ClaimKind.CAUSAL,
+    prior=0.9,
+)
+```
+
+This requires one small v0.6 widening: `Causes` endpoint validation should accept
+`Term | ClaimAtom`. The current v0.5 term-only variable path stays valid.
+
+The resulting causal relation is a normal Claim. It can be supported, attacked,
+reviewed, imported, exported, and assigned a prior like any other Claim.
+
+```python
+field_study = claim("In the field study, rain events precede wet ground events.")
+
+infer(
+    field_study,
+    hypothesis=rain_causes_wet,
+    p_e_given_h=0.8,
+    p_e_given_not_h=0.2,
+)
+```
+
+This `infer(...)` supports the causal Claim. It does not create a separate
+causal edge.
+
+### 2.2 Existing path: variable-level causality
+
+The current v0.5 style remains valid:
+
+```python
+from gaia.lang import Real, Variable, causal
+
+co2 = Variable(symbol="co2", domain=Real)
+temp = Variable(symbol="temp", domain=Real)
+
+co2_causes_temp = causal(
+    co2,
+    temp,
+    prior=0.85,
+    describe="Atmospheric CO2 concentration causes mean temperature change.",
+)
+```
+
+This keeps the existing formula/Variable capability without forcing users into a
+new graph API.
+
+### 2.3 Explicit formula path
+
+Advanced users can still write the normalized formula directly:
+
+```python
+from gaia.lang import ClaimKind, ClaimAtom, Causes, claim
+
+edge = claim(
+    "Rain causes wet ground.",
+    formula=Causes(ClaimAtom(rain), ClaimAtom(wet)),
+    kind=ClaimKind.CAUSAL,
+    prior=0.9,
+)
+```
+
+The public rule is:
+
+```text
+causal(...) is the Pythonic surface.
+Causes(...) is the normalized formula representation.
+```
+
+### 2.4 What is not added
+
+Do not add:
+
+- `mechanism(...)`
+- `cause(...)`
+- `is_causal=True` on `infer`, `support`, `derive`, or `implies`
+- a separate action type whose only purpose is to create causal edges
+
+The edge exists because there is a causal Claim.
 
 ---
 
-## 1. Architectural Position
+## 3. Core Semantics
 
-```
-┌────────────────────────────────────────────────────────────┐
-│  Gaia Lang predicate layer                                  │
-│  ────────────────────────                                    │
-│  Causes(X, Y) inside Claim.formula                           │
-│  causal(...) -> a truth-bearing CAUSAL Claim                  │
-└────────────────────────┬───────────────────────────────────┘
-                         │  formula lowering: predicate metadata only
-                         ▼
-┌────────────────────────────────────────────────────────────┐
-│  Gaia Lang action layer                                     │
-│  ─────────────────────                                      │
-│  mechanism(cause, effect, backing_claim, CPD)                │
-│  the only source of interventional mechanism edges           │
-└────────────────────────┬───────────────────────────────────┘
-                         │  compiler emits causal-mechanism records (§7)
-                         ▼
-┌────────────────────────────────────────────────────────────┐
-│  Gaia IR  (unchanged schema — only metadata enriched)      │
-│  ──────────                                                  │
-│  Claims may carry predicate metadata                         │
-│  Mechanism actions emit metadata.causal_mechanism records     │
-└────────────────────────┬───────────────────────────────────┘
-                         │  gaia.causal (NEW)
-          ┌──────────────┼────────────────────────────┐
-          ▼              ▼                            ▼
-   gaia.causal.dag  gaia.causal.intervene      gaia.causal.adapters.y0
-   ──────────────  ──────────────────────      ───────────────────────
-   (kernel)        (kernel, via gaia.bp)       (extra: gaia[causal-do])
-   NetworkX DAG    mutilate + Gaia BP           symbolic do-calculus
-   d-separation    numeric P(Y|do(X=x))          identification
+### 3.1 Three relations that must stay separate
+
+```text
+implication:
+  If A is true, B should be true in the same world.
+
+infer:
+  Evidence E changes belief in hypothesis H.
+
+causation:
+  Under intervention do(A=a), the generating process for B changes.
 ```
 
-Four surfaces are involved, with strict ownership: predicate claims say what the author believes, mechanism actions say which propositions/variables enter an interventional graph, `gaia.causal` reads that graph, and the y0 adapter performs optional symbolic identification. **IR schema is unchanged** — only well-known metadata keys are added, consistent with how `gaia.stats` evolved.
+Therefore:
 
-### 1.1 Two metadata contracts
+- `implies(A, B)` is not a causal edge.
+- `infer(evidence=E, hypothesis=H)` is not a causal edge.
+- `infer(evidence=E, hypothesis=causal(A, B))` supports the edge Claim.
+- `causal(A, B)` is the only authoring surface that contributes an edge to
+  CausalDAG.
 
-PR #510 introduced compiler-owned `metadata.causal` operand descriptors on causal formula claims. This spec keeps that metadata predicate-scoped:
+### 3.2 Prior means belief in the edge, not effect strength
+
+For a causal Claim:
 
 ```python
-# On a Claim whose formula is Causes(X, Y), or a generated instance of one:
+edge = causal(A, B, prior=0.9)
+```
+
+`prior=0.9` means:
+
+```text
+P("A causes B" is true) = 0.9
+```
+
+It does not mean:
+
+```text
+P(B | A) = 0.9
+P(B | do(A)) = 0.9
+```
+
+This distinction is non-negotiable. Edge belief and mechanism strength are
+different quantities.
+
+### 3.3 CausalDAG does not compute probabilities
+
+A DAG such as:
+
+```text
+Z -> X
+Z -> Y
+X -> Y
+```
+
+can answer structural questions:
+
+- Is the graph acyclic?
+- Is a do-query structurally meaningful?
+- Which variables are ancestors or descendants?
+- Which adjustment sets identify `P(Y | do(X))`?
+
+It cannot answer numeric questions by itself:
+
+- `P(Y=1 | do(X=1)) = ?`
+- `ATE(X -> Y) = ?`
+
+Numeric answers require CPDs, observational distributions, Gaia BP beliefs, or
+data estimators. The minimal v0.6 causal layer only promises symbolic
+identification, not numeric effect estimation.
+
+---
+
+## 4. IR and Metadata Contract
+
+### 4.1 Source of truth
+
+The source of truth is the compiled causal Claim:
+
+```python
 {
-    "causal": {
-        "predicate": {
-            "cause":  {"kind": "variable" | "knowledge", ...},
-            "effect": {"kind": "variable" | "knowledge", ...},
-        }
-    }
+    "id": "pkg::rain_causes_wet",
+    "type": "claim",
+    "metadata": {
+        "prior": 0.9,
+        "formula_atom": {"kind": "causes"},
+        "causal": {
+            "cause": {"kind": "claim", "qid": "pkg::rain"},
+            "effect": {"kind": "claim", "qid": "pkg::wet"},
+        },
+    },
 }
 ```
 
-The compatibility shape already emitted by v0.5, `metadata.causal = {"cause": ..., "effect": ...}`, is accepted as a predicate descriptor and should be normalized to the nested `predicate` shape on recompile. It is **not** a mechanism edge.
-
-`mechanism(...)` actions compile to a separate mechanism record:
+The exact metadata shape can preserve the current v0.5 flat form:
 
 ```python
-{
-    "causal_mechanism": {
-        "action_label": "x_causes_y_mechanism",
-        "backing_claim_qid": "<QID of the causal proposition Claim>",
-        "cause_id": "<QID or CNID>",
-        "effect_id": "<QID or CNID>",
-        "endpoint_kind": "variable" | "claim",
-        "policy": "structural",          # build_dag includes authored mechanisms
-        # Present when numeric intervention lowering is requested:
-        "cpd": {
-            "kind": "binary_edge",
-            "p_effect_given_cause": 0.85,
-            "p_effect_given_not_cause": 0.05,
-        },
-    }
+metadata["causal"] = {"cause": ..., "effect": ...}
+```
+
+No `metadata.causal_mechanism` key is introduced.
+
+### 4.2 Endpoint descriptors
+
+`metadata.causal.cause` and `metadata.causal.effect` describe nodes in the
+derived CausalDAG.
+
+Supported in the minimal design:
+
+```python
+{"kind": "claim", "qid": "<compiled Claim QID>"}
+{"kind": "variable", "symbol": "co2", "domain": "Real", "cnid": "<stable CNID>"}
+```
+
+Rules:
+
+- Claim endpoints use QIDs.
+- Variable endpoints use stable CNIDs because `Variable` is Lang-only and does
+  not enter the IR Knowledge map.
+- Cross-package variables use the declaring package when known; otherwise the
+  current package namespace is used as a fallback.
+- Quantified causal formulas are allowed as Claims, but the minimal DAG builder
+  only includes endpoints that can be normalized to concrete QIDs or CNIDs.
+
+### 4.3 Optional CPD metadata
+
+CPD support is not required for symbolic identification. It is optional metadata
+for later numeric intervention work:
+
+```python
+edge = causal(
+    A,
+    B,
+    prior=0.9,
+    cpd=BinaryCPD(
+        p_effect_given_cause=0.8,
+        p_effect_given_not_cause=0.1,
+    ),
+)
+```
+
+Compiled metadata:
+
+```python
+metadata["causal"]["cpd"] = {
+    "kind": "binary",
+    "p_effect_given_cause": 0.8,
+    "p_effect_given_not_cause": 0.1,
 }
 ```
 
-`cause_id` / `effect_id` are either compiled QIDs (for Claim endpoints) or synthesized CNIDs (for Variable endpoints — see §3.1). Consumers distinguish them with `gaia.ir.knowledge.is_qid()`.
-
-`metadata.causal_mechanism.cpd` is intentionally separate from both `metadata.causal.predicate` and `metadata.bayes`. The CPD is a structural mechanism parameter used by intervention lowering; it is not an observational likelihood, a Bayes model-comparison record, or an observation noise payload. D₂.5 stochastic interventions may reuse the `gaia.lang.bayes` distribution protocol for authored distributions, but compiled mechanism parameters remain under `metadata.causal_mechanism`.
-
-The invariant is simple:
+Only one CPD shape is in scope for the minimal spec:
 
 ```python
-if "causal_mechanism" not in metadata:
-    # Review/render the causal proposition if present, but do not add a DAG edge.
-    pass
+BinaryCPD(p_effect_given_cause: float, p_effect_given_not_cause: float)
 ```
 
-For factor-level provenance, D₂ copies the mechanism record into `Factor.metadata`:
-
-```python
-Factor(
-    ...,
-    metadata={
-        "modality": "causal",
-        "causal_mechanism": {
-            "action_label": "...",
-            "backing_claim_qid": "...",
-            "cause_id": "...",
-            "effect_id": "...",
-        },
-        "cpd": {
-            "kind": "binary_edge",
-            "p_effect_given_cause": 0.85,
-            "p_effect_given_not_cause": 0.05,
-        },
-    },
-)
-```
-
-### 1.2 `gaia.bp` additions
-
-One public helper is added to `gaia.bp`:
-
-```python
-# gaia/bp/factor_graph.py
-def mutilate(fg: FactorGraph, intervened: set[str]) -> FactorGraph:
-    """Return a new FactorGraph with **causal** factors whose `conclusion` is
-    in `intervened` removed. Logical/structural factors (deduction-derived
-    SOFT_ENTAILMENT, Decompose-generated helpers, and
-    IMPLICATION/EQUIVALENCE/CONJUNCTION/DISJUNCTION operator factors) are
-    preserved regardless of their conclusion — see §4.4 for the
-    first-principles justification.
-
-    The caller follows up with fg.observe(x, value) for each intervened var."""
-```
-
-For this to be implementable after lowering, D₂ extends `Factor` / `add_factor(...)` with a small metadata field:
-
-```python
-Factor(
-    ...,
-    metadata={
-        "modality": "causal",               # or absent / "logical"
-        "causal_mechanism": {
-            "action_label": "<label>",
-            "backing_claim_qid": "<QID>",
-            "cause_id": "...",
-            "effect_id": "...",
-        },
-    },
-)
-```
-
-The modality test (causal vs. logical) reads `factor.metadata["modality"]`, not the original predicate claim. The `causal_mechanism` record is emitted only from `mechanism(...)` actions. The companion CNID variable registration is performed during normal lowering of mechanism actions; no separate `gaia.causal.lowering` module is required (§4.3).
-
-### 1.3 Dependency layout in `pyproject.toml`
-
-```toml
-dependencies = [
-    # existing...
-    "networkx>=3",
-]
-
-[project.optional-dependencies]
-# existing dev extra...
-causal-do = ["y0>=0.2"]
-```
-
-No `causal-bn` / pgmpy extra. We do not need it — numeric intervention answers go through Gaia's own BP (§4).
+No noisy-OR, no arbitrary multi-parent CPT, no estimator registry. If an effect
+has multiple causal parents and numeric intervention is required, v0.6 may report
+that numeric lowering is not implemented for that graph. y0 symbolic
+identification can still run because it only needs structure.
 
 ---
 
-## 2. Module Code Layout
+## 5. CausalDAG Projection
 
-```
-gaia/
-├── bp/
-│   └── factor_graph.py          # + modality-aware mutilate() helper (§1.2)
-├── causal/                      # NEW
-│   ├── __init__.py              # public surface
-│   ├── dag.py                   # CausalDAG, build_dag()
-│   ├── queries.py               # d_sep(), ancestors(), descendants(),
-│   │                            #   adjustment_sets()
-│   ├── intervene.py             # Intervention, do(), .query(), ate()
-│   ├── errors.py                # CausalCycleError, CausalMetadataMissingError,
-│   │                            #   InterventionUndefinedError, NotIdentifiable
-│   └── adapters/
-│       ├── __init__.py          # (empty — extras are opt-in)
-│       └── y0.py                # identify(); lazy imports y0
-├── lang/
-│   └── dsl/
-│       ├── sugar.py             # existing causal() Claim helper (predicate layer)
-│       └── causal.py            # NEW: mechanism() action helper
-└── lang/
-    └── compiler/
-        ├── compile.py           # + compile Mechanism actions into causal_mechanism records
-        └── lower_formula.py     # keeps Causes(...) predicate metadata scoped to claims
-```
-
-### 2.1 Boundaries
-
-- `gaia.causal.dag` **reads** a `CollectedPackage` (or equivalent) and produces a `CausalDAG`. It does not write IR.
-- `gaia.causal.queries` operates on a `CausalDAG`. Pure graph algorithms, no IR awareness.
-- `gaia.causal.intervene` **reads** a compiled IR artifact, lowers it through the standard `gaia.bp.lowering` path (which now handles `mechanism()` actions and per-instance grounding), rewrites the resulting `FactorGraph` (`mutilate`), and runs BP. It does not write IR. **No separate causal lowering module is needed** — compiled mechanism records and CPD parameters carry enough information that ordinary lowering can register CNID variables and emit the causal CPT factor.
-- `gaia.causal.adapters.y0` **reads** a `CausalDAG` and a symbolic query; returns an expression or a `NotIdentifiable` diagnosis. It does not touch `FactorGraph`.
-- `gaia.lang.dsl.sugar.causal` remains the authored-side `causal()` Claim helper, already re-exported by `gaia.lang` and `gaia.lang.dsl`. It stays predicate-only.
-- `gaia.lang.dsl.causal.mechanism` is the authored-side action helper that promotes a causal proposition into a mechanism edge.
-- `gaia.causal` is the runtime query surface for `do()`, `query()`, and `ate()`. A `gaia.lang.dsl.causal` compatibility re-export can be added later if the broader DSL wants all verbs in `gaia.lang.dsl`, but it is not required for the core implementation.
-
-This partitions the work so each module is independently testable and no file grows oversized.
-
----
-
-## 3. Causal Structure Layer (Spec 1)
-
-### 3.1 `CausalDAG` — view constructed from a package
+### 5.1 Public API
 
 ```python
-# gaia/causal/dag.py
-from dataclasses import dataclass
-import networkx as nx
+from gaia.causal import build_causal_dag
+
+dag = build_causal_dag(artifact.graph)
+```
+
+Minimal data model:
+
+```python
+@dataclass(frozen=True)
+class CausalNode:
+    id: str                 # QID or CNID
+    kind: Literal["claim", "variable"]
+    label: str | None = None
+
 
 @dataclass(frozen=True)
 class CausalEdge:
-    cause_id: str        # QID or CNID (see §3.1)
-    effect_id: str       # QID or CNID
-    source_action_label: str           # which mechanism action declared this edge
-    backing_claim_qid: str | None      # causal proposition used as warrant/provenance
-    backing_claim_prior: float | None  # belief that the backing proposition is true
+    cause_id: str
+    effect_id: str
+    witness_claim_qid: str
+    belief: float | None = None
+    cpd: BinaryCPD | None = None
 
-@dataclass
+
+@dataclass(frozen=True)
 class CausalDAG:
-    nodes: frozenset[str]              # CNIDs for Variables, QIDs for Claims if supported
+    nodes: dict[str, CausalNode]
     edges: tuple[CausalEdge, ...]
-    # Internal NetworkX view (not part of public API; rebuildable from edges):
-    _graph: nx.DiGraph
 ```
 
-Construction:
+### 5.2 Projection rule
 
-```python
-def build_dag(pkg_or_graph) -> CausalDAG:
-    """Walk compiled causal_mechanism records and assemble a DAG.
+`build_causal_dag(graph)` scans compiled knowledges and includes a Claim when all
+of these are true:
 
-    Bare Claim(formula=Causes(...)) nodes are causal propositions, not
-    mechanism edges, and are ignored unless a mechanism action promotes them.
-    """
+1. The knowledge is a Claim.
+2. It has a top-level causal formula marker. In compiled IR this is
+   `metadata.formula_atom.kind == "causes"` plus `metadata.causal`; in runtime
+   objects it may also be visible as `Claim.kind == ClaimKind.CAUSAL`.
+3. `metadata.causal.cause` and `metadata.causal.effect` can be normalized to QID
+   or CNID endpoints.
+4. The resulting graph remains acyclic.
+
+The edge is:
+
+```text
+cause_id -> effect_id
+witnessed_by = causal Claim QID
+belief = causal Claim prior, if present
 ```
 
-The node identifier is a **string ID** — not a Python object — so `CausalDAG` is picklable, diffable, and consumable by the JSON renderer. Two kinds of node IDs coexist in a DAG:
+The default projection is structural: it includes authored causal Claims without
+thresholding on prior. Applications can filter low-belief edges before calling
+`build_causal_dag`, but the core API does not guess a MAP structure.
 
-- **Claim endpoints**: use the compiled Claim **QID** directly (`{namespace}:{package}::{label}` per `gaia.ir.knowledge.is_qid`). This is the propositional/action layer: one Claim's truth causally changes another Claim's truth.
-- **Variable endpoints**: use a synthesized **causal node ID** (`CNID`). Variables have no IR Knowledge per PR #505 §2.4, so they have no QID; we mint a stable synthetic ID with a visually distinct prefix: `@var:{namespace}:{package_name}:{symbol}`. The `@` prefix makes `is_qid()` return False, so no consumer confuses a CNID with a QID. The CNID is deterministic — identical inputs produce identical IDs across compilations, satisfying the audit-hash requirements of §4.8.
+### 5.3 Validation failures
 
-Current PR #505 code accepts `Causes(Term, Term)`, so predicate-level causal claims are term-level today. Claim-to-claim causation is not represented by `Causes(ClaimAtom(A), ClaimAtom(B))`; it is represented by the `mechanism(...)` action with Claim endpoints.
+Hard errors:
 
-See Open Question 2 (§12) on the declaring-vs-using package question for cross-package Variable references.
+- endpoint cannot be normalized
+- duplicate contradictory endpoint descriptors for the same causal Claim
+- cycle in the projected CausalDAG
+- `do(X)` requested for a node that is not in the CausalDAG
 
-### 3.2 Acyclicity is enforced at build time
+Warnings:
 
-`build_dag()` runs `nx.is_directed_acyclic_graph(self._graph)` before returning. Failure raises `CausalCycleError` listing the cycle; this plugs into `gaia check causal` (§8).
-
-### 3.3 Queries
-
-```python
-# gaia/causal/queries.py
-def ancestors(dag: CausalDAG, node: str) -> frozenset[str]: ...
-def descendants(dag: CausalDAG, node: str) -> frozenset[str]: ...
-def parents(dag: CausalDAG, node: str) -> frozenset[str]: ...
-def children(dag: CausalDAG, node: str) -> frozenset[str]: ...
-
-def d_separated(
-    dag: CausalDAG, x: str, y: str, given: frozenset[str] = frozenset()
-) -> bool:
-    """Pearl d-separation. Wrap nx.d_separated if available, fall back
-    to an in-house implementation for NetworkX versions that lack it."""
-
-def adjustment_sets(
-    dag: CausalDAG, cause: str, effect: str
-) -> list[frozenset[str]]:
-    """All back-door adjustment sets for P(effect | do(cause)).
-    Returned list is sorted by cardinality (smaller first)."""
-```
-
-`d_separated` is the **one** semantic query the reviewer pipeline will lean on — it detects unblocked confounder paths. `adjustment_sets` is convenience sugar frequently asked about back-door identification.
-
-### 3.4 Rendering hooks
-
-The Obsidian wiki renderer gets two distinct sections:
-
-- On causal proposition Claims: "**Causal proposition:** Causes(A, B)" plus formula metadata.
-- On mechanism actions / backing claims: "**Causal mechanism:** A → B" plus action label, CPD, and intervention status.
-- "**Ancestors:** …"
-- "**D-separated from:** … given { … }" (when nontrivial)
-
-These wire into `gaia render` through a tiny `render_causal_block(dag, node_or_action_id)` helper in `gaia.causal.dag` module. The SVG renderer uses directed edges with arrowheads only for mechanism actions, not for every `Causes(...)` predicate claim.
-
-### 3.5 Prior on a causal proposition — what it means and what it is not
-
-The `prior` on a causal proposition Claim is the agent's confidence that **the proposition "X causes Y" is true**. This is the same semantics PR #505 §4 gives to any claim with a formula: `prior = P(claim is true before evidence)`.
-
-The numeric strength of a promoted mechanism — `P(effect=1 | cause=1)` and `P(effect=1 | cause=0)` — is a **separate quantity**, supplied through the `mechanism()` action's `p_effect_given_cause` and `p_effect_given_not_cause` parameters (§4.1). These two parameters are independent of the backing claim's `prior`:
-
-- `prior = 0.9, p_effect_given_cause = 0.15, p_effect_given_not_cause = 0.05` — "I'm 90% sure smoking causes lung cancer; the mechanism kicks in 15% of the time among smokers, baseline 5% otherwise"
-- `prior = 0.5, p_effect_given_cause = 0.99, p_effect_given_not_cause = 0.01` — "Coin-flip belief that this mechanism exists; if it does, it's nearly deterministic"
-
-Conflating belief and strength into one number (e.g., reusing `prior` as the noisy-OR leak parameter) is a documented pitfall — see §12 Q4 for the rationale.
-
-For v0.6, DAG-build treats every authored mechanism action as **structurally present regardless of backing-claim `prior`**; see §3.5.1.
-
-#### 3.5.1 Soft edges, MAP structure, and the v0.6 default
-
-A mechanism backed by a causal proposition with `prior < 1` is a **softly believed mechanism**, not a fuzzy DAG edge. The structure exists at the DAG level because the author explicitly wrote a mechanism action; the numeric mechanism is supplied by CPD parameters (`p_effect_given_cause`, `p_effect_given_not_cause`, or an explicit CPT). D₂ does **not** reuse `prior` as a CPD entry. Future ensemble semantics may decide how posterior mechanism belief modulates graph structure or model averaging, but that is outside v0.6.
-
-Whether DAG-build should also filter edges by `prior > threshold` (MAP semantics) is **deferred** — see §12 Q1.
-
-### 3.6 Independent Variables and isolated sub-DAGs
-
-A variable never used as a `mechanism(...)` endpoint is not a DAG node, even if it appears in a bare `Causes(...)` predicate claim. A package can host multiple disconnected causal sub-DAGs — `CausalDAG` records components; `gaia check causal` warns if a `do()` target is on an isolated component and the user queries a disconnected effect.
+- causal Claim has no prior
+- causal Claim has no CPD and user requested numeric intervention
+- quantified causal Claim has not been grounded
 
 ---
 
-## 4. Intervention Layer (Spec 2)
+## 6. Symbolic Identification with y0
 
-The centerpiece. `do(X=x)` is the primitive that separates causal from conditional reasoning.
-
-### 4.1 Authored DSL — `mechanism()` action helper
-
-`mechanism(...)` is the v0.6 surface for declaring a causal mechanism. It promotes a causal proposition into the interventional graph and is parameterized by **two independent quantities**:
-
-- `backing_claim.prior` — the agent's belief that the causal proposition is true (semantics shared with all `Claim` priors per §3.5)
-- `(p_effect_given_cause, p_effect_given_not_cause)` — the single-parent CPD entries `P(effect=1 | cause=1)` and `P(effect=1 | cause=0)`, structurally identical to `infer()`'s `(p_e_given_h, p_e_given_not_h)` and `support()`'s deprecated `(p1, p2)` (see §12 Q4 for the choice of separate parameters)
-
-Runtime shape:
+### 6.1 Gaia-facing API
 
 ```python
-# gaia/lang/runtime/action.py
-@dataclass
-class Mechanism(Action):
-    """Interventional mechanism edge. Parallel to Support/Structural/Probabilistic."""
+from gaia.causal import identify_effect
 
-    cause: Claim | Variable | None = None
-    effect: Claim | Variable | None = None
-    backing_claim: Claim | None = None
-    p_effect_given_cause: float | None = None
-    p_effect_given_not_cause: float | None = None
-```
-
-`Mechanism` is intentionally not a `Support` or `Probabilistic` subclass. `infer()` says evidence updates belief in a hypothesis; `mechanism()` says intervening on one node changes the production of another node. They may use similar binary CPT numbers, but `mutilate()` must distinguish their modalities.
-
-Authored shape:
-
-```python
-from gaia.lang import Bool, Variable, causal, mechanism
-from gaia.causal import do, query
-
-co2  = Variable(symbol="co2_level", domain=Bool)
-temp = Variable(symbol="temperature", domain=Bool)
-G    = Variable(symbol="greenhouse_gas_other", domain=Bool)
-
-g_causes_co2 = causal(
-    cause=G, effect=co2,
-    prior=0.8,
-    rationale="Other greenhouse gases drive CO₂ via shared industrial sources.",
-    label="g_causes_co2_claim",
-)
-mechanism(
-    cause=G,
-    effect=co2,
-    backing_claim=g_causes_co2,
-    p_effect_given_cause=0.7,
-    p_effect_given_not_cause=0.05,
-    label="g_causes_co2_mechanism",
+result = identify_effect(
+    dag,
+    treatment=rain,
+    outcome=wet,
 )
 
-g_causes_temp = causal(cause=G, effect=temp, prior=0.7, label="g_causes_temp_claim")
-co2_causes_temp = causal(cause=co2, effect=temp, prior=0.9, label="co2_causes_temp_claim")
-mechanism(cause=G, effect=temp, backing_claim=g_causes_temp, p_effect_given_cause=0.6, p_effect_given_not_cause=0.05)
-mechanism(cause=co2, effect=temp, backing_claim=co2_causes_temp, p_effect_given_cause=0.85, p_effect_given_not_cause=0.05)
-
-# Query at runtime (invoked by `gaia infer --causal` or in an action body):
-result = do(co2=1).query(temp)              # numeric P(temp=1 | do(co2=1))
-result = query(temp, given_do={co2: 1})     # equivalent long form
+print(result.expression_latex)
 ```
 
-`causal()` returns the underlying `Claim(formula=Causes(cause, effect), kind=ClaimKind.CAUSAL, prior=prior)` and records no CPD. The existing lowercase `causes()` formula helper remains available when an author needs only the formula AST and no Claim. `mechanism()` returns/registers a `Mechanism` Action and records CPD parameters for compiler/lowering. The v0.6 compiler normalizes those action parameters into `metadata.causal_mechanism.cpd` (§1.1).
-
-#### 4.1.1 Default strengths (omitted parameters)
-
-If the author omits `p_effect_given_cause` / `p_effect_given_not_cause`, the mechanism lowering uses the v0.5 deduction default — `(1 − ε, 0.5)` — making the edge a **hard causal implication** equivalent in BP behavior to `deduction([cause], effect)` plus a causal-modality tag. This makes hard causation and soft causation traverse the same lowering path with different parameters.
-
-#### 4.1.2 Multi-parent effect: noisy-OR composition (default)
-
-When an effect node has multiple `mechanism()` parents, each edge supplies its single-parent absolute CPD entries. The compiler groups incoming mechanism actions by effect and composes them into the effect node's canonical CPT using **leak-aware noisy-OR** by default.
-
-First choose the effect-level leak:
-
-- if all incoming edges agree on `p_effect_given_not_cause`, that shared value is the leak;
-- otherwise the author must provide an explicit effect-level leak (or a full CPT once the authoring escape hatch ships); v0.6 must not silently use `max` or `mean` because either choice changes the baseline model.
-
-For each active edge:
-
-```
-strength_i = (p_effect_given_cause_i - leak) / (1 - leak)
-```
-
-The compiler rejects `p_effect_given_cause_i < leak` for noisy-OR because that is inhibitory rather than activating. The CPT entry for a parent assignment is:
-
-```
-P(effect = 1 | active parents A) =
-    1 − (1 − leak) * ∏_{i in A} (1 − strength_i)
-```
-
-With no active parents (`A = ∅`), this returns `leak`, so `P(effect=1 | all causes=0)` is preserved.
-
-The machine contract is still a full binary `CONDITIONAL` CPT; noisy-OR is only an authoring/lowering transform. Authors who need inhibition, synergy, or any other non-noisy-OR interaction need the full-CPT authoring escape hatch discussed in §12 Q4.
-
-#### 4.1.3 Soft `do()` deferred to D₂.5
-
-`do(X = Distribution(...))` and other stochastic-intervention forms are scoped to a follow-up milestone D₂.5 — see §10 and §12 Q5 for the rationale. The authored distribution type should reuse the current `gaia.lang.bayes.distributions.protocol.Distribution` contract (`model_dump`, `logpmf` / `logpdf`, `support`) instead of inventing a second `DistributionSpec`. For binary soft interventions, v0.6 can either use the existing `Binomial(n=1, p=p)` literal or add a thin `Bernoulli(p)` alias in `gaia.lang.bayes`; both compile to the same unary intervention distribution.
-
-### 4.2 Intervention object
+Gaia owns the public result type:
 
 ```python
-# gaia/causal/intervene.py
-@dataclass(frozen=True)
-class Intervention:
-    assignments: dict[str, int]   # QID or CNID -> {0, 1}
-
-    def query(self, target: str | VarRef) -> CausalQueryResult: ...
-    def query_all(self, targets: Iterable) -> dict[str, CausalQueryResult]: ...
-
-@dataclass(frozen=True)
-class CausalQueryResult:
-    target_id: str                 # QID or CNID
-    intervention: dict[str, int]
-    belief: float                  # P(target=1 | do(assignments))
-    dag_snapshot: CausalDAG        # DAG used (for audit)
-    factor_graph_digest: str       # sha256 of the mutilated FG (for audit)
-    identified: bool | None = None   # True / False / None if y0 not consulted
-    id_expression_latex: str | None = None # symbolic identifier, if computed
-    id_node_map: dict[str, str] | None = None # display symbol -> Gaia QID/CNID
-```
-
-`belief` is always numerically produced by Gaia BP (it is always *computable* — whether or not it is *identifiable from data alone* is a separate question answered by the optional adapter).
-
-#### 4.2.1 Average causal effect helper — `ate()`
-
-A thin DSL wrapper over two `do()` queries:
-
-```python
-from gaia.causal import ate
-
-ate_co2_to_temp = ate(co2, temp)
-# Equivalent to:
-#   do(co2=1).query(temp).belief - do(co2=0).query(temp).belief
-```
-
-`ate()` returns a `CausalATEResult(..., belief_diff: float, do1: CausalQueryResult, do0: CausalQueryResult)`. **Semantics:** the average causal effect on a *per-instance* DAG node — not a population ATE (Gaia is per-instance grounded; see §5). Population-level ATE / CATE is deferred (§11).
-
-### 4.3 Numeric computation — mutilate + BP
-
-```python
-# gaia/causal/intervene.py, conceptual pseudo-code
-from gaia.bp.factor_graph import mutilate                 # §1.2
-from gaia.bp.lowering import lower_local_graph            # existing
-from gaia.bp.engine import InferenceEngine                # existing
-
-def _compute(
-    pkg_artifact,
-    intervention: dict[str, int],
-    target: str,
-) -> CausalQueryResult:
-    dag = build_dag(pkg_artifact)
-    # 1. Lower the compiled local graph normally. Mechanism actions have already
-    #    been compiled to causal CONDITIONAL factors; the
-    #    multi-parent noisy-OR composition (§4.1.2) is performed here at lower
-    #    time, producing one provenance-tagged CONDITIONAL factor per causal effect node.
-    fg  = lower_local_graph(pkg_artifact.local_canonical_graph)
-    # 2. Mutilate: drop *causal* factors whose conclusion ∈ intervened set
-    #    (see §4.4 — logical SOFT_ENTAILMENT factors are NOT mutilated).
-    fg2 = mutilate(fg, set(intervention))
-    # 3. Clamp intervened vars to their assigned values.
-    for qid, val in intervention.items():
-        fg2.observe(qid, val)
-    # 4. Run BP via the existing engine and read off target marginal.
-    beliefs = InferenceEngine().run(fg2).beliefs          # uses JT exact when treewidth allows
-    return CausalQueryResult(
-        target_id=target,
-        intervention=dict(intervention),
-        belief=beliefs[target],
-        dag_snapshot=dag,
-        factor_graph_digest=_canonical_digest(fg2),       # see §4.8
-    )
-```
-
-**Why this is correct.** For a DAG with factorization `P(V) = ∏ᵢ P(vᵢ | pa(vᵢ))`, Pearl's truncated factorization for `P(V | do(X=x))` is identical to `P(V)` with every `P(xᵢ | pa(xᵢ))` replaced by the point mass on `xᵢ = x`. In Gaia v0.6 this is realised by:
-
-1. Each `mechanism()` action contributes explicit CPD parameters. Multi-parent effects compose via noisy-OR (§4.1.2) into one canonical `CONDITIONAL` factor per effect node.
-2. CNID variables (Variables, per PR #505 §2.4 they have no IR Knowledge) are registered as BP variables during causal lowering inside the standard `gaia.bp.lowering` path.
-3. The generated causal factor carries `metadata={"modality": "causal", "causal_mechanism": {...}}` copied from the compiled mechanism action metadata (§1.2).
-4. `mutilate(fg, intervened)` identifies and drops only the factor whose conclusion ∈ intervened **and** whose factor metadata says `modality == "causal"` (see §4.4). Logical and structural factors (`deduction`, `decompose`, IMPLICATION/EQUIVALENCE operator helpers) are preserved.
-5. `observe()` clamps the intervened variable to its target value.
-
-This yields exactly the truncated factorization for the per-instance DAG.
-
-### 4.4 Mutilation respects modality — first-principles boundary
-
-The `mutilate()` helper distinguishes **causal** factors from **logical** factors. Only the former are removed under `do()`. This is not a convention — it is forced by the meaning of `do()`:
-
-> `do(X = x)` is an **intervention on the world**. Causal edges describe how the world produces effects from causes; intervening severs that production. Logical edges describe how *statements about* the world are related (entailment, definition, identity); intervention has no purchase on them.
-
-A short tour of the thought experiments motivating this rule:
-
-| # | Setup | `do()` query | Pearl-correct behavior | Implication for Gaia |
-|---|---|---|---|---|
-| 1 | "All men are mortal; Socrates is a man." | `do(¬"all men are mortal")` | Ill-defined. You cannot intervene on a logical truth. | **Logical edges admit no `do()` semantics**; they are preserved under mutilation. |
-| 2 | Fire → Smoke (causal) | `do(Smoke = 1)` (smoke machine) | `P(Fire) = P(Fire)` — base rate, unchanged. | Causal edges are **severed**; intervened node loses its causal parents. |
-| 3 | "Bachelor" ↔ "unmarried man" (definitional) | `do(¬"unmarried")` | Both flip together — they are the same fact. | Use EQUIVALENCE operator, not Causes / deduction. EQUIVALENCE is **not mutilated** (it's a structural identity, not a mechanism). |
-| 4 | F = ma (physical law) | `do(a = 0)` | Ambiguous — depends on whether F=ma is read as constraint (then F→0) or mechanism (then F unchanged, supported by counter-force). | **Author must choose** — declare F→a with `mechanism()` (mechanism, F preserved) or as `deduction([F, m], a)` (constraint, F follows). Engine will not guess. |
-| 5 | Temperature ⇄ Evaporation | `do(Evap = 0)` (sealed bucket) | Temperature unchanged at the mutilation step. | Direction matters; each direction is a separate cause. |
-| 6 | Whole claim decomposed via `decompose(C, [A, B], A & B)` | `do(C = 0)` | The decomposition remains a structural identity; it is not a production mechanism. | `Decompose` is a `Structural` action in current v0.5, so generated factors are **not mutilated**. |
-| 7 | Mixed: Hot → Cooked (causal); Cooked ↔ "not raw" (logical) | `do(Hot = 0)` | Cuts only the (empty) causal in-edges of `Hot`; `Cooked` propagates normally; logical "not raw" follows. | **Mixed graphs work cleanly** as long as each edge declares its modality. |
-| 8 | (Generalization) Node has both causal and logical/structural incoming edges. | `do(node = v)` | Cuts only the causal in-edges; logical/structural edges remain live and propagate. | Implementation: filter on factor metadata `modality == "causal"`. |
-| 9 | Same fact authored as both `causal()` and a logical/structural relation | — | Engine cannot disambiguate. | `gaia check causal` raises a warning when an effect node has both modalities incoming (§8.1, new rule). |
-
-Concretely the rule is:
-
-> **`mutilate(fg, intervened)` drops factor `f` iff:**
-> 1. **`f.conclusion ∈ intervened`** — standard truncation condition; AND
-> 2. **`f` is causal** — i.e., `f.metadata.get("modality") == "causal"`.
->
-> Logical SOFT_ENTAILMENT (deduction-derived), `decompose()`-generated structural helpers, IMPLICATION operator factors, and EQUIVALENCE / CONJUNCTION / DISJUNCTION / CONTRADICTION operator factors are **never** mutilated.
-
-This rule matches Pearl's standard mutilation when the graph is purely causal, and degrades gracefully when logical edges are present.
-
-#### 4.4.1 Definitional escape hatch — not needed
-
-Earlier drafts of this spec proposed a `definitional=True` flag on deduction edges to mark them "do-resistant". The first-principles analysis above makes the flag redundant: deduction edges are already do-resistant by virtue of being logical. No new author-facing flag is introduced.
-
-### 4.5 Interaction with strategy-embedded operators (`FormalExpr`)
-
-A `FormalStrategy` may embed multiple `Operator`s inside a `FormalExpr`. When lowered to `FactorGraph`, each embedded operator produces its own factor. `Decompose` similarly generates structural helper/formula factors from an action-level decomposition. `mutilate` walks the resulting factor list and applies the §4.4 rule uniformly — embedded operators and decomposition helpers are logical/structural by origin, so they pass through mutilation unchanged.
-
-### 4.6 Only causally authored intervention is permitted
-
-An intervention is only well-defined over nodes that are **DAG nodes** — i.e., participate in at least one `mechanism()` edge. Attempting `do(X = 1)` on a node that has no causal in-edges raises `InterventionUndefinedError` with a message pointing the author at `mechanism(...)`.
-
-This is a deliberate restriction motivated by thought experiment 1 (§4.4): `do()` on a node with only logical parents has no Pearl-style semantics. The error message must surface this rationale rather than say "node not found."
-
-### 4.7 Target types
-
-`query(target)` accepts:
-
-- A `Variable` reference (compiled to its synthesized CNID) — the common case.
-- A `Claim` reference (compiled QID) — useful for `do(X=1).query(some_claim)` where the author wants to see the claim's belief under intervention.
-- A string QID — the machine-friendly form.
-
-The result's `target_id` is always the compiled QID (for Knowledge targets) or CNID (for Variable targets) regardless of input form.
-
-### 4.8 Deterministic auditability
-
-Every `CausalQueryResult` carries:
-
-- `dag_snapshot` — the causal DAG used.
-- `factor_graph_digest` — sha256 of the post-mutilation factor graph (canonicalized per §3.2 of `strategy.py`).
-
-These let a reviewer re-run the query and verify bit-equality. The digest is the primary audit hash; the DAG snapshot is for human inspection.
-
----
-
-## 5. Predicate Claims and Mechanism Grounding
-
-Gaia Lang is **predicate-level** (PR #505: Variables, Domains, quantifiers, Causes); Gaia BP is **propositional** (Boolean Knowledge nodes + factors). The grounding rule has two stages:
-
-1. Formula lowering grounds causal **propositions** exactly like other quantified formulas. This creates reviewable Knowledge nodes and deduction links, but no mechanism factors.
-2. Mechanism lowering grounds only authored `mechanism(...)` **actions** into DAG nodes and causal `CONDITIONAL` factors.
-
-This section fixes the grounding contract for causal propositions and mechanism actions under universal quantification, in **strict duality with the v0.5 logical-quantifier grounding** already implemented in `gaia/lang/compiler/lower_formula.py:107-192`.
-
-### 5.1 The v0.5 baseline: how `forall` is grounded today
-
-For a logical universal `forall(x: D, P(x))`, the v0.5 lowerer (commit a1f8c319, PR #510) emits:
-
-- One **universal claim** Knowledge node (the source claim).
-- For each `v ∈ D.members`: one **instance claim** `P_v` and one `deduction` strategy `universal_claim ⇒ P_v`.
-
-There is **no NOISY_AND** linking the instances back to the universal — the universal is the deductive *parent*, and instances inherit truth from it through standard SOFT_ENTAILMENT / weak-syllogism flow.
-
-In BP: `universal = true` ⇒ each `P_v` ≈ 1; `universal = false` ⇒ each `P_v` retreats to base rate. Evidence on any `P_v` weakly raises the universal via reverse syllogism.
-
-**This is the model we mirror for causal proposition universals.** Mechanism factors are an additional action-layer lowering step, not a side effect of the formula lowerer.
-
-### 5.2 The causal universal: proposition grounding plus mechanism grounding
-
-For a causal universal `forall(p: D, Causes(X(p), Y(p)))`, the compiler emits:
-
-- One **universal causal claim** Knowledge node — same node the author wrote.
-- For each `v ∈ D.members`:
-  - Instance causal claim Knowledge — the per-instance assertion that "X_v causes Y_v".
-  - `deduction` strategy: `universal_causal_claim ⇒ instance_causal_claim` — exactly as the logical case.
-  - Predicate metadata on the instance claim records the instantiated `cause` / `effect` descriptors.
-
-If, and only if, the author also writes a `mechanism(...)` action whose `backing_claim` is this universal causal claim, the mechanism lowering additionally emits for each `v ∈ D.members`:
-
-- Instance CNID variables `X_v`, `Y_v` — generated causal node IDs such as `@var:{namespace}:{package}:{symbol}_{digest}`. These are BP/DAG variables, **not** IR Knowledge nodes.
-- One `metadata.causal_mechanism` record with `cause_id = X_v`, `effect_id = Y_v`, `backing_claim_qid = instance_causal_claim`.
-- One provenance-tagged `CONDITIONAL` factor on `(X_v, Y_v)`, with CPT parameters taken from the `mechanism(...)` action and normalized into the mechanism record.
-
-The proposition part is **structurally dual** to the v0.5 logical lowering: each instance gets a propositional copy, the universal claim is the deductive parent, and BP propagates exactly as it does today for universal logical claims. The mechanism part is action-layer promotion: it reads those grounded proposition nodes as provenance and emits causal factors only where the author explicitly asked for an interventional mechanism.
-
-```
-                   ┌────────────────────────────┐
-                   │  universal_causal_claim    │ (Knowledge)
-	                   └────────────┬───────────────┘
-	                  deduction     │     deduction
-        ┌──────────────────┐    │   ┌──────────────────┐
-        ▼                  │    │   ▼                  │
-	 instance_v₁_causal    instance_v₂_causal     ...        (per-instance Knowledge)
-	        │                                │
-	        │ mechanism action lowers         │ mechanism action lowers
-	        │ this proposition into           │ this proposition into
-	        │ CONDITIONAL (causal, CPT)       │ CONDITIONAL (causal, CPT)
-	        ▼                                ▼
-	 X_v₁ ──→ Y_v₁                    X_v₂ ──→ Y_v₂              (propositional CNIDs)
-```
-
-`do(X_v₁ = 1)` operates on a **specific instance** only if the corresponding mechanism action exists — Pearl-correct semantics, no ambiguity about which person/particle is being intervened on. `do(universal_causal_claim = 1)` is rejected because the universal claim is a proposition, not a causal DAG node; authors who want to assert the universal should use `observe(universal_causal_claim, 1)`.
-
-### 5.3 Why per-instance grounding (not single-representative or population-parameter)
-
-We considered three grounding strategies during design (recorded for posterity):
-
-| Strategy | What it does | Why rejected for v0.6 |
-|---|---|---|
-| **A. Full individual grounding** *(adopted — §5.2)* | One instance per Domain member, exactly mirroring v0.5 logical-quantifier grounding. | Adopted. |
-| B. Single representative | One pair `(X_template, Y_template)` per causal universal regardless of Domain size. | Asymmetric with logical `forall` lowering; loses the per-instance addressability that makes per-individual evidence and reviewer queries possible. |
-| C. Population-parameter grounding | Introduce a "rate" / continuous-valued parameter node summarising the population. | Requires hierarchical SCM and continuous-valued nodes — not v0.5/v0.6 BP. Deferred to v0.7+ (§11). |
-
-Strategy A is correct because it preserves the cleanest property of Pearl's framework: every node in the DAG is a concrete event whose `do()` semantics is unambiguous.
-
-### 5.4 What this grounding does **not** support
-
-- **Population-level intervention.** "What happens if 30% of the population is intervened on `X`?" requires marginalising over instance choice — out of scope. Authors who need this should run a population study externally (DoWhy/EconML) and feed the result back as evidence on the universal claim.
-- **Heterogeneous treatment effects (CATE).** Per-instance grounding gives one effect strength per universal — variation across subgroups requires multiple universals partitioned by subgroup, which the author can express manually but the engine does not synthesise.
-- **Counterfactual reasoning at the universal.** Counterfactuals at the per-instance level *do* compose under §4 mutilation; counterfactuals at the universal-claim level (e.g. "what if this universal had not held") are not given a special treatment — they reduce to instance-level counterfactuals.
-
-These limits are recorded in §11 (out of scope).
-
-### 5.5 Naming and identifier discipline
-
-Per-instance grounded Knowledge nodes follow the synthesizer used by `gaia/lang/compiler/lower_formula.py:973` for logical instances — labels of the form `__forall_{symbol}_{digest}`. CNID synthesis for instance Variables follows §3.1 (`@var:{namespace}:{package}:{symbol}_{digest}`) so the same Variable used in two distinct universals produces two distinct CNIDs.
-
----
-
-## 6. Symbolic Identification (Spec 3, optional)
-
-### 6.1 Adapter contract
-
-```python
-# gaia/causal/adapters/y0.py
-def identify(
-    dag: CausalDAG,
-    target: str,
-    intervention: dict[str, int],
-) -> IdentificationResult:
-    """Ask y0 whether P(target | do(intervention)) is identifiable from
-    observational data under the given DAG. Returns the symbolic expression
-    if yes, or a NotIdentifiable with the obstruction witness if no.
-
-    Imports y0 lazily; raises MissingDependencyError if y0 is not installed.
-    """
-
 @dataclass(frozen=True)
 class IdentificationResult:
+    treatment_id: str
+    outcome_id: str
     identifiable: bool
-    expression_latex: str | None # y0's rendered Expression.to_latex()
-    node_map: dict[str, str]     # display symbol -> Gaia QID/CNID
-    obstruction: str | None      # human-readable witness when not
-
-class MissingDependencyError(ImportError): ...
-class NotIdentifiable(Exception): ...
+    backend: Literal["y0"]
+    expression_latex: str | None
+    expression_text: str | None
+    assumptions: tuple[str, ...] = ()
 ```
 
-### 6.2 Opt-in call site
+y0 is a first-party backend behind this API. Users do not need to construct y0
+objects directly.
 
-Identification runs **only on explicit request** — either through a `gaia check causal --identify` CLI flag or a keyword `do(co2=1).query(temp, identify=True)`. When requested and y0 is installed, the `CausalQueryResult` is populated with `identified`, `id_expression_latex`, and `id_node_map`.
+### 6.2 Backend boundary
 
-This keeps the default path (`do().query()`) dependency-free.
+Gaia does not store y0 objects in IR. The adapter converts at runtime:
 
-### 6.3 Lazy import pattern
+```text
+CausalDAG -> y0 graph/expression -> IdentificationResult
+```
 
-The adapter imports y0 inside the function body; `ImportError` is translated to `MissingDependencyError("install gaia[causal-do] to use do-calculus identification")`. This is the same pattern `gaia.stats.adapters` uses for scipy.
+This keeps Gaia's schema stable and lets future adapters coexist without
+rewriting causal Claims.
 
-### 6.4 What identification does and does not provide
+### 6.3 Why DoWhy is deferred
 
-- ✅ Symbolic guarantee that the numeric answer in `result.belief` **could** have been computed from purely observational data under the DAG.
-- ✅ Witness obstruction (e.g., "unblocked back-door path through G") when the query is not identifiable.
-- ❌ Estimation uncertainty — that requires real data and is out of scope.
-- ❌ Automatic adjustment — Gaia BP already uses all the structure it has; identification is a **meta-assurance** layer on top of the numeric answer.
+DoWhy is valuable for empirical workflows:
+
+```text
+CausalDAG + dataset -> estimate/refute
+```
+
+That requires decisions Gaia should not make in this minimal spec:
+
+- dataset binding
+- column naming
+- treatment/outcome schema
+- estimator selection
+- confidence intervals and robustness checks
+
+The minimal v0.6 target is:
+
+```text
+CausalDAG -> symbolic estimand
+```
+
+That is the y0-shaped problem.
 
 ---
 
-## 7. Compiler Changes
+## 7. Relationship to BP and `do()`
 
-### 7.1 Normalize predicate metadata
+### 7.1 Minimal v0.6
 
-```python
-causal = claim.metadata.get("causal")
-if not causal or "cause" not in causal or "effect" not in causal:
-    raise CausalMetadataMissingError(
-        "CAUSAL claim is missing predicate causal descriptors; "
-        "recompile with the v0.6 formula-lowering compiler"
-    )
+The first deliverable does not need numeric `do()`:
 
-claim.metadata["causal"] = {
-    "predicate": {"cause": causal["cause"], "effect": causal["effect"]}
-}
+```text
+causal Claims -> CausalDAG -> y0 symbolic identification
 ```
 
-D1 builds on the v0.5 formula-lowering path. After QID assignment, the compiler walks Claims whose formula is a top-level `Causes(X, Y)` (`kind == CAUSAL`), quantified Claims whose grounded body is `Causes(...)` (`kind == QUANTIFIED`), or generated instances of either. It validates that formula lowering already populated predicate descriptors and normalizes them into `metadata.causal.predicate`.
+This is enough to answer:
 
-This pass intentionally does **not** write `dag_edge` or `cpd`. Those are mechanism-action concepts.
+```text
+Is P(Y | do(X)) identifiable from this causal structure?
+What expression should be estimated from observational quantities?
+```
 
-### 7.2 Compile mechanism actions
+### 7.2 Later numeric intervention
 
-The compiler separately walks `Mechanism` actions. For each action it:
+Numeric intervention requires more than the DAG:
 
-1. Registers the `backing_claim` and endpoint Claims, if present, as normal Knowledge.
-2. Resolves endpoint IDs:
-   - Claim endpoints resolve to compiled QIDs.
-   - Variable endpoints synthesize CNIDs using §3.1.
-3. Validates that a backing causal proposition, if provided, is compatible with the action endpoints. A mismatch is an error; this prevents a claim saying `Causes(X, Y)` from backing a mechanism `Z → Y`.
-4. Emits a `metadata.causal_mechanism` record (§1.1) that `build_dag` and BP lowering can consume.
+```text
+CausalDAG + CPDs or observational distribution + BP/data backend
+```
 
-For `Variable` operands, `resolve_causal_id` synthesizes a **CNID** with the format `@var:{namespace}:{package_name}:{symbol}` — visually distinct from QIDs and guaranteed to fail `is_qid()`. For Claim endpoints, it uses the compiled QID directly. No broadening of `Causes` is needed for claim-to-claim causation because that path lives in `mechanism(...)`, not in the formula predicate.
+When numeric `do()` is added, the rule should be:
 
-### 7.3 No new IR schema, no overloaded strategy type
+1. Validate the treatment node exists in CausalDAG.
+2. Use CausalDAG to identify which causal incoming edge factors to remove.
+3. Use CPD metadata or an observational estimand to build a numeric query.
+4. Reuse Gaia BP when the query can be represented as a FactorGraph.
 
-All the new semantics live in metadata and in `gaia.causal`. IR `Operator`, `Strategy`, `StrategyType`, `OperatorType` enums — all unchanged. The compiler must not encode mechanism actions as ordinary `infer`, `support`, or `deduction` strategies without an explicit `metadata.causal_mechanism` record; doing so would lose the modality needed by `mutilate()`.
-
-### 7.4 Migration concern: existing `CAUSAL` claims
-
-Packages compiled after PR #510 but before v0.6 can already contain `metadata.causal.cause` / `.effect`. Handling:
-
-- If `metadata.causal` is absent on a causal proposition claim, the artifact is malformed for v0.6 causal proposition tooling.
-- If `metadata.causal` exists with top-level `cause` / `effect`, recompile normalizes it to `metadata.causal.predicate`.
-- If a package has causal proposition Claims but no `mechanism(...)` actions, `build_dag` returns no edges and `do()` targets are undefined. This is intentional and should be explained by diagnostics rather than treated as missing metadata.
+This later work must not infer CPDs from causal Claim priors.
 
 ---
 
-## 8. `gaia check causal`
+## 8. Implementation Plan
 
-A new CLI sub-check. Invoked as `gaia check causal <package>` or bundled into `gaia check` when a package contains any `CAUSAL` claim or `Mechanism` action.
+### D1. Normalize causal authoring
 
-### 8.1 Rules
+- Keep `causal(cause, effect, ...)` as the primary public API.
+- Extend it to accept Claim endpoints by wrapping them in `ClaimAtom`.
+- Widen `Causes` endpoint validation to accept `Term | ClaimAtom`.
+- Keep Variable/Term endpoints working as they do today.
+- Keep explicit `Claim(formula=Causes(...), kind=CAUSAL)` valid.
+- Do not add `mechanism(...)` or `is_causal`.
 
-| Rule | Severity | Triggered by |
-|---|---|---|
-| Acyclicity | Error | `CausalCycleError` from `build_dag` |
-| Intervention target is a DAG node | Error | `InterventionUndefinedError` on any authored `do(...)` |
-| Bare causal proposition | Info | A `Claim(formula=Causes(...), kind=CAUSAL)` or quantified causal proposition exists with no `mechanism(...)` action. It is reviewable as a proposition but does not enter DAG/intervention semantics. |
-| Mechanism/backing mismatch | Error | A `mechanism(...)` action's endpoints disagree with its backing causal proposition. |
-| Open back-door path | Warning | For every mechanism edge `X → Y`, inspect paths from `X` to `Y` that enter `X` after removing outgoing edges from `X`. If any path remains open under the declared observed covariates, surface the minimal candidate adjustment sets from `adjustment_sets(...)` or report that no valid set is available. Never condition on `X` or `Y` themselves. |
-| Mixed-modality incoming edges | Warning (Error under `--strict`) | Effect node has both `mechanism()` and logical/structural incoming factors (`deduction()`, `decompose()`, EQUIVALENCE, etc.). Author should clarify whether the non-causal edge is a definitional consequence (then mutilation will preserve it correctly per §4.4) or actually a mis-typed causal mechanism (then re-author as `mechanism()`). See §4.4 thought experiment 9. |
-| Identification (opt-in) | Info / Warning | Requires `--identify`; emits obstruction witness per non-identifiable authored `do()` |
-| Variable reuse across sub-DAGs | Warning | The same Variable appearing in disconnected components — likely an authoring error |
+### D2. Compile causal endpoint descriptors
 
-### 8.2 Output format
+- Preserve the current `metadata.causal = {"cause": ..., "effect": ...}` shape.
+- Add descriptor support for ClaimAtom endpoints:
 
-JSON, keyed by rule. Fits into the existing `gaia check` aggregated report so reviewers get one unified view.
+```python
+{"kind": "claim", "qid": "..."}
+```
+
+- Add stable CNIDs for Variable endpoints:
+
+```python
+{"kind": "variable", "symbol": "x", "domain": "Real", "cnid": "..."}
+```
+
+### D3. Add `gaia.causal.dag`
+
+- Implement `CausalNode`, `CausalEdge`, `CausalDAG`.
+- Implement `build_causal_dag(graph)`.
+- Validate acyclicity.
+- Expose structural helpers only if needed by y0 adapter.
+
+### D4. Add y0 adapter
+
+- Add `gaia.causal.identify_effect(...)`.
+- Add runtime conversion from `CausalDAG` to y0.
+- Return Gaia-owned `IdentificationResult`.
+- Lazy-import y0 or place it behind a small optional extra.
+
+### D5. Defer numeric intervention
+
+Do not implement full numeric `do()` until after D1-D4 are stable. Add only the
+minimal `BinaryCPD` payload if needed to preserve authored parameters.
 
 ---
 
-## 9. DSL Surface Summary
+## 9. Open Questions
 
-```python
-# Authoring — separate causal proposition from mechanism action
-from gaia.lang import Bool, Variable, causal, mechanism
+Only two questions remain open for the minimal spec:
 
-X = Variable(symbol="X", domain=Bool)
-Y = Variable(symbol="Y", domain=Bool)
+1. **Should y0 be a hard dependency or optional extra?**
 
-c = causal(
-    cause=X, effect=Y,
-    prior=0.9,
-    rationale="…",
-    label="x_causes_y_claim",
-)
-m = mechanism(
-    cause=X,
-    effect=Y,
-    backing_claim=c,
-    p_effect_given_cause=0.85,
-    p_effect_given_not_cause=0.05,
-    label="x_causes_y_mechanism",
-)
-# `c` is the reviewable CAUSAL Claim. `m` is the mechanism edge.
-# The lowercase causes() formula helper remains available when you only need the AST node.
-```
+   Recommendation: first-party API, lazy-import backend. User experience is
+   built-in; Gaia IR does not depend on y0 object types.
 
-```python
-# Queries
-from gaia.causal import do, query, ate
+2. **Should quantified causal Claims be grounded in v0.6?**
 
-result = do(X=1).query(Y)                            # numeric, hard intervention
-result = do(X=1).query(Y, identify=True)             # numeric + symbolic (needs extra)
-result = query(Y, given_do={X: 1})                   # long form
-result = ate(X, Y)                                   # do(X=1).Y - do(X=0).Y
+   Recommendation: not in the first causal PR. Store and render quantified
+   causal Claims, but require concrete QID/CNID endpoints for CausalDAG
+   projection.
 
-# D₂.5 (separate milestone): stochastic intervention
-from gaia.lang.bayes import Binomial
-result = do(X=Binomial(n=1, p=0.1)).query(Y)
-```
-
-```python
-# Library (for tool authors / reviewers)
-from gaia.causal import build_dag, d_separated, ancestors, adjustment_sets
-
-dag = build_dag(compiled_artifact)
-dag.nodes          # frozenset[str]
-dag.edges          # tuple[CausalEdge, ...]
-d_separated(dag, "@var:github:pkg:X", "@var:github:pkg:Y", frozenset({"@var:github:pkg:Z"}))
-ancestors(dag, "@var:github:pkg:Y")
-adjustment_sets(dag, "@var:github:pkg:X", "@var:github:pkg:Y")       # list[frozenset[str]]
-```
-
-```python
-# Optional symbolic identification (extra)
-from gaia.causal.adapters.y0 import identify        # lazy y0 import
-
-identify(dag, target="@var:github:pkg:temp",
-         intervention={"@var:github:pkg:co2": 1})
-# → IdentificationResult(identifiable=True, expression_latex="...", node_map={...})
-# or IdentificationResult(identifiable=False, obstruction="back-door path via G")
-```
+Everything else is intentionally out of scope for the minimal release.
 
 ---
 
-## 10. Implementation Milestones
+## 10. Non-Goals Recap
 
-Five independent PR slices, strictly ordered.
-
-### Milestone D₁ — Causal structure layer (Spec 1)
-
-Depends on: PR #505 and PR #510 (merged to `v0.5`).
-
-- **Compiler:** validate and normalize existing `metadata.causal` operand descriptors as predicate metadata; compile `Mechanism` actions into `metadata.causal_mechanism` records (§7.1, §7.2).
-- **`gaia.causal.dag`:** `CausalDAG`, `CausalEdge`, `build_dag`. Cycle detection.
-- **`gaia.causal.queries`:** `ancestors`, `descendants`, `parents`, `children`, `d_separated`, `adjustment_sets`.
-- **`gaia.causal.errors`:** `CausalCycleError`, `CausalMetadataMissingError`, `InterventionUndefinedError`.
-- **DSL:** keep existing `causal()` as Claim/formula sugar; add `mechanism()` action helper with CPD parameters (§4.1); keep `causes()` exported as formula sugar (§0.4).
-- **`pyproject.toml`:** `networkx>=3` added to base dependencies.
-- **Renderer hook:** separate "Causal proposition" and "Causal mechanism" sections in Obsidian wiki output.
-- **Tests:** compiler preserves `metadata.causal.cause` / `.effect` from formula lowering as predicate metadata; bare `causal()` returns a `CAUSAL` Claim but does not create DAG edges; `mechanism()` emits a causal mechanism record and preserves CPD metadata for D₂; `causes()` remains importable; DAG construction, acyclicity, d-separation parity with textbook examples (confounder, chain, collider); adjustment-set enumeration on canonical DAGs.
-
-Independently shippable: enables `gaia check causal`, makes renderings causal-aware, but does not yet execute interventions. Roughly 2–3 weeks.
-
-### Milestone D₂ — Intervention primitive (Spec 2)
-
-Depends on: D₁.
-
-- **`gaia.bp.factor_graph.mutilate`:** modality-aware helper (§1.2, §4.3, §4.4). Drops only provenance-tagged causal `CONDITIONAL` factors; logical factors preserved.
-- **Multi-parent noisy-OR composition:** lowering pass that combines multiple `mechanism()` edges into one provenance-tagged `CONDITIONAL` factor per effect node (§4.1.2). Sits inside the existing `gaia/bp/lowering.py` — no new `gaia.causal.lowering` module needed; the compiled mechanism records and CPD parameters carry enough information to register CNID variables and emit the canonical CPT factor at standard lower time.
-- **Per-instance grounding for causal universals:** formula lowering emits per-instance causal proposition Knowledge nodes plus deduction edges from universal to instance; mechanism lowering emits generated CNID variables and one provenance-tagged causal `CONDITIONAL` factor per instance pair only when a `mechanism()` action promotes the universal (§5.2).
-- **`gaia.causal.intervene`:** `Intervention`, `CausalQueryResult`, `_compute` using `mutilate` + Gaia BP (no separate causal lowering module).
-- **`gaia.causal`:** `do()`, `query()`, `ate()` surface (§4.1, §4.2.1); keep `causal()` itself on the existing `gaia.lang` / `gaia.lang.dsl` export path.
-- **`gaia check causal`:** acyclicity, intervention-target, bare-proposition, mechanism/backing mismatch, and mixed-modality rules (§8.1).
-- **Tests:** `mechanism()` lowers to a provenance-tagged causal `CONDITIONAL` factor with the expected CPT; bare `causal()` does not; smoked against canonical SCMs (confounder, front-door, chain, collider); belief values compared against hand-computed truncated factorizations; thought-experiment 1–9 (§4.4) regression coverage; per-instance grounding parity with logical-quantifier grounding; ATE round-trip.
-
-Independently shippable: Gaia answers `P(Y | do(X))` and `ATE(X, Y)` numerically. Roughly 3–4 weeks (most of the work is tests, multi-parent noisy-OR composition, and per-instance grounding parity; `mutilate` itself is a small filter-and-rebuild pass).
-
-### Milestone D₂.5 — Stochastic intervention (`do(X ~ dist)`)
-
-Depends on: D₂.
-
-- **Authored DSL:** `do(X = Binomial(n=1, p=p))` and equivalent shorthand for stochastic / soft interventions (§4.1.3). A `Bernoulli(p)` alias may be added in `gaia.lang.bayes` for ergonomics, but it must share the existing Distribution protocol.
-- **`mutilate` extension:** instead of clamping intervened nodes via `observe`, install a unary likelihood factor matching the intervention distribution.
-- **`Intervention.assignments`:** widen type from `dict[str, int]` to `dict[str, int | Distribution]` where `Distribution` is the current `gaia.lang.bayes` protocol.
-- **Tests:** stochastic-do parity against analytic Bernoulli-equivalent examples; `do(X = Binomial(n=1, p=0.0))` and `do(X = Binomial(n=1, p=1.0))` collapse to hard-do behaviour.
-
-Roughly 1 week. Carved out separately because the semantics warrant focused review (Pearl-stochastic vs. Pearl-deterministic interventions are documented differently in the literature) and to keep D₂'s footprint small.
-
-### Milestone D₃ — y0 identification adapter (Spec 3)
-
-Depends on: D₁ (D₂ not required — identification is numeric-agnostic).
-
-- **`gaia.causal.adapters.y0`:** `identify`, `IdentificationResult`, `NotIdentifiable`, `MissingDependencyError`.
-- **`pyproject.toml`:** `causal-do` extra with `y0>=0.2`.
-- **`gaia check causal --identify`:** opt-in CLI rule.
-- **Docs:** installation note for the extra.
-- **Tests:** pin y0 version, verify identifiable / non-identifiable canonical DAGs (back-door, front-door, ID algorithm base cases) produce the expected classification. Skip-marker for environments without the extra installed.
-
-Independently shippable. Roughly 1–2 weeks (mostly glue + tests).
-
-### Milestone D₄ — Package migrations and doc refresh
-
-Depends on: D₁, D₂ (D₃ optional).
-
-- Update `docs/foundations/` — add a `causal/` sub-page reflecting the new primitives; link into the existing structure without redefining. Remove the "v0.6 interventional factor" placeholder from PR #505 §10.
-- `gaia-lang` docs: `causal()`, `causes()`, `mechanism()`, `do()`, `query()`, `ate()` reference; worked examples (Pearl's smoking/genetics, Simpson's paradox).
-- Audit first-party packages (Mendel, Galileo, Superconductivity) for any claim that would benefit from an explicit causal-claim rewrite — do not force, but list candidates in a follow-up issue.
-
----
-
-## 11. Out of Scope / Deferred
-
-| Item | Why deferred |
-|---|---|
-| **Counterfactual queries (Pearl level 3)** | Requires explicit exogenous noise variables, parameterized structural equations, and a different inference mode (abduction–action–prediction or twin networks). Gaia's propositional claim + prior model is not a structural causal model; promoting it would be a major world-view surgery. We will reopen this conversation only when a concrete scientific-reasoning use case demands it. |
-| **Population-level intervention and heterogeneous treatment effects (CATE)** | §5 grounds causal universals **per instance**. Population-level queries ("intervene on 30% of the population") and CATE ("effect varies by subgroup") require either marginalising over instance choice or hierarchical SCM with subgroup-conditioned strengths — neither is supported by v0.5/v0.6 BP. Authors who need population effects should run a study externally and feed the result back as evidence on the universal claim. |
-| **Causal discovery from data** | Gaia is a symbolic / prior-based reasoning system; DAG structure is authored, not learned. Tools like `causal-learn` or `causalnex` exist for that purpose and are external to our scope. |
-| **Continuous / parameterized structural equations** | Gaia claims are Boolean; numeric values live in Variables with priors, not as draws from a structural equation. Promoting Gaia to continuous SCMs is equivalent to replacing the BP engine with pyro/numpyro — out of scope. |
-| **`pgmpy` adapter** | Gaia BP answers the numeric intervention question once D₂ ships. Adding pgmpy would be a second inference engine with no additional capability. |
-| **Front-door / back-door automatic adjustment in numeric BP** | Numeric BP runs on Gaia's authored causal factor graph, not on an observational dataset requiring covariate adjustment. `adjustment_sets()` in §3.3 is for *reviewer* use (auditing which covariates would need to be observed if working from data). |
-| **Hidden confounders / ADMGs / Ananke integration** | v0.7 topic — requires lattice of bidirectional edges. |
-| **Conditional / policy interventions (`do(X = g(Z))`)** | Single-atomic and stochastic interventions cover the core v0.6 use cases. Conditional interventions add notational complexity without comparable demand. v0.7+ if a use case appears. |
-| **Custom multi-parent composition rules** | v0.6 ships leak-aware noisy-OR as the default authoring transform (§4.1.2). The internal machine contract is still a full CPT; author-facing full-CPT input is left to §12 Q4, and `noisy_and` remains v0.7+. |
-
----
-
-## 12. Open Questions
-
-1. **MAP vs. ensemble causal structure.** §3.5 states that DAG-build treats every authored `mechanism(...)` action as structurally present regardless of backing-claim prior. Is there a use case (reviewer workflow?) where the user wants `d_separated` computed against the *MAP* DAG (mechanisms with backing-claim belief > 0.5 only)? If yes, we add a `build_dag(..., policy="map" | "structural")` knob — otherwise, leave it out of v0.6.
-2. **Variable CNID synthesis.** §3.1 proposes `@var:{namespace}:{package_name}:{symbol}`. Conflict to resolve: when a Variable is declared in package A but used in a `mechanism(...)` action in package B, do we stamp the CNID with the *declaring* package or the *using* package? Proposal: declaring package — matches how PR #505 proposes cross-package Variable lookups. The `@` prefix ensures `is_qid()` returns False so no consumer confuses a CNID with a Knowledge QID.
-3. **Default stance on `do()` target that is not a DAG node.** §4.6 raises an error. An alternative is a warning + fall through to conditioning. Recommendation: error — silent "meaningless intervention" is the exact footgun the causal layer is meant to prevent.
-4. **Full-CPT authoring timing.** §4.1.2 fixes the v0.6 machine contract as a canonical full binary CPT and uses leak-aware noisy-OR as the default authoring transform. Open question: should v0.6 also expose an advanced `mechanism_cpt(...)` authoring helper, or should D₂ only implement noisy-OR authoring and keep full-CPT authoring for v0.7?
-5. **Soft-do timing.** §10 carves D₂.5 as a separate milestone after D₂ to keep `do()` semantics review-able piece by piece. Alternative: bundle stochastic intervention into D₂ for a single "intervention" PR. Recommendation: separate (more reviewable). Open to revisiting if reviewers prefer one combined PR.
-6. **Mixed-modality warning level.** §4.4 thought experiment 9 says when an effect node has both `mechanism()` and logical/structural incoming factors, `gaia check causal` warns. Should this be a hard error in `gaia check causal --strict` mode? When does the situation actually represent author intent (e.g. "the structural relation is a derived consequence, the cause is the mechanism") vs. an authoring mistake?
-7. **Identification output format.** Raw y0 `Expression.to_latex()` vs. a Gaia-normalized string with QIDs. Recommendation: LaTeX for v0.6 plus a `node_map` from display symbols to QID/CNID; a fully Gaia-native symbolic expression can come later.
-
----
-
-## 13. Examples
-
-### 13.1 Pearl's smoking / genetics (confounding)
-
-```python
-from gaia.lang import Bool, Variable, causal, mechanism
-from gaia.causal import do, query, ate
-
-G = Variable(symbol="G", domain=Bool)   # genetic predisposition
-X = Variable(symbol="X", domain=Bool)   # smoking
-Z = Variable(symbol="Z", domain=Bool)   # yellow fingers
-Y = Variable(symbol="Y", domain=Bool)   # lung cancer
-
-g_causes_x = causal(cause=G, effect=X, prior=0.6, label="g_causes_x_claim")
-g_causes_y = causal(cause=G, effect=Y, prior=0.7, label="g_causes_y_claim")
-x_causes_z = causal(cause=X, effect=Z, prior=0.9, label="x_causes_z_claim")
-
-mechanism(cause=G, effect=X, backing_claim=g_causes_x, p_effect_given_cause=0.55, p_effect_given_not_cause=0.20)
-mechanism(cause=G, effect=Y, backing_claim=g_causes_y, p_effect_given_cause=0.30, p_effect_given_not_cause=0.05)
-mechanism(cause=X, effect=Z, backing_claim=x_causes_z, p_effect_given_cause=0.85, p_effect_given_not_cause=0.05)
-# No X → Y edge — smoking does not directly cause cancer in this toy model.
-
-from gaia.causal import build_dag, d_separated, adjustment_sets
-dag = build_dag(pkg)
-assert not d_separated(dag, "@var:github:pkg:X", "@var:github:pkg:Y")                            # observed assoc
-assert     d_separated(dag, "@var:github:pkg:X", "@var:github:pkg:Y", {"@var:github:pkg:G"})     # controlled for G
-print(adjustment_sets(dag, "@var:github:pkg:X", "@var:github:pkg:Y"))                            # [{G}]
-
-r1 = do(X=1).query(Y)          # P(Y | do(X=1)) — ≈ base rate of cancer
-r2 = query(Y, given={X: 1})    # P(Y | X=1)     — elevated by confounding
-# r1.belief < r2.belief — the exact effect that disappears under intervention.
-
-eff = ate(X, Y)                # do(X=1).Y - do(X=0).Y; ≈ 0 in this DAG
-```
-
-### 13.2 Simpson's paradox (Gaia surfaces it automatically)
-
-Given a DAG where `X → Y`, `Z → X`, `Z → Y`, authored via `mechanism()` actions backed by causal proposition Claims, `do(X).query(Y)` gives the unconfounded effect while `query(Y, given={X: 1})` aggregates over `Z` and can reverse direction. `gaia check causal` (no flags) reports the mechanism DAG and any bare causal propositions separately; with `--identify`, y0 confirms `P(Y | do(X))` is identifiable via back-door over `Z`.
-
-### 13.3 Multi-step intervention with mixed causal+logical edges
-
-```python
-from gaia.lang import Bool, Variable, causal, mechanism
-from gaia.causal import do
-from gaia.lang.dsl import deduction
-
-T = Variable(symbol="T", domain=Bool)   # treatment
-S = Variable(symbol="S", domain=Bool)   # side-effect mitigation
-R = Variable(symbol="R", domain=Bool)   # recovery
-L = Variable(symbol="L", domain=Bool)   # logged-as-recovered
-
-# Causal mechanisms
-t_causes_s = causal(cause=T, effect=S, prior=0.7, label="t_causes_s_claim")
-t_causes_r = causal(cause=T, effect=R, prior=0.6, label="t_causes_r_claim")
-s_causes_r = causal(cause=S, effect=R, prior=0.5, label="s_causes_r_claim")
-mechanism(cause=T, effect=S, backing_claim=t_causes_s, p_effect_given_cause=0.8, p_effect_given_not_cause=0.1)
-mechanism(cause=T, effect=R, backing_claim=t_causes_r, p_effect_given_cause=0.7, p_effect_given_not_cause=0.2)
-mechanism(cause=S, effect=R, backing_claim=s_causes_r, p_effect_given_cause=0.6, p_effect_given_not_cause=0.3)
-
-# Pure logical edge: "logged-as-recovered" follows recovery deductively (definitional)
-deduction([R], L)
-
-# Compound intervention: force treatment and mitigation simultaneously
-do(T=1, S=1).query(R)
-# `mutilate` drops the causal CONDITIONAL factors with conclusion in {T, S}.
-# The deduction([R], L) factor is preserved (logical modality, §4.4 thought experiment 6).
-```
-
-### 13.4 Per-instance grounding for a causal universal
-
-```python
-from gaia.lang import Bool, Causes, Claim, ClaimKind, Domain, Variable, forall, mechanism
-from gaia.causal import do, ate
-
-Person = Domain(name="Person", members=["alice", "bob", "carol"])
-p = Variable(symbol="p", domain=Person)
-Smokes = Variable(symbol="Smokes", domain=Bool)
-Cancer = Variable(symbol="Cancer", domain=Bool)
-
-# Universal causal claim — grounded per-instance per §5.2
-smoking_causes_cancer = Claim(
-    "Smoking causes lung cancer (universal)",
-    formula=forall(p, Causes(Smokes, Cancer)),
-    kind=ClaimKind.QUANTIFIED,
-    prior=0.85,
-    label="smoking_causes_cancer",
-)
-
-mechanism(
-    cause=Smokes,
-    effect=Cancer,
-    backing_claim=smoking_causes_cancer,
-    p_effect_given_cause=0.15,
-    p_effect_given_not_cause=0.05,
-    label="smoking_causes_cancer_mechanism",
-)
-
-# Formula lowering emits per-instance causal proposition claims for alice/bob/carol.
-# Mechanism lowering emits per-instance CNID variables and causal factors.
-# do() and ate() operate on a chosen instance.
-ate_alice = ate(target_instance="alice", cause_var=Smokes, effect_var=Cancer)
-# Population-level ATE is NOT supported (§11) — this is the per-instance ATE.
-```
-
-The universal Claim carries the reviewable proposition. The `mechanism(...)` action carries the CPD. The compiler grounds the proposition first, then grounds the mechanism action against those instances; no CPD is stored on the causal Claim itself.
-
----
-
-## 14. Prior-Art Anchors
-
-- Pearl, *Causality* (2nd ed., 2009) — DAG semantics, do-operator, back-door / front-door.
-- Pearl & Mackenzie, *The Book of Why* (2018) — levels of the causal ladder.
-- Shpitser & Pearl, "Identification of Conditional Interventional Distributions" (2006) — IDC algorithm y0 implements.
-- [y0](https://github.com/y0-causal-inference/y0) — symbolic do-calculus implementation (adapter target).
-- [NetworkX](https://networkx.org/) — DAG infrastructure (promoted to kernel dep).
-- PR #505 — claim formula schema (supplies `Causes`, `Variable`, `Domain`).
-- PR #510 — formula lowering into IR metadata (supplies `metadata.causal.cause` / `.effect`).
-- `docs/superpowers/specs/2026-04-25-unit-stats-constants-design.md` — kernel-vs-adapter separation template.
+- No `mechanism` action.
+- No `is_causal` boolean flag.
+- No DoWhy in the first causal release.
+- No data-driven estimation.
+- No causal discovery.
+- No counterfactuals.
+- No full CPD taxonomy.
+- No attempt to recover causal structure from ordinary `infer` or
+  `implies` relations.

--- a/docs/specs/2026-05-05-causal-reasoning-design.md
+++ b/docs/specs/2026-05-05-causal-reasoning-design.md
@@ -1,11 +1,11 @@
 # Causal Reasoning Design — Structure + Intervention
 
 > **Status:** Target design (proposal)
-> **Branch:** `docs/causal-reasoning-design` (off `v0.5`)
-> **Target release:** v0.6 (built on v0.5 foundation + PR #505 lifted Lang)
+> **Branch:** `codex/v05-causal-docs-refresh` (off `v0.5`)
+> **Target release:** v0.6 (built on the v0.5 lifted Lang, role/decompose, and Bayes foundations)
 > **Date:** 2026-05-05
 > **Scope:** Promote `Causes(X, Y)` from a v0.5 marker to first-class causal reasoning — DAG semantics, d-separation, `do(X=x)` interventions, numeric answers via existing Gaia BP, and optional symbolic do-calculus identification via y0.
-> **Depends on:** PR #505 (Variable / Domain / Formula AST with `Causes` predicate).
+> **Depends on:** PR #505 (Variable / Domain / Formula AST with `Causes` predicate), PR #510 (formula metadata lowering), PR #524 (current Action families + `decompose`), and PR #523/#526 (Bayes distribution/action surface).
 > **Non-goals:** Counterfactual reasoning (Pearl level 3); structure learning from data; data-driven effect estimation.
 
 ---
@@ -30,7 +30,7 @@ This spec covers all three. Counterfactual reasoning (Pearl level 3) is **out of
 
 ### 0.3 First-principles position
 
-We adopt the `gaia.stats` pattern (`docs/superpowers/specs/2026-04-25-unit-stats-constants-design.md`):
+We adopt the `gaia.stats` / `gaia.lang.bayes` pattern:
 
 - **Kernel layers declare what; they do not compute heavy statistics.** Lang/IR represent causal structure as metadata + schema; they never import scientific computing libraries.
 - **Adapters live outside the kernel.** Heavy or narrow-use dependencies ship in `project.optional-dependencies`.
@@ -41,12 +41,14 @@ Concretely:
 | Layer | What it owns | Dependencies |
 |---|---|---|
 | `gaia.lang.formula.predicate.Causes` | AST marker (exists today via PR #505) | none |
-| `gaia.lang.dsl.causal.causal` / existing `gaia.lang.dsl.sugar.causal` re-export | `causal()` declaration helper — fourth verb family alongside Relate / Correlate / Strategy | none |
+| existing `gaia.lang.dsl.sugar.causal` re-exported by `gaia.lang` / `gaia.lang.dsl` | `causal()` declaration helper — a mechanism/interventional declaration, not a replacement for the current Support / Structural / Probabilistic Action families | none |
 | `gaia.causal.dag` (NEW, kernel) | `CausalDAG` view over a `CollectedPackage` | `networkx` |
 | `gaia.causal.intervene` (NEW, kernel) | `do(X=x)` rewrite + `.query(Y)` | reuses `gaia.bp` |
 | `gaia.causal.adapters.y0` (NEW, extra) | Symbolic do-calculus identification | `y0` (extra: `gaia[causal-do]`) |
 
 `networkx` is promoted to a kernel dependency (pure Python, ~3MB, no native extensions, widely trusted). `y0` is not — its base install pulls pandas + scikit-learn + statsmodels, which violates the "kernel stays light" rule, and Gaia only uses its symbolic identifier, not its data-driven parts.
+
+The current v0.5 Action hierarchy is `Support`, `Structural`, `Probabilistic`, `Scaffold`, and `Compose`. Causal declarations should not reintroduce the older `Relate` / `Correlate` taxonomy. `causal()` stays a Claim/formula authoring helper in D1/D2; if a future Action class is needed, it should be introduced as a separate mechanism/intervention family with its own lowering contract.
 
 ### 0.4 Naming convention: `causal` vs `causes` vs `Causes`
 
@@ -121,6 +123,8 @@ PR #510 introduced the compiler-owned `metadata.causal` operand descriptors. D1 
 
 `dag_edge` is populated by the compiler **after** QID assignment. Lang runtime never sets it — consumers that need to read the DAG use `dag_edge`; consumers that need provenance back to authored Variables read the original `cause` / `effect`. `cpd` is populated from the `causal()` declaration's authored parameters or from explicit universal-claim metadata (§5.2). A `CAUSAL` claim missing `metadata.causal.cause` or `.effect` is invalid under the v0.6 compiler path and should fail fast.
 
+`metadata.causal.cpd` is intentionally separate from `metadata.bayes`. The CPD is a structural mechanism parameter used by intervention lowering; it is not an observational likelihood, a Bayes model-comparison record, or an observation noise payload. D₂.5 stochastic interventions may reuse the `gaia.lang.bayes` distribution protocol for authored distributions, but compiled causal mechanism parameters remain under `metadata.causal`.
+
 ### 1.2 `gaia.bp` additions
 
 One public helper is added to `gaia.bp`:
@@ -129,10 +133,11 @@ One public helper is added to `gaia.bp`:
 # gaia/bp/factor_graph.py
 def mutilate(fg: FactorGraph, intervened: set[str]) -> FactorGraph:
     """Return a new FactorGraph with **causal** factors whose `conclusion` is
-    in `intervened` removed. Logical factors (deduction-derived
-    SOFT_ENTAILMENT, IMPLICATION/EQUIVALENCE/CONJUNCTION/DISJUNCTION
-    operator factors) are preserved regardless of their conclusion — see §4.4
-    for the first-principles justification.
+    in `intervened` removed. Logical/structural factors (deduction-derived
+    SOFT_ENTAILMENT, Decompose-generated helpers, and
+    IMPLICATION/EQUIVALENCE/CONJUNCTION/DISJUNCTION operator factors) are
+    preserved regardless of their conclusion — see §4.4 for the
+    first-principles justification.
 
     The caller follows up with fg.observe(x, value) for each intervened var."""
 ```
@@ -188,7 +193,7 @@ gaia/
 │       └── y0.py                # identify(); lazy imports y0
 ├── lang/
 │   └── dsl/
-│       └── causal.py            # NEW: causal(), do(), query(), ate() DSL
+│       └── sugar.py             # extend existing causal() helper with CPD params
 └── lang/
     └── compiler/
         ├── compile.py           # + populate metadata.causal.dag_edge for CAUSAL claims
@@ -201,7 +206,8 @@ gaia/
 - `gaia.causal.queries` operates on a `CausalDAG`. Pure graph algorithms, no IR awareness.
 - `gaia.causal.intervene` **reads** a compiled IR artifact, lowers it through the standard `gaia.bp.lowering` path (which now handles `causal()` declarations and per-instance grounding), rewrites the resulting `FactorGraph` (`mutilate`), and runs BP. It does not write IR. **No separate causal lowering module is needed** — the compiled causal metadata and declaration parameters carry enough information that ordinary lowering can register CNID variables and emit the causal CPT factor.
 - `gaia.causal.adapters.y0` **reads** a `CausalDAG` and a symbolic query; returns an expression or a `NotIdentifiable` diagnosis. It does not touch `FactorGraph`.
-- `gaia.lang.dsl.causal` is the authored-side surface: `causal()`, `do()`, `query()`, `ate()`.
+- `gaia.lang.dsl.sugar.causal` remains the authored-side `causal()` declaration helper, already re-exported by `gaia.lang` and `gaia.lang.dsl`. D1 extends that existing helper rather than moving it.
+- `gaia.causal` is the runtime query surface for `do()`, `query()`, and `ate()`. A `gaia.lang.dsl.causal` compatibility re-export can be added later if the broader DSL wants all verbs in `gaia.lang.dsl`, but it is not required for the core implementation.
 
 This partitions the work so each module is independently testable and no file grows oversized.
 
@@ -331,7 +337,7 @@ Authored shape:
 
 ```python
 from gaia.lang import Bool, Variable, causal
-from gaia.lang.dsl.causal import do, query
+from gaia.causal import do, query
 
 co2  = Variable(symbol="co2_level", domain=Bool)
 temp = Variable(symbol="temperature", domain=Bool)
@@ -386,7 +392,7 @@ The machine contract is still a full binary `CONDITIONAL` CPT; noisy-OR is only 
 
 #### 4.1.3 Soft `do()` deferred to D₂.5
 
-`do(X = Bernoulli(p))` and other stochastic-intervention forms are scoped to a follow-up milestone D₂.5 — see §9 and §12 Q5 for the rationale.
+`do(X = Distribution(...))` and other stochastic-intervention forms are scoped to a follow-up milestone D₂.5 — see §10 and §12 Q5 for the rationale. The authored distribution type should reuse the current `gaia.lang.bayes.distributions.protocol.Distribution` contract (`model_dump`, `logpmf` / `logpdf`, `support`) instead of inventing a second `DistributionSpec`. For binary soft interventions, v0.6 can either use the existing `Binomial(n=1, p=p)` literal or add a thin `Bernoulli(p)` alias in `gaia.lang.bayes`; both compile to the same unary intervention distribution.
 
 ### 4.2 Intervention object
 
@@ -468,7 +474,7 @@ def _compute(
 1. Each `causal()` declaration contributes explicit CPD parameters. Multi-parent effects compose via noisy-OR (§4.1.2) into one canonical `CONDITIONAL` factor per effect node.
 2. CNID variables (Variables, per PR #505 §2.4 they have no IR Knowledge) are registered as BP variables during causal lowering inside the standard `gaia.bp.lowering` path.
 3. The generated causal factor carries `metadata={"modality": "causal", "source_claim_qid": ..., "dag_edge": ...}` copied from the compiled claim metadata (§1.2).
-4. `mutilate(fg, intervened)` identifies and drops only the factor whose conclusion ∈ intervened **and** whose factor metadata says `modality == "causal"` (see §4.4). Logical factors (deduction, IMPLICATION operator helpers) are preserved.
+4. `mutilate(fg, intervened)` identifies and drops only the factor whose conclusion ∈ intervened **and** whose factor metadata says `modality == "causal"` (see §4.4). Logical and structural factors (`deduction`, `decompose`, IMPLICATION/EQUIVALENCE operator helpers) are preserved.
 5. `observe()` clamps the intervened variable to its target value.
 
 This yields exactly the truncated factorization for the per-instance DAG.
@@ -488,9 +494,10 @@ A short tour of the thought experiments motivating this rule:
 | 3 | "Bachelor" ↔ "unmarried man" (definitional) | `do(¬"unmarried")` | Both flip together — they are the same fact. | Use EQUIVALENCE operator, not Causes / deduction. EQUIVALENCE is **not mutilated** (it's a structural identity, not a mechanism). |
 | 4 | F = ma (physical law) | `do(a = 0)` | Ambiguous — depends on whether F=ma is read as constraint (then F→0) or mechanism (then F unchanged, supported by counter-force). | **Author must choose** — declare F→a as `causal()` (mechanism, F preserved) or as `deduction([F, m], a)` (constraint, F follows). Engine will not guess. |
 | 5 | Temperature ⇄ Evaporation | `do(Evap = 0)` (sealed bucket) | Temperature unchanged at the mutilation step. | Direction matters; each direction is a separate cause. |
-| 6 | Mixed: Hot → Cooked (causal); Cooked ↔ "not raw" (logical) | `do(Hot = 0)` | Cuts only the (empty) causal in-edges of `Hot`; `Cooked` propagates normally; logical "not raw" follows. | **Mixed graphs work cleanly** as long as each edge declares its modality. |
-| 7 | (Generalization) Node has both causal and logical incoming edges. | `do(node = v)` | Cuts only the causal in-edges; logical edges remain live and propagate. | Implementation: filter on factor metadata `modality == "causal"`. |
-| 8 | Same fact authored as both `causal()` and `deduction()` | — | Engine cannot disambiguate. | `gaia check causal` raises a warning when an effect node has both modalities incoming (§8.1, new rule). |
+| 6 | Whole claim decomposed via `decompose(C, [A, B], A & B)` | `do(C = 0)` | The decomposition remains a structural identity; it is not a production mechanism. | `Decompose` is a `Structural` action in current v0.5, so generated factors are **not mutilated**. |
+| 7 | Mixed: Hot → Cooked (causal); Cooked ↔ "not raw" (logical) | `do(Hot = 0)` | Cuts only the (empty) causal in-edges of `Hot`; `Cooked` propagates normally; logical "not raw" follows. | **Mixed graphs work cleanly** as long as each edge declares its modality. |
+| 8 | (Generalization) Node has both causal and logical/structural incoming edges. | `do(node = v)` | Cuts only the causal in-edges; logical/structural edges remain live and propagate. | Implementation: filter on factor metadata `modality == "causal"`. |
+| 9 | Same fact authored as both `causal()` and a logical/structural relation | — | Engine cannot disambiguate. | `gaia check causal` raises a warning when an effect node has both modalities incoming (§8.1, new rule). |
 
 Concretely the rule is:
 
@@ -498,7 +505,7 @@ Concretely the rule is:
 > 1. **`f.conclusion ∈ intervened`** — standard truncation condition; AND
 > 2. **`f` is causal** — i.e., `f.metadata.get("modality") == "causal"`.
 >
-> Logical SOFT_ENTAILMENT (deduction-derived), IMPLICATION operator factors, EQUIVALENCE / CONJUNCTION / DISJUNCTION / CONTRADICTION operator factors are **never** mutilated.
+> Logical SOFT_ENTAILMENT (deduction-derived), `decompose()`-generated structural helpers, IMPLICATION operator factors, and EQUIVALENCE / CONJUNCTION / DISJUNCTION / CONTRADICTION operator factors are **never** mutilated.
 
 This rule matches Pearl's standard mutilation when the graph is purely causal, and degrades gracefully when logical edges are present.
 
@@ -508,7 +515,7 @@ Earlier drafts of this spec proposed a `definitional=True` flag on deduction edg
 
 ### 4.5 Interaction with strategy-embedded operators (`FormalExpr`)
 
-A `FormalStrategy` may embed multiple `Operator`s inside a `FormalExpr`. When lowered to `FactorGraph`, each embedded operator produces its own factor. `mutilate` walks the resulting factor list and applies the §4.4 rule uniformly — embedded operators are logical by origin, so they pass through mutilation unchanged.
+A `FormalStrategy` may embed multiple `Operator`s inside a `FormalExpr`. When lowered to `FactorGraph`, each embedded operator produces its own factor. `Decompose` similarly generates structural helper/formula factors from an action-level decomposition. `mutilate` walks the resulting factor list and applies the §4.4 rule uniformly — embedded operators and decomposition helpers are logical/structural by origin, so they pass through mutilation unchanged.
 
 ### 4.6 Only causally authored intervention is permitted
 
@@ -710,7 +717,7 @@ A new CLI sub-check. Invoked as `gaia check causal <package>` or bundled into `g
 | Acyclicity | Error | `CausalCycleError` from `build_dag` |
 | Intervention target is a DAG node | Error | `InterventionUndefinedError` on any authored `do(...)` |
 | Open back-door path | Warning | For every `Causes(X, Y)` claim, inspect paths from `X` to `Y` that enter `X` after removing outgoing edges from `X`. If any path remains open under the declared observed covariates, surface the minimal candidate adjustment sets from `adjustment_sets(...)` or report that no valid set is available. Never condition on `X` or `Y` themselves. |
-| Mixed-modality incoming edges | Warning (Error under `--strict`) | Effect node has both `causal()` and `deduction()` incoming. Author should clarify whether the deduction edge is a definitional consequence (then mutilation will preserve it correctly per §4.4) or actually a mis-typed causal mechanism (then re-author as `causal()`). See §4.4 thought experiment 8. |
+| Mixed-modality incoming edges | Warning (Error under `--strict`) | Effect node has both `causal()` and logical/structural incoming factors (`deduction()`, `decompose()`, EQUIVALENCE, etc.). Author should clarify whether the non-causal edge is a definitional consequence (then mutilation will preserve it correctly per §4.4) or actually a mis-typed causal mechanism (then re-author as `causal()`). See §4.4 thought experiment 9. |
 | Identification (opt-in) | Info / Warning | Requires `--identify`; emits obstruction witness per non-identifiable authored `do()` |
 | Variable reuse across sub-DAGs | Warning | The same Variable appearing in disconnected components — likely an authoring error |
 
@@ -723,7 +730,7 @@ JSON, keyed by rule. Fits into the existing `gaia check` aggregated report so re
 ## 9. DSL Surface Summary
 
 ```python
-# Authoring — `causal()` declaration helper, fourth-family per foundation spec §18
+# Authoring — extend the existing `causal()` declaration helper
 from gaia.lang import Bool, Variable, causal
 
 X = Variable(symbol="X", domain=Bool)
@@ -743,7 +750,7 @@ c = causal(
 
 ```python
 # Queries
-from gaia.lang.dsl.causal import do, query, ate
+from gaia.causal import do, query, ate
 
 result = do(X=1).query(Y)                            # numeric, hard intervention
 result = do(X=1).query(Y, identify=True)             # numeric + symbolic (needs extra)
@@ -751,8 +758,8 @@ result = query(Y, given_do={X: 1})                   # long form
 result = ate(X, Y)                                   # do(X=1).Y - do(X=0).Y
 
 # D₂.5 (separate milestone): stochastic intervention
-from gaia.stats import Bernoulli
-result = do(X=Bernoulli(0.1)).query(Y)
+from gaia.lang.bayes import Binomial
+result = do(X=Binomial(n=1, p=0.1)).query(Y)
 ```
 
 ```python
@@ -806,9 +813,9 @@ Depends on: D₁.
 - **Multi-parent noisy-OR composition:** lowering pass that combines multiple `causal()` edges into one provenance-tagged `CONDITIONAL` factor per effect node (§4.1.2). Sits inside the existing `gaia/bp/lowering.py` — no new `gaia.causal.lowering` module needed; the compiled claim metadata and CPD parameters carry enough information to register CNID variables and emit the canonical CPT factor at standard lower time.
 - **Per-instance grounding for causal `forall`:** compiler dual to `gaia/lang/compiler/lower_formula.py:107-192`'s logical lowering — emits per-instance Knowledge nodes plus deduction edges from universal to instance, generated CNID variables for each instance, and one provenance-tagged causal `CONDITIONAL` factor per instance pair (§5.2).
 - **`gaia.causal.intervene`:** `Intervention`, `CausalQueryResult`, `_compute` using `mutilate` + Gaia BP (no separate causal lowering module).
-- **`gaia.lang.dsl.causal`:** `do()`, `query()`, `ate()` surface (§4.1, §4.2.1).
-- **`gaia check causal`:** acyclicity, intervention-target, mixed-modality (effect node has both `causal()` and `deduction()` incoming) rules (§8.1).
-- **Tests:** `causal()` lowers to a provenance-tagged causal `CONDITIONAL` factor with the expected CPT; smoked against canonical SCMs (confounder, front-door, chain, collider); belief values compared against hand-computed truncated factorizations; thought-experiment 1–8 (§4.4) regression coverage; per-instance grounding parity with logical-quantifier grounding; ATE round-trip.
+- **`gaia.causal`:** `do()`, `query()`, `ate()` surface (§4.1, §4.2.1); keep `causal()` itself on the existing `gaia.lang` / `gaia.lang.dsl` export path.
+- **`gaia check causal`:** acyclicity, intervention-target, mixed-modality (effect node has both `causal()` and logical/structural incoming factors) rules (§8.1).
+- **Tests:** `causal()` lowers to a provenance-tagged causal `CONDITIONAL` factor with the expected CPT; smoked against canonical SCMs (confounder, front-door, chain, collider); belief values compared against hand-computed truncated factorizations; thought-experiment 1–9 (§4.4) regression coverage; per-instance grounding parity with logical-quantifier grounding; ATE round-trip.
 
 Independently shippable: Gaia answers `P(Y | do(X))` and `ATE(X, Y)` numerically. Roughly 3–4 weeks (most of the work is tests, multi-parent noisy-OR composition, and per-instance grounding parity; `mutilate` itself is a small filter-and-rebuild pass).
 
@@ -816,10 +823,10 @@ Independently shippable: Gaia answers `P(Y | do(X))` and `ATE(X, Y)` numerically
 
 Depends on: D₂.
 
-- **Authored DSL:** `do(X = Bernoulli(p))` and equivalent shorthand for stochastic / soft interventions (§4.1.3).
+- **Authored DSL:** `do(X = Binomial(n=1, p=p))` and equivalent shorthand for stochastic / soft interventions (§4.1.3). A `Bernoulli(p)` alias may be added in `gaia.lang.bayes` for ergonomics, but it must share the existing Distribution protocol.
 - **`mutilate` extension:** instead of clamping intervened nodes via `observe`, install a unary likelihood factor matching the intervention distribution.
-- **`Intervention.assignments`:** widen type from `dict[str, int]` to `dict[str, int | DistributionSpec]` (`DistributionSpec` per `gaia.stats`).
-- **Tests:** stochastic-do parity against analytic Bernoulli/uniform examples; `do(X = Bernoulli(0.0))` and `do(X = Bernoulli(1.0))` collapse to hard-do behaviour.
+- **`Intervention.assignments`:** widen type from `dict[str, int]` to `dict[str, int | Distribution]` where `Distribution` is the current `gaia.lang.bayes` protocol.
+- **Tests:** stochastic-do parity against analytic Bernoulli-equivalent examples; `do(X = Binomial(n=1, p=0.0))` and `do(X = Binomial(n=1, p=1.0))` collapse to hard-do behaviour.
 
 Roughly 1 week. Carved out separately because the semantics warrant focused review (Pearl-stochastic vs. Pearl-deterministic interventions are documented differently in the literature) and to keep D₂'s footprint small.
 
@@ -868,7 +875,7 @@ Depends on: D₁, D₂ (D₃ optional).
 3. **Default stance on `do()` target that is not a DAG node.** §4.6 raises an error. An alternative is a warning + fall through to conditioning. Recommendation: error — silent "meaningless intervention" is the exact footgun the causal layer is meant to prevent.
 4. **Full-CPT authoring timing.** §4.1.2 fixes the v0.6 machine contract as a canonical full binary CPT and uses leak-aware noisy-OR as the default authoring transform. Open question: should v0.6 also expose an advanced `causal_cpt(...)` authoring helper, or should D₂ only implement noisy-OR authoring and keep full-CPT authoring for v0.7?
 5. **Soft-do timing.** §10 carves D₂.5 as a separate milestone after D₂ to keep `do()` semantics review-able piece by piece. Alternative: bundle stochastic intervention into D₂ for a single "intervention" PR. Recommendation: separate (more reviewable). Open to revisiting if reviewers prefer one combined PR.
-6. **Mixed-modality warning level.** §4.4 thought experiment 8 says when an effect node has both `causal()` and `deduction()` incoming, `gaia check causal` warns. Should this be a hard error in `gaia check causal --strict` mode? When does the situation actually represent author intent (e.g. "the deduction is a derived consequence, the cause is the mechanism") vs. an authoring mistake?
+6. **Mixed-modality warning level.** §4.4 thought experiment 9 says when an effect node has both `causal()` and logical/structural incoming factors, `gaia check causal` warns. Should this be a hard error in `gaia check causal --strict` mode? When does the situation actually represent author intent (e.g. "the structural relation is a derived consequence, the cause is the mechanism") vs. an authoring mistake?
 7. **Identification output format.** Raw y0 `Expression.to_latex()` vs. a Gaia-normalized string with QIDs. Recommendation: LaTeX for v0.6 plus a `node_map` from display symbols to QID/CNID; a fully Gaia-native symbolic expression can come later.
 
 ---
@@ -879,7 +886,7 @@ Depends on: D₁, D₂ (D₃ optional).
 
 ```python
 from gaia.lang import Bool, Variable, causal
-from gaia.lang.dsl.causal import do, query, ate
+from gaia.causal import do, query, ate
 
 G = Variable(symbol="G", domain=Bool)   # genetic predisposition
 X = Variable(symbol="X", domain=Bool)   # smoking
@@ -912,7 +919,7 @@ Given a DAG where `X → Y`, `Z → X`, `Z → Y`, authored via `causal()`, `do(
 
 ```python
 from gaia.lang import Bool, Variable, causal
-from gaia.lang.dsl.causal import do
+from gaia.causal import do
 from gaia.lang.dsl import deduction
 
 T = Variable(symbol="T", domain=Bool)   # treatment
@@ -938,7 +945,7 @@ do(T=1, S=1).query(R)
 
 ```python
 from gaia.lang import Bool, Causes, Claim, ClaimKind, Domain, Variable, forall
-from gaia.lang.dsl.causal import do, ate
+from gaia.causal import do, ate
 
 Person = Domain(name="Person", members=["alice", "bob", "carol"])
 p = Variable(symbol="p", domain=Person)

--- a/docs/specs/2026-05-05-causal-reasoning-design.md
+++ b/docs/specs/2026-05-05-causal-reasoning-design.md
@@ -262,10 +262,13 @@ depending on Claim metadata as its primary structure.
 Minimal runtime shape:
 
 ```python
+CausalEndpoint = Claim | Variable
+
+
 @dataclass(init=False, eq=False)
 class CausalMechanism(Knowledge):
-    cause: Knowledge | Variable
-    effect: Knowledge | Variable
+    cause: CausalEndpoint
+    effect: CausalEndpoint
     cpd: BinaryCPD | None = None
 ```
 
@@ -274,7 +277,12 @@ Rules:
 - It subclasses `Knowledge`, not `Claim`.
 - It cannot carry `prior`.
 - It does not participate in BP as a Boolean variable by default.
-- Its endpoints are typed references to Claims or Variables.
+- Its endpoints are typed references to Claims or Variables. They are not
+  arbitrary `Knowledge` nodes; `Note`, `Composition`, and other non-causal-node
+  objects are rejected.
+- `Variable` happens to subclass runtime `Knowledge`, but it is Lang-only and
+  compiles to a CNID endpoint rather than an IR Knowledge QID. The explicit
+  `CausalEndpoint` alias keeps that distinction visible.
 - Its `metadata` may carry display/provenance information, but not causal edge
   identity; the object itself is the edge identity.
 
@@ -541,6 +549,8 @@ The discussion should cover:
 ### D1. Runtime and DSL
 
 - Add runtime `CausalMechanism(Knowledge)`.
+- Add a narrow `CausalEndpoint = Claim | Variable` contract; do not accept
+  arbitrary `Knowledge`.
 - Add `mechanism(cause, effect, *, cpd=None, label=None, describe=None)`.
 - Ensure `mechanism(...)` returns Knowledge, not Claim and not Action.
 - Keep `causal(...)` as compatibility Claim helper or deprecate it after a

--- a/docs/specs/2026-05-05-causal-reasoning-design.md
+++ b/docs/specs/2026-05-05-causal-reasoning-design.md
@@ -1,10 +1,10 @@
-# Causal Reasoning Design — Structure + Intervention
+# Causal Reasoning Design — Predicate Claims + Mechanism Actions + Intervention
 
 > **Status:** Target design (proposal)
 > **Branch:** `codex/v05-causal-docs-refresh` (off `v0.5`)
 > **Target release:** v0.6 (built on the v0.5 lifted Lang, role/decompose, and Bayes foundations)
 > **Date:** 2026-05-05
-> **Scope:** Promote `Causes(X, Y)` from a v0.5 marker to first-class causal reasoning — DAG semantics, d-separation, `do(X=x)` interventions, numeric answers via existing Gaia BP, and optional symbolic do-calculus identification via y0.
+> **Scope:** Separate predicate-level causal propositions from action-level causal mechanisms, then add DAG semantics, d-separation, `do(X=x)` interventions, numeric answers via existing Gaia BP, and optional symbolic do-calculus identification via y0.
 > **Depends on:** PR #505 (Variable / Domain / Formula AST with `Causes` predicate), PR #510 (formula metadata lowering), PR #524 (current Action families + `decompose`), and PR #523/#526 (Bayes distribution/action surface).
 > **Non-goals:** Counterfactual reasoning (Pearl level 3); structure learning from data; data-driven effect estimation.
 
@@ -16,17 +16,18 @@
 
 PR #505 introduced `Causes(X, Y)` as a **marker predicate** in the formula AST (`gaia/lang/formula/predicate.py:129`) and added `Claim.formula` / `Claim.kind`. PR #510 then lowered atomic formulas into IR metadata: a fresh-compiled `Claim(formula=Causes(...), kind=CAUSAL)` now carries `metadata.causal = {"cause": ..., "effect": ...}`.
 
-Today this marker is still **structurally inert**: compiled artifacts have the authored cause/effect descriptors, but no compiled `dag_edge`, nothing reads `metadata.causal`, nothing enforces acyclicity, nothing distinguishes `Causes(X, Y)` from `Causes(Y, X)` structurally, and there is no DSL for asking a causal question.
+Today this marker is still **structurally inert**: compiled artifacts have the authored cause/effect descriptors, but no compiled mechanism record, nothing reads `metadata.causal` as an interventional edge, nothing enforces acyclicity, nothing distinguishes `Causes(X, Y)` from `Causes(Y, X)` structurally, and there is no DSL for asking a causal question.
 
 ### 0.2 What v0.6 needs to deliver
 
-Three concrete capabilities, ordered by dependency:
+Four concrete capabilities, ordered by dependency:
 
-1. **Causal structure** — a real DAG built from `Causes()` calls, with acyclicity enforcement, ancestor / descendant / parent queries, and d-separation. Surfaced in rendering and review.
-2. **Interventions** — a `do(X=x)` DSL action that produces a numeric answer `P(Y | do(X=x))` using Gaia's existing BP engine. This is the primitive that distinguishes causal reasoning from conditional probability.
-3. **Symbolic identification** (optional extra) — `identify(P(Y | do(X)))` returns either an identifiable expression (back-door / front-door / ID algorithm) or "not identifiable from observational data" — delegated to [y0](https://pypi.org/project/y0/), lazy-imported from an optional adapter.
+1. **Causal propositions** — keep `Causes(X, Y)` as a formula predicate inside an ordinary truth-bearing `Claim`. A causal proposition can be reviewed, supported, contradicted, quantified, or used as a warrant, but by itself it is not a BP factor and not an intervention target.
+2. **Causal mechanisms** — add an action-level declaration that promotes a causal proposition into an interventional mechanism edge with CPD parameters. This is the only authoring surface that creates DAG edges.
+3. **Interventions** — a `do(X=x)` query primitive that produces a numeric answer `P(Y | do(X=x))` using Gaia's existing BP engine. This is the primitive that distinguishes causal reasoning from conditional probability.
+4. **Symbolic identification** (optional extra) — `identify(P(Y | do(X)))` returns either an identifiable expression (back-door / front-door / ID algorithm) or "not identifiable from observational data" — delegated to [y0](https://pypi.org/project/y0/), lazy-imported from an optional adapter.
 
-This spec covers all three. Counterfactual reasoning (Pearl level 3) is **out of scope** — see §11.
+This spec covers all four. Counterfactual reasoning (Pearl level 3) is **out of scope** — see §11.
 
 ### 0.3 First-principles position
 
@@ -40,30 +41,39 @@ Concretely:
 
 | Layer | What it owns | Dependencies |
 |---|---|---|
-| `gaia.lang.formula.predicate.Causes` | AST marker (exists today via PR #505) | none |
-| existing `gaia.lang.dsl.sugar.causal` re-exported by `gaia.lang` / `gaia.lang.dsl` | `causal()` declaration helper — a mechanism/interventional declaration, not a replacement for the current Support / Structural / Probabilistic Action families | none |
+| `gaia.lang.formula.predicate.Causes` | Predicate-level AST marker inside a `Claim.formula` (exists today via PR #505) | none |
+| existing `gaia.lang.dsl.sugar.causal` re-exported by `gaia.lang` / `gaia.lang.dsl` | Claim helper for authoring a causal proposition. It returns `Claim(formula=Causes(...), kind=CAUSAL)` and does **not** declare a mechanism edge. | none |
+| `gaia.lang.dsl.causal.mechanism` (NEW) | Action-level mechanism declaration. This is the surface that owns CPD parameters and creates DAG edges. | none |
 | `gaia.causal.dag` (NEW, kernel) | `CausalDAG` view over a `CollectedPackage` | `networkx` |
 | `gaia.causal.intervene` (NEW, kernel) | `do(X=x)` rewrite + `.query(Y)` | reuses `gaia.bp` |
 | `gaia.causal.adapters.y0` (NEW, extra) | Symbolic do-calculus identification | `y0` (extra: `gaia[causal-do]`) |
 
 `networkx` is promoted to a kernel dependency (pure Python, ~3MB, no native extensions, widely trusted). `y0` is not — its base install pulls pandas + scikit-learn + statsmodels, which violates the "kernel stays light" rule, and Gaia only uses its symbolic identifier, not its data-driven parts.
 
-The current v0.5 Action hierarchy is `Support`, `Structural`, `Probabilistic`, `Scaffold`, and `Compose`. Causal declarations should not reintroduce the older `Relate` / `Correlate` taxonomy. `causal()` stays a Claim/formula authoring helper in D1/D2; if a future Action class is needed, it should be introduced as a separate mechanism/intervention family with its own lowering contract.
+The current v0.5 Action hierarchy is `Support`, `Structural`, `Probabilistic`, `Scaffold`, and `Compose`. Causal mechanisms should not be smuggled into formula metadata or reintroduce the older `Relate` / `Correlate` taxonomy. `causal()` stays a Claim/formula authoring helper; v0.6 adds a distinct `Mechanism` action family with its own lowering contract.
 
-### 0.4 Naming convention: `causal` vs `causes` vs `Causes`
+### 0.4 Layering and naming convention
 
-This spec keeps the existing formula surface intact and extends the higher-level causal declaration helper. The names are deliberately layered:
+This spec keeps the existing formula surface intact and adds a separate action helper. The names are deliberately layered:
 
 ```python
-from gaia.lang import Causes, causes, causal
+from gaia.lang import Causes, causes, causal, mechanism
 
-f1 = Causes(X, Y)                         # AST dataclass
+f1 = Causes(X, Y)                         # formula AST dataclass
 f2 = causes(X, Y)                         # existing formula helper
-c  = causal(cause=X, effect=Y,            # extended authoring helper
-            p_effect_given_cause=0.85, ...)
+c  = causal(cause=X, effect=Y, prior=0.8) # causal proposition Claim
+m  = mechanism(                           # action-level mechanism edge
+    cause=X,
+    effect=Y,
+    backing_claim=c,
+    p_effect_given_cause=0.85,
+    p_effect_given_not_cause=0.05,
+)
 ```
 
-`Causes(...)` and `causes(...)` are formula-layer constructs: they express the causal predicate but do not carry CPD parameters. `causal(...)` is the authoring-layer declaration: it creates the underlying `Claim(formula=Causes(...), kind=CAUSAL, prior=...)` and carries the CPD parameters needed by D₂. No new public `cause()` helper is introduced; `causes()` remains exported from `gaia.lang` and `gaia.lang.dsl` for compatibility.
+`Causes(...)` and `causes(...)` are formula-layer constructs: they express the causal predicate but do not carry CPD parameters. `causal(...)` is claim sugar: it creates the underlying `Claim(formula=Causes(...), kind=CAUSAL, prior=...)` and is the object reviewers argue about. `mechanism(...)` is the propositional/action-layer declaration: it creates the interventional edge and carries the CPD parameters needed by D₂. No public `cause()` helper is introduced; `causes()` remains exported from `gaia.lang` and `gaia.lang.dsl` for compatibility.
+
+The compiler must not infer a mechanism from a bare `CAUSAL` claim. Promotion is explicit: no `mechanism(...)`, no DAG edge, no BP causal factor, and no valid `do()` target.
 
 ---
 
@@ -71,17 +81,26 @@ c  = causal(cause=X, effect=Y,            # extended authoring helper
 
 ```
 ┌────────────────────────────────────────────────────────────┐
-│  Gaia Lang  (unchanged by this spec — already has Causes)  │
-│  ──────────                                                  │
-│  PR #505: Variable, Domain, Causes(X, Y), formula AST        │
+│  Gaia Lang predicate layer                                  │
+│  ────────────────────────                                    │
+│  Causes(X, Y) inside Claim.formula                           │
+│  causal(...) -> a truth-bearing CAUSAL Claim                  │
 └────────────────────────┬───────────────────────────────────┘
-                         │  Compiler (+ causal metadata §7)
+                         │  formula lowering: predicate metadata only
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│  Gaia Lang action layer                                     │
+│  ─────────────────────                                      │
+│  mechanism(cause, effect, backing_claim, CPD)                │
+│  the only source of interventional mechanism edges           │
+└────────────────────────┬───────────────────────────────────┘
+                         │  compiler emits causal-mechanism records (§7)
                          ▼
 ┌────────────────────────────────────────────────────────────┐
 │  Gaia IR  (unchanged schema — only metadata enriched)      │
 │  ──────────                                                  │
-│  v0.5 compiler writes metadata.causal cause/effect            │
-│  D1 adds metadata.causal.dag_edge = (cause_id, effect_id)     │
+│  Claims may carry predicate metadata                         │
+│  Mechanism actions emit metadata.causal_mechanism records     │
 └────────────────────────┬───────────────────────────────────┘
                          │  gaia.causal (NEW)
           ┌──────────────┼────────────────────────────┐
@@ -93,37 +112,80 @@ c  = causal(cause=X, effect=Y,            # extended authoring helper
    d-separation    numeric P(Y|do(X=x))          identification
 ```
 
-Three write surfaces are introduced: a DAG view, an intervention primitive, and an identification adapter. **IR schema is unchanged** — only a new well-known metadata key is added, consistent with how `gaia.stats` evolved.
+Four surfaces are involved, with strict ownership: predicate claims say what the author believes, mechanism actions say which propositions/variables enter an interventional graph, `gaia.causal` reads that graph, and the y0 adapter performs optional symbolic identification. **IR schema is unchanged** — only well-known metadata keys are added, consistent with how `gaia.stats` evolved.
 
-### 1.1 New `metadata.causal` contract
+### 1.1 Two metadata contracts
 
-PR #510 introduced the compiler-owned `metadata.causal` operand descriptors. D1 extends that shape with compiled edge identifiers:
+PR #510 introduced compiler-owned `metadata.causal` operand descriptors on causal formula claims. This spec keeps that metadata predicate-scoped:
 
 ```python
+# On a Claim whose formula is Causes(X, Y), or a generated instance of one:
 {
-    "cause":  {"kind": "variable" | "knowledge", ...},   # PR #510
-    "effect": {"kind": "variable" | "knowledge", ...},   # PR #510
-    # NEW in D1:
-    "dag_edge": {
-        "cause_id":  "<QID or CNID>",           # always present
-        "effect_id": "<QID or CNID>",           # always present
-    },
-    # NEW in D2 when numeric intervention is requested:
-    "cpd": {
-        "kind": "binary_edge",
-        "p_effect_given_cause": 0.85,
-        "p_effect_given_not_cause": 0.05,
-    },
+    "causal": {
+        "predicate": {
+            "cause":  {"kind": "variable" | "knowledge", ...},
+            "effect": {"kind": "variable" | "knowledge", ...},
+        }
+    }
 }
 ```
 
-`cause` / `effect` are human-auditable descriptors of the authored operands. D1 extends this contract with `dag_edge`, the machine-stable edge used by `gaia.causal`.
+The compatibility shape already emitted by v0.5, `metadata.causal = {"cause": ..., "effect": ...}`, is accepted as a predicate descriptor and should be normalized to the nested `predicate` shape on recompile. It is **not** a mechanism edge.
 
-`cause_id` / `effect_id` are either compiled QIDs (for Knowledge-typed operands) or synthesized CNIDs (for Variable operands — see §3.1). They coexist in the same field; consumers distinguish them with `gaia.ir.knowledge.is_qid()`.
+`mechanism(...)` actions compile to a separate mechanism record:
 
-`dag_edge` is populated by the compiler **after** QID assignment. Lang runtime never sets it — consumers that need to read the DAG use `dag_edge`; consumers that need provenance back to authored Variables read the original `cause` / `effect`. `cpd` is populated from the `causal()` declaration's authored parameters or from explicit universal-claim metadata (§5.2). A `CAUSAL` claim missing `metadata.causal.cause` or `.effect` is invalid under the v0.6 compiler path and should fail fast.
+```python
+{
+    "causal_mechanism": {
+        "action_label": "x_causes_y_mechanism",
+        "backing_claim_qid": "<QID of the causal proposition Claim>",
+        "cause_id": "<QID or CNID>",
+        "effect_id": "<QID or CNID>",
+        "endpoint_kind": "variable" | "claim",
+        "policy": "structural",          # build_dag includes authored mechanisms
+        # Present when numeric intervention lowering is requested:
+        "cpd": {
+            "kind": "binary_edge",
+            "p_effect_given_cause": 0.85,
+            "p_effect_given_not_cause": 0.05,
+        },
+    }
+}
+```
 
-`metadata.causal.cpd` is intentionally separate from `metadata.bayes`. The CPD is a structural mechanism parameter used by intervention lowering; it is not an observational likelihood, a Bayes model-comparison record, or an observation noise payload. D₂.5 stochastic interventions may reuse the `gaia.lang.bayes` distribution protocol for authored distributions, but compiled causal mechanism parameters remain under `metadata.causal`.
+`cause_id` / `effect_id` are either compiled QIDs (for Claim endpoints) or synthesized CNIDs (for Variable endpoints — see §3.1). Consumers distinguish them with `gaia.ir.knowledge.is_qid()`.
+
+`metadata.causal_mechanism.cpd` is intentionally separate from both `metadata.causal.predicate` and `metadata.bayes`. The CPD is a structural mechanism parameter used by intervention lowering; it is not an observational likelihood, a Bayes model-comparison record, or an observation noise payload. D₂.5 stochastic interventions may reuse the `gaia.lang.bayes` distribution protocol for authored distributions, but compiled mechanism parameters remain under `metadata.causal_mechanism`.
+
+The invariant is simple:
+
+```python
+if "causal_mechanism" not in metadata:
+    # Review/render the causal proposition if present, but do not add a DAG edge.
+    pass
+```
+
+For factor-level provenance, D₂ copies the mechanism record into `Factor.metadata`:
+
+```python
+Factor(
+    ...,
+    metadata={
+        "modality": "causal",
+        "causal_mechanism": {
+            "action_label": "...",
+            "backing_claim_qid": "...",
+            "cause_id": "...",
+            "effect_id": "...",
+        },
+        "cpd": {
+            "kind": "binary_edge",
+            "p_effect_given_cause": 0.85,
+            "p_effect_given_not_cause": 0.05,
+        },
+    },
+)
+```
 
 ### 1.2 `gaia.bp` additions
 
@@ -149,13 +211,17 @@ Factor(
     ...,
     metadata={
         "modality": "causal",               # or absent / "logical"
-        "source_claim_qid": "<QID>",
-        "dag_edge": {"cause_id": "...", "effect_id": "..."},
+        "causal_mechanism": {
+            "action_label": "<label>",
+            "backing_claim_qid": "<QID>",
+            "cause_id": "...",
+            "effect_id": "...",
+        },
     },
 )
 ```
 
-The modality test (causal vs. logical) reads `factor.metadata["modality"]`, not the original IR claim. The `dag_edge` copied into factor metadata is populated by D₁'s compiler pass (§7.1). The companion CNID variable registration is performed during normal lowering of `causal()` declarations; no separate `gaia.causal.lowering` module is required (§4.3).
+The modality test (causal vs. logical) reads `factor.metadata["modality"]`, not the original predicate claim. The `causal_mechanism` record is emitted only from `mechanism(...)` actions. The companion CNID variable registration is performed during normal lowering of mechanism actions; no separate `gaia.causal.lowering` module is required (§4.3).
 
 ### 1.3 Dependency layout in `pyproject.toml`
 
@@ -193,20 +259,22 @@ gaia/
 │       └── y0.py                # identify(); lazy imports y0
 ├── lang/
 │   └── dsl/
-│       └── sugar.py             # extend existing causal() helper with CPD params
+│       ├── sugar.py             # existing causal() Claim helper (predicate layer)
+│       └── causal.py            # NEW: mechanism() action helper
 └── lang/
     └── compiler/
-        ├── compile.py           # + populate metadata.causal.dag_edge for CAUSAL claims
-        └── lower_formula.py     # + per-instance grounding for forall(...,Causes(...,...)) (§5.2)
+        ├── compile.py           # + compile Mechanism actions into causal_mechanism records
+        └── lower_formula.py     # keeps Causes(...) predicate metadata scoped to claims
 ```
 
 ### 2.1 Boundaries
 
 - `gaia.causal.dag` **reads** a `CollectedPackage` (or equivalent) and produces a `CausalDAG`. It does not write IR.
 - `gaia.causal.queries` operates on a `CausalDAG`. Pure graph algorithms, no IR awareness.
-- `gaia.causal.intervene` **reads** a compiled IR artifact, lowers it through the standard `gaia.bp.lowering` path (which now handles `causal()` declarations and per-instance grounding), rewrites the resulting `FactorGraph` (`mutilate`), and runs BP. It does not write IR. **No separate causal lowering module is needed** — the compiled causal metadata and declaration parameters carry enough information that ordinary lowering can register CNID variables and emit the causal CPT factor.
+- `gaia.causal.intervene` **reads** a compiled IR artifact, lowers it through the standard `gaia.bp.lowering` path (which now handles `mechanism()` actions and per-instance grounding), rewrites the resulting `FactorGraph` (`mutilate`), and runs BP. It does not write IR. **No separate causal lowering module is needed** — compiled mechanism records and CPD parameters carry enough information that ordinary lowering can register CNID variables and emit the causal CPT factor.
 - `gaia.causal.adapters.y0` **reads** a `CausalDAG` and a symbolic query; returns an expression or a `NotIdentifiable` diagnosis. It does not touch `FactorGraph`.
-- `gaia.lang.dsl.sugar.causal` remains the authored-side `causal()` declaration helper, already re-exported by `gaia.lang` and `gaia.lang.dsl`. D1 extends that existing helper rather than moving it.
+- `gaia.lang.dsl.sugar.causal` remains the authored-side `causal()` Claim helper, already re-exported by `gaia.lang` and `gaia.lang.dsl`. It stays predicate-only.
+- `gaia.lang.dsl.causal.mechanism` is the authored-side action helper that promotes a causal proposition into a mechanism edge.
 - `gaia.causal` is the runtime query surface for `do()`, `query()`, and `ate()`. A `gaia.lang.dsl.causal` compatibility re-export can be added later if the broader DSL wants all verbs in `gaia.lang.dsl`, but it is not required for the core implementation.
 
 This partitions the work so each module is independently testable and no file grows oversized.
@@ -226,8 +294,9 @@ import networkx as nx
 class CausalEdge:
     cause_id: str        # QID or CNID (see §3.1)
     effect_id: str       # QID or CNID
-    source_claim_qid: str              # which causal claim declared this edge
-    prior: float | None                # the claim's prior (agent confidence in edge truth)
+    source_action_label: str           # which mechanism action declared this edge
+    backing_claim_qid: str | None      # causal proposition used as warrant/provenance
+    backing_claim_prior: float | None  # belief that the backing proposition is true
 
 @dataclass
 class CausalDAG:
@@ -241,21 +310,19 @@ Construction:
 
 ```python
 def build_dag(pkg_or_graph) -> CausalDAG:
-    """Walk the compiled artifact's knowledge nodes, pick up every claim
-    whose metadata.causal.dag_edge is populated, and assemble a DAG.
+    """Walk compiled causal_mechanism records and assemble a DAG.
 
-    Variables appearing as cause/effect become DAG nodes (they have no
-    IR Knowledge — their CNID is synthesized from symbol+domain per PR 505 §2.4).
-    Knowledge-typed endpoints become DAG nodes under their compiled QID.
+    Bare Claim(formula=Causes(...)) nodes are causal propositions, not
+    mechanism edges, and are ignored unless a mechanism action promotes them.
     """
 ```
 
 The node identifier is a **string ID** — not a Python object — so `CausalDAG` is picklable, diffable, and consumable by the JSON renderer. Two kinds of node IDs coexist in a DAG:
 
-- **Knowledge-typed endpoints** (a `ClaimAtom`-based cause/effect): use the compiled Knowledge **QID** directly (`{namespace}:{package}::{label}` per `gaia.ir.knowledge.is_qid`).
+- **Claim endpoints**: use the compiled Claim **QID** directly (`{namespace}:{package}::{label}` per `gaia.ir.knowledge.is_qid`). This is the propositional/action layer: one Claim's truth causally changes another Claim's truth.
 - **Variable endpoints**: use a synthesized **causal node ID** (`CNID`). Variables have no IR Knowledge per PR #505 §2.4, so they have no QID; we mint a stable synthetic ID with a visually distinct prefix: `@var:{namespace}:{package_name}:{symbol}`. The `@` prefix makes `is_qid()` return False, so no consumer confuses a CNID with a QID. The CNID is deterministic — identical inputs produce identical IDs across compilations, satisfying the audit-hash requirements of §4.8.
 
-Current PR #505 code accepts `Causes(Term, Term)`, so D1 should treat Variable endpoints as the required path. Knowledge-typed endpoints are a reserved extension that requires explicitly broadening `Causes` to accept `ClaimAtom` or another claim-reference term.
+Current PR #505 code accepts `Causes(Term, Term)`, so predicate-level causal claims are term-level today. Claim-to-claim causation is not represented by `Causes(ClaimAtom(A), ClaimAtom(B))`; it is represented by the `mechanism(...)` action with Claim endpoints.
 
 See Open Question 2 (§12) on the declaring-vs-using package question for cross-package Variable references.
 
@@ -289,36 +356,37 @@ def adjustment_sets(
 
 ### 3.4 Rendering hooks
 
-The Obsidian wiki renderer gets a new section per causal claim:
+The Obsidian wiki renderer gets two distinct sections:
 
-- "**Causal role:** A → B"
+- On causal proposition Claims: "**Causal proposition:** Causes(A, B)" plus formula metadata.
+- On mechanism actions / backing claims: "**Causal mechanism:** A → B" plus action label, CPD, and intervention status.
 - "**Ancestors:** …"
 - "**D-separated from:** … given { … }" (when nontrivial)
 
-These wire into `gaia render` through a tiny `render_causal_block(dag, claim_qid)` helper in `gaia.causal.dag` module. The SVG renderer uses directed edges with arrowheads for `Causes`, which visually distinguishes them from `deduction` / `support` edges.
+These wire into `gaia render` through a tiny `render_causal_block(dag, node_or_action_id)` helper in `gaia.causal.dag` module. The SVG renderer uses directed edges with arrowheads only for mechanism actions, not for every `Causes(...)` predicate claim.
 
-### 3.5 Prior on a causal claim — what it means and what it is not
+### 3.5 Prior on a causal proposition — what it means and what it is not
 
-The `prior` on a causal claim is the agent's confidence that **the causal relation actually holds** — i.e., that the mechanism `cause → effect` is real, not that the effect is likely under intervention. This is the same semantics PR #505 §4 gives to any claim with a formula: `prior = P(claim is true before evidence)`.
+The `prior` on a causal proposition Claim is the agent's confidence that **the proposition "X causes Y" is true**. This is the same semantics PR #505 §4 gives to any claim with a formula: `prior = P(claim is true before evidence)`.
 
-The numeric strength of the mechanism — `P(effect=1 | cause=1)` and `P(effect=1 | cause=0)` — is a **separate quantity**, supplied through the `causal()` declaration's `p_effect_given_cause` and `p_effect_given_not_cause` parameters (§4.1). These two parameters are independent of `prior`:
+The numeric strength of a promoted mechanism — `P(effect=1 | cause=1)` and `P(effect=1 | cause=0)` — is a **separate quantity**, supplied through the `mechanism()` action's `p_effect_given_cause` and `p_effect_given_not_cause` parameters (§4.1). These two parameters are independent of the backing claim's `prior`:
 
 - `prior = 0.9, p_effect_given_cause = 0.15, p_effect_given_not_cause = 0.05` — "I'm 90% sure smoking causes lung cancer; the mechanism kicks in 15% of the time among smokers, baseline 5% otherwise"
 - `prior = 0.5, p_effect_given_cause = 0.99, p_effect_given_not_cause = 0.01` — "Coin-flip belief that this mechanism exists; if it does, it's nearly deterministic"
 
 Conflating belief and strength into one number (e.g., reusing `prior` as the noisy-OR leak parameter) is a documented pitfall — see §12 Q4 for the rationale.
 
-For v0.6, DAG-build treats every causal claim as **structurally present regardless of `prior`**; see §3.5.1.
+For v0.6, DAG-build treats every authored mechanism action as **structurally present regardless of backing-claim `prior`**; see §3.5.1.
 
 #### 3.5.1 Soft edges, MAP structure, and the v0.6 default
 
-A causal claim with `prior < 1` is a **soft edge**: the structure exists at the DAG level (so d-separation, adjustment sets, and `do()` all work), while the numeric mechanism is supplied by the separate CPD parameters (`p_effect_given_cause`, `p_effect_given_not_cause`, or an explicit CPT). D₂ does **not** reuse `prior` as a CPD entry. Future ensemble semantics may decide how posterior edge belief modulates graph structure or model averaging, but that is outside v0.6.
+A mechanism backed by a causal proposition with `prior < 1` is a **softly believed mechanism**, not a fuzzy DAG edge. The structure exists at the DAG level because the author explicitly wrote a mechanism action; the numeric mechanism is supplied by CPD parameters (`p_effect_given_cause`, `p_effect_given_not_cause`, or an explicit CPT). D₂ does **not** reuse `prior` as a CPD entry. Future ensemble semantics may decide how posterior mechanism belief modulates graph structure or model averaging, but that is outside v0.6.
 
 Whether DAG-build should also filter edges by `prior > threshold` (MAP semantics) is **deferred** — see §12 Q1.
 
 ### 3.6 Independent Variables and isolated sub-DAGs
 
-A variable never mentioned in any `Causes(...)` is not a DAG node. A package can host multiple disconnected causal sub-DAGs — `CausalDAG` records components; `gaia check causal` warns if a `do()` target is on an isolated component and the user queries a disconnected effect.
+A variable never used as a `mechanism(...)` endpoint is not a DAG node, even if it appears in a bare `Causes(...)` predicate claim. A package can host multiple disconnected causal sub-DAGs — `CausalDAG` records components; `gaia check causal` warns if a `do()` target is on an isolated component and the user queries a disconnected effect.
 
 ---
 
@@ -326,47 +394,74 @@ A variable never mentioned in any `Causes(...)` is not a DAG node. A package can
 
 The centerpiece. `do(X=x)` is the primitive that separates causal from conditional reasoning.
 
-### 4.1 Authored DSL — `causal()` declaration helper
+### 4.1 Authored DSL — `mechanism()` action helper
 
-`causal(...)` is the v0.6 surface for declaring a causal mechanism. It is parameterized by **two independent quantities**:
+`mechanism(...)` is the v0.6 surface for declaring a causal mechanism. It promotes a causal proposition into the interventional graph and is parameterized by **two independent quantities**:
 
-- `prior` — the agent's belief that the mechanism exists (semantics shared with all `Claim` priors per §3.5)
+- `backing_claim.prior` — the agent's belief that the causal proposition is true (semantics shared with all `Claim` priors per §3.5)
 - `(p_effect_given_cause, p_effect_given_not_cause)` — the single-parent CPD entries `P(effect=1 | cause=1)` and `P(effect=1 | cause=0)`, structurally identical to `infer()`'s `(p_e_given_h, p_e_given_not_h)` and `support()`'s deprecated `(p1, p2)` (see §12 Q4 for the choice of separate parameters)
+
+Runtime shape:
+
+```python
+# gaia/lang/runtime/action.py
+@dataclass
+class Mechanism(Action):
+    """Interventional mechanism edge. Parallel to Support/Structural/Probabilistic."""
+
+    cause: Claim | Variable | None = None
+    effect: Claim | Variable | None = None
+    backing_claim: Claim | None = None
+    p_effect_given_cause: float | None = None
+    p_effect_given_not_cause: float | None = None
+```
+
+`Mechanism` is intentionally not a `Support` or `Probabilistic` subclass. `infer()` says evidence updates belief in a hypothesis; `mechanism()` says intervening on one node changes the production of another node. They may use similar binary CPT numbers, but `mutilate()` must distinguish their modalities.
 
 Authored shape:
 
 ```python
-from gaia.lang import Bool, Variable, causal
+from gaia.lang import Bool, Variable, causal, mechanism
 from gaia.causal import do, query
 
 co2  = Variable(symbol="co2_level", domain=Bool)
 temp = Variable(symbol="temperature", domain=Bool)
 G    = Variable(symbol="greenhouse_gas_other", domain=Bool)
 
-causal(
+g_causes_co2 = causal(
     cause=G, effect=co2,
-    p_effect_given_cause=0.7, p_effect_given_not_cause=0.05,
     prior=0.8,
     rationale="Other greenhouse gases drive CO₂ via shared industrial sources.",
-    label="g_causes_co2",
+    label="g_causes_co2_claim",
 )
-causal(cause=G,   effect=temp, p_effect_given_cause=0.6,  p_effect_given_not_cause=0.05, prior=0.7)
-causal(cause=co2, effect=temp, p_effect_given_cause=0.85, p_effect_given_not_cause=0.05, prior=0.9)
+mechanism(
+    cause=G,
+    effect=co2,
+    backing_claim=g_causes_co2,
+    p_effect_given_cause=0.7,
+    p_effect_given_not_cause=0.05,
+    label="g_causes_co2_mechanism",
+)
+
+g_causes_temp = causal(cause=G, effect=temp, prior=0.7, label="g_causes_temp_claim")
+co2_causes_temp = causal(cause=co2, effect=temp, prior=0.9, label="co2_causes_temp_claim")
+mechanism(cause=G, effect=temp, backing_claim=g_causes_temp, p_effect_given_cause=0.6, p_effect_given_not_cause=0.05)
+mechanism(cause=co2, effect=temp, backing_claim=co2_causes_temp, p_effect_given_cause=0.85, p_effect_given_not_cause=0.05)
 
 # Query at runtime (invoked by `gaia infer --causal` or in an action body):
 result = do(co2=1).query(temp)              # numeric P(temp=1 | do(co2=1))
 result = query(temp, given_do={co2: 1})     # equivalent long form
 ```
 
-`causal()` returns the underlying `Claim(formula=Causes(cause, effect), kind=ClaimKind.CAUSAL, prior=prior)` and records the CPD parameters for compiler/lowering. The v0.6 compiler normalizes those parameters into `metadata.causal.cpd` (§1.1) after formula lowering has populated `metadata.causal.cause` / `.effect`. The existing lowercase `causes()` formula helper remains available when an author needs only the formula AST and no CPD-bearing declaration.
+`causal()` returns the underlying `Claim(formula=Causes(cause, effect), kind=ClaimKind.CAUSAL, prior=prior)` and records no CPD. The existing lowercase `causes()` formula helper remains available when an author needs only the formula AST and no Claim. `mechanism()` returns/registers a `Mechanism` Action and records CPD parameters for compiler/lowering. The v0.6 compiler normalizes those action parameters into `metadata.causal_mechanism.cpd` (§1.1).
 
 #### 4.1.1 Default strengths (omitted parameters)
 
-If the author omits `p_effect_given_cause` / `p_effect_given_not_cause`, the lowering uses the v0.5 deduction default — `(1 − ε, 0.5)` — making the edge a **hard causal implication** equivalent in BP behavior to `deduction([cause], effect)` plus a causal-modality tag. This makes hard causation and soft causation traverse the same lowering path with different parameters.
+If the author omits `p_effect_given_cause` / `p_effect_given_not_cause`, the mechanism lowering uses the v0.5 deduction default — `(1 − ε, 0.5)` — making the edge a **hard causal implication** equivalent in BP behavior to `deduction([cause], effect)` plus a causal-modality tag. This makes hard causation and soft causation traverse the same lowering path with different parameters.
 
 #### 4.1.2 Multi-parent effect: noisy-OR composition (default)
 
-When an effect node has multiple `causal()` parents, each edge supplies its single-parent absolute CPD entries. The compiler groups incoming edges by effect and composes them into the effect node's canonical CPT using **leak-aware noisy-OR** by default.
+When an effect node has multiple `mechanism()` parents, each edge supplies its single-parent absolute CPD entries. The compiler groups incoming mechanism actions by effect and composes them into the effect node's canonical CPT using **leak-aware noisy-OR** by default.
 
 First choose the effect-level leak:
 
@@ -447,8 +542,8 @@ def _compute(
     target: str,
 ) -> CausalQueryResult:
     dag = build_dag(pkg_artifact)
-    # 1. Lower the compiled local graph normally. Causal claims have already
-    #    been compiled to causal CONDITIONAL factors via causal() declarations; the
+    # 1. Lower the compiled local graph normally. Mechanism actions have already
+    #    been compiled to causal CONDITIONAL factors; the
     #    multi-parent noisy-OR composition (§4.1.2) is performed here at lower
     #    time, producing one provenance-tagged CONDITIONAL factor per causal effect node.
     fg  = lower_local_graph(pkg_artifact.local_canonical_graph)
@@ -471,9 +566,9 @@ def _compute(
 
 **Why this is correct.** For a DAG with factorization `P(V) = ∏ᵢ P(vᵢ | pa(vᵢ))`, Pearl's truncated factorization for `P(V | do(X=x))` is identical to `P(V)` with every `P(xᵢ | pa(xᵢ))` replaced by the point mass on `xᵢ = x`. In Gaia v0.6 this is realised by:
 
-1. Each `causal()` declaration contributes explicit CPD parameters. Multi-parent effects compose via noisy-OR (§4.1.2) into one canonical `CONDITIONAL` factor per effect node.
+1. Each `mechanism()` action contributes explicit CPD parameters. Multi-parent effects compose via noisy-OR (§4.1.2) into one canonical `CONDITIONAL` factor per effect node.
 2. CNID variables (Variables, per PR #505 §2.4 they have no IR Knowledge) are registered as BP variables during causal lowering inside the standard `gaia.bp.lowering` path.
-3. The generated causal factor carries `metadata={"modality": "causal", "source_claim_qid": ..., "dag_edge": ...}` copied from the compiled claim metadata (§1.2).
+3. The generated causal factor carries `metadata={"modality": "causal", "causal_mechanism": {...}}` copied from the compiled mechanism action metadata (§1.2).
 4. `mutilate(fg, intervened)` identifies and drops only the factor whose conclusion ∈ intervened **and** whose factor metadata says `modality == "causal"` (see §4.4). Logical and structural factors (`deduction`, `decompose`, IMPLICATION/EQUIVALENCE operator helpers) are preserved.
 5. `observe()` clamps the intervened variable to its target value.
 
@@ -492,7 +587,7 @@ A short tour of the thought experiments motivating this rule:
 | 1 | "All men are mortal; Socrates is a man." | `do(¬"all men are mortal")` | Ill-defined. You cannot intervene on a logical truth. | **Logical edges admit no `do()` semantics**; they are preserved under mutilation. |
 | 2 | Fire → Smoke (causal) | `do(Smoke = 1)` (smoke machine) | `P(Fire) = P(Fire)` — base rate, unchanged. | Causal edges are **severed**; intervened node loses its causal parents. |
 | 3 | "Bachelor" ↔ "unmarried man" (definitional) | `do(¬"unmarried")` | Both flip together — they are the same fact. | Use EQUIVALENCE operator, not Causes / deduction. EQUIVALENCE is **not mutilated** (it's a structural identity, not a mechanism). |
-| 4 | F = ma (physical law) | `do(a = 0)` | Ambiguous — depends on whether F=ma is read as constraint (then F→0) or mechanism (then F unchanged, supported by counter-force). | **Author must choose** — declare F→a as `causal()` (mechanism, F preserved) or as `deduction([F, m], a)` (constraint, F follows). Engine will not guess. |
+| 4 | F = ma (physical law) | `do(a = 0)` | Ambiguous — depends on whether F=ma is read as constraint (then F→0) or mechanism (then F unchanged, supported by counter-force). | **Author must choose** — declare F→a with `mechanism()` (mechanism, F preserved) or as `deduction([F, m], a)` (constraint, F follows). Engine will not guess. |
 | 5 | Temperature ⇄ Evaporation | `do(Evap = 0)` (sealed bucket) | Temperature unchanged at the mutilation step. | Direction matters; each direction is a separate cause. |
 | 6 | Whole claim decomposed via `decompose(C, [A, B], A & B)` | `do(C = 0)` | The decomposition remains a structural identity; it is not a production mechanism. | `Decompose` is a `Structural` action in current v0.5, so generated factors are **not mutilated**. |
 | 7 | Mixed: Hot → Cooked (causal); Cooked ↔ "not raw" (logical) | `do(Hot = 0)` | Cuts only the (empty) causal in-edges of `Hot`; `Cooked` propagates normally; logical "not raw" follows. | **Mixed graphs work cleanly** as long as each edge declares its modality. |
@@ -519,7 +614,7 @@ A `FormalStrategy` may embed multiple `Operator`s inside a `FormalExpr`. When lo
 
 ### 4.6 Only causally authored intervention is permitted
 
-An intervention is only well-defined over nodes that are **DAG nodes** — i.e., participate in at least one `causal()` edge. Attempting `do(X = 1)` on a node that has no causal in-edges raises `InterventionUndefinedError` with a message pointing the author at `causal(...)`.
+An intervention is only well-defined over nodes that are **DAG nodes** — i.e., participate in at least one `mechanism()` edge. Attempting `do(X = 1)` on a node that has no causal in-edges raises `InterventionUndefinedError` with a message pointing the author at `mechanism(...)`.
 
 This is a deliberate restriction motivated by thought experiment 1 (§4.4): `do()` on a node with only logical parents has no Pearl-style semantics. The error message must surface this rationale rather than say "node not found."
 
@@ -544,11 +639,14 @@ These let a reviewer re-run the query and verify bit-equality. The digest is the
 
 ---
 
-## 5. Predicate-layer causation grounded into propositional BP
+## 5. Predicate Claims and Mechanism Grounding
 
-Gaia Lang is **predicate-level** (PR #505: Variables, Domains, quantifiers, Causes); Gaia BP is **propositional** (Boolean Knowledge nodes + factors). Every causal claim must therefore be grounded — translated from a quantified universal claim into a concrete set of propositional nodes and factors that BP can evaluate.
+Gaia Lang is **predicate-level** (PR #505: Variables, Domains, quantifiers, Causes); Gaia BP is **propositional** (Boolean Knowledge nodes + factors). The grounding rule has two stages:
 
-This section fixes the grounding contract for causal claims under universal quantification, in **strict duality with the v0.5 logical-quantifier grounding** already implemented in `gaia/lang/compiler/lower_formula.py:107-192`.
+1. Formula lowering grounds causal **propositions** exactly like other quantified formulas. This creates reviewable Knowledge nodes and deduction links, but no mechanism factors.
+2. Mechanism lowering grounds only authored `mechanism(...)` **actions** into DAG nodes and causal `CONDITIONAL` factors.
+
+This section fixes the grounding contract for causal propositions and mechanism actions under universal quantification, in **strict duality with the v0.5 logical-quantifier grounding** already implemented in `gaia/lang/compiler/lower_formula.py:107-192`.
 
 ### 5.1 The v0.5 baseline: how `forall` is grounded today
 
@@ -561,38 +659,43 @@ There is **no NOISY_AND** linking the instances back to the universal — the un
 
 In BP: `universal = true` ⇒ each `P_v` ≈ 1; `universal = false` ⇒ each `P_v` retreats to base rate. Evidence on any `P_v` weakly raises the universal via reverse syllogism.
 
-**This is the model we mirror for causal universals.**
+**This is the model we mirror for causal proposition universals.** Mechanism factors are an additional action-layer lowering step, not a side effect of the formula lowerer.
 
-### 5.2 The causal universal: per-instance grounding
+### 5.2 The causal universal: proposition grounding plus mechanism grounding
 
 For a causal universal `forall(p: D, Causes(X(p), Y(p)))`, the compiler emits:
 
 - One **universal causal claim** Knowledge node — same node the author wrote.
 - For each `v ∈ D.members`:
-  - Instance CNID variables `X_v`, `Y_v` — generated causal node IDs such as `@var:{namespace}:{package}:{symbol}_{digest}`. These are BP/DAG variables, **not** IR Knowledge nodes.
   - Instance causal claim Knowledge — the per-instance assertion that "X_v causes Y_v".
   - `deduction` strategy: `universal_causal_claim ⇒ instance_causal_claim` — exactly as the logical case.
-  - `metadata.causal.dag_edge` on the instance claim points at the generated CNIDs.
-  - One provenance-tagged `CONDITIONAL` factor on `(X_v, Y_v)`, with CPT parameters taken from the universal claim's authored `causal_cpd` values and normalized into each instance claim's `metadata.causal.cpd`.
+  - Predicate metadata on the instance claim records the instantiated `cause` / `effect` descriptors.
 
-This is **structurally dual** to the v0.5 logical lowering: each instance gets a propositional copy, the universal claim is the deductive parent, and BP propagates exactly as it does today for universal logical claims.
+If, and only if, the author also writes a `mechanism(...)` action whose `backing_claim` is this universal causal claim, the mechanism lowering additionally emits for each `v ∈ D.members`:
+
+- Instance CNID variables `X_v`, `Y_v` — generated causal node IDs such as `@var:{namespace}:{package}:{symbol}_{digest}`. These are BP/DAG variables, **not** IR Knowledge nodes.
+- One `metadata.causal_mechanism` record with `cause_id = X_v`, `effect_id = Y_v`, `backing_claim_qid = instance_causal_claim`.
+- One provenance-tagged `CONDITIONAL` factor on `(X_v, Y_v)`, with CPT parameters taken from the `mechanism(...)` action and normalized into the mechanism record.
+
+The proposition part is **structurally dual** to the v0.5 logical lowering: each instance gets a propositional copy, the universal claim is the deductive parent, and BP propagates exactly as it does today for universal logical claims. The mechanism part is action-layer promotion: it reads those grounded proposition nodes as provenance and emits causal factors only where the author explicitly asked for an interventional mechanism.
 
 ```
                    ┌────────────────────────────┐
                    │  universal_causal_claim    │ (Knowledge)
-                   └────────────┬───────────────┘
-                  deduction     │     deduction
+	                   └────────────┬───────────────┘
+	                  deduction     │     deduction
         ┌──────────────────┐    │   ┌──────────────────┐
         ▼                  │    │   ▼                  │
- instance_v₁_causal    instance_v₂_causal     ...        (per-instance Knowledge)
-        │                                │
-        │ CONDITIONAL (causal,            │ CONDITIONAL (causal,
-        │  provenance-tagged CPT)         │  provenance-tagged CPT)
-        ▼                                ▼
- X_v₁ ──→ Y_v₁                    X_v₂ ──→ Y_v₂              (propositional CNIDs)
+	 instance_v₁_causal    instance_v₂_causal     ...        (per-instance Knowledge)
+	        │                                │
+	        │ mechanism action lowers         │ mechanism action lowers
+	        │ this proposition into           │ this proposition into
+	        │ CONDITIONAL (causal, CPT)       │ CONDITIONAL (causal, CPT)
+	        ▼                                ▼
+	 X_v₁ ──→ Y_v₁                    X_v₂ ──→ Y_v₂              (propositional CNIDs)
 ```
 
-`do(X_v₁ = 1)` operates on a **specific instance** — Pearl-correct semantics, no ambiguity about which person/particle is being intervened on. `do(universal_causal_claim = 1)` is rejected because the universal claim is not a causal DAG node; authors who want to assert the universal should use `observe(universal_causal_claim, 1)`.
+`do(X_v₁ = 1)` operates on a **specific instance** only if the corresponding mechanism action exists — Pearl-correct semantics, no ambiguity about which person/particle is being intervened on. `do(universal_causal_claim = 1)` is rejected because the universal claim is a proposition, not a causal DAG node; authors who want to assert the universal should use `observe(universal_causal_claim, 1)`.
 
 ### 5.3 Why per-instance grounding (not single-representative or population-parameter)
 
@@ -670,45 +773,55 @@ The adapter imports y0 inside the function body; `ImportError` is translated to 
 
 ## 7. Compiler Changes
 
-### 7.1 Populate `metadata.causal.dag_edge`
-
-D1 builds on the v0.5 formula-lowering path. After QID assignment, the compiler walks claims whose formula is a top-level `Causes(X, Y)` (i.e., `kind == CAUSAL`), strict-validates that formula lowering already populated `metadata.causal.cause` and `.effect`, then writes the compiled edge identifiers:
+### 7.1 Normalize predicate metadata
 
 ```python
 causal = claim.metadata.get("causal")
 if not causal or "cause" not in causal or "effect" not in causal:
     raise CausalMetadataMissingError(
-        "CAUSAL claim is missing metadata.causal descriptors; "
+        "CAUSAL claim is missing predicate causal descriptors; "
         "recompile with the v0.6 formula-lowering compiler"
     )
 
-causal["dag_edge"] = {
-    "cause_id":  resolve_causal_id(claim.formula.cause),
-    "effect_id": resolve_causal_id(claim.formula.effect),
+claim.metadata["causal"] = {
+    "predicate": {"cause": causal["cause"], "effect": causal["effect"]}
 }
 ```
 
-`resolve_causal_id` is a new helper. For `Variable` operands it synthesizes a **CNID** (see §3.1) with the format `@var:{namespace}:{package_name}:{symbol}` — visually distinct from QIDs and guaranteed to fail `is_qid()`. If D1 chooses to support claim endpoints, then `Causes` must first be broadened beyond its current `Term`-only contract; only then should `Knowledge` / `ClaimAtom` operands resolve to compiled QIDs.
+D1 builds on the v0.5 formula-lowering path. After QID assignment, the compiler walks Claims whose formula is a top-level `Causes(X, Y)` (`kind == CAUSAL`), quantified Claims whose grounded body is `Causes(...)` (`kind == QUANTIFIED`), or generated instances of either. It validates that formula lowering already populated predicate descriptors and normalizes them into `metadata.causal.predicate`.
 
-This is an additive extension to the existing `metadata.causal` descriptor, not a new IR schema and not a replacement for formula lowering.
+This pass intentionally does **not** write `dag_edge` or `cpd`. Those are mechanism-action concepts.
 
-### 7.2 No new IR schema, no new strategy type
+### 7.2 Compile mechanism actions
 
-All the new semantics live in metadata and in `gaia.causal`. IR `Operator`, `Strategy`, `StrategyType`, `OperatorType` enums — all unchanged. This is deliberate: IR is the CLI↔LKM protocol contract, and the project policy (CLAUDE.md "Protected Layers") requires a separate PR for any IR schema change.
+The compiler separately walks `Mechanism` actions. For each action it:
 
-### 7.3 Migration concern: existing `CAUSAL` claims
+1. Registers the `backing_claim` and endpoint Claims, if present, as normal Knowledge.
+2. Resolves endpoint IDs:
+   - Claim endpoints resolve to compiled QIDs.
+   - Variable endpoints synthesize CNIDs using §3.1.
+3. Validates that a backing causal proposition, if provided, is compatible with the action endpoints. A mismatch is an error; this prevents a claim saying `Causes(X, Y)` from backing a mechanism `Z → Y`.
+4. Emits a `metadata.causal_mechanism` record (§1.1) that `build_dag` and BP lowering can consume.
 
-Packages compiled after PR #510 but before v0.6 can already contain `metadata.causal.cause` / `.effect` without `dag_edge`. Handling:
+For `Variable` operands, `resolve_causal_id` synthesizes a **CNID** with the format `@var:{namespace}:{package_name}:{symbol}` — visually distinct from QIDs and guaranteed to fail `is_qid()`. For Claim endpoints, it uses the compiled QID directly. No broadening of `Causes` is needed for claim-to-claim causation because that path lives in `mechanism(...)`, not in the formula predicate.
 
-- If `metadata.causal` is absent on a `CAUSAL` claim, the artifact is malformed for v0.6 causal tooling.
-- If `metadata.causal` exists but `dag_edge` is missing, `build_dag` raises `CausalMetadataMissingError` with a message telling the user to recompile under v0.6 to populate `metadata.causal.dag_edge`.
-- Re-compiling a package with v0.6 populates `dag_edge` definitively; the reviewer prefers `dag_edge` when present.
+### 7.3 No new IR schema, no overloaded strategy type
+
+All the new semantics live in metadata and in `gaia.causal`. IR `Operator`, `Strategy`, `StrategyType`, `OperatorType` enums — all unchanged. The compiler must not encode mechanism actions as ordinary `infer`, `support`, or `deduction` strategies without an explicit `metadata.causal_mechanism` record; doing so would lose the modality needed by `mutilate()`.
+
+### 7.4 Migration concern: existing `CAUSAL` claims
+
+Packages compiled after PR #510 but before v0.6 can already contain `metadata.causal.cause` / `.effect`. Handling:
+
+- If `metadata.causal` is absent on a causal proposition claim, the artifact is malformed for v0.6 causal proposition tooling.
+- If `metadata.causal` exists with top-level `cause` / `effect`, recompile normalizes it to `metadata.causal.predicate`.
+- If a package has causal proposition Claims but no `mechanism(...)` actions, `build_dag` returns no edges and `do()` targets are undefined. This is intentional and should be explained by diagnostics rather than treated as missing metadata.
 
 ---
 
 ## 8. `gaia check causal`
 
-A new CLI sub-check. Invoked as `gaia check causal <package>` or bundled into `gaia check` when a package contains any `CAUSAL` claim.
+A new CLI sub-check. Invoked as `gaia check causal <package>` or bundled into `gaia check` when a package contains any `CAUSAL` claim or `Mechanism` action.
 
 ### 8.1 Rules
 
@@ -716,8 +829,10 @@ A new CLI sub-check. Invoked as `gaia check causal <package>` or bundled into `g
 |---|---|---|
 | Acyclicity | Error | `CausalCycleError` from `build_dag` |
 | Intervention target is a DAG node | Error | `InterventionUndefinedError` on any authored `do(...)` |
-| Open back-door path | Warning | For every `Causes(X, Y)` claim, inspect paths from `X` to `Y` that enter `X` after removing outgoing edges from `X`. If any path remains open under the declared observed covariates, surface the minimal candidate adjustment sets from `adjustment_sets(...)` or report that no valid set is available. Never condition on `X` or `Y` themselves. |
-| Mixed-modality incoming edges | Warning (Error under `--strict`) | Effect node has both `causal()` and logical/structural incoming factors (`deduction()`, `decompose()`, EQUIVALENCE, etc.). Author should clarify whether the non-causal edge is a definitional consequence (then mutilation will preserve it correctly per §4.4) or actually a mis-typed causal mechanism (then re-author as `causal()`). See §4.4 thought experiment 9. |
+| Bare causal proposition | Info | A `Claim(formula=Causes(...), kind=CAUSAL)` or quantified causal proposition exists with no `mechanism(...)` action. It is reviewable as a proposition but does not enter DAG/intervention semantics. |
+| Mechanism/backing mismatch | Error | A `mechanism(...)` action's endpoints disagree with its backing causal proposition. |
+| Open back-door path | Warning | For every mechanism edge `X → Y`, inspect paths from `X` to `Y` that enter `X` after removing outgoing edges from `X`. If any path remains open under the declared observed covariates, surface the minimal candidate adjustment sets from `adjustment_sets(...)` or report that no valid set is available. Never condition on `X` or `Y` themselves. |
+| Mixed-modality incoming edges | Warning (Error under `--strict`) | Effect node has both `mechanism()` and logical/structural incoming factors (`deduction()`, `decompose()`, EQUIVALENCE, etc.). Author should clarify whether the non-causal edge is a definitional consequence (then mutilation will preserve it correctly per §4.4) or actually a mis-typed causal mechanism (then re-author as `mechanism()`). See §4.4 thought experiment 9. |
 | Identification (opt-in) | Info / Warning | Requires `--identify`; emits obstruction witness per non-identifiable authored `do()` |
 | Variable reuse across sub-DAGs | Warning | The same Variable appearing in disconnected components — likely an authoring error |
 
@@ -730,22 +845,28 @@ JSON, keyed by rule. Fits into the existing `gaia check` aggregated report so re
 ## 9. DSL Surface Summary
 
 ```python
-# Authoring — extend the existing `causal()` declaration helper
-from gaia.lang import Bool, Variable, causal
+# Authoring — separate causal proposition from mechanism action
+from gaia.lang import Bool, Variable, causal, mechanism
 
 X = Variable(symbol="X", domain=Bool)
 Y = Variable(symbol="Y", domain=Bool)
 
 c = causal(
     cause=X, effect=Y,
-    p_effect_given_cause=0.85,
-    p_effect_given_not_cause=0.05,
     prior=0.9,
     rationale="…",
-    label="x_causes_y",
+    label="x_causes_y_claim",
 )
-# Returns the underlying CAUSAL Claim. The lowercase causes() formula
-# helper remains available when you only need the AST node.
+m = mechanism(
+    cause=X,
+    effect=Y,
+    backing_claim=c,
+    p_effect_given_cause=0.85,
+    p_effect_given_not_cause=0.05,
+    label="x_causes_y_mechanism",
+)
+# `c` is the reviewable CAUSAL Claim. `m` is the mechanism edge.
+# The lowercase causes() formula helper remains available when you only need the AST node.
 ```
 
 ```python
@@ -794,14 +915,14 @@ Five independent PR slices, strictly ordered.
 
 Depends on: PR #505 and PR #510 (merged to `v0.5`).
 
-- **Compiler:** validate existing `metadata.causal` operand descriptors and populate `metadata.causal.dag_edge` for `CAUSAL` claims (§7.1).
+- **Compiler:** validate and normalize existing `metadata.causal` operand descriptors as predicate metadata; compile `Mechanism` actions into `metadata.causal_mechanism` records (§7.1, §7.2).
 - **`gaia.causal.dag`:** `CausalDAG`, `CausalEdge`, `build_dag`. Cycle detection.
 - **`gaia.causal.queries`:** `ancestors`, `descendants`, `parents`, `children`, `d_separated`, `adjustment_sets`.
 - **`gaia.causal.errors`:** `CausalCycleError`, `CausalMetadataMissingError`, `InterventionUndefinedError`.
-- **DSL:** extend the existing `causal()` helper with CPD parameters (§4.1); keep `causes()` exported as formula sugar (§0.4).
+- **DSL:** keep existing `causal()` as Claim/formula sugar; add `mechanism()` action helper with CPD parameters (§4.1); keep `causes()` exported as formula sugar (§0.4).
 - **`pyproject.toml`:** `networkx>=3` added to base dependencies.
-- **Renderer hook:** per-claim "Causal role" section in Obsidian wiki output.
-- **Tests:** compiler preserves `metadata.causal.cause` / `.effect` from formula lowering and adds `dag_edge`; `causal()` returns a `CAUSAL` Claim and preserves CPD metadata for D₂; `causes()` remains importable; DAG construction, acyclicity, d-separation parity with textbook examples (confounder, chain, collider); adjustment-set enumeration on canonical DAGs.
+- **Renderer hook:** separate "Causal proposition" and "Causal mechanism" sections in Obsidian wiki output.
+- **Tests:** compiler preserves `metadata.causal.cause` / `.effect` from formula lowering as predicate metadata; bare `causal()` returns a `CAUSAL` Claim but does not create DAG edges; `mechanism()` emits a causal mechanism record and preserves CPD metadata for D₂; `causes()` remains importable; DAG construction, acyclicity, d-separation parity with textbook examples (confounder, chain, collider); adjustment-set enumeration on canonical DAGs.
 
 Independently shippable: enables `gaia check causal`, makes renderings causal-aware, but does not yet execute interventions. Roughly 2–3 weeks.
 
@@ -810,12 +931,12 @@ Independently shippable: enables `gaia check causal`, makes renderings causal-aw
 Depends on: D₁.
 
 - **`gaia.bp.factor_graph.mutilate`:** modality-aware helper (§1.2, §4.3, §4.4). Drops only provenance-tagged causal `CONDITIONAL` factors; logical factors preserved.
-- **Multi-parent noisy-OR composition:** lowering pass that combines multiple `causal()` edges into one provenance-tagged `CONDITIONAL` factor per effect node (§4.1.2). Sits inside the existing `gaia/bp/lowering.py` — no new `gaia.causal.lowering` module needed; the compiled claim metadata and CPD parameters carry enough information to register CNID variables and emit the canonical CPT factor at standard lower time.
-- **Per-instance grounding for causal `forall`:** compiler dual to `gaia/lang/compiler/lower_formula.py:107-192`'s logical lowering — emits per-instance Knowledge nodes plus deduction edges from universal to instance, generated CNID variables for each instance, and one provenance-tagged causal `CONDITIONAL` factor per instance pair (§5.2).
+- **Multi-parent noisy-OR composition:** lowering pass that combines multiple `mechanism()` edges into one provenance-tagged `CONDITIONAL` factor per effect node (§4.1.2). Sits inside the existing `gaia/bp/lowering.py` — no new `gaia.causal.lowering` module needed; the compiled mechanism records and CPD parameters carry enough information to register CNID variables and emit the canonical CPT factor at standard lower time.
+- **Per-instance grounding for causal universals:** formula lowering emits per-instance causal proposition Knowledge nodes plus deduction edges from universal to instance; mechanism lowering emits generated CNID variables and one provenance-tagged causal `CONDITIONAL` factor per instance pair only when a `mechanism()` action promotes the universal (§5.2).
 - **`gaia.causal.intervene`:** `Intervention`, `CausalQueryResult`, `_compute` using `mutilate` + Gaia BP (no separate causal lowering module).
 - **`gaia.causal`:** `do()`, `query()`, `ate()` surface (§4.1, §4.2.1); keep `causal()` itself on the existing `gaia.lang` / `gaia.lang.dsl` export path.
-- **`gaia check causal`:** acyclicity, intervention-target, mixed-modality (effect node has both `causal()` and logical/structural incoming factors) rules (§8.1).
-- **Tests:** `causal()` lowers to a provenance-tagged causal `CONDITIONAL` factor with the expected CPT; smoked against canonical SCMs (confounder, front-door, chain, collider); belief values compared against hand-computed truncated factorizations; thought-experiment 1–9 (§4.4) regression coverage; per-instance grounding parity with logical-quantifier grounding; ATE round-trip.
+- **`gaia check causal`:** acyclicity, intervention-target, bare-proposition, mechanism/backing mismatch, and mixed-modality rules (§8.1).
+- **Tests:** `mechanism()` lowers to a provenance-tagged causal `CONDITIONAL` factor with the expected CPT; bare `causal()` does not; smoked against canonical SCMs (confounder, front-door, chain, collider); belief values compared against hand-computed truncated factorizations; thought-experiment 1–9 (§4.4) regression coverage; per-instance grounding parity with logical-quantifier grounding; ATE round-trip.
 
 Independently shippable: Gaia answers `P(Y | do(X))` and `ATE(X, Y)` numerically. Roughly 3–4 weeks (most of the work is tests, multi-parent noisy-OR composition, and per-instance grounding parity; `mutilate` itself is a small filter-and-rebuild pass).
 
@@ -847,7 +968,7 @@ Independently shippable. Roughly 1–2 weeks (mostly glue + tests).
 Depends on: D₁, D₂ (D₃ optional).
 
 - Update `docs/foundations/` — add a `causal/` sub-page reflecting the new primitives; link into the existing structure without redefining. Remove the "v0.6 interventional factor" placeholder from PR #505 §10.
-- `gaia-lang` docs: `causal()`, `causes()`, `do()`, `query()`, `ate()` reference; worked examples (Pearl's smoking/genetics, Simpson's paradox).
+- `gaia-lang` docs: `causal()`, `causes()`, `mechanism()`, `do()`, `query()`, `ate()` reference; worked examples (Pearl's smoking/genetics, Simpson's paradox).
 - Audit first-party packages (Mendel, Galileo, Superconductivity) for any claim that would benefit from an explicit causal-claim rewrite — do not force, but list candidates in a follow-up issue.
 
 ---
@@ -870,12 +991,12 @@ Depends on: D₁, D₂ (D₃ optional).
 
 ## 12. Open Questions
 
-1. **MAP vs. ensemble causal structure.** §3.5 states that DAG-build treats every `CAUSAL` claim as structurally present regardless of prior. Is there a use case (reviewer workflow?) where the user wants `d_separated` computed against the *MAP* DAG (edges with belief > 0.5 only)? If yes, we add a `build_dag(..., policy="map" | "structural")` knob — otherwise, leave it out of v0.6.
-2. **Variable CNID synthesis.** §3.1 proposes `@var:{namespace}:{package_name}:{symbol}`. Conflict to resolve: when a Variable is declared in package A but used in a `Causes(...)` claim in package B, do we stamp the CNID with the *declaring* package or the *using* package? Proposal: declaring package — matches how PR #505 proposes cross-package Variable lookups. The `@` prefix ensures `is_qid()` returns False so no consumer confuses a CNID with a Knowledge QID.
+1. **MAP vs. ensemble causal structure.** §3.5 states that DAG-build treats every authored `mechanism(...)` action as structurally present regardless of backing-claim prior. Is there a use case (reviewer workflow?) where the user wants `d_separated` computed against the *MAP* DAG (mechanisms with backing-claim belief > 0.5 only)? If yes, we add a `build_dag(..., policy="map" | "structural")` knob — otherwise, leave it out of v0.6.
+2. **Variable CNID synthesis.** §3.1 proposes `@var:{namespace}:{package_name}:{symbol}`. Conflict to resolve: when a Variable is declared in package A but used in a `mechanism(...)` action in package B, do we stamp the CNID with the *declaring* package or the *using* package? Proposal: declaring package — matches how PR #505 proposes cross-package Variable lookups. The `@` prefix ensures `is_qid()` returns False so no consumer confuses a CNID with a Knowledge QID.
 3. **Default stance on `do()` target that is not a DAG node.** §4.6 raises an error. An alternative is a warning + fall through to conditioning. Recommendation: error — silent "meaningless intervention" is the exact footgun the causal layer is meant to prevent.
-4. **Full-CPT authoring timing.** §4.1.2 fixes the v0.6 machine contract as a canonical full binary CPT and uses leak-aware noisy-OR as the default authoring transform. Open question: should v0.6 also expose an advanced `causal_cpt(...)` authoring helper, or should D₂ only implement noisy-OR authoring and keep full-CPT authoring for v0.7?
+4. **Full-CPT authoring timing.** §4.1.2 fixes the v0.6 machine contract as a canonical full binary CPT and uses leak-aware noisy-OR as the default authoring transform. Open question: should v0.6 also expose an advanced `mechanism_cpt(...)` authoring helper, or should D₂ only implement noisy-OR authoring and keep full-CPT authoring for v0.7?
 5. **Soft-do timing.** §10 carves D₂.5 as a separate milestone after D₂ to keep `do()` semantics review-able piece by piece. Alternative: bundle stochastic intervention into D₂ for a single "intervention" PR. Recommendation: separate (more reviewable). Open to revisiting if reviewers prefer one combined PR.
-6. **Mixed-modality warning level.** §4.4 thought experiment 9 says when an effect node has both `causal()` and logical/structural incoming factors, `gaia check causal` warns. Should this be a hard error in `gaia check causal --strict` mode? When does the situation actually represent author intent (e.g. "the structural relation is a derived consequence, the cause is the mechanism") vs. an authoring mistake?
+6. **Mixed-modality warning level.** §4.4 thought experiment 9 says when an effect node has both `mechanism()` and logical/structural incoming factors, `gaia check causal` warns. Should this be a hard error in `gaia check causal --strict` mode? When does the situation actually represent author intent (e.g. "the structural relation is a derived consequence, the cause is the mechanism") vs. an authoring mistake?
 7. **Identification output format.** Raw y0 `Expression.to_latex()` vs. a Gaia-normalized string with QIDs. Recommendation: LaTeX for v0.6 plus a `node_map` from display symbols to QID/CNID; a fully Gaia-native symbolic expression can come later.
 
 ---
@@ -885,7 +1006,7 @@ Depends on: D₁, D₂ (D₃ optional).
 ### 13.1 Pearl's smoking / genetics (confounding)
 
 ```python
-from gaia.lang import Bool, Variable, causal
+from gaia.lang import Bool, Variable, causal, mechanism
 from gaia.causal import do, query, ate
 
 G = Variable(symbol="G", domain=Bool)   # genetic predisposition
@@ -893,9 +1014,13 @@ X = Variable(symbol="X", domain=Bool)   # smoking
 Z = Variable(symbol="Z", domain=Bool)   # yellow fingers
 Y = Variable(symbol="Y", domain=Bool)   # lung cancer
 
-causal(cause=G, effect=X, p_effect_given_cause=0.55, p_effect_given_not_cause=0.20, prior=0.6)
-causal(cause=G, effect=Y, p_effect_given_cause=0.30, p_effect_given_not_cause=0.05, prior=0.7)
-causal(cause=X, effect=Z, p_effect_given_cause=0.85, p_effect_given_not_cause=0.05, prior=0.9)
+g_causes_x = causal(cause=G, effect=X, prior=0.6, label="g_causes_x_claim")
+g_causes_y = causal(cause=G, effect=Y, prior=0.7, label="g_causes_y_claim")
+x_causes_z = causal(cause=X, effect=Z, prior=0.9, label="x_causes_z_claim")
+
+mechanism(cause=G, effect=X, backing_claim=g_causes_x, p_effect_given_cause=0.55, p_effect_given_not_cause=0.20)
+mechanism(cause=G, effect=Y, backing_claim=g_causes_y, p_effect_given_cause=0.30, p_effect_given_not_cause=0.05)
+mechanism(cause=X, effect=Z, backing_claim=x_causes_z, p_effect_given_cause=0.85, p_effect_given_not_cause=0.05)
 # No X → Y edge — smoking does not directly cause cancer in this toy model.
 
 from gaia.causal import build_dag, d_separated, adjustment_sets
@@ -913,12 +1038,12 @@ eff = ate(X, Y)                # do(X=1).Y - do(X=0).Y; ≈ 0 in this DAG
 
 ### 13.2 Simpson's paradox (Gaia surfaces it automatically)
 
-Given a DAG where `X → Y`, `Z → X`, `Z → Y`, authored via `causal()`, `do(X).query(Y)` gives the unconfounded effect while `query(Y, given={X: 1})` aggregates over `Z` and can reverse direction. `gaia check causal` (no flags) simply reports the DAG; with `--identify`, y0 confirms `P(Y | do(X))` is identifiable via back-door over `Z`.
+Given a DAG where `X → Y`, `Z → X`, `Z → Y`, authored via `mechanism()` actions backed by causal proposition Claims, `do(X).query(Y)` gives the unconfounded effect while `query(Y, given={X: 1})` aggregates over `Z` and can reverse direction. `gaia check causal` (no flags) reports the mechanism DAG and any bare causal propositions separately; with `--identify`, y0 confirms `P(Y | do(X))` is identifiable via back-door over `Z`.
 
 ### 13.3 Multi-step intervention with mixed causal+logical edges
 
 ```python
-from gaia.lang import Bool, Variable, causal
+from gaia.lang import Bool, Variable, causal, mechanism
 from gaia.causal import do
 from gaia.lang.dsl import deduction
 
@@ -928,9 +1053,12 @@ R = Variable(symbol="R", domain=Bool)   # recovery
 L = Variable(symbol="L", domain=Bool)   # logged-as-recovered
 
 # Causal mechanisms
-causal(cause=T, effect=S, p_effect_given_cause=0.8, p_effect_given_not_cause=0.1, prior=0.7)
-causal(cause=T, effect=R, p_effect_given_cause=0.7, p_effect_given_not_cause=0.2, prior=0.6)
-causal(cause=S, effect=R, p_effect_given_cause=0.6, p_effect_given_not_cause=0.3, prior=0.5)
+t_causes_s = causal(cause=T, effect=S, prior=0.7, label="t_causes_s_claim")
+t_causes_r = causal(cause=T, effect=R, prior=0.6, label="t_causes_r_claim")
+s_causes_r = causal(cause=S, effect=R, prior=0.5, label="s_causes_r_claim")
+mechanism(cause=T, effect=S, backing_claim=t_causes_s, p_effect_given_cause=0.8, p_effect_given_not_cause=0.1)
+mechanism(cause=T, effect=R, backing_claim=t_causes_r, p_effect_given_cause=0.7, p_effect_given_not_cause=0.2)
+mechanism(cause=S, effect=R, backing_claim=s_causes_r, p_effect_given_cause=0.6, p_effect_given_not_cause=0.3)
 
 # Pure logical edge: "logged-as-recovered" follows recovery deductively (definitional)
 deduction([R], L)
@@ -944,7 +1072,7 @@ do(T=1, S=1).query(R)
 ### 13.4 Per-instance grounding for a causal universal
 
 ```python
-from gaia.lang import Bool, Causes, Claim, ClaimKind, Domain, Variable, forall
+from gaia.lang import Bool, Causes, Claim, ClaimKind, Domain, Variable, forall, mechanism
 from gaia.causal import do, ate
 
 Person = Domain(name="Person", members=["alice", "bob", "carol"])
@@ -953,27 +1081,31 @@ Smokes = Variable(symbol="Smokes", domain=Bool)
 Cancer = Variable(symbol="Cancer", domain=Bool)
 
 # Universal causal claim — grounded per-instance per §5.2
-Claim(
+smoking_causes_cancer = Claim(
     "Smoking causes lung cancer (universal)",
     formula=forall(p, Causes(Smokes, Cancer)),
-    kind=ClaimKind.CAUSAL,
+    kind=ClaimKind.QUANTIFIED,
     prior=0.85,
     label="smoking_causes_cancer",
-    metadata={
-        "causal_cpd": {
-            "p_effect_given_cause": 0.15,
-            "p_effect_given_not_cause": 0.05,
-        },
-    },
 )
 
-# Compiler emits per-instance causal claims plus CNID variables for alice/bob/carol; do() and ate()
-# operate on a chosen instance.
+mechanism(
+    cause=Smokes,
+    effect=Cancer,
+    backing_claim=smoking_causes_cancer,
+    p_effect_given_cause=0.15,
+    p_effect_given_not_cause=0.05,
+    label="smoking_causes_cancer_mechanism",
+)
+
+# Formula lowering emits per-instance causal proposition claims for alice/bob/carol.
+# Mechanism lowering emits per-instance CNID variables and causal factors.
+# do() and ate() operate on a chosen instance.
 ate_alice = ate(target_instance="alice", cause_var=Smokes, effect_var=Cancer)
 # Population-level ATE is NOT supported (§11) — this is the per-instance ATE.
 ```
 
-`metadata["causal_cpd"]` carrying `p_effect_given_cause` / `p_effect_given_not_cause` on the universal claim is the bridge for D₂'s lowering pass: the compiler normalizes it into each per-instance claim's `metadata.causal.cpd`, and each per-instance causal factor reads those parameters. (For non-universal `causal()` declarations the parameters are kwargs on the helper — see §4.1.)
+The universal Claim carries the reviewable proposition. The `mechanism(...)` action carries the CPD. The compiler grounds the proposition first, then grounds the mechanism action against those instances; no CPD is stored on the causal Claim itself.
 
 ---
 


### PR DESCRIPTION
## Summary
- align the causal design spec with the latest v0.5 Action hierarchy, keeping causal declarations separate from Support / Structural / Probabilistic actions
- keep causal() on the existing gaia.lang / gaia.lang.dsl sugar export path while moving do/query/ate examples to gaia.causal
- update stochastic intervention notes to reuse the gaia.lang.bayes Distribution protocol and include decompose/Structural factors in mutilation rules

## Verification
- git diff --check
- uv run --project . ruff format --check .