### PR TITLE
docs(gaia-ir): align 08-validation.md StrategyType allowed set with live enum

### DIFF
--- a/docs/foundations/gaia-ir/08-validation.md
+++ b/docs/foundations/gaia-ir/08-validation.md
@@ -83,7 +83,7 @@ helper claim 的命名纪律见 [04-helper-claims.md](04-helper-claims.md)。
 2. `premises` 中的 Knowledge 必须全部是 `claim`
 3. `conclusion` 若非空，必须引用 `claim`
 4. `background` 可引用任意允许类型
-5. `type` 必须属于允许集合：`infer` | `noisy_and` | `deduction` | `abduction` | `analogy` | `extrapolation` | `elimination` | `mathematical_induction` | `case_analysis` | `reductio`（deferred）
+5. `type` 必须属于允许集合（与 `gaia/ir/strategy.py::StrategyType` 同步，共 14 个）：`infer` | `associate` | `noisy_and`（deprecated → 编译时自动转 `support`，发 `DeprecationWarning`，仍接受） | `deduction` | `reductio`（deferred） | `elimination` | `mathematical_induction` | `case_analysis` | `abduction` | `analogy` | `extrapolation` | `support` | `compare` | `induction`
 6. 三种形态互斥：
    - 基本 Strategy：无 `sub_strategies`，无 `formal_expr`
    - `CompositeStrategy`：必须有非空 `sub_strategies`


### PR DESCRIPTION
## Problem

`docs/foundations/gaia-ir/08-validation.md §4 item 5` lists the allowed
`StrategyType` set as 10 members:

> `type` 必须属于允许集合：`infer` | `noisy_and` | `deduction` | `abduction` |
> `analogy` | `extrapolation` | `elimination` | `mathematical_induction` |
> `case_analysis` | `reductio`（deferred）

But the live enum `gaia/ir/strategy.py::StrategyType` defines **14** members:

`infer · associate · noisy_and · deduction · reductio · elimination ·
mathematical_induction · case_analysis · abduction · analogy · extrapolation ·
support · compare · induction`

Four members are absent from `08-validation.md`'s allowed set:

- `associate` — basic Strategy in the enum
- `support` — listed by `02-gaia-ir.md §3.3` (line 361) as the canonical
  FormalStrategy that replaces `noisy_and`
- `compare` — member of `_FORMAL_STRATEGY_TYPES` (`strategy.py:111`)
- `induction` — composite strategy in the enum

Additionally, `noisy_and` is listed as plain "allowed" in `08-validation.md`,
but `02-gaia-ir.md:421` documents it as deprecated:

> 已废弃，使用 `support` 替代。`noisy_and` 在代码中仍可使用但会发出
> `DeprecationWarning`，编译时自动转换为 `support`。

So `08-validation.md` and `02-gaia-ir.md` disagree on the `noisy_and` framing,
and `08-validation.md` is out of sync with the live enum on four members.

## Source of truth

`gaia/ir/strategy.py::StrategyType` is canonical — the enum at the code layer
enumerates the strategy types the runtime actually accepts and is the arbiter
for the validator's allowed set. `02-gaia-ir.md §3.3` already reflects the
live enum and stays as-is. `08-validation.md §4 item 5` is brought into
alignment with the code, not the other way around. Per `AGENTS.md § Doc
Fidelity`, the contradiction is recorded (above) and the resolution treats
the established canonical layer as the arbiter; no side-picking in passing.

## Fix

`08-validation.md §4 item 5` rewritten to list all 14 enum members, with
`noisy_and` reframed per the deprecated-but-accepted contract from
`02-gaia-ir.md:421`. `§4 item 10` (``noisy_and`` 不应用来压平命名策略的整体语义)
is a separate semantic note and stays.

No code change; no test change.

## Verification

- `uv run pre-commit run --all-files` — all hooks passed
- `uv run pytest` — 1605 passed, 3 skipped, coverage 91.57% (≥ 90% gate)