### PR TITLE
docs(foundations): cover inquiry/trace/starmap + v0.5 lowering in cli/

### DIFF
--- a/docs/foundations/cli/compilation.md
+++ b/docs/foundations/cli/compilation.md
@@ -1,7 +1,7 @@
 ---
 status: current-canonical
 layer: cli
-since: v5-phase-1
+since: v0.5
 ---
 
 # Compilation and Validation

--- a/docs/foundations/cli/inference.md
+++ b/docs/foundations/cli/inference.md
@@ -1,7 +1,7 @@
 ---
 status: current-canonical
 layer: cli
-since: v5-phase-2
+since: v0.5
 ---
 
 # Inference Pipeline
@@ -330,25 +330,20 @@ Deterministic factors use Cromwell-softened potentials (`HIGH = 1 - EPS`,
 
 ### Strategy lowering
 
-Strategies are lowered by type:
+Strategies are lowered by type. In v0.5 the canonical authoring path is through Action verbs (`derive` / `observe` / `compute` / `predict` / `infer` / `associate` / `equal` / `contradict` / `exclusive` / `decompose`); the entries below describe how each underlying strategy type lowers, regardless of whether it came from an Action verb or a legacy v5 strategy verb.
 
-- **`infer`**: `CONDITIONAL` factor with full CPT. When
-  `infer_use_degraded_noisy_and=True`, falls back to
-  `CONJUNCTION + SOFT_ENTAILMENT`.
-- **`deduction`**: `CONJUNCTION` for multiple premises, then a hard
-  `CONDITIONAL` implication with CPT `[0.5, 1 - EPS]`. Review gates whether
-  the warrant enters the information set; it does not supply a numeric prior.
-- **`support`**: soft implication via `SOFT_ENTAILMENT`; legacy `prior=`
-  folds into its effective `p1`.
-- **`noisy_and`**: `CONJUNCTION + SOFT_ENTAILMENT`. Single premise omits
-  conjunction.
-- **Other named formal types** (elimination, etc.): auto-formalized via
-  `formalize_named_strategy()`, then expanded to deterministic factors.
-- **`FormalStrategy`**: each operator maps to a deterministic factor via
-  `_OPERATOR_MAP`.
+- **`infer`**: `CONDITIONAL` factor with full CPT. With `given=G` on the action, the CPT gates on `G` so that the relation collapses to MaxEnt (0.5) when any of `G` is false (the *infer-with-given gating* introduced in v0.5). When `infer_use_degraded_noisy_and=True`, falls back to `CONJUNCTION + SOFT_ENTAILMENT`.
+- **`deduction`** (lowering target of `derive` and the deprecated `deduction` strategy): `CONJUNCTION` for multiple premises, then a hard `CONDITIONAL` implication with CPT `[0.5, 1 - EPS]`. Review gates whether the warrant enters the information set; it does not supply a numeric prior.
+- **`support`** (deprecated v5 strategy; lowering preserved for compatibility): soft implication via `SOFT_ENTAILMENT`; legacy `prior=` folds into its effective `p1`.
+- **`noisy_and`** (deprecated): `CONJUNCTION + SOFT_ENTAILMENT`. Single premise omits conjunction.
+- **`associate`**: pairwise potential between two Claims using the author-supplied `p_a_given_b` / `p_b_given_a` and at least one marginal prior.
+- **Bayes likelihood** (`bayes.likelihood(...)`): emits one `infer` strategy per hypothesis with `[0.5, clamp(exp(logL_i - logL_max))]`, plus rigid relation operators driven by the `exclusivity` setting.
+- **Other named formal types** (legacy v5: `elimination`, `case_analysis`, `analogy`, `extrapolation`, ...): auto-formalized via `formalize_named_strategy()`, then expanded to deterministic factors.
+- **`FormalStrategy`**: each embedded operator maps to a deterministic factor via `_OPERATOR_MAP`.
 - **`CompositeStrategy`**: recursively lowers each sub-strategy.
+- **`Compose`**: not a strategy — preserved as a first-class IR node (`composes: list[Compose]`) and does not produce a BP factor directly; its child actions retain their own lowerings.
 
-Reference: [Lowering](../gaia-ir/07-lowering.md)
+Reference: [Lowering](../gaia-ir/07-lowering.md), [BP factor potentials](../bp/potentials.md), [BP formal-strategy lowering](../bp/formal-strategy-lowering.md).
 
 ## Package Environment Setup
 

--- a/docs/foundations/cli/inference.md
+++ b/docs/foundations/cli/inference.md
@@ -312,11 +312,12 @@ operators get `1 - CROMWELL_EPS`, compositional operators get `0.5`).
 
 ### Factor types
 
