### PR TITLE
docs(foundations): tidy bayes.md + package.md for v0.5

### DIFF
--- a/docs/foundations/bp/inference.md
+++ b/docs/foundations/bp/inference.md
@@ -23,7 +23,7 @@ FactorGraph 是一个**概念**，不绑定特定的存储或运行方式：
 
 **v1（Graph IR 管线）**：`libs/inference/factor_graph.py`，使用 int 索引、`premises`/`conclusions`/`edge_type` 字符串。供 `scripts/pipeline/run_local_bp.py` 等包内 BP 使用。
 
-**v2（理论对齐 BP 引擎）**：`gaia/bp/factor_graph.py`，使用字符串 ID、八种 `FactorType`（六种确定性 + SOFT_ENTAILMENT + CONDITIONAL）、`variables` + `conclusion` 结构。势函数见 [potentials.md](potentials.md)。包含 loopy BP、Junction Tree、GBP、exact brute-force、`InferenceEngine` 自动选择。
+**v2（理论对齐 BP 引擎）**：`gaia/bp/factor_graph.py`，使用字符串 ID、十种 `FactorType`（IMPLICATION, NEGATION, CONJUNCTION, DISJUNCTION, EQUIVALENCE, CONTRADICTION, COMPLEMENT, SOFT_ENTAILMENT, CONDITIONAL, PAIRWISE_POTENTIAL）、`variables` + `conclusion` 结构。势函数见 [potentials.md](potentials.md)。包含 loopy BP、Junction Tree、GBP、exact brute-force、`InferenceEngine` 自动选择。
 
 ### 从 Gaia IR 构建
 

--- a/docs/foundations/gaia-lang/bayes.md
+++ b/docs/foundations/gaia-lang/bayes.md
@@ -1,3 +1,9 @@
+---
+status: current-canonical
+layer: gaia-lang
+since: v0.5
+---
+
 # Bayes Module
 
 `gaia.lang.bayes` is the lifted authoring surface for model-data likelihood
@@ -15,7 +21,13 @@ updates. It decomposes the paper narrative into reviewable Gaia claims:
 The Bayes module does not add IR knowledge types, BP factor types, or new
 operator enums. `PredictiveModel` and `Likelihood` are action-shaped runtime
 objects; their helper claims carry `metadata["bayes"]["role"]` values
