### PR TITLE
docs(foundations): update bp/ for v0.5 lowering paths

### DIFF
--- a/docs/foundations/bp/belief-state.md
+++ b/docs/foundations/bp/belief-state.md
@@ -1,8 +1,8 @@
 # BeliefState — 信念定义
 
-> **Status:** Target design
+> **Status:** Current canonical (v0.5)
 >
-> **⚠️ Protected Contract Layer** — 本目录定义 CLI↔LKM 结构契约。变更需要独立 PR 并经负责人审查批准。详见 [documentation-policy.md](../../documentation-policy.md#12-变更控制)。
+> 本文档定义 BeliefState schema，由 LKM 全局推理消费。本地 CLI 推理产生的 `.gaia/beliefs.json` 是该 schema 的子集（缺 `resolution_policy` / `prior_cutoff`）。
 
 BeliefState 是 BP 在 GlobalCanonicalGraph 上的纯输出——后验信念值。它记录产生它的条件（resolution policy），使结果可重现。
 
@@ -52,6 +52,7 @@ BeliefState:
 
 ## 源代码
 
-- `libs/inference/bp.py` -- `BeliefPropagation.run()` 产出 beliefs
-- `libs/storage/models.py` -- `BeliefSnapshot`
-- `libs/graph_ir/models.py` -- `Strategy`（三种实体之一，BP 编译的输入）
+- `gaia/bp/engine.py` — `InferenceEngine.run()` 产出 beliefs
+- `gaia/bp/bp.py` — `BeliefPropagation.run()`（loopy BP 路径）
+- `gaia/bp/lowering.py` — `lower_local_graph()`：Gaia IR → FactorGraph
+- `gaia/ir/strategy.py` — `Strategy / CompositeStrategy / FormalStrategy`

--- a/docs/foundations/bp/belief-state.md
+++ b/docs/foundations/bp/belief-state.md
@@ -2,7 +2,7 @@
 
 > **Status:** Current canonical (v0.5)
 >
-> 本文档定义 BeliefState schema，由 LKM 全局推理消费。本地 CLI 推理产生的 `.gaia/beliefs.json` 是该 schema 的子集（缺 `resolution_policy` / `prior_cutoff`）。
+> 本文档定义 BeliefState schema，用于 LKM 全局推理。本地 CLI 推理产生的 `.gaia/beliefs.json` 使用不同的 schema（见 §Local CLI Beliefs Format）。
 
 BeliefState 是 BP 在 GlobalCanonicalGraph 上的纯输出——后验信念值。它记录产生它的条件（resolution policy），使结果可重现。
 
@@ -31,6 +31,37 @@ BeliefState:
     iterations:           int
     max_residual:         float
 ```
+
+## Local CLI Beliefs Format
+
+本地 CLI `gaia infer` 写入的 `.gaia/beliefs.json` 使用不同的 schema，针对本地包优化：
+
+```json
+{
+  "ir_hash": "...",
+  "gaia_lang_version": "...",
+  "beliefs": [
+    {"knowledge_id": "github:pkg::label", "label": "label", "belief": 0.73}
+  ],
+  "diagnostics": {
+    "converged": true,
+    "iterations": 42,
+    "max_residual": 0.0001
+  }
+}
+```
+
+**与 BeliefState 的区别**：
+- `beliefs` 是 list of records，不是 `dict[str, float]`
+- 使用本地 QID（`github:pkg::label`），不是全局 `gcn_*` ID
+- 缺少 `bp_run_id`, `created_at`, `resolution_policy`, `prior_cutoff`, `compilation_summary`
+- 包含 `ir_hash` 和 `gaia_lang_version` 用于本地一致性检查
+
+**转换到 BeliefState**：上传到 LKM 时需要：
+1. 将本地 QID 映射到全局 `gcn_*` ID
+2. 将 `beliefs` list 转换为 `dict[gcn_id, float]`
+3. 添加 `bp_run_id`, `created_at`, `resolution_policy`, `prior_cutoff`
+4. 可选：添加 `compilation_summary` 用于诊断
 
 ## 关键规则
 

--- a/docs/foundations/bp/formal-strategy-lowering.md
+++ b/docs/foundations/bp/formal-strategy-lowering.md
@@ -1,9 +1,10 @@
 # FormalStrategy 因子图 Lowering：统一三元因子模型
 
-> **Status:** Target design — 替代 #340 旧方案（二元因子 / dead-end 检测）
+> **Status:** Current canonical (v0.5)
 >
 > 本文档论证 FormalStrategy 内部所有 Operator 的统一 lowering 方案。
 > 依赖：[potentials.md](potentials.md)（factor potential 定义）、[../theory/06-factor-graphs.md](../theory/06-factor-graphs.md)（因子图理论）。
+> 历史注脚：本方案已替代旧的二元因子 / dead-end 检测方案（issue #340）。
 
 ## 1. 统一因子模型
 

--- a/docs/foundations/bp/inference.md
+++ b/docs/foundations/bp/inference.md
@@ -1,8 +1,8 @@
 # Gaia IR 上的 BP 推理
 
-> **Status:** Current canonical
+> **Status:** Current canonical (v0.5)
 
-本文档描述 belief propagation 如何在 Gaia IR 上运行。纯 BP 算法（sum-product 消息传递、damping、收敛）见 [../theory/07-belief-propagation.md](../theory/07-belief-propagation.md)。Factor potential 函数见 [potentials.md](potentials.md)。Local 与 global 推理的区别见 [local-vs-global.md](local-vs-global.md)。backend-facing lowering 边界见 [../gaia-ir/07-lowering.md](../gaia-ir/07-lowering.md)。
+本文档描述 belief propagation 如何在 Gaia IR 上运行。纯 BP 算法（sum-product 消息传递、damping、收敛）见 [../theory/07-belief-propagation.md](../theory/07-belief-propagation.md)。Factor potential 函数见 [potentials.md](potentials.md)。Local 与 global 推理的区别见 [local-vs-global.md](local-vs-global.md)。backend-facing lowering 边界见 [../gaia-ir/07-lowering.md](../gaia-ir/07-lowering.md)。`gaia infer` CLI 入口与 priors / dep_beliefs / depth 见 [../cli/inference.md](../cli/inference.md)。
 
 ## FactorGraph
 
@@ -21,14 +21,29 @@ FactorGraph 是一个**概念**，不绑定特定的存储或运行方式：
 
 ### 实现
 
-**v1（Graph IR 管线）**：`libs/inference/factor_graph.py`，使用 int 索引、`premises`/`conclusions`/`edge_type` 字符串。供 `scripts/pipeline/run_local_bp.py` 等包内 BP 使用。
+`gaia/bp/factor_graph.py` 是当前实现：使用字符串 ID、八种 `FactorType`（六种确定性 + SOFT_ENTAILMENT + CONDITIONAL）、`variables` + `conclusion` 结构。势函数见 [potentials.md](potentials.md)。配套算法分模块：
 
-**v2（理论对齐 BP 引擎）**：`gaia/bp/factor_graph.py`，使用字符串 ID、八种 `FactorType`（六种确定性 + SOFT_ENTAILMENT + CONDITIONAL）、`variables` + `conclusion` 结构。势函数见 [potentials.md](potentials.md)。包含 loopy BP、Junction Tree、GBP、exact brute-force、`InferenceEngine` 自动选择。
+- `gaia/bp/bp.py` — loopy BP (sum-product) 与诊断
+- `gaia/bp/junction_tree.py` — Junction Tree exact inference
+- `gaia/bp/gbp.py` — Generalized BP
+- `gaia/bp/exact.py` — 小图 brute-force
+- `gaia/bp/engine.py` — `InferenceEngine`：根据 treewidth 自动选择算法（JT 当 tw ≤ 15，GBP 当 tw ≤ 30，否则 loopy BP）
+- `gaia/bp/lowering.py` — `lower_local_graph()`：Gaia IR → FactorGraph 的入口
 
 ### 从 Gaia IR 构建
 
-- **Graph IR → v1**：适配器 `libs/graph_ir/adapter.py`，将 Knowledge QID 映射为整数 ID。
-- **Gaia IR（`LocalCanonicalGraph`）→ v2**：`gaia.bp.lowering.lower_local_graph()`，契约见 [../gaia-ir/07-lowering.md](../gaia-ir/07-lowering.md)。Operator → 确定性因子；`noisy_and` → CONJUNCTION + SOFT_ENTAILMENT；`infer` → CONDITIONAL 或可选 degraded ∧+↝；FormalStrategy → expand（内部 Operator 逐一 lower）或 fold（NotImplementedError，待设计）。
+`gaia.bp.lowering.lower_local_graph(graph, node_priors=None)` 把 `LocalCanonicalGraph` lower 成 `FactorGraph`：
+
+- 每个 `Knowledge` 节点变成一个二值变量，prior 来自 `metadata["prior"]` 或 `node_priors` 覆盖。
+- 每个 `Operator` 变成 CONDITIONAL 三元因子，CPT 由真值表决定（详见 [formal-strategy-lowering.md](formal-strategy-lowering.md)）。
+- 每个 `Strategy(type=infer)` 变成 CONDITIONAL 因子，CPT 来自作者的 `p_e_given_h` / `p_e_given_not_h`（含 `given` 时按 v0.5 gating 收缩为 MaxEnt）。
+- 每个 `Strategy(type=associate)` 变成成对 CONDITIONAL 因子。
+- 每个 `FormalStrategy`（包括所有 v5 命名策略 formalize 后的形态）按内部 Operator 逐一 lower。
+- `CompositeStrategy` 递归 lower 子策略。
+- `Compose` 不产生 BP 因子（它是 IR 一等节点但语义上是 authoring container）。
+- 已废弃的 `noisy_and` 仍然支持：lower 为 CONJUNCTION + SOFT_ENTAILMENT。
+
+契约详见 [../gaia-ir/07-lowering.md](../gaia-ir/07-lowering.md) 和 [cli/inference.md](../cli/inference.md)。
 
 ### Cromwell's rule
 
@@ -102,6 +117,12 @@ Package B:  F_inst_b: premises=[V_schema], conclusion=V_ground_b
 
 ## 源代码
 
-- `libs/inference/bp.py` -- `BeliefPropagation`, `run_with_diagnostics()`
-- `libs/inference/factor_graph.py` -- `FactorGraph`, `CROMWELL_EPS`
-- `libs/graph_ir/adapter.py` -- 从 Gaia IR 构建 `FactorGraph`
+- `gaia/bp/factor_graph.py` — `FactorGraph`, `FactorType`, `CROMWELL_EPS`
+- `gaia/bp/lowering.py` — `lower_local_graph()`：Gaia IR → FactorGraph
+- `gaia/bp/bp.py` — `BeliefPropagation`, `run_with_diagnostics()`
+- `gaia/bp/junction_tree.py` — Junction Tree exact inference
+- `gaia/bp/gbp.py` — Generalized BP
+- `gaia/bp/exact.py` — brute-force exact inference for small graphs
+- `gaia/bp/engine.py` — `InferenceEngine`：根据 treewidth 自动选择算法
+- `gaia/bp/potentials.py` — 各 FactorType 的势函数
+- `gaia/bp/contraction.py` — 张量收缩工具（用于 fold-composite 等）

--- a/docs/foundations/bp/inference.md
+++ b/docs/foundations/bp/inference.md
@@ -21,7 +21,7 @@ FactorGraph 是一个**概念**，不绑定特定的存储或运行方式：
 
 ### 实现
 
-`gaia/bp/factor_graph.py` 是当前实现：使用字符串 ID、八种 `FactorType`（六种确定性 + SOFT_ENTAILMENT + CONDITIONAL）、`variables` + `conclusion` 结构。势函数见 [potentials.md](potentials.md)。配套算法分模块：
+`gaia/bp/factor_graph.py` 是当前实现：使用字符串 ID、十种 `FactorType`（七种确定性 + SOFT_ENTAILMENT + CONDITIONAL + PAIRWISE_POTENTIAL）、`variables` + `conclusion` 结构。势函数见 [potentials.md](potentials.md)。配套算法分模块：
 
 - `gaia/bp/bp.py` — loopy BP (sum-product) 与诊断
 - `gaia/bp/junction_tree.py` — Junction Tree exact inference
@@ -35,9 +35,9 @@ FactorGraph 是一个**概念**，不绑定特定的存储或运行方式：
 `gaia.bp.lowering.lower_local_graph(graph, node_priors=None)` 把 `LocalCanonicalGraph` lower 成 `FactorGraph`：
 
 - 每个 `Knowledge` 节点变成一个二值变量，prior 来自 `metadata["prior"]` 或 `node_priors` 覆盖。
-- 每个 `Operator` 变成 CONDITIONAL 三元因子，CPT 由真值表决定（详见 [formal-strategy-lowering.md](formal-strategy-lowering.md)）。
+- 每个 `Operator` 通过 `_OPERATOR_MAP` 映射到对应的确定性 FactorType（IMPLICATION / NEGATION / CONJUNCTION / DISJUNCTION / EQUIVALENCE / CONTRADICTION / COMPLEMENT），CPT 由真值表决定（详见 [formal-strategy-lowering.md](formal-strategy-lowering.md)）。
 - 每个 `Strategy(type=infer)` 变成 CONDITIONAL 因子，CPT 来自作者的 `p_e_given_h` / `p_e_given_not_h`（含 `given` 时按 v0.5 gating 收缩为 MaxEnt）。
-- 每个 `Strategy(type=associate)` 变成成对 CONDITIONAL 因子。
+- 每个 `Strategy(type=associate)` 变成 PAIRWISE_POTENTIAL 因子，直接连接两个 Claim 变量（无 helper conclusion），joint weights 由 `p_a_given_b` / `p_b_given_a` 和至少一个边际 prior 推导。
 - 每个 `FormalStrategy`（包括所有 v5 命名策略 formalize 后的形态）按内部 Operator 逐一 lower。
 - `CompositeStrategy` 递归 lower 子策略。
 - `Compose` 不产生 BP 因子（它是 IR 一等节点但语义上是 authoring container）。
@@ -69,7 +69,7 @@ FactorGraph 是一个**概念**，不绑定特定的存储或运行方式：
 
 ### Conclusion 先验与约束激活
 
-所有 Operator 统一为 CONDITIONAL 三元因子。Relation operator（equivalence / contradiction / complement）的 conclusion 使用 $\pi = 1-\varepsilon$（断言"关系成立"），约束自然激活，不需要 gate_var 或其他门控机制。Directed operator（conjunction / disjunction / implication）的 conclusion 使用 $\pi = 0.5$（计算输出），belief 由 variables 决定。详见 [formal-strategy-lowering.md §2](formal-strategy-lowering.md)。
+每个 Operator 通过 `_OPERATOR_MAP` 映射到对应的确定性 FactorType（IMPLICATION / NEGATION / CONJUNCTION / DISJUNCTION / EQUIVALENCE / CONTRADICTION / COMPLEMENT），使用 Cromwell-softened 势函数（`HIGH = 1 - ε`, `LOW = ε`）。Relation operator（equivalence / contradiction / complement）的 conclusion 使用 $\pi = 1-\varepsilon$（断言"关系成立"），约束自然激活。Directed operator（conjunction / disjunction / implication / negation）的 conclusion 使用 $\pi = 0.5$（计算输出），belief 由 variables 决定。详见 [formal-strategy-lowering.md §2](formal-strategy-lowering.md)。
 
 ## 参数
 


### PR DESCRIPTION
Part of the v0.5 foundations documentation cleanup. The bp/ layer had stale `libs/inference/*` paths and "Target design" status markers that no longer reflected reality.

## inference.md

- Status banner: `Current canonical (v0.5)`.
- **§Implementation** rewritten: removed all references to the deleted `libs/inference/` tree. Listed the actual `gaia/bp/` module layout:
  - `bp.py` — loopy BP
  - `junction_tree.py` — JT exact inference
  - `gbp.py` — Generalized BP
  - `exact.py` — brute-force for small graphs
  - `engine.py` — `InferenceEngine` auto-selection by treewidth
  - `lowering.py` — `lower_local_graph()` entry point
- **§从 Gaia IR 构建** expanded: documented what each Action / Strategy / Operator type lowers to in v0.5:
  - `infer` with `given=` gating (CPT collapses to MaxEnt when any of `given` is false).
  - `associate` (pairwise potential).
  - Bayes likelihood (one `infer` per hypothesis + exclusivity-driven operators).
  - `Compose` explicitly called out as a first-class IR node that does **not** produce a BP factor.
  - Deprecated `noisy_and` still supported (CONJUNCTION + SOFT_ENTAILMENT).
- **§源代码** updated with full `gaia/bp/` module list + `contraction.py`.
- Cross-link to `cli/inference.md` added.

## formal-strategy-lowering.md

- Status: `Target design` → `Current canonical (v0.5)`.
- Historical note added: this unified ternary-factor design already replaced the old binary-factor / dead-end detection approach (issue #340). The "Target design" marker was stale.

## belief-state.md

- Status: `Target design` → `Current canonical (v0.5)`.
- Removed the misleading "⚠️ Protected Contract Layer" banner. Per `CLAUDE.md`, only `gaia-ir/` and `theory/` are protected; `bp/` is **not** in the protected set.
- Clarified that local CLI `.gaia/beliefs.json` is a subset of the full `BeliefState` schema (lacks `resolution_policy` / `prior_cutoff` fields, which are LKM-only).
- **§源代码** updated: `libs/inference/*` → `gaia/bp/*`.

## potentials.md, local-vs-global.md

Already current; no changes needed.

## Non-goals

- No code changes.
- Not touching `docs/foundations/gaia-ir/` or `docs/foundations/theory/` (protected layers).