-The `FactorType` enum defines 8 factor types:
+The `FactorType` enum defines 10 factor types:
 
 | FactorType | Parameters | Arity constraint |
 |------------|-----------|-----------------|
 | `IMPLICATION` | none (deterministic) | exactly 1 premise |
+| `NEGATION` | none (deterministic) | exactly 1 premise |
 | `CONJUNCTION` | none (deterministic) | 2+ premises |
 | `DISJUNCTION` | none (deterministic) | 2+ premises |
 | `EQUIVALENCE` | none (deterministic) | exactly 2 premises |
@@ -324,6 +325,7 @@ The `FactorType` enum defines 8 factor types:
 | `COMPLEMENT` | none (deterministic) | exactly 2 premises |
 | `SOFT_ENTAILMENT` | `p1`, `p2` (require `p1 + p2 > 1`) | exactly 1 premise |
 | `CONDITIONAL` | `cpt` (length `2^k`) | 1+ premises |
+| `PAIRWISE_POTENTIAL` | `cpt` (length 4: joint weights) | exactly 2 variables (no conclusion) |
 
 Deterministic factors use Cromwell-softened potentials (`HIGH = 1 - EPS`,
 `LOW = EPS`).
@@ -336,7 +338,7 @@ Strategies are lowered by type. In v0.5 the canonical authoring path is through 
 - **`deduction`** (lowering target of `derive` and the deprecated `deduction` strategy): `CONJUNCTION` for multiple premises, then a hard `CONDITIONAL` implication with CPT `[0.5, 1 - EPS]`. Review gates whether the warrant enters the information set; it does not supply a numeric prior.
 - **`support`** (deprecated v5 strategy; lowering preserved for compatibility): soft implication via `SOFT_ENTAILMENT`; legacy `prior=` folds into its effective `p1`.
 - **`noisy_and`** (deprecated): `CONJUNCTION + SOFT_ENTAILMENT`. Single premise omits conjunction.
-- **`associate`**: pairwise potential between two Claims using the author-supplied `p_a_given_b` / `p_b_given_a` and at least one marginal prior.
+- **`associate`**: `PAIRWISE_POTENTIAL` factor over two Claims with joint weights derived from `p_a_given_b`, `p_b_given_a`, and at least one marginal prior. No helper conclusion variable.
 - **Bayes likelihood** (`bayes.likelihood(...)`): emits one `infer` strategy per hypothesis with `[0.5, clamp(exp(logL_i - logL_max))]`, plus rigid relation operators driven by the `exclusivity` setting.
 - **Other named formal types** (legacy v5: `elimination`, `case_analysis`, `analogy`, `extrapolation`, ...): auto-formalized via `formalize_named_strategy()`, then expanded to deterministic factors.
 - **`FormalStrategy`**: each embedded operator maps to a deterministic factor via `_OPERATOR_MAP`.

--- a/docs/foundations/cli/registration.md
+++ b/docs/foundations/cli/registration.md
@@ -1,7 +1,7 @@
 ---
 status: current-canonical
 layer: cli
