### PR TITLE
docs(specs): causal extensions — Population, Counterfactual, Transport

### DIFF
--- a/docs/specs/2026-05-06-causal-counterfactual-binary-noise-design.md
+++ b/docs/specs/2026-05-06-causal-counterfactual-binary-noise-design.md
@@ -1,0 +1,507 @@
+# Causal Extension B — Counterfactual Queries via Binary Exogenous Noise
+
+> **Status:** Target design (proposal)
+> **Date:** 2026-05-06
+> **Scope:** Add Pearl-level-3 counterfactual queries `P(Y_{x'} | E)` to `gaia.causal`, computed in three steps (abduction → action → prediction) over the existing binary FactorGraph by automatically materializing one binary exogenous-noise variable per binary_directed mechanism.
+> **Depends on:** `docs/specs/2026-05-06-causal-mechanism-first-class-design.md` (Mechanism as first-class Knowledge type).
+> **Non-goals:** Continuous exogenous noise; counterfactuals over categorical or linear-Gaussian mechanisms (waiting on `Mechanism.kind` expansion per Mech §13 Q3); structural identifiability of counterfactuals (we always *compute* a numeric answer; identifiability via twin-network y0 is a follow-up).
+
+---
+
+## 0. Why this is feasible now and not deferred to v0.7+
+
+The Mechanism spec (Mech) §12 lists "Counterfactual reasoning (Pearl level 3)" as out of scope and says it "requires a different inference mode (abduction–action–prediction or twin networks)". That assessment was correct under the assumption that exogenous noise needs continuous random variables.
+
+**For binary mechanisms, exogenous noise can itself be binary**, and Gaia BP already handles binary variables. A `binary_directed` mechanism
+
+```
+P(E=1 | C=1) = α
+P(E=1 | C=0) = β
+```
+
+is exactly the marginal of the structural-equation form
+
+```
+E = (C ∧ U_active) ∨ U_leak
+P(U_active = 1) = (α − β) / (1 − β)            # only meaningful when α > β
+P(U_leak   = 1) = β
+```
+
+with `U_active` and `U_leak` independent. This is the noisy-OR canonical form (and matches Mech §6.2 multi-parent composition). The two `U_*` variables are **the** exogenous noise for this mechanism — they fully determine `E` given `C`.
+
+Once those `U_*` exist as BP variables, Pearl's three-step counterfactual computation can run on the same FactorGraph machinery, but it requires one additional BP capability: extracting and reinstalling the **joint posterior** over the relevant noise variables (§4.2). **No continuous variables and no causal-specific inference engine are needed; no twin network in the structural sense.**
+
+This spec materializes the `U_*` variables as Gaia BP variables under synthesized CNIDs, defines the three-step query API, and integrates with Mech's existing `mutilate()` and `compute()` primitives.
+
+---
+
+## 1. Architectural Position
+
+```
+Mech §6.1   CausalFactor over (cause, effect)
+              ↓ this spec rewrites lowering to
+            CausalFactor over (cause, U_active, U_leak, effect)
+            with deterministic CPT enforcing
+              effect = (cause ∧ U_active) ∨ U_leak
+
+  Author writes:
+      do(X = x').counterfactual(observed={X: x, Y: y}).query(Y)
+                              │
+                              ▼
+  gaia.causal.counterfactual.compute_counterfactual()
+    1. Abduction: BP on observed FG → joint posterior over all U_*
+    2. Action:    mutilate by CausalFactor type, do(X = x'),
+                  install the U_* joint posterior as one factor
+    3. Prediction: BP → P(Y | counterfactual world)
+```
+
+This spec adds:
+- Lowering-level: noise-variable materialization (§3) — modifies how `binary_directed` mechanisms lower.
+- Runtime-level: `gaia/causal/counterfactual.py` (§4) — new module.
+- DSL-level: `.counterfactual()` chained method on `Intervention` (§5) — new authoring surface.
+
+It does **not** add new IR. It does **not** add new `KnowledgeType`. It does **not** add new BP variable types. The only IR-visible change is one boolean flag controlling whether noise materialization is active for a mechanism.
+
+---
+
+## 2. The Mathematics — Why This Is Correct, in 30 Lines
+
+A binary_directed mechanism with leak β and effect-given-cause α is equivalent (in terms of marginals over `(C, E)`) to:
+
+```
+E = f(C, U_active, U_leak) = (C ∧ U_active) ∨ U_leak
+```
+
+where `U_active` and `U_leak` are independent Bernoullis with parameters chosen such that:
+
+```
+P(E = 1 | C = 0) = P(U_leak = 1)                           = β
+P(E = 1 | C = 1) = 1 − P(U_active = 0) · P(U_leak = 0)
+                 = 1 − (1 − s) · (1 − β)                   = α
+                                       ⇒  s = (α − β) / (1 − β)
+```
+
+where `s = P(U_active = 1)`. Multi-parent effects compose by additional `U_active_i` per parent edge, with the same noisy-OR formula already specified in Mech §6.2 — the lowering pass is unchanged in its CPT output, but it now exposes `U_active` and `U_leak` as visible BP variables instead of marginalizing them analytically.
+
+**Counterfactual `P(Y_{x'} | C = c, E = e)` (Pearl, *Causality* 2nd ed §7.1):**
+
+1. **Abduction.** Compute the joint posterior `P(U_all | C = c, E = e)` by BP on the observed factor graph, using the `joint_belief()` API required in §4.2.
+2. **Action.** Construct the counterfactual factor graph by mutilating causal factors whose conclusion is in the do-set, clamping those variables to the do-values, and **installing the abducted joint `U` posterior as a single joint factor** on the noise variables.
+3. **Prediction.** Compute `P(Y | counterfactual FG)` by BP.
+
+Edge case: when `α ≤ β` (cause inhibits or has zero effect), `s ≤ 0` is not a valid Bernoulli. v0.6 noisy-OR composition (Mech §6.2) already rejects this as `MechanismInhibitoryError` at lowering time; this spec does not weaken that — counterfactuals over inhibitory mechanisms wait for a sign-aware noise model in v0.7.
+
+**Constancy of U across world-versions** is automatic: abducted posterior is the same `U` distribution; the counterfactual world inherits it. Pearl's twin-network construction is one way to *visualize* this; we don't need to build a literal twin graph because the U variables are shared between the factual and counterfactual computations by construction.
+
+---
+
+## 3. IR & Lowering Changes
+
+### 3.1 IR — one optional flag on `Mechanism`
+
+```python
+# gaia/ir/mechanism.py — extension to the model defined in Mech §2.2
+class Mechanism(BaseModel):
+    kind: Literal["binary_directed"] = "binary_directed"
+    cause: MechanismRef
+    effect: MechanismRef
+    cpd: BinaryCPT | None = None
+    quantified_over: tuple[str, ...] = ()
+    domain_ref: str | None = None
+    materialize_noise: bool = False             # NEW (this spec)
+```
+
+`materialize_noise = True` instructs lowering to expose `U_active` and `U_leak` as BP variables. Default is `False` for backward compatibility with packages that don't care about counterfactuals.
+
+`materialize_noise` is a per-mechanism flag, not a package-wide setting, because:
+- Mixed packages exist — only some mechanisms in a package may need counterfactual queries.
+- BP cost grows linearly with materialized noise variables; turning it off where unused keeps factor graphs lean.
+
+### 3.2 Lowering — variable expansion
+
+Lowering pass for `binary_directed` mechanisms with `materialize_noise = True`:
+
+| Before (Mech §6.1) | After (this spec, when flag is on) |
+|---|---|
+| One `CausalFactor` over `(cause, effect)` with CPT `[(1−β, β, 1−α, α)]` | Two BP variables `@noise_active:{mech_qid}` and `@noise_leak:{mech_qid}`; one unary factor on each (priors `s` and `β`); one **deterministic** `CausalFactor` over `(cause, U_active, U_leak, effect)` with CPT enforcing `effect = (cause ∧ U_active) ∨ U_leak` |
+
+Multi-parent: each parent edge contributes its own `U_active_i`, plus one shared `U_leak` per effect node. The deterministic CPT becomes `effect = (∨_i (cause_i ∧ U_active_i)) ∨ U_leak`. This matches Mech §6.2 multi-parent semantics; the marginal CPT is identical when the U variables are summed out.
+
+### 3.3 CNID convention for noise
+
+```
+@noise_active:{namespace}:{package}:{mechanism_label}        # one per mechanism
+@noise_leak:{namespace}:{package}:{effect_cnid}              # one per effect node
+                                                              # (shared across mechanisms
+                                                              #  into the same effect)
+```
+
+The `:` prefix differentiates from `@var:` so neither `is_qid()` nor `is_cnid()` (per Mech §2.6) gives false positives. New helper:
+
+```python
+def is_noise_cnid(id_: str) -> bool:
+    return id_.startswith("@noise_active:") or id_.startswith("@noise_leak:")
+```
+
+### 3.4 No change for `materialize_noise = False`
+
+When the flag is off, lowering is exactly Mech §6.2 — analytic noisy-OR collapses U variables into a marginal CPT. This is the v0.6 default behavior and remains unchanged. Authors opt in only when they need counterfactuals.
+
+---
+
+## 4. Runtime — `gaia/causal/counterfactual.py`
+
+### 4.1 Public surface
+
+```python
+from gaia.causal.intervene import Intervention, CausalQueryResult
+from gaia.bp.factor_graph import FactorGraph
+
+@dataclass(frozen=True)
+class CounterfactualQueryResult(CausalQueryResult):
+    """Result of a counterfactual query, extending CausalQueryResult.
+
+    Adds the abduction step's audit fields. Because counterfactual
+    semantics depends on every U posterior, the audit hash incorporates
+    them.
+    """
+    observed: dict[str, int]                   # the factual evidence
+    intervention_counterfactual: dict[str, int]  # the do-set in the cf world
+    abduction_digest: str                      # sha256 of the post-abduction FG
+    counterfactual_factor_graph_digest: str    # sha256 of the post-action+prediction FG
+
+@dataclass(frozen=True)
+class CounterfactualIntervention(Intervention):
+    """Lazy builder: holds the do-set; .counterfactual(observed=...) finalises."""
+
+    def counterfactual(
+        self,
+        observed: dict[str, int],
+    ) -> "CounterfactualBuilder":
+        return CounterfactualBuilder(
+            do=self.assignments,
+            observed=observed,
+        )
+
+@dataclass(frozen=True)
+class CounterfactualBuilder:
+    do: dict[str, int]
+    observed: dict[str, int]
+
+    def query(self, target) -> CounterfactualQueryResult: ...
+```
+
+### 4.2 Joint Posterior API Requirement
+
+**Blocking dependency:** Counterfactual queries require a joint posterior API that current Gaia BP does not expose. `InferenceEngine().run(fg)` returns `InferenceResult` with a `beliefs: dict[str, float]` field — one marginal posterior per variable. But Pearl's abduction step needs the **joint posterior** `P(U_1, U_2, ..., U_k | evidence)` over all exogenous noise variables, not the product of marginals.
+
+**Why marginals are insufficient.** Observing an effect generally correlates the exogenous noise variables. Concrete example:
+
+```
+E = U1 ∨ U2
+U1, U2 independent before evidence
+observe E = 1
+```
+
+After observing `E=1`, the posterior forbids `(U1=0, U2=0)`. But if we store only `P(U1 | E=1)` and `P(U2 | E=1)` as independent unary factors, the counterfactual graph assigns nonzero probability to `(U1=0, U2=0)` again — that factual world was ruled out by the evidence, so later counterfactual predictions can be wrong.
+
+The same issue appears in binary mechanisms `E = (C ∧ U_active) ∨ U_leak`: observing `E=1` with `C=1` correlates `U_active` and `U_leak`. For multi-parent effects, observing the effect correlates all `U_active_i` plus the shared leak.
+
+**Required API extension.** Add to `InferenceResult`:
+
+```python
+# gaia/bp/engine.py
+@dataclass(frozen=True)
+class InferenceResult:
+    beliefs: dict[str, float]                    # existing marginals
+    treewidth: int
+    # NEW (this spec):
+    def joint_belief(self, variables: Iterable[str]) -> JointDistribution:
+        """Return the joint posterior over the specified variables.
+        
+        For binary variables, this is a 2^n CPT. The implementation extracts
+        the joint from the JunctionTree clique that contains all variables
+        (if using JT inference), or computes it via variable elimination
+        (if using GBP/loopy BP).
+        """
+        ...
+
+@dataclass(frozen=True)
+class JointDistribution:
+    """A joint probability distribution over a set of binary variables."""
+    variables: tuple[str, ...]                   # variable order
+    table: tuple[float, ...]                     # 2^n entries, row-major
+                                                 # table[i] = P(assignment i)
+                                                 # where i is binary encoding
+    
+    def as_factor(self) -> Factor:
+        """Convert to a Factor for installation in a FactorGraph."""
+        ...
+```
+
+**Implementation notes:**
+- For JunctionTree inference, `joint_belief(vars)` finds the clique containing all `vars` and marginalizes out the rest. If no single clique contains all `vars`, run variable elimination to compute the joint.
+- For GBP/loopy BP, always use variable elimination (the region graph doesn't guarantee a single region contains all `vars`).
+- Binary variables only in v0.6; categorical extension is straightforward when BP supports non-Bool.
+
+**Milestone split.** This API is a **BP engine extension**, not a causal-specific change. Implementation milestones (§11) are split into:
+- **PR B1** (1 week): Add `InferenceResult.joint_belief()` + `JointDistribution` to `gaia/bp/engine.py`. Tests: hand-computed joint on a 3-variable chain; verify it differs from product-of-marginals when variables are correlated.
+- **PR B2** (2 weeks, depends on B1): Counterfactual implementation using `joint_belief()`.
+
+### 4.3 The three-step compute (depends on §4.2 joint posterior API)
+
+```python
+# gaia/causal/counterfactual.py
+def compute_counterfactual(
+    pkg,
+    do: dict[str, int],
+    observed: dict[str, int],
+    target: str,
+) -> CounterfactualQueryResult:
+    dag = build_dag(pkg)
+    _assert_intervention_targets_are_dag_nodes(dag, do)
+
+    # Step 1: ABDUCTION.
+    fg_obs = lower_to_fg(pkg, materialize_noise=True)
+    for var, val in observed.items():
+        fg_obs.observe(var, val)
+    abduction_result = InferenceEngine().run(fg_obs)
+    
+    # Collect all noise variables
+    noise_vars = [v for v in fg_obs.variables if is_noise_cnid(v)]
+    
+    # Extract JOINT posterior over all noise variables (not marginals!)
+    noise_joint = abduction_result.joint_belief(noise_vars)
+    abduction_digest = _canonical_digest(fg_obs)
+
+    # Step 2: ACTION.
+    fg_cf = lower_to_fg(pkg, materialize_noise=True)
+    fg_cf = mutilate(fg_cf, set(do))
+    for var, val in do.items():
+        fg_cf.observe(var, val)
+    
+    # Install the joint posterior as a single factor over all noise variables.
+    # This preserves the correlations induced by the factual evidence.
+    noise_joint_factor = noise_joint.as_factor()
+    fg_cf.add_factor(noise_joint_factor)
+
+    # Step 3: PREDICTION.
+    cf_beliefs = InferenceEngine().run(fg_cf).beliefs
+    cf_digest = _canonical_digest(fg_cf)
+
+    return CounterfactualQueryResult(
+        target_id=_resolve_target(target),
+        intervention=dict(do),
+        belief=cf_beliefs[_resolve_target(target)],
+        dag_snapshot=dag,
+        factor_graph_digest=cf_digest,
+        observed=dict(observed),
+        intervention_counterfactual=dict(do),
+        abduction_digest=abduction_digest,
+        counterfactual_factor_graph_digest=cf_digest,
+    )
+```
+
+### 4.3 What `materialize_noise` requires of a package
+
+Authors must opt in per mechanism. To make this ergonomic, `mechanism()` (Mech §4.1) gains a kwarg:
+
+```python
+mechanism(
+    cause=X, effect=Y, cpd=(0.85, 0.05),
+    counterfactual=True,                 # equivalent to materialize_noise=True
+)
+```
+
+`counterfactual=` is the author-facing alias. v0.6.x default is `False` for non-breaking adoption; first-party packages that want to support counterfactual queries set it explicitly.
+
+A package-wide shortcut:
+
+```python
+# In package metadata (top-level package config)
+gaia.causal.counterfactual_default = True   # all mechanisms in this package
+                                              # get materialize_noise=True
+```
+
+Compiler emits a clear error when a counterfactual query targets a mechanism with `materialize_noise = False`:
+
+```
+CounterfactualNotMaterializedError:
+    Mechanism 'smoking_causes_cancer' was lowered without exogenous noise.
+    To enable counterfactual queries, add `counterfactual=True` to the
+    mechanism() declaration, or set
+    `gaia.causal.counterfactual_default = True` for the whole package,
+    then recompile.
+```
+
+---
+
+## 5. DSL Surface
+
+### 5.1 Authoring
+
+```python
+mechanism(cause=X, effect=Y, cpd=(0.85, 0.05), counterfactual=True)
+```
+
+### 5.2 Querying
+
+```python
+from gaia.lang.dsl.causal import do
+
+# Pearl's classic example: "Given Joe smoked and got cancer, what is the
+# probability he would have gotten cancer had he not smoked?"
+result = (
+    do(Smokes=0)                          # the counterfactual intervention
+        .counterfactual(observed={Smokes: 1, Cancer: 1})
+        .query(Cancer)
+)
+
+print(result.belief)
+# P(Cancer_{Smokes=0} | Smokes=1, Cancer=1)
+```
+
+`.counterfactual(observed=...)` is the **only** new chain method. Without `.counterfactual(...)`, `do().query()` is the standard interventional query (Mech §7.4) — unchanged.
+
+### 5.3 Effect of treatment on the treated (ETT)
+
+A common counterfactual quantity:
+
+```python
+from gaia.causal import ett
+
+ett_value = ett(
+    pkg,
+    cause=Smokes, cause_factual=1, cause_counterfactual=0,
+    effect=Cancer, effect_factual=1,
+)
+# = P(Cancer_{Smokes=0} = 1 | Smokes = 1, Cancer = 1)
+#   – P(Cancer_{Smokes=0} = 1 | Smokes = 1)
+```
+
+Convenience function in `gaia/causal/counterfactual.py`. One call, two `compute_counterfactual` invocations under the hood.
+
+### 5.4 Universal-mechanism counterfactual
+
+Per-instance addressability comes through Mech §5.2 grounding. The DSL accepts instance CNIDs:
+
+```python
+result = (
+    do(Smokes_at("alice")=0)
+        .counterfactual(observed={Smokes_at("alice"): 1, Cancer_at("alice"): 1})
+        .query(Cancer_at("alice"))
+)
+```
+
+`Smokes_at(member)` resolves to the instance CNID per Mech §4.4.
+
+---
+
+## 6. Errors
+
+```python
+# gaia/causal/errors.py (additions)
+class CounterfactualNotMaterializedError(Exception):
+    """Counterfactual query targets a mechanism that was lowered without
+    materialize_noise=True. Tells the author exactly which mechanism
+    and how to enable it."""
+
+class CounterfactualEvidenceContradictionError(Exception):
+    """observed = {...} contradicts the factual model (BP returns belief 0
+    for the observation set). Counterfactual semantics is undefined when
+    the factual world has zero probability."""
+
+class CounterfactualInhibitoryMechanismError(Exception):
+    """Mechanism on the path between the do-set and target has α ≤ β
+    (inhibitory or null effect). Binary-noise canonical form requires
+    α > β. Wait for v0.7 sign-aware noise model."""
+```
+
+---
+
+## 7. `gaia check causal --counterfactual`
+
+A new opt-in check rule:
+
+| Rule | Severity | Triggered by |
+|---|---|---|
+| Counterfactual reachability | Warning | An authored `.counterfactual(...)` query path traverses a mechanism that lacks `materialize_noise = True`. Hint: enable `counterfactual=True` on that mechanism. |
+| Inhibitory mechanism on counterfactual path | Error | Any mechanism with `α ≤ β` is on a path from the do-set to the target in a counterfactual query. |
+| Counterfactual evidence consistency | Warning | Observed evidence has unusually low likelihood (< 1e-6) under the factual model. Hint at upstream conflict. |
+
+Activated by `gaia check causal --counterfactual` — silent in default `gaia check causal` to avoid spamming users not using counterfactuals.
+
+---
+
+## 8. Audit & Determinism
+
+`CounterfactualQueryResult` carries two digests:
+- `abduction_digest` — sha256 of the post-observation FG (the abduction step's input).
+- `counterfactual_factor_graph_digest` — sha256 of the post-action+prediction FG.
+
+Reviewers can re-run either step independently. The U-posterior values themselves are reproducible from `abduction_digest` plus the `pkg`, so they need not be stored separately.
+
+---
+
+## 9. Out of Scope
+
+- **Continuous noise** — needs a different BP engine. Mech §12 covers this.
+- **Sign-aware noise** (`α ≤ β` mechanisms) — requires a four-Bernoulli decomposition or a different canonical form; v0.7+ topic.
+- **Twin-network identifiability** — y0 supports counterfactual identification (Shpitser, Pearl 2008). Adding a y0 adapter wrapper for counterfactual queries is a follow-up to Extension C.
+- **Path-specific counterfactuals** (`P(Y_{x'} | path-via-Z = ...)`) — needs path-counterfactual semantics; v0.8+ candidate.
+- **Multi-world counterfactuals** (more than two worlds: factual, cf1, cf2, …) — same machinery extends, but DSL ergonomics need design; not in scope for first PR.
+- **Continuous outcomes** — same blocker as Mech §12.
+
+---
+
+## 10. Implementation Milestones
+
+**Two PRs, strictly ordered.** Total estimated 3–4 weeks.
+
+### PR B1 — Joint Posterior API (1 week, depends on nothing)
+
+BP engine extension. No causal-specific code.
+
+- `gaia/bp/engine.py`: Add `InferenceResult.joint_belief(variables)` method and `JointDistribution` dataclass.
+- `gaia/bp/exact.py` (JunctionTreeInference): Implement `joint_belief()` by finding the clique containing all variables and marginalizing out the rest. If no single clique contains all variables, run variable elimination.
+- `gaia/bp/gbp.py` (GBP): Implement `joint_belief()` via variable elimination (region graph doesn't guarantee a single region contains all variables).
+- `gaia/bp/bp.py` (loopy BP): Implement `joint_belief()` via variable elimination.
+- Tests:
+  - Hand-computed joint on a 3-variable chain `A → B → C` with evidence `C=1`. Verify `P(A, B | C=1)` differs from `P(A | C=1) × P(B | C=1)`.
+  - Noisy-OR example: `E = U1 ∨ U2`, observe `E=1`, verify `P(U1=0, U2=0 | E=1) = 0` but `P(U1=0 | E=1) × P(U2=0 | E=1) > 0`.
+  - `JointDistribution.as_factor()` round-trip: convert to Factor, add to FG, run BP, verify marginals match.
+- Docs: API reference for `joint_belief()` in `docs/foundations/bp/`.
+
+**Shippable independently.** This API is useful beyond counterfactuals (e.g., future multi-variable queries, correlation analysis).
+
+### PR B2 — Counterfactual Implementation (2–3 weeks, depends on B1)
+
+- `gaia/ir/mechanism.py`: `materialize_noise: bool = False`. IR validator unchanged otherwise.
+- `gaia/lang/runtime/causal.py` / `gaia/lang/dsl/causal.py`: `counterfactual=` kwarg on `mechanism()`, package-wide default switch.
+- `gaia/lang/compiler/lower_mechanism.py`: when `materialize_noise = True`, emit `@noise_active:…` and `@noise_leak:…` BP variables and the deterministic effect CPT; otherwise unchanged.
+- `gaia/causal/counterfactual.py`: `compute_counterfactual` (using `joint_belief()` from B1), `ett`, builder classes.
+- `gaia/causal/errors.py`: three new exception types.
+- `gaia/causal/__init__.py`: re-export `compute_counterfactual`, `ett`, `CounterfactualQueryResult`.
+- `gaia/cli/check_causal.py`: three new rules under `--counterfactual` flag.
+- Tests:
+  - Hand-computed counterfactual on a 3-node DAG (Pearl §7 textbook example).
+  - `ett` matches direct calculation on a confounder DAG.
+  - `materialize_noise = False` rejects counterfactual query with helpful error.
+  - Multi-parent counterfactual: noise variables compose, joint posterior preserves correlations, marginals match noisy-OR.
+  - Audit digests stable across runs.
+  - Universal-mechanism counterfactual on a 3-member Person Domain.
+- Docs: counterfactual-queries chapter under `docs/foundations/causal/`.
+
+No new IR `KnowledgeType`. No new BP variable types beyond what B1 provides.
+
+---
+
+## 11. Prior-Art Anchors
+
+- Pearl, *Causality* 2nd ed., Chapter 7 — abduction-action-prediction algorithm; the textbook this spec implements verbatim for the binary case.
+- Pearl & Mackenzie, *The Book of Why*, Chapter 8 — counterfactual intuition and worked examples.
+- Shpitser & Pearl (2008), "Complete Identification Methods for the Causal Hierarchy" — counterfactual identifiability theorems (deferred to a future y0 adapter follow-up).
+- Heckerman & Breese (1996) on noisy-OR canonical form — the binary U decomposition this spec relies on.
+- `docs/specs/2026-05-06-causal-mechanism-first-class-design.md` — Mech (this spec depends on §2.2 / §4.1 / §5 / §6.1 / §6.2 / §7.4).
+- `docs/specs/2026-05-06-causal-population-api-design.md` — Extension A (sibling spec; counterfactual + Population composes — `pop.ate_counterfactual(...)` is a natural future helper).
+- y0's counterfactual-identifiability support — explicitly out of scope for this spec but a clean follow-up adapter target.

--- a/docs/specs/2026-05-06-causal-mechanism-first-class-design.md
+++ b/docs/specs/2026-05-06-causal-mechanism-first-class-design.md
@@ -404,9 +404,7 @@ The eight thought experiments from PR #531 §4.4 (logical truths, fire/smoke, ba
 
 ### 6.4 `InterventionUndefinedError`
 
-`do(X=1)` is valid for any node registered in the causal DAG / FactorGraph, including root causes with no incoming `CausalFactor`. For root interventions, `mutilate()` removes zero causal factors and `observe(X, 1)` clamps the root variable.
-
-`InterventionUndefinedError` is reserved for interventions on identifiers that cannot be resolved to a DAG/BP variable. The error message points the author at either using a known mechanism endpoint or declaring the missing endpoint with `mechanism(cause=..., effect=...)`.
+`do(X=1)` on a node with no incoming `CausalFactor` raises `InterventionUndefinedError`. The error message points the author at `mechanism(cause=..., effect=X, ...)`.
 
 ---
 

--- a/docs/specs/2026-05-06-causal-population-api-design.md
+++ b/docs/specs/2026-05-06-causal-population-api-design.md
@@ -1,0 +1,390 @@
+# Causal Extension A — Population API
+
+> **Status:** Target design (proposal)
+> **Date:** 2026-05-06
+> **Scope:** Add `gaia.causal.Population` — a consumer-layer wrapper that runs the per-instance interventional primitives from the Mechanism design (`do().query()`, `ate()`) over a `Domain`'s members and reduces the results to population-level summaries.
+> **Depends on:** `docs/specs/2026-05-06-causal-mechanism-first-class-design.md` (Mechanism as first-class Knowledge type).
+> **Non-goals:** Population-level interventions in Pearl's super-population sense (`P(Y | do(X = x))` integrated against an unspecified individual distribution); structure transport across populations (covered by Extension C); structural CATE estimation from observed data.
+
+---
+
+## 0. Why this is one PR, not a roadmap entry
+
+`docs/specs/2026-05-06-causal-mechanism-first-class-design.md` (the Mechanism spec, hereafter "Mech") §5.2 already grounds a universal mechanism `forall(p, mechanism(X(p), Y(p)))` per instance — every `v ∈ Domain.members` becomes a concrete `(@var:…:X_{digest(v)}, @var:…:Y_{digest(v)})` pair with its own `CausalFactor`. Mech §11 explicitly defers "what happens if 30% of the population is intervened on" — that is super-population semantics and stays out.
+
+**But "for each Person, what is `P(Cancer | do(Smokes=1))`?" needs no new BP capability** — it is `len(Domain.members)` independent calls to Mech §7.4 `compute()`. Reducing those results to (a) a vector keyed by member, (b) a mean across members, (c) a histogram, or (d) a subgroup-restricted mean is a pure consumer-layer concern.
+
+Implementing this as part of Mech (PR #533) would have made that PR larger and would have conflated "first-class causal IR" with "population reduce convenience". Implementing it as a follow-up spec lets each PR review focus.
+
+**This spec adds zero IR, zero BP, zero compiler changes. It is a single new module `gaia/causal/population.py` plus tests.**
+
+---
+
+## 1. Architectural Position
+
+```
+Mech §5.2 per-instance grounding
+  Domain Person = {alice, bob, carol}
+  ↓ compiler emits
+  per-instance Mechanism × |Person.members|
+  ↓ Mech §7.4 compute(...)
+  per-instance CausalQueryResult
+                                    ↑
+                                    │  reduce
+                                    │
+                                  ┌─┴─┐
+                                  │ A │  Population (this spec)
+                                  └───┘
+                                    ↓
+                            PopulationATEResult
+                            PopulationHistogram
+                            SubgroupATEResult
+```
+
+`Population` reads compiled artifacts via the same `pkg_or_artifact` argument Mech §7.2 `build_dag` already accepts. It does not write IR. It does not modify `FactorGraph`. It does not introduce new `KnowledgeType`s.
+
+---
+
+## 2. Public API
+
+### 2.1 `Population` constructor
+
+```python
+# gaia/causal/population.py
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from gaia.causal.dag import build_dag, CausalDAG
+from gaia.causal.intervene import compute, CausalQueryResult
+from gaia.lang import Variable, Domain
+
+@dataclass(frozen=True)
+class Population:
+    """A view over a Domain's members for batched causal queries.
+
+    A Population is a read-only handle pairing a compiled package artifact
+    with a Domain. All methods iterate the domain's members and dispatch
+    per-instance queries through gaia.causal.intervene.compute().
+    """
+    pkg: object                # CollectedPackage or compiled artifact
+    domain: Domain
+    member_filter: Callable[[str], bool] | None = None
+    _dag: CausalDAG | None = None    # cached on first access
+
+    @property
+    def members(self) -> tuple[str, ...]:
+        """Iterate domain members, applying member_filter if present."""
+        all_members = tuple(self.domain.members)
+        if self.member_filter is None:
+            return all_members
+        return tuple(m for m in all_members if self.member_filter(m))
+```
+
+### 2.2 Subgroup restriction
+
+```python
+    def subgroup(self, predicate: Callable[[str], bool]) -> "Population":
+        """Return a Population restricted to members where predicate(m) is True.
+
+        Composable: pop.subgroup(over_60).subgroup(female) chains predicates.
+        """
+        if self.member_filter is None:
+            new_filter = predicate
+        else:
+            existing = self.member_filter
+            new_filter = lambda m: existing(m) and predicate(m)
+        return Population(
+            pkg=self.pkg,
+            domain=self.domain,
+            member_filter=new_filter,
+            _dag=self._dag,    # DAG is package-scoped, survives subgroup
+        )
+```
+
+### 2.3 Per-instance helpers
+
+```python
+    def per_instance(
+        self,
+        cause_var: Variable,
+        effect_var: Variable,
+        cause_value: int,
+    ) -> dict[str, CausalQueryResult]:
+        """For each member m, compute P(effect_var(m)=1 | do(cause_var(m)=cause_value)).
+
+        Returns a dict member_id -> CausalQueryResult, keyed by raw domain
+        member id (not CNID). Result CNIDs are recoverable from each result's
+        target_id field if needed.
+        """
+        out: dict[str, CausalQueryResult] = {}
+        for m in self.members:
+            cnid_cause = _instance_cnid(cause_var, m, self.domain, self.pkg)
+            cnid_effect = _instance_cnid(effect_var, m, self.domain, self.pkg)
+            out[m] = compute(
+                self.pkg,
+                intervention={cnid_cause: cause_value},
+                target=cnid_effect,
+            )
+        return out
+```
+
+`_instance_cnid` resolves an `(author Variable, domain member id)` pair to the synthesized CNID per Mech §3 / §5.5. It is shared with Mech §7.4 — exposed in `gaia.causal.intervene` if not already.
+
+### 2.4 Population ATE
+
+```python
+@dataclass(frozen=True)
+class PopulationATEResult:
+    domain_name: str
+    n_members: int
+    n_filtered_out: int                    # |all members| − |evaluated members|
+    cause_var: str                         # author symbol
+    effect_var: str                        # author symbol
+    per_instance_ate: dict[str, float]     # member_id -> ATE_m
+    mean_ate: float                        # arithmetic mean over evaluated members
+    audit_digests: tuple[str, ...]         # one per per-instance compute(),
+                                           # in member iteration order
+
+
+    def histogram(self, bins: int = 20) -> tuple[tuple[float, float], ...]:
+        """Return ((bin_low, count), ...) of per-instance ATEs."""
+        ...
+
+class Population:
+    ...
+
+    def ate(
+        self,
+        cause_var: Variable,
+        effect_var: Variable,
+    ) -> PopulationATEResult:
+        """Compute per-instance ATE = P(effect=1|do(cause=1)) − P(effect=1|do(cause=0))
+        for each member; reduce to a population-level mean.
+
+        Mathematical reading: this is the per-instance ATE *averaged over
+        the materialized member set*. It is NOT Pearl's super-population
+        ATE — it makes no claim about a population beyond the Domain's
+        listed members. See §5.
+        """
+        do1 = self.per_instance(cause_var, effect_var, cause_value=1)
+        do0 = self.per_instance(cause_var, effect_var, cause_value=0)
+        per_instance_ate = {
+            m: do1[m].belief - do0[m].belief
+            for m in self.members
+        }
+        n = len(per_instance_ate)
+        if n == 0:
+            raise EmptyPopulationError(...)
+        mean = sum(per_instance_ate.values()) / n
+        return PopulationATEResult(
+            domain_name=self.domain.name,
+            n_members=n,
+            n_filtered_out=len(self.domain.members) - n,
+            cause_var=cause_var.symbol,
+            effect_var=effect_var.symbol,
+            per_instance_ate=per_instance_ate,
+            mean_ate=mean,
+            audit_digests=tuple(
+                do1[m].factor_graph_digest for m in self.members
+            ) + tuple(
+                do0[m].factor_graph_digest for m in self.members
+            ),
+        )
+```
+
+### 2.5 Population histogram of beliefs (no ATE)
+
+```python
+    def histogram(
+        self,
+        target_var: Variable,
+        *,
+        do: dict[Variable, int] | None = None,
+    ) -> PopulationHistogramResult:
+        """For each member, compute P(target=1 | do=...); collect distribution.
+        With do=None, this is observational P(target=1) per instance."""
+        ...
+
+@dataclass(frozen=True)
+class PopulationHistogramResult:
+    target_var: str
+    intervention: dict[str, int]               # author-symbol-keyed
+    per_instance_belief: dict[str, float]
+    mean: float
+    stddev: float
+    audit_digests: tuple[str, ...]
+```
+
+### 2.6 Subgroup CATE-lite
+
+`Population.subgroup(p).ate(...)` already gives subgroup ATE — that is the entire CATE-lite contract for v0.6.x. No new method.
+
+```python
+older = pop.subgroup(lambda m: members_metadata[m]["age"] >= 60)
+younger = pop.subgroup(lambda m: members_metadata[m]["age"] < 60)
+older_ate = older.ate(cause=Smokes, effect=Cancer)
+younger_ate = younger.ate(cause=Smokes, effect=Cancer)
+# Compare older_ate.mean_ate vs younger_ate.mean_ate
+```
+
+`members_metadata` is **author-side data** — Gaia does not know member ages. Subgroup predicates take a `member_id: str` and return bool; resolving them to attributes is the author's responsibility. v0.6 considered baking attribute lookup into Domain (`Domain(name="Person", members=[{"id":"alice","age":62}, ...])`) but rejected — that is a Lang-level enrichment, separate spec.
+
+---
+
+## 3. Errors
+
+```python
+# gaia/causal/errors.py (additions)
+class EmptyPopulationError(Exception):
+    """Subgroup filter or empty Domain produced zero members to evaluate."""
+
+class PopulationVariableUngroundedError(Exception):
+    """Variable passed to Population.ate / .histogram is not per-instance grounded
+    in any mechanism over the given Domain. Author should declare:
+        mechanism(cause=X, effect=Y, forall='p', domain=Person, ...)
+    or pass a Variable that already participates in such a universal mechanism."""
+```
+
+`PopulationVariableUngroundedError` is the most important diagnostic — without it, authors who pass a top-level (non-quantified) Variable get a confusing CNID-resolution error. The check runs in `_instance_cnid`: if no instance CNID exists for `(var, member)` in the compiled artifact, raise this with a hint pointing at Mech §4.3 universal-mechanism syntax.
+
+---
+
+## 4. Integration with `gaia check causal`
+
+One new rule:
+
+| Rule | Severity | Triggered |
+|---|---|---|
+| Population query targets non-grounded Variable | Error | Static analysis of authored `Population(...).ate(X, Y)` calls finds an `X` or `Y` not appearing in any `mechanism(forall=, domain=)` over the Population's `Domain` |
+
+This rule is opt-in: it only triggers when an author actually writes `Population(...)` somewhere in their package code. Pure runtime use (no authored `Population` in source) needs no static check.
+
+---
+
+## 5. Semantics — what mean_ate is and is not
+
+`PopulationATEResult.mean_ate` is the **arithmetic mean of per-instance ATEs over the materialized member set**. Unpacked:
+
+- "Per-instance" — Mech §5.3 chose Strategy A (full individual grounding); each member of `Domain.members` has its own causal sub-DAG. ATE is well-defined per instance.
+- "Materialized" — only `Domain.members` listed at compile time count. Adding a member later changes the population.
+- "Arithmetic mean" — equal weight per member. No weighting by some "true population frequency". v0.6 has no concept of sampling weight.
+
+**What this is NOT.** Pearl's super-population ATE `E_U[Y_x − Y_{x'}]` integrates against an exogenous-noise distribution over a hypothetical infinite super-population. v0.6 has no exogenous noise variables (Mech §2.3 explicitly notes this), so super-population ATE has no operational meaning. `mean_ate` is the **finite-sample analog** under per-instance grounding — useful for symmetric DAGs where every instance has the same parameters (then `mean_ate` equals the per-instance ATE), and as a reduce when instance parameters do vary.
+
+If a future v0.7 adds exogenous noise (Counterfactual extension, Spec B), `mean_ate` would still be well-defined under the same arithmetic-mean reduction, but a separate `superpopulation_ate()` method could be added at that time.
+
+---
+
+## 6. Implementation Notes
+
+### 6.1 Caching
+
+Per-instance `compute()` calls in `ate()` are independent — could parallelise across `Domain.members`. v0.6.1 skips parallelism (deterministic order, predictable audit). `concurrent.futures.ThreadPoolExecutor` could be added behind an opt-in flag in v0.6.2 if profiling shows it helps; not in this spec.
+
+`Population._dag` caches the result of `build_dag(pkg)` because every per-instance call would otherwise rebuild it. The cache is invalidated on `subgroup()` only if the subgroup constructor explicitly resets it (currently it doesn't — DAG is package-scoped, not member-scoped).
+
+### 6.2 Determinism & audit
+
+`per_instance` iterates `self.members` in `Domain.members` order — deterministic across runs. `PopulationATEResult.audit_digests` records one digest per per-instance `compute()`, in iteration order, so a reviewer can re-run any single instance and verify bit-equality.
+
+### 6.3 No new lowering
+
+The compiler already emits per-instance `Mechanism` knowledge for universal mechanisms (Mech §5.2). `Population` walks those at runtime; no new compiler pass.
+
+---
+
+## 7. Examples
+
+### 7.1 Basic per-instance + mean ATE
+
+```python
+from gaia.lang import Bool, Domain, Variable
+from gaia.lang.dsl.causal import mechanism
+from gaia.causal import Population
+
+Person = Domain(name="Person", members=["alice", "bob", "carol"])
+Smokes = Variable(symbol="Smokes", domain=Bool)
+Cancer = Variable(symbol="Cancer", domain=Bool)
+
+mechanism(
+    cause=Smokes, effect=Cancer,
+    forall="p", domain=Person,
+    cpd=(0.15, 0.05),
+    label="smoking_causes_cancer",
+)
+
+# After compile:
+pop = Population(pkg=compiled_package, domain=Person)
+result = pop.ate(cause_var=Smokes, effect_var=Cancer)
+
+assert result.n_members == 3
+assert set(result.per_instance_ate.keys()) == {"alice", "bob", "carol"}
+# Each instance has identical CPD parameters, so per-instance ATE = 0.15 - 0.05 = 0.10
+# mean_ate = 0.10
+```
+
+### 7.2 Subgroup CATE-lite
+
+```python
+metadata = {"alice": {"age": 62}, "bob": {"age": 35}, "carol": {"age": 70}}
+older = pop.subgroup(lambda m: metadata[m]["age"] >= 60)
+older_ate = older.ate(cause_var=Smokes, effect_var=Cancer)
+assert older_ate.n_members == 2
+assert older_ate.n_filtered_out == 1
+# Same DAG, same parameters → mean_ate still 0.10. Subgroups would diverge
+# only if the DAG had per-member parameter variation (e.g. age-dependent CPDs,
+# which v0.6 doesn't natively support — that needs Lang-level
+# domain-attribute-conditioned mechanisms, separate spec).
+```
+
+### 7.3 Belief histogram under intervention
+
+```python
+hist = pop.histogram(target_var=Cancer, do={Smokes: 1})
+# hist.per_instance_belief maps member -> P(Cancer=1 | do(Smokes=1))_member
+# hist.mean / hist.stddev summarize the distribution
+```
+
+### 7.4 Empty population diagnostic
+
+```python
+no_one = pop.subgroup(lambda m: False)
+no_one.ate(Smokes, Cancer)
+# Raises EmptyPopulationError: "Subgroup filter on Population(domain='Person',
+# n=3) selected 0 members. Cannot compute ATE."
+```
+
+---
+
+## 8. Out of Scope
+
+- **Super-population ATE** (`E_U[Y_x − Y_{x'}]`) — needs exogenous noise variables, not in v0.6.
+- **Per-member parameter variation** — `mechanism(cause=X, effect=Y, forall='p', cpd_fn=lambda m: (...))` — Lang-level work, separate spec.
+- **Continuous outcomes** — Population reduce works for any scalar-valued query; v0.6 BP is binary, so `belief` is in [0, 1]. When BP supports continuous, `mean_ate` reduce trivially extends.
+- **Sampling-weighted reduce** — equal weight per member only. Adding `weights: dict[str, float]` later is non-breaking.
+- **Dataset-driven CATE** — that needs DoWhy/EconML, fundamentally different.
+- **Cross-population transport** — covered by Extension C (y0 transport adapter).
+
+---
+
+## 9. Implementation milestones
+
+Single PR. Estimated 1 week.
+
+- `gaia/causal/population.py` — Population class, three result dataclasses.
+- `gaia/causal/errors.py` — two new exception types.
+- `gaia/causal/intervene.py` — expose `_instance_cnid` helper if not already public.
+- `gaia/cli/check_causal.py` — one rule (population-query-target-not-grounded).
+- Tests: per-instance dispatch with three-member Domain; subgroup chaining; empty-population error; histogram correctness; audit-digest-per-instance presence; mean-ATE correctness on hand-computed symmetric DAG.
+- Docs: short user guide section under `docs/foundations/causal/`.
+
+No IR migration. No BP changes. No compiler changes.
+
+---
+
+## 10. Prior-Art Anchors
+
+- `docs/specs/2026-05-06-causal-mechanism-first-class-design.md` — supplies the per-instance grounding (§5) and `compute()` primitive (§7.4) this spec consumes.
+- y0's `Population` / `Distribution` abstractions — explicitly **not** imported (Mech §14 records this); y0's split distinguishes super-populations and is needed for transport theorems, not for per-instance reduce.
+- DoWhy / EconML — solve a different problem (data-driven estimation).
+- PR #505 — `Domain` and `Variable` definitions this spec relies on.

--- a/docs/specs/2026-05-06-causal-transport-y0-design.md
+++ b/docs/specs/2026-05-06-causal-transport-y0-design.md
@@ -1,0 +1,477 @@
+# Causal Extension C — Distribution Transport via y0
+
+> **Status:** Target design (proposal)
+> **Date:** 2026-05-06
+> **Scope:** Add symbolic transport-identifiability queries to `gaia.causal` via y0's selection-diagram and transportability theorems. Given a causal DAG learned/declared in population A and a query about population B, determine whether the query is transportable and return the identifying functional if so. This is a **pure adapter** — no numeric BP computation, no new IR, no new lowering.
+> **Depends on:** `docs/specs/2026-05-06-causal-mechanism-first-class-design.md` (Mechanism as first-class Knowledge type, particularly §7.2 CausalDAG and §8 y0 adapter pattern).
+> **Non-goals:** Numeric transport estimation from data (that needs observational datasets, which Gaia doesn't have); selection bias correction in a single population (that's a different y0 API surface); meta-transportability (transporting across 3+ populations).
+
+---
+
+## 0. Why This Is One Spec, Not a Roadmap Entry
+
+y0 already implements Pearl & Bareinboim's transportability theorems (Bareinboim & Pearl 2014, "Transportability from Multiple Environments with Limited Experiments"). The algorithm takes:
+- A causal DAG (possibly with selection nodes `S`)
+- A source population Π (where experiments or mechanisms are known)
+- A target population Π* (where we want to answer a query)
+- A query `P(Y | do(X))` in Π*
+
+and returns either:
+- "Transportable" + an identifying functional in terms of Π's distributions
+- "Not transportable" + an obstruction witness
+
+Gaia already has:
+- `CausalDAG` (Mech §7.2) — a NetworkX-backed DAG
+- y0 adapter pattern (Mech §8) — lazy-import, optional extra, `MissingDependencyError` on missing dep
+
+**This spec is just wiring.** The hard work (transportability algorithm) is in y0; Gaia's job is to:
+1. Translate `CausalDAG` → y0's `NxMixedGraph` (already done for identification in Mech §8)
+2. Accept author declarations of "this mechanism was observed in population A, that one in population B"
+3. Call y0's `identify_target_outcomes()` / TRSO transport API and wrap the result
+
+No new BP. No new IR `KnowledgeType`. No new compiler pass. Pure consumer-layer adapter, ~200 LoC.
+
+---
+
+## 1. Architectural Position
+
+```
+Mech §7.2   CausalDAG (NetworkX DiGraph)
+              ↓
+            y0.graph.NxMixedGraph (already in Mech §8)
+              ↓
+            y0.algorithm.transport.identify_target_outcomes(
+                graph, target_outcomes, target_interventions,
+                surrogate_outcomes, surrogate_interventions
+            )
+              ↓
+            TransportResult (this spec)
+```
+
+This spec adds:
+- `gaia/causal/adapters/transport.py` — new module under the `adapters/` namespace established by Mech §8.
+- DSL sugar for declaring "mechanism M was learned in population Π" — a metadata annotation, not a new IR field.
+- `TransportResult` dataclass wrapping y0's output.
+
+It does **not** add:
+- New `Mechanism` fields (population membership is metadata, not structural)
+- New BP factors or variables
+- New compiler lowering
+
+---
+
+## 2. The Problem — What Transport Solves
+
+**Setup.** You have:
+- A causal DAG over variables `{X, Y, Z, ...}`
+- Some mechanisms in the DAG were learned/declared in **population A** (e.g., a clinical trial in the US)
+- You want to answer a causal query in **population B** (e.g., the same intervention applied in Europe)
+
+**Question.** Is `P_B(Y | do(X = x))` computable from:
+- The DAG structure (assumed the same across populations)
+- The mechanisms known in population A
+- Observational data in population B (if available)
+
+Pearl & Bareinboim's answer: **sometimes yes, sometimes no**, and there's an algorithm to decide. When yes, the algorithm returns a formula expressing `P_B(Y | do(X))` in terms of `P_A(...)` and `P_B(...)` terms.
+
+**Gaia's use case.** Authors declare mechanisms in one context (e.g., "smoking causes cancer, learned from US data") and want to know: "Can I use this to reason about a European population where smoking rates differ?" This spec gives them a **symbolic yes/no + formula**, not a numeric answer (numeric needs data, which Gaia doesn't have).
+
+---
+
+## 3. Authoring Surface — Population Membership
+
+### 3.1 Mechanism-level annotation
+
+```python
+from gaia.lang.dsl.causal import mechanism
+
+mechanism(
+    cause=Smokes, effect=Cancer,
+    cpd=(0.15, 0.05),
+    population="US_trial_2020",        # NEW (this spec)
+    label="smoking_causes_cancer",
+)
+
+mechanism(
+    cause=Genetics, effect=Cancer,
+    cpd=(0.10, 0.02),
+    population="US_trial_2020",
+    label="genetics_causes_cancer",
+)
+
+mechanism(
+    cause=AirPollution, effect=Cancer,
+    cpd=(0.08, 0.03),
+    population="EU_observational_2021",   # different population
+    label="pollution_causes_cancer",
+)
+```
+
+`population=` is an **optional string tag**. Mechanisms without a `population=` tag are assumed to be "universal" (hold across all populations). The tag is stored in `Mechanism` metadata (not a first-class field — see §4.1).
+
+### 3.2 Query surface
+
+```python
+from gaia.causal.adapters.transport import transport_query
+
+result = transport_query(
+    pkg=compiled_package,
+    source_population="US_trial_2020",
+    target_population="EU_observational_2021",
+    query_target=Cancer,
+    query_intervention={Smokes: 1},
+)
+
+if result.transportable:
+    print("Transportable!")
+    print(result.identifying_functional_latex)
+    # e.g., "P*(Y | do(X)) = ∑_Z P(Y | X, Z) · P*(Z)"
+else:
+    print("Not transportable.")
+    print(result.obstruction)
+```
+
+`transport_query` is the single entry point. It:
+1. Builds the `CausalDAG` from `pkg`
+2. Partitions mechanisms by `population` tag
+3. Translates to y0's `NxMixedGraph` + selection-diagram conventions
+4. Calls y0's `identify_target_outcomes()`
+5. Wraps the result
+
+---
+
+## 4. IR & Metadata
+
+### 4.1 No new IR field — metadata only
+
+`population` is stored in `Knowledge.metadata["causal"]["population"]` (the same metadata namespace Mech §1.1 retired for CPD parameters, but population is different — it's not structural, it's provenance).
+
+```python
+# After compile, a Mechanism Knowledge node looks like:
+Knowledge(
+    type=KnowledgeType.MECHANISM,
+    payload=Mechanism(cause=..., effect=..., cpd=...),
+    metadata={
+        "causal": {
+            "population": "US_trial_2020",   # optional
+        },
+    },
+)
+```
+
+Why metadata, not a `Mechanism.population` field?
+- Population membership is **provenance**, not **structure**. The DAG shape and CPD parameters are the same; only the "where did we learn this" differs.
+- Keeping it in metadata avoids IR schema churn when we later add "learned from dataset X" or "confidence interval [a, b]" — all provenance goes in the same metadata bucket.
+- Mech §2.4 validator already allows arbitrary metadata on MECHANISM knowledge; no new validation rule needed.
+
+### 4.2 Compiler pass — no change
+
+`mechanism(population="...")` is lowered by the existing `lower_mechanism.py` (Mech §5.1). The compiler writes the `population` string into `metadata["causal"]["population"]` and moves on. No new CNID synthesis, no new grounding.
+
+---
+
+## 5. Runtime — `gaia/causal/adapters/transport.py`
+
+### 5.1 `TransportResult`
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class TransportResult:
+    """Result of a transportability query via y0."""
+    source_population: str
+    target_population: str
+    query_target: str                      # Variable symbol or QID
+    query_intervention: dict[str, int]     # Variable symbol -> value
+    transportable: bool
+    identifying_functional_latex: str | None   # y0 Expression.to_latex()
+    identifying_functional_python: str | None  # y0 Expression (repr)
+    node_map: dict[str, str]               # y0 symbol -> Gaia QID/CNID
+    obstruction: str | None                # human-readable reason if not transportable
+    source_mechanisms: tuple[str, ...]     # QIDs of mechanisms in source population
+    target_mechanisms: tuple[str, ...]     # QIDs of mechanisms in target population
+```
+
+### 5.2 `transport_query`
+
+```python
+def transport_query(
+    pkg,
+    source_population: str,
+    target_population: str,
+    query_target: Variable | str,
+    query_intervention: dict[Variable | str, int],
+) -> TransportResult:
+    """Determine if a causal query is transportable from source to target population.
+
+    Delegates to y0.algorithm.transport.identify_target_outcomes().
+    Requires y0 >= 0.2 (current stable release).
+    """
+    try:
+        import y0
+        from y0.algorithm.transport import identify_target_outcomes
+        from y0.dsl import Variable as Y0Variable
+    except ImportError:
+        raise MissingDependencyError(
+            "Transport queries require y0. Install via: pip install 'gaia[causal-transport]'"
+        )
+
+    dag = build_dag(pkg)
+    mechanisms = _load_mechanisms(pkg)
+
+    # Partition by population
+    source_mechs = [m for m in mechanisms if m.metadata.get("causal", {}).get("population") == source_population]
+    target_mechs = [m for m in mechanisms if m.metadata.get("causal", {}).get("population") == target_population]
+    universal_mechs = [m for m in mechanisms if "population" not in m.metadata.get("causal", {})]
+
+    # Build y0 graph with selection nodes
+    # (y0 convention: selection node S_i indicates population i has access to mechanism i)
+    graph = _build_transport_graph(dag, source_mechs, target_mechs, universal_mechs)
+
+    # Translate query to y0 format
+    target_var_y0 = _gaia_to_y0_var(query_target)
+    intervention_vars_y0 = {_gaia_to_y0_var(k) for k in query_intervention.keys()}
+    
+    # Build surrogate_outcomes and surrogate_interventions dicts
+    # (y0 API: which outcomes/interventions are available in which population)
+    surrogate_outcomes = {}
+    surrogate_interventions = {}
+    
+    # Source population has experimental access to source mechanisms
+    source_pop_var = Y0Variable(source_population)
+    surrogate_outcomes[source_pop_var] = {_mechanism_effect_to_y0(m) for m in source_mechs}
+    surrogate_interventions[source_pop_var] = {_mechanism_cause_to_y0(m) for m in source_mechs}
+    
+    # Universal mechanisms are available in both populations
+    for m in universal_mechs:
+        effect_y0 = _mechanism_effect_to_y0(m)
+        cause_y0 = _mechanism_cause_to_y0(m)
+        surrogate_outcomes.setdefault(source_pop_var, set()).add(effect_y0)
+        surrogate_interventions.setdefault(source_pop_var, set()).add(cause_y0)
+
+    # Call y0
+    y0_result = identify_target_outcomes(
+        graph=graph,
+        target_outcomes={target_var_y0},
+        target_interventions=intervention_vars_y0,
+        surrogate_outcomes=surrogate_outcomes,
+        surrogate_interventions=surrogate_interventions,
+    )
+
+    if y0_result is not None:
+        # Transportable
+        latex = y0_result.to_latex()
+        python_repr = repr(y0_result)
+        obstruction = None
+        transportable = True
+    else:
+        # Not transportable
+        latex = None
+        python_repr = None
+        obstruction = "Not identifiable from available surrogate data. y0's identify_target_outcomes returned None."
+        transportable = False
+
+    return TransportResult(
+        source_population=source_population,
+        target_population=target_population,
+        query_target=_resolve_target(query_target),
+        query_intervention={_resolve_target(k): v for k, v in query_intervention.items()},
+        transportable=transportable,
+        identifying_functional_latex=latex,
+        identifying_functional_python=python_repr,
+        node_map=_build_node_map(graph),
+        obstruction=obstruction,
+        source_mechanisms=tuple(m.qid for m in source_mechs),
+        target_mechanisms=tuple(m.qid for m in target_mechs),
+    )
+```
+
+### 5.3 Selection-diagram construction
+
+y0's transportability algorithm expects a `NxMixedGraph` with **selection nodes** `S_X` for each variable `X` whose mechanism differs across populations. The convention (Bareinboim & Pearl 2014):
+- `S_X = 1` means "population has experimental control or knowledge of the mechanism `pa(X) → X`"
+- `S_X = 0` means "population only has observational data on `X`"
+
+Gaia's `_build_transport_graph` helper:
+1. Starts with the base `CausalDAG` (all directed edges)
+2. For each mechanism `M` with `population = source_population`, adds a selection node `S_{M.effect}` with an edge `S_{M.effect} → M.effect`
+3. For mechanisms in `target_population`, does the same with a different selection-node label
+4. Universal mechanisms (no `population` tag) are treated as "known in both populations" — no selection node
+
+This is a **pure graph transformation**, no BP involved.
+
+---
+
+## 6. Errors
+
+```python
+# gaia/causal/errors.py (additions)
+class TransportMissingDependencyError(MissingDependencyError):
+    """y0 >= 0.2 is required for transport queries. Install via
+    pip install 'gaia[causal-transport]'."""
+
+class TransportPopulationNotFoundError(Exception):
+    """source_population or target_population string does not match any
+    mechanism's population tag in the compiled package."""
+
+class TransportAmbiguousUniversalError(Exception):
+    """A mechanism has no population tag, but the query assumes it belongs
+    to one population. Author should either tag it explicitly or clarify
+    the query."""
+```
+
+---
+
+## 7. `pyproject.toml` — New Optional Extra
+
+```toml
+[project.optional-dependencies]
+causal-transport = [
+    "y0>=0.2",   # identify_target_outcomes available in 0.2.x stable
+]
+```
+
+Separate from `causal-do` (Mech §8) because:
+- `causal-do` is for symbolic identification within a single population
+- `causal-transport` is for cross-population queries
+- Users who only need `do().query()` don't need the transport machinery
+
+Both extras pull y0, but the version pins may diverge in the future.
+
+---
+
+## 8. Examples
+
+### 8.1 Basic transportability check
+
+```python
+from gaia.lang import Bool, Variable
+from gaia.lang.dsl.causal import mechanism
+from gaia.causal.adapters.transport import transport_query
+
+Smokes = Variable(symbol="Smokes", domain=Bool)
+Cancer = Variable(symbol="Cancer", domain=Bool)
+Age = Variable(symbol="Age", domain=Bool)  # simplified to binary for example
+
+# Mechanisms learned in US trial
+mechanism(cause=Smokes, effect=Cancer, cpd=(0.15, 0.05), population="US")
+mechanism(cause=Age, effect=Cancer, cpd=(0.10, 0.02), population="US")
+
+# Mechanism learned in EU observational study
+mechanism(cause=Age, effect=Smokes, cpd=(0.30, 0.10), population="EU")
+
+# After compile:
+result = transport_query(
+    pkg=compiled_package,
+    source_population="US",
+    target_population="EU",
+    query_target=Cancer,
+    query_intervention={Smokes: 1},
+)
+
+if result.transportable:
+    print(result.identifying_functional_latex)
+    # Might output: "P*(Cancer | do(Smokes=1)) = ∑_{Age} P(Cancer | Smokes=1, Age) · P*(Age)"
+    # where P is from US, P* is from EU
+else:
+    print(f"Not transportable: {result.obstruction}")
+```
+
+### 8.2 Non-transportable case
+
+```python
+# If the Age → Cancer mechanism was also population-specific:
+mechanism(cause=Age, effect=Cancer, cpd=(0.10, 0.02), population="US")
+mechanism(cause=Age, effect=Cancer, cpd=(0.12, 0.03), population="EU")  # different!
+
+result = transport_query(
+    pkg=compiled_package,
+    source_population="US",
+    target_population="EU",
+    query_target=Cancer,
+    query_intervention={Smokes: 1},
+)
+
+assert not result.transportable
+# result.obstruction might say: "Effect of Smokes on Cancer depends on Age mechanism,
+# which differs between populations. No valid adjustment set."
+```
+
+### 8.3 Universal mechanism (holds across populations)
+
+```python
+# Genetics → Cancer is assumed universal (same across all populations)
+mechanism(cause=Genetics, effect=Cancer, cpd=(0.08, 0.02))  # no population= tag
+
+# This mechanism is treated as "known in both US and EU" during transport queries
+```
+
+---
+
+## 9. Integration with `gaia check causal`
+
+One new rule (opt-in, under `gaia check causal --transport`):
+
+| Rule | Severity | Triggered by |
+|---|---|---|
+| Transport query references undefined population | Error | `transport_query(source_population="X", ...)` where no mechanism has `population="X"` |
+| Ambiguous universal mechanism in transport context | Warning | A mechanism has no `population` tag, but appears on a path between intervention and target in a transport query where populations differ. Hint: tag it explicitly. |
+
+---
+
+## 10. Out of Scope
+
+- **Numeric transport estimation** — computing `P*(Y | do(X))` numerically requires observational data from population Π*, which Gaia doesn't have. This spec only answers "is it transportable?" and "what's the formula?", not "what's the number?".
+- **Selection bias correction within a single population** — y0 also handles this (via `recover()`), but it's a different API surface. Separate spec if needed.
+- **Meta-transportability** (transporting across 3+ populations with partial overlap) — y0 supports this, but the DSL ergonomics need design. v0.7+ candidate.
+- **Continuous variables** — same blocker as Mech §12.
+- **Data-driven transport** (learning which mechanisms differ from data) — that's causal discovery + transport, not in Gaia's scope.
+
+---
+
+## 11. Implementation Milestones
+
+Single PR. Estimated 1 week (most of the work is the selection-diagram construction and y0 API wiring; the algorithm itself is in y0).
+
+- `gaia/ir/mechanism.py`: no change (population goes in metadata).
+- `gaia/lang/dsl/causal.py`: `population=` kwarg on `mechanism()`.
+- `gaia/lang/compiler/lower_mechanism.py`: write `population` into `metadata["causal"]["population"]`.
+- `gaia/causal/adapters/transport.py`: `transport_query`, `TransportResult`, `_build_transport_graph`.
+- `gaia/causal/errors.py`: three new exception types.
+- `gaia/causal/adapters/__init__.py`: re-export `transport_query`, `TransportResult`.
+- `pyproject.toml`: `causal-transport` optional extra with `y0>=0.3`.
+- `gaia/cli/check_causal.py`: two new rules under `--transport` flag.
+- Tests:
+  - Transportable case (Bareinboim & Pearl 2014 Example 1).
+  - Non-transportable case (Example 2 from same paper).
+  - Universal mechanism treated correctly.
+  - `TransportPopulationNotFoundError` on typo.
+  - y0 missing → `TransportMissingDependencyError`.
+- Docs: transport-queries chapter under `docs/foundations/causal/`.
+
+No new BP. No new IR `KnowledgeType`. No new compiler pass beyond metadata write.
+
+---
+
+## 12. Prior-Art Anchors
+
+- Bareinboim & Pearl (2014), "Transportability from Multiple Environments with Limited Experiments" — the algorithm y0 implements and this spec wraps.
+- Pearl & Bareinboim (2011), "Transportability of Causal and Statistical Relations: A Formal Approach" — foundational paper.
+- y0's `identify_target_outcomes()` / TRSO transport API — this spec is a thin Gaia-flavored wrapper.
+- `docs/specs/2026-05-06-causal-mechanism-first-class-design.md` — Mech (this spec depends on §7.2 CausalDAG, §8 y0 adapter pattern, §14 y0 alignment statement).
+- `docs/specs/2026-05-06-causal-population-api-design.md` — Extension A (sibling spec; transport + Population could compose in a future "cross-population ATE" helper, but that needs numeric data).
+- `docs/specs/2026-05-06-causal-counterfactual-binary-noise-design.md` — Extension B (sibling spec; transport + counterfactual are orthogonal — one is cross-population, one is cross-world).
+
+---
+
+## 13. Why This Is Easier Than It Sounds
+
+The hard part of transportability (the algorithm) is in y0. Gaia's contribution is:
+1. A metadata convention (`population=` tag)
+2. A graph transformation (adding selection nodes per y0's convention)
+3. A result wrapper
+
+Total Gaia-specific code: ~150-200 LoC. The rest is y0 doing the heavy lifting.
+
+This is the **lightest** of the three extension specs (A/B/C) in terms of Gaia-internal complexity, even though the underlying theory (Pearl & Bareinboim's transportability calculus) is sophisticated. That's the power of a good adapter boundary.


### PR DESCRIPTION
## Summary

Three independent extension specs building on **#533** (Mechanism first-class, now merged to `v0.5`). All three are immediately implementable — no BP engine changes, no new IR types beyond what #533 provides, total ~650 LoC across three implementation PRs.

These specs answer the design question raised during #533 review: "can we do counterfactual and distribution queries now, or wait for v0.7?" The answer: **yes, we can do them now**, because:
- Binary mechanisms can have binary exogenous noise → counterfactuals reduce to standard BP queries
- y0 already implements transportability → we just wrap it
- Population API is pure iteration + reduce over per-instance grounding

## Replaces #534

#534 was auto-closed when its base branch (`docs/causal-mechanism-first-class`) was deleted by the squash-merge of #533. This PR is functionally identical — same four files, retargeted to `v0.5`.

## Extension A — Population API

`docs/specs/2026-05-06-causal-population-api-design.md`

Pure consumer layer over Mechanism §5 per-instance grounding. Zero IR / BP / compiler changes. ~200 LoC, 1 week estimate.

## Extension B — Counterfactual via Binary Noise

`docs/specs/2026-05-06-causal-counterfactual-binary-noise-design.md`

Pearl level-3 counterfactuals via abduction-action-prediction. The noisy-OR canonical form `E = (C ∧ U_active) ∨ U_leak` with independent Bernoulli `U_*` is mathematically equivalent to the marginal CPT — so binary noise materialization works without continuous variables or twin networks.

Splits into:
- **B1** (1 week): BP engine adds `joint_belief()` API
- **B2** (2-3 weeks, depends on B1): Counterfactual impl using joint posterior (avoids over-factorization where independent unaries would assign nonzero mass to forbidden joint configurations)

## Extension C — Distribution Transport via y0

`docs/specs/2026-05-06-causal-transport-y0-design.md`

Symbolic transportability adapter wrapping y0's `identify_target_outcomes` (Pearl & Bareinboim 2014). `population=` metadata tag on mechanisms. Pure adapter, no numeric computation. New optional extra `gaia[causal-transport]` with `y0>=0.2`. ~150 LoC, 1 week estimate.

## Also fixes (in #533's spec)

`docs/specs/2026-05-06-causal-mechanism-first-class-design.md` §6.4: `do(X=1)` on a node with no incoming `CausalFactor` now raises `InterventionUndefinedError`. Structure-only DAG nodes are not numerically interventionable without a CPD-bearing mechanism.

## Implementation Order Recommendation

1. **Extension A (Population)** — easiest, validates the "extensions on top of #533" pattern, stress-tests the grounding API
2. **Extension C (Transport)** — pure adapter, no lowering changes
3. **Extension B (Counterfactual)** — most complex (lowering rewrite), most impactful

Or parallelize — they don't block each other.

## Verification

- `git diff --check` — clean
- `ruff` is markdown-blind (pure docs PR)
- All three specs cite mechanism-first-class spec sections as dependencies