-`"prediction"` and `"comparison"` respectively.
+`"prediction"` and `"comparison"` respectively. Both action subclasses go
+through the standard action lowering pipeline (see
+[knowledge-and-reasoning.md §4](knowledge-and-reasoning.md#4-action-lowering)),
+share the package-wide `action_label_map`, and emit warrant helper Claims
+that are addressable via `[@label]` references. Specs:
+[Bayes Module Design](../../specs/2026-05-04-bayes-module-design.md),
+[Bayes Actions Design](../../specs/2026-05-05-bayes-actions-design.md).
 
 ## Import Surface
 
@@ -27,8 +39,10 @@ from gaia.lang import bayes
 dist = bayes.Binomial(n=395, p=0.75)
 ```
 
-`from gaia.lang import predict` is the core Bayes-free prediction verb. Keep
-Bayes distribution literals and likelihood helpers under `gaia.lang.bayes`.
+`from gaia.lang import predict` is the core Bayes-free prediction verb (a
+`Support` action). The legacy `bayes.predict(...)` function is kept as a
+deprecation alias for `bayes.model(...)` and emits `DeprecationWarning`;
+new packages should call `bayes.model(...)` directly.
 
 The v1 distribution set is:
 
@@ -37,9 +51,53 @@ The v1 distribution set is:
   `ChiSquared`
 
 Each distribution delegates numeric evaluation to `scipy.stats`. Parameters may
-be concrete numbers or PR 505 `Variable` objects. Deferred variable parameters
+be concrete numbers or `Variable` objects (PR #505). Deferred variable parameters
 are resolved by the compiler from hypothesis formulas; their serialized
 descriptors are audit metadata, not identity keys.
+
+## Verbs at a Glance
+
+```python
+bayes.model(
+    hypothesis: Claim,
+    *,
+    observable: Variable,
+    distribution: Distribution,
+    background: list[Knowledge] | None = None,
+    rationale: str = "",
+    label: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Claim                               # returns the prediction helper claim
+
+bayes.likelihood(
+    data: Claim | list[Claim] | tuple[Claim, ...],
+    *,
+    model: Claim,
+    against: Claim | list[Claim] | tuple[Claim, ...] = (),
+    background: list[Knowledge] | None = None,
+    rationale: str = "",
+    label: str | None = None,
+    exclusivity: str = "pairwise_contradiction",
+    precomputed: dict[Claim, float] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Claim                               # returns the comparison helper claim
+```
+
+`exclusivity` accepts:
+
+- `"none"` — no relation operators emitted; all listed hypotheses are
+  independent.
+- `"pairwise_contradiction"` (default) — listed hypotheses are *at most one
+  true*; emits a reviewable `Contradict` action for each pair that does not
+  already have one.
+- `"exhaustive_pairwise_complement"` — listed hypotheses are *exactly one
+  true*; emits a reviewable `Exclusive` action when there are two
+  hypotheses, or pairwise `Contradict` actions plus a clamped disjunction
+  helper when there are three or more.
+
+All emitted relation actions are auto-generated only when the equivalent
+explicit author action does not already exist; this lets the author
+override the structural pattern by writing the relation by hand.
 
 ## Worked Example
 

--- a/docs/foundations/gaia-lang/package.md
+++ b/docs/foundations/gaia-lang/package.md
@@ -1,12 +1,12 @@
 ---
 status: current-canonical
 layer: gaia-lang
-since: v5-phase-1
+since: v0.5
 ---
 
 # Gaia Lang Package Model
 
-A Gaia knowledge package is a standard Python library that declares knowledge (claims, settings, questions), reasoning strategies, and logical operators using the Gaia Lang DSL. This document defines how packages are structured, configured, named, and what artifacts they produce.
+A Gaia knowledge package is a standard Python library that declares knowledge (claims, notes, questions), reasoning actions, and logical operators using the Gaia Lang DSL. This document defines how packages are structured, configured, named, and what artifacts they produce. For the conceptual model behind the surface, see [knowledge-and-reasoning.md](knowledge-and-reasoning.md).
 
 ## Package Creation
 
@@ -17,7 +17,24 @@ gaia init galileo-falling-bodies-gaia
 cd galileo-falling-bodies-gaia
 ```
 
-This scaffolds the complete package: `pyproject.toml` (with `[tool.gaia]` config and a generated UUID), the `src/` directory layout, a DSL template in `__init__.py`, and `.gitignore` with `.gaia/` entry. Package name must end with `-gaia`.
+This wraps `uv init --lib` to scaffold a standard Python library, then patches `pyproject.toml` to add `[tool.hatch.build.targets.wheel]` (so the renamed `src/<import_name>/` is picked up) and `[tool.gaia]` with a generated UUID. It also writes a v0.5 DSL template to `__init__.py`, appends Gaia ignore patterns to `.gitignore`, and runs `uv add gaia-lang`. Package name must end with `-gaia`.
+
+The generated `__init__.py` template uses the v0.5 action surface:
+
+```python
+from gaia.lang import claim, derive, note
+
+context = note("Background context for this package.")
+hypothesis = claim("A scientific hypothesis.")
+prediction = derive(
+    "A testable prediction follows from the hypothesis.",
+    given=hypothesis,
+    background=[context],
+    rationale="Explain why the hypothesis entails this prediction.",
+)
+
+__all__ = ["hypothesis", "prediction"]
+```
 
 ## pyproject.toml Structure
 
@@ -117,7 +134,7 @@ Three visibility levels control what the compiler exports and how labels are ass
 | **Public** | No `_` prefix, not necessarily in `__all__` | Package-internal. Variable name becomes the label. Compiled into IR. |
 | **Private** | `_` prefix | Not labeled by the CLI. Still compiled into IR as anonymous nodes. Local helpers only. |
 
-Labels are assigned automatically from variable names during package loading. If a `Knowledge` or `Strategy` object is bound to a module-level variable and listed in `__all__` (or is public with no `__all__`), its variable name becomes its `.label` field. The label then forms the final segment of the object's QID.
+Labels are assigned automatically from variable names during package loading. If a `Knowledge` or `Action` object is bound to a module-level variable and listed in `__all__` (or is public with no `__all__`), its variable name becomes its `.label` field. The label then forms the final segment of the object's QID. Action labels are addressable via `[@label]` references the same way Knowledge labels are; see [knowledge-and-reasoning.md §4.3](knowledge-and-reasoning.md#43-action-label-references).
 
 Example:
 
@@ -156,9 +173,12 @@ dependencies = [
 
 ```python
 # galileo_falling_bodies/reasoning.py
+from gaia.lang import claim, derive
 from aristotle_mechanics import natural_motion
 
-hypothesis = claim("Heavy objects fall faster.", given=[natural_motion])
+hypothesis = claim("Heavy objects fall faster.")
+derive(hypothesis, given=natural_motion,
+       rationale="Aristotle's natural-motion doctrine entails it.")
 ```
 
 At compile time, imported Knowledge objects retain their foreign QIDs (e.g., `github:aristotle_mechanics::natural_motion`). The local graph records both owned and foreign QIDs. See [../gaia-ir/03-identity-and-hashing.md](../gaia-ir/03-identity-and-hashing.md) for the ownership vs. reference distinction.
@@ -201,13 +221,17 @@ priors, and model warrants with current action/relation verbs.
 
 All artifacts are written to `.gaia/` within the package root.
 
-| Artifact | Written by | Contents |
-|----------|-----------|----------|
-| `.gaia/ir.json` | `gaia compile` | `LocalCanonicalGraph` -- the complete compiled IR |
-| `.gaia/ir_hash` | `gaia compile` | SHA-256 hash of the canonical IR serialization |
-| `.gaia/beliefs.json` | `gaia infer` | BP inference output: posterior beliefs per knowledge node |
+| Artifact | Written by | Tracked in git? | Contents |
+|----------|-----------|-----------------|----------|
+| `.gaia/ir.json` | `gaia compile` | yes | `LocalCanonicalGraph` -- the complete compiled IR |
+| `.gaia/ir_hash` | `gaia compile` | yes | SHA-256 hash of the canonical IR serialization |
+| `.gaia/beliefs.json` | `gaia infer` | no (gitignored) | BP inference output: posterior beliefs per knowledge node |
+| `.gaia/dep_beliefs/` | `gaia infer` | no (gitignored) | cached posterior beliefs from upstream `*-gaia` dependencies |
 
-The `.gaia/` directory should be git-tracked so that compiled artifacts travel with the source. Add `__pycache__/` and `*.pyc` to `.gitignore`, but not `.gaia/`.
+The first two artifacts must travel with the source so that registry
+clients can verify the compiled graph; the inference outputs are
+reproducible from source + priors and are intentionally regenerated.
+`gaia init` writes both ignore patterns into `.gitignore` automatically.
 
 ## Package Lifecycle
 
@@ -234,6 +258,6 @@ The check command validates three categories:
 
 **Object-level:** Every Knowledge has a valid type and non-empty content.
 
-**Graph-level:** All referenced IDs exist, strategy premises/conclusions are claims (not settings or questions), no cyclic dependencies, ID uniqueness.
+**Graph-level:** All referenced IDs exist; strategy and action premises / conclusions are Claims (not Notes or Questions); decomposition graphs have no cycles and every atomic part appears in the formula exactly once; no cyclic strategy / operator dependencies; ID uniqueness; Knowledge labels and Action labels do not collide within the same package.
 
 **Artifact-level:** `.gaia/ir_hash` matches current source compilation, `.gaia/ir.json` is consistent.


### PR DESCRIPTION
Part of the v0.5 foundations documentation cleanup. Combined PR for the two smallest gaia-lang docs.

## bayes.md

- Add `status: current-canonical / layer: gaia-lang / since: v0.5` frontmatter.
- Cross-link to `knowledge-and-reasoning.md §4 Action Lowering` so readers know bayes verbs share the package-wide `action_label_map` and `[@label]` resolution.
- Link to specs `2026-05-04-bayes-module-design.md` and `2026-05-05-bayes-actions-design.md`.
- New **Verbs at a Glance** section with full `bayes.model(...)` and `bayes.likelihood(...)` signatures and an explicit enumeration of the three `exclusivity` literals (`none` / `pairwise_contradiction` / `exhaustive_pairwise_complement`) — verified against `gaia/lang/bayes/verbs/likelihood.py`.
- Explicit deprecation note for legacy `bayes.predict` (kept as alias for `bayes.model`, emits `DeprecationWarning`).

## package.md

- Frontmatter bumped `v5-phase-1 → v0.5`.
- `gaia init` description rewritten to reflect actual behavior in `gaia/cli/commands/init.py`: wraps `uv init --lib`, patches in `[tool.hatch.build.targets.wheel]` + `[tool.gaia]` (generated UUID), writes the v0.5 `claim / derive / note` DSL template, appends `.gaia/beliefs.json` + `.gaia/dep_beliefs/` to `.gitignore`, and runs `uv add gaia-lang`.
- Build Artifacts table now distinguishes git-tracked (`ir.json`, `ir_hash`) from gitignored (`beliefs.json`, `dep_beliefs/`) — corrects the old claim that the whole `.gaia/` should be tracked.
- Visibility section mentions `Action` objects alongside `Knowledge` as labelable; cross-link to `knowledge-and-reasoning.md §4.3` for action-label reference resolution.
- Cross-package example replaced with a `derive(...)` invocation (the previous example used `claim(content, given=...)`, which is not a real signature — `given=` lives on action verbs).
- Validation summary expanded: decomposition cycles, action premises must be Claims (not Notes/Questions), and the new Knowledge-vs-Action label collision rule.

## Non-goals

- No code changes.
- Not changing `docs/foundations/gaia-ir/` (protected layer).