### PR TITLE
fix(packaging): include gaia.inquiry and gaia.trace subpackages in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,16 @@ requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["gaia", "gaia.ir*", "gaia.lang*", "gaia.bp*", "gaia.cli*", "gaia.review*"]
+include = [
+    "gaia",
+    "gaia.bp*",
+    "gaia.cli*",
+    "gaia.inquiry*",
+    "gaia.ir*",
+    "gaia.lang*",
+    "gaia.review*",
+    "gaia.trace*",
+]
 
 [tool.setuptools.package-data]
 "gaia.cli.templates.pages" = ["**/*"]


### PR DESCRIPTION
## Summary

`[tool.setuptools.packages.find].include` is missing `gaia.inquiry*` and `gaia.trace*`, so `setuptools.packages.find` silently drops both directories when building the release wheel — even though their sources exist in the tree and the CLI imports them at startup. Net effect: `pip install` from a release tag (non-editable) produces a broken install where `gaia --help` crashes immediately.

## Reproduction

```bash
# from a clean python env
git clone https://github.com/SiliconEinstein/Gaia.git /tmp/gaia-repro
cd /tmp/gaia-repro
git checkout v0.4.4               # also reproduces on current main
pip install . --no-deps
gaia --help
# Traceback (most recent call last):
#   File ".../bin/gaia", line 3, in <module>
#     from gaia.cli.main import app
#   File ".../site-packages/gaia/cli/main.py", line 14, in <module>
#     from gaia.cli.commands.inquiry import inquiry_app
#   File ".../site-packages/gaia/cli/commands/inquiry.py", line 18, in <module>
#     from gaia.inquiry.review import (
# ModuleNotFoundError: No module named 'gaia.inquiry'
```

Why this hasn't been caught: every dev does `pip install -e .`, and editable mode puts the repo root on `sys.path` and bypasses the wheel filter, so `gaia/inquiry/` and `gaia/trace/` are importable from the source tree directly. The bug only surfaces in non-editable installs (the actual end-user / CI release path).

## Root cause

At `main` HEAD (`941719ec`), `gaia/` contains seven real subpackages:

```
bp, cli, inquiry, ir, lang, review, trace
```

but `pyproject.toml` declares:

```toml
[tool.setuptools.packages.find]
include = ["gaia", "gaia.ir*", "gaia.lang*", "gaia.bp*", "gaia.cli*", "gaia.review*"]
```

`gaia.inquiry*` and `gaia.trace*` were never added when those subpackages were introduced. Meanwhile the CLI imports them unconditionally:

- `gaia/cli/commands/inquiry.py` imports `gaia.inquiry.review`, `gaia.inquiry.focus`, `gaia.inquiry.state`
- `gaia/cli/commands/trace.py` imports `gaia.trace.hashing`, `gaia.trace.loader`, `gaia.trace.render`, `gaia.trace.review`

## Fix

Add both globs to the include list (and sort entries alphabetically while we're here):

```toml
[tool.setuptools.packages.find]
include = [
    "gaia",
    "gaia.bp*",
    "gaia.cli*",
    "gaia.inquiry*",
    "gaia.ir*",
    "gaia.lang*",
    "gaia.review*",
    "gaia.trace*",
]
```

## Verification

```bash
pip wheel . --no-deps -w /tmp/wheel-test
unzip -l /tmp/wheel-test/gaia_lang-*.whl | grep -E 'gaia/[^/]+/__init__\.py'
#   gaia/__init__.py
#   gaia/bp/__init__.py
#   gaia/cli/__init__.py
#   gaia/inquiry/__init__.py    <- newly bundled
#   gaia/ir/__init__.py
#   gaia/lang/__init__.py
#   gaia/review/__init__.py
#   gaia/trace/__init__.py      <- newly bundled
```

All 11 files under `gaia/inquiry/` and all 9 files under `gaia/trace/` are now in the wheel. `pip install /tmp/wheel-test/gaia_lang-*.whl` followed by `gaia --help` runs cleanly.

## Related (not in this PR)

The `v0.5` branch already adds `gaia.inquiry*` and `gaia.logic*` to the include list, but is still missing `gaia.trace*`. The same fix should be applied there in a separate PR (or via merge of this branch into v0.5).

## Test plan

- [x] `pip wheel . --no-deps` from a clean checkout of this branch
- [x] Confirm `gaia/inquiry/*` and `gaia/trace/*` are present in the resulting `.whl`
- [x] `pip install` the wheel into a clean env and confirm `gaia --help` runs without `ModuleNotFoundError`
- [ ] (Maintainer) Apply the same `gaia.trace*` addition to `v0.5`

Made with [Cursor](https://cursor.com)