-since: v5-phase-1
+since: v0.5
 ---
 
 # Registry Registration

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -73,7 +73,7 @@ gaia compile [PATH]
 3. Assigns labels from Python variable names to unlabeled objects (Knowledge labels and Action labels share a single namespace per package; collision is a compile error — see [../gaia-lang/knowledge-and-reasoning.md §4.3](../gaia-lang/knowledge-and-reasoning.md#43-action-label-references)).
 4. Compiles the collected package to Gaia IR via `gaia.lang.compiler.compile_package`. Action lowering, formula lowering, and bayes lowering all run as part of this step.
 5. Validates the resulting `LocalCanonicalGraph` (warnings printed, errors abort).
-6. Generates a baseline `ReviewManifest` over every action target and merges it with `.gaia/review_manifest.json` if present.
+6. Generates a baseline `ReviewManifest` over every action target and attaches it in memory to `CompiledPackage.review`. The manifest is not persisted by `gaia compile`; it is read/merged later by `gaia inquiry review` and `gaia infer` when `.gaia/review_manifest.json` exists.
 7. Writes `.gaia/ir.json` and `.gaia/ir_hash` to the package directory.
 
 Compilation is deterministic: same source produces the same `ir_hash`. No LLM
@@ -351,11 +351,11 @@ gaia starmap [PATH] [--format html|dot|svg] [--theme light|stellaris|dark] [--ou
 | Stage    | Command          | Key Artifacts |
 |----------|------------------|---------------|
 | Init     | `gaia init`      | `pyproject.toml` with `[tool.gaia]`, `src/<import_name>/__init__.py` with DSL template |
-| Compile  | `gaia compile`   | `.gaia/ir.json`, `.gaia/ir_hash`, `.gaia/review_manifest.json` (baseline if absent) |
+| Compile  | `gaia compile`   | `.gaia/ir.json`, `.gaia/ir_hash`, `.gaia/compile_metadata.json`, `.gaia/formalization_manifest.json` |
 | Check    | `gaia check`     | (validation only) |
 | Add      | `gaia add`       | Updated `pyproject.toml` dependencies, `uv.lock` |
-| Inquiry  | `gaia inquiry`   | `.gaia/inquiry/state.json`, `.gaia/inquiry/tactics.jsonl`, `.gaia/inquiry/reviews/<review_id>.json` |
-| Infer    | `gaia infer`     | `.gaia/beliefs.json`, trace under `.gaia/trace/` |
+| Inquiry  | `gaia inquiry`   | `.gaia/inquiry/state.json`, `.gaia/inquiry/tactics.jsonl`, `.gaia/inquiry/reviews/<review_id>.json`, `.gaia/review_manifest.json` (persisted by inquiry review) |
+| Infer    | `gaia infer`     | `.gaia/beliefs.json`, trace under `.gaia/trace/`, `.gaia/review_manifest.json` (merged/persisted if reviews exist) |
 | Trace    | `gaia trace`     | (audit only; reads trace files) |
 | Render   | `gaia render`    | `docs/detailed-reasoning.md`, `.github-output/` |
 | Starmap  | `gaia starmap`   | `.gaia/starmap.{html,dot,svg}` |

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -20,7 +20,7 @@ Two side-channel command groups support the authoring loop without producing or 
 ```
 gaia inquiry  — local review loop (focus / obligation / hypothesis / review)
 gaia trace    — inference-trace verification and audit (verify / review / show)
-gaia starmap  — package-graph visualization (dot / svg / Sigma.js bundle)
+gaia starmap  — package-graph visualization (html / dot / svg)
 ```
 
 `gaia infer` is required before `gaia render --target github`; `--target docs` works without it (beliefs enrich the output when available but are not required).
@@ -73,7 +73,7 @@ gaia compile [PATH]
 3. Assigns labels from Python variable names to unlabeled objects (Knowledge labels and Action labels share a single namespace per package; collision is a compile error — see [../gaia-lang/knowledge-and-reasoning.md §4.3](../gaia-lang/knowledge-and-reasoning.md#43-action-label-references)).
 4. Compiles the collected package to Gaia IR via `gaia.lang.compiler.compile_package`. Action lowering, formula lowering, and bayes lowering all run as part of this step.
 5. Validates the resulting `LocalCanonicalGraph` (warnings printed, errors abort).
-6. Generates a baseline `ReviewManifest` over every action target and merges it with `<pkg>/reviews.json` if present.
+6. Generates a baseline `ReviewManifest` over every action target and merges it with `.gaia/review_manifest.json` if present.
 7. Writes `.gaia/ir.json` and `.gaia/ir_hash` to the package directory.
 
 Compilation is deterministic: same source produces the same `ir_hash`. No LLM
@@ -307,7 +307,7 @@ gaia inquiry tactics log
 gaia inquiry review                    # full review loop (compile + validate + analyze + snapshot)
 ```
 
-State persists in `.gaia/inquiry-state.json`. Review snapshots persist in `.gaia/reviews/<review_id>.json` for diffing.
+State persists in `.gaia/inquiry/state.json` and `.gaia/inquiry/tactics.jsonl`. Review snapshots persist in `.gaia/inquiry/reviews/<review_id>.json` for diffing.
 
 Reference: [../review/review-pipeline.md §4](../review/review-pipeline.md#4-cli-gaia-inquiry-review).
 
@@ -334,14 +334,14 @@ Reference: [../review/review-pipeline.md §6](../review/review-pipeline.md#6-cli
 Cross-paper / cross-package knowledge-graph visualization. Reads compiled IR (and optionally registry metadata) to render the constellation of claims, actions, and modules.
 
 ```
-gaia starmap [PATH] [--format dot|svg|sigma] [--theme stellaris] [--out OUTPUT]
+gaia starmap [PATH] [--format html|dot|svg] [--theme light|stellaris|dark] [--out OUTPUT]
 ```
 
 | Option | Default | Description |
 |---|---|---|
-| `--format` | `dot` | `dot` → Graphviz `.dot` source (paper-ready); `svg` → injected stellaris-glow SVG; `sigma` → Sigma.js / ForceAtlas2 bundle with HTML index |
-| `--theme` | `stellaris` | Visual theme; currently only `stellaris` is shipped |
-| `--out` | stdout / `.gaia/starmap/` | Output destination |
+| `--format` | `html` | `html` → interactive Sigma.js single-file bundle; `dot` → Graphviz `.dot` source (paper-ready); `svg` → rendered SVG with optional stellaris glow filters |
+| `--theme` | `light` | Visual theme: `light` (flat paper-friendly), `stellaris` / `dark` (deep-space dark with glow filters for svg) |
+| `--out` | `.gaia/starmap.{html,dot,svg}` | Output destination |
 
 `gaia starmap-replay` is an experimental sibling that renders an animated playback of declaration order.
 
@@ -351,14 +351,14 @@ gaia starmap [PATH] [--format dot|svg|sigma] [--theme stellaris] [--out OUTPUT]
 | Stage    | Command          | Key Artifacts |
 |----------|------------------|---------------|
 | Init     | `gaia init`      | `pyproject.toml` with `[tool.gaia]`, `src/<import_name>/__init__.py` with DSL template |
-| Compile  | `gaia compile`   | `.gaia/ir.json`, `.gaia/ir_hash`, baseline `reviews.json` (if absent) |
+| Compile  | `gaia compile`   | `.gaia/ir.json`, `.gaia/ir_hash`, `.gaia/review_manifest.json` (baseline if absent) |
 | Check    | `gaia check`     | (validation only) |
 | Add      | `gaia add`       | Updated `pyproject.toml` dependencies, `uv.lock` |
-| Inquiry  | `gaia inquiry`   | `.gaia/inquiry-state.json`, `.gaia/reviews/<review_id>.json` |
+| Inquiry  | `gaia inquiry`   | `.gaia/inquiry/state.json`, `.gaia/inquiry/tactics.jsonl`, `.gaia/inquiry/reviews/<review_id>.json` |
 | Infer    | `gaia infer`     | `.gaia/beliefs.json`, trace under `.gaia/trace/` |
 | Trace    | `gaia trace`     | (audit only; reads trace files) |
 | Render   | `gaia render`    | `docs/detailed-reasoning.md`, `.github-output/` |
-| Starmap  | `gaia starmap`   | `.gaia/starmap/` (or stdout) |
+| Starmap  | `gaia starmap`   | `.gaia/starmap.{html,dot,svg}` |
 | Register | `gaia register`  | `packages/<name>/Package.toml`, `Versions.toml`, `Deps.toml` (in registry repo) |
 
 

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -1,26 +1,31 @@
 ---
 status: current-canonical
 layer: cli
-since: v5-phase-1
+since: v0.5
 ---
 
 # CLI Workflow
 
 ## Overview
 
-The Gaia CLI is a knowledge package authoring toolkit. It provides a seven-command
-pipeline that takes a Python DSL package from scaffolding to registry registration:
+The Gaia CLI is a knowledge package authoring toolkit. The main authoring pipeline takes a Python DSL package from scaffolding to registry registration:
 
 ```
-gaia init --> gaia add --> write package --> gaia compile --> gaia infer --> gaia render --> git tag --> gaia register
-(scaffold)   (add deps)    (DSL code)      (DSL -> IR)     (optional*)     (present)              (registry PR)
+gaia init --> gaia add --> write package --> gaia compile --> gaia check --> gaia infer --> gaia render --> git tag --> gaia register
+(scaffold)   (add deps)    (DSL code)      (DSL -> IR)     (validate)    (BP)            (present)              (registry PR)
 ```
 
-`*` `gaia infer` is required before `gaia render --target github`; `--target docs`
-works without it (beliefs enrich the output when available but are not required).
+Two side-channel command groups support the authoring loop without producing or modifying IR / priors / beliefs:
 
-Entry point: installed as the `gaia` CLI command via `pyproject.toml`
-`[project.scripts]`, backed by a Typer app at `gaia.cli.main:app`.
+```
+gaia inquiry  — local review loop (focus / obligation / hypothesis / review)
+gaia trace    — inference-trace verification and audit (verify / review / show)
+gaia starmap  — package-graph visualization (dot / svg / Sigma.js bundle)
+```
+
+`gaia infer` is required before `gaia render --target github`; `--target docs` works without it (beliefs enrich the output when available but are not required).
+
+Entry point: installed as the `gaia` CLI command via `pyproject.toml` `[project.scripts]`, backed by a Typer app at `gaia.cli.main:app`.
 
 
 ## Commands
@@ -64,11 +69,12 @@ gaia compile [PATH]
 **What it does:**
 
 1. Loads the package from `pyproject.toml` (requires `[tool.gaia].type = "knowledge-package"`).
-2. Imports the Python module, collects `Knowledge`, `Strategy`, and `Operator` declarations.
-3. Assigns labels from Python variable names to unlabeled objects.
-4. Compiles the collected package to Gaia IR via `gaia.lang.compiler.compile_package`.
+2. Imports the Python module, collects `Knowledge`, `Action` (including `Compose`), `Strategy`, and `Operator` declarations registered to the active `CollectedPackage`.
+3. Assigns labels from Python variable names to unlabeled objects (Knowledge labels and Action labels share a single namespace per package; collision is a compile error — see [../gaia-lang/knowledge-and-reasoning.md §4.3](../gaia-lang/knowledge-and-reasoning.md#43-action-label-references)).
+4. Compiles the collected package to Gaia IR via `gaia.lang.compiler.compile_package`. Action lowering, formula lowering, and bayes lowering all run as part of this step.
 5. Validates the resulting `LocalCanonicalGraph` (warnings printed, errors abort).
-6. Writes `.gaia/ir.json` and `.gaia/ir_hash` to the package directory.
+6. Generates a baseline `ReviewManifest` over every action target and merges it with `<pkg>/reviews.json` if present.
+7. Writes `.gaia/ir.json` and `.gaia/ir_hash` to the package directory.
 
 Compilation is deterministic: same source produces the same `ir_hash`. No LLM
 calls, no network access.
@@ -284,16 +290,75 @@ gaia register [PATH] [--tag TAG] [--repo URL] [--registry-dir PATH]
 Reference: [Registration](registration.md) for details.
 
 
+## Authoring Side-Channels
+
+These commands support the authoring loop but do not produce or mutate IR, priors, or beliefs. They read what `gaia compile` and `gaia infer` already wrote.
+
+### `gaia inquiry`
+
+Local review loop and proof-state ledger. Reads the compiled IR, the merged review manifest, the current focus claim, obligations, and working hypotheses; never modifies `.py` source, IR, priors, or beliefs.
+
+```
+gaia inquiry focus [TARGET]            # set / clear / push / pop / inspect focus
+gaia inquiry obligation add|list|close
+gaia inquiry hypothesis add|list|remove
+gaia inquiry reject [TARGET]
+gaia inquiry tactics log
+gaia inquiry review                    # full review loop (compile + validate + analyze + snapshot)
+```
+
+State persists in `.gaia/inquiry-state.json`. Review snapshots persist in `.gaia/reviews/<review_id>.json` for diffing.
+
+Reference: [../review/review-pipeline.md §4](../review/review-pipeline.md#4-cli-gaia-inquiry-review).
+
+### `gaia trace`
+
+ARM (Auditable Reasoning Manifest) trace reviewer. Inference and other agent-side workflows emit hash-chained trace files; this command verifies and audits them.
+
+```
+gaia trace verify <PATH>                                  # schema + hash-chain check
+gaia trace review <PATH> [--mode trace|publish] [--package PKG] [--json|--markdown] [--strict]
+gaia trace show <PATH> [--kind KIND] [--limit N] [--json]
+```
+
+Exit codes:
+- `verify`: 0 clean / 1 chain or manifest mismatch / 2 schema error.
+- `review`: 0 clean / 1 error diagnostic (or `--strict` warning) / 2 invalid CLI args.
+
+`--mode publish` weighs diagnostics more strictly for release-gate use; `--mode trace` is the authoring-time view. `--package <pkg>` cross-references `claim_ref` events against the package's `Review` records.
+
+Reference: [../review/review-pipeline.md §6](../review/review-pipeline.md#6-cli-gaia-trace-verify--review--show).
+
+### `gaia starmap`
+
+Cross-paper / cross-package knowledge-graph visualization. Reads compiled IR (and optionally registry metadata) to render the constellation of claims, actions, and modules.
+
+```
+gaia starmap [PATH] [--format dot|svg|sigma] [--theme stellaris] [--out OUTPUT]
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `--format` | `dot` | `dot` → Graphviz `.dot` source (paper-ready); `svg` → injected stellaris-glow SVG; `sigma` → Sigma.js / ForceAtlas2 bundle with HTML index |
+| `--theme` | `stellaris` | Visual theme; currently only `stellaris` is shipped |
+| `--out` | stdout / `.gaia/starmap/` | Output destination |
+
+`gaia starmap-replay` is an experimental sibling that renders an animated playback of declaration order.
+
+
 ## Artifacts by Stage
 
 | Stage    | Command          | Key Artifacts |
 |----------|------------------|---------------|
 | Init     | `gaia init`      | `pyproject.toml` with `[tool.gaia]`, `src/<import_name>/__init__.py` with DSL template |
-| Compile  | `gaia compile`   | `.gaia/ir.json`, `.gaia/ir_hash` |
+| Compile  | `gaia compile`   | `.gaia/ir.json`, `.gaia/ir_hash`, baseline `reviews.json` (if absent) |
 | Check    | `gaia check`     | (validation only) |
 | Add      | `gaia add`       | Updated `pyproject.toml` dependencies, `uv.lock` |
-| Infer    | `gaia infer`     | `.gaia/beliefs.json` |
+| Inquiry  | `gaia inquiry`   | `.gaia/inquiry-state.json`, `.gaia/reviews/<review_id>.json` |
+| Infer    | `gaia infer`     | `.gaia/beliefs.json`, trace under `.gaia/trace/` |
+| Trace    | `gaia trace`     | (audit only; reads trace files) |
 | Render   | `gaia render`    | `docs/detailed-reasoning.md`, `.github-output/` |
+| Starmap  | `gaia starmap`   | `.gaia/starmap/` (or stdout) |
 | Register | `gaia register`  | `packages/<name>/Package.toml`, `Versions.toml`, `Deps.toml` (in registry repo) |
 
 
@@ -306,7 +371,7 @@ A valid Gaia knowledge package has:
 - `[project].version` set.
 - `[tool.gaia].uuid` set to a valid UUID (required for `register`).
 - A Python module at `src/<import_name>/` or `<import_name>/` that declares
-  `Knowledge`, `Strategy`, and/or `Operator` objects.
+  `Knowledge`, `Action` (including `Compose`), `Strategy`, and/or `Operator` objects.
 
 The import name is derived from the project name: strip the `-gaia` suffix and
 replace hyphens with underscores (e.g., `galileo-falling-bodies-gaia` becomes


### PR DESCRIPTION
Part of the v0.5 foundations documentation cleanup.

## workflow.md

Three side-channel command groups landed in v0.5 but were missing from the CLI overview entirely:

- **`gaia inquiry`** — local review loop (`focus` / `obligation` / `hypothesis` / `reject` / `tactics` / `review`)
- **`gaia trace`** — ARM trace verification/audit (`verify` / `review` / `show`)
- **`gaia starmap`** — knowledge-graph visualization (`--format dot|svg|sigma`, `--theme stellaris`)

All three are documented under a new **Authoring Side-Channels** section, with cross-links to `review/review-pipeline.md §4 / §6`. The `gaia compile` step is also updated to mention Action / formula / bayes lowering and the Knowledge-vs-Action label-collision rule. The Artifacts table expands accordingly.

Frontmatter: `since: v5-phase-1 → v0.5`.

## inference.md

- Frontmatter: `since: v5-phase-2 → v0.5`.
- Strategy lowering section restructured: lead paragraph explains that the v0.5 surface is Action verbs while strategy *types* stay the same. The list itself now covers:
  - **infer** with explicit *infer-with-given gating* (CPT collapses to MaxEnt when any of `given` is false — the v0.5 contract introduced earlier this milestone).
  - **associate** (pairwise potential).
  - **Bayes likelihood** lowering (one `infer` per hypothesis + exclusivity-driven operators).
  - **Compose** explicitly called out as a first-class IR node that does **not** produce a BP factor.
- Legacy `support` / `deduction` / `noisy_and` entries kept but flagged as the deprecated v5 surface.
- Added cross-links to `bp/potentials.md` and `bp/formal-strategy-lowering.md`.

## compilation.md, registration.md

Frontmatter bumped to `v0.5`. No content changes — already aligned with current code.

## Non-goals

- No code changes.
- Not touching `docs/foundations/gaia-ir/` (protected layer).