### PR TITLE
fix(v0.5): resolve immediate issue triage

### DIFF
--- a/docs/foundations/gaia-lang/predicate-logic.md
+++ b/docs/foundations/gaia-lang/predicate-logic.md
@@ -369,7 +369,8 @@ As a rule of thumb:
 ## 5. Structured Formula Sugar
 
 Most authors do not need to hand-write every AST node for common data claims.
-Gaia provides three helpers.
+Gaia provides two formula helpers, plus the normal `observe(...)` action for
+measured values.
 
 ### `parameter(variable, value, ...)`
 
@@ -397,31 +398,33 @@ Equals(theta, Constant(0.75, Probability))
 Current limit: `parameter(...)` supports primitive variables only. It does not
 bind a finite `Domain` member.
 
-### `observation(...)`
+### Structured observed values
 
-Use this to record observed primitive values:
+Use a normal formula claim for observed primitive values, then mark it with
+`observe(...)`. Observation is an action verb, not a `ClaimKind` and not a
+structured-claim sugar.
 
 ```python
-from gaia.lang import Nat, Variable, observation
+from gaia.lang import Constant, Nat, Variable, claim, equals, land, observe
 
-n = Variable(symbol="n", domain=Nat, value=395)
-k = Variable(symbol="k", domain=Nat, value=295)
+n = Variable(symbol="n", domain=Nat)
+k = Variable(symbol="k", domain=Nat)
 
-data = observation(
-    n=n,
-    k=k,
-    describe="Observed 295 dominant phenotypes out of 395 F2 plants.",
-    prior=0.999,
-    label="f2_data",
+data = observe(
+    claim(
+        "Observed 295 dominant phenotypes out of 395 F2 plants.",
+        formula=land(equals(n, Constant(395, Nat)), equals(k, Constant(295, Nat))),
+    ),
+    rationale="Extracted from the reported count table.",
+    label="observe_f2_data",
 )
+data.label = "f2_data"
 ```
 
-One observed variable lowers to one equality. Multiple observed variables lower
-to a conjunction of equalities, and the compiler copies the primitive bindings
-back onto the source claim as `parameters` plus `metadata.formula_bindings`.
-
-Current limit: `observation(...)` expects variables whose domains are primitive
-types and whose `value` fields are already set.
+One equality records one observed binding. Multiple observed bindings should be
+written as a conjunction of equalities. The compiler copies primitive formula
+bindings onto the source claim as `parameters` plus `metadata.formula_bindings`;
+the zero-premise `observe(...)` action pins the claim to `1 - CROMWELL_EPS`.
 
 ### `causal(cause, effect, ...)`
 
@@ -658,7 +661,8 @@ Current non-goals:
 - no nested-quantifier lowering contract;
 - no automatic Skolemization for `forall x exists y`;
 - no zero-arity predicate symbols;
-- no `parameter(...)` / `observation(...)` sugar for finite `Domain` values.
+- no `parameter(...)` sugar or special observation helper for finite `Domain`
+  values.
 
 ---
 
@@ -729,7 +733,7 @@ treats them as the same node.
 | A simple scientific assertion | `claim("...")` |
 | Background text with no truth variable | `note("...")` |
 | A scalar parameter value | `parameter(variable, value, ...)` |
-| Observed primitive values | `observation(...)` |
+| Observed primitive values | `claim(formula=...)` plus `observe(...)` |
 | A causal marker claim | `causal(cause, effect, ...)` |
 | Boolean structure over existing claims | `claim(formula=land(...))`, `implies(...)`, etc. |
 | A finite-domain universal or existential claim | `claim(formula=forall(...))` / `claim(formula=exists(...))` |

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -384,6 +384,10 @@ def _action_label(action: Any, pkg: CollectedPackage, action_index: int) -> str:
     return _make_action_qid(pkg.namespace, pkg.name, label)
 
 
+def _action_label_display(action_label: str) -> str:
+    return action_label.rsplit("::action::", maxsplit=1)[-1]
+
+
 def _action_metadata(
     action: Any,
     pkg: CollectedPackage,
@@ -753,6 +757,12 @@ class _ActionCompiler:
     def _record_action_target(self, action_label: str, target_id: str | None) -> None:
         if target_id is None:
             return
+        existing_target_id = self.action_label_map.get(action_label)
+        if existing_target_id is not None and existing_target_id != target_id:
+            raise ValueError(
+                f"duplicate action label '{_action_label_display(action_label)}' "
+                f"targets both {existing_target_id!r} and {target_id!r}"
+            )
         self.action_label_map[action_label] = target_id
         self.target_action_labels_by_id[target_id] = action_label
 

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -388,6 +388,40 @@ def _action_label_display(action_label: str) -> str:
     return action_label.rsplit("::action::", maxsplit=1)[-1]
 
 
+def _record_action_label_target(
+    action_label_map: dict[str, str],
+    target_action_labels_by_id: dict[str, str],
+    action_label: str,
+    target_id: str | None,
+) -> None:
+    if target_id is None:
+        return
+    existing_target_id = action_label_map.get(action_label)
+    if existing_target_id is not None:
+        raise ValueError(
+            f"duplicate action label '{_action_label_display(action_label)}' "
+            f"targets both {existing_target_id!r} and {target_id!r}"
+        )
+    action_label_map[action_label] = target_id
+    target_action_labels_by_id[target_id] = action_label
+
+
+def _merge_action_label_targets(
+    action_label_map: dict[str, str],
+    target_action_labels_by_id: dict[str, str],
+    incoming_action_label_map: dict[str, str],
+    incoming_target_action_labels_by_id: dict[str, str],
+) -> None:
+    for action_label, target_id in incoming_action_label_map.items():
+        _record_action_label_target(
+            action_label_map,
+            target_action_labels_by_id,
+            action_label,
+            target_id,
+        )
+    target_action_labels_by_id.update(incoming_target_action_labels_by_id)
+
+
 def _action_metadata(
     action: Any,
     pkg: CollectedPackage,
@@ -755,16 +789,12 @@ class _ActionCompiler:
         ]
 
     def _record_action_target(self, action_label: str, target_id: str | None) -> None:
-        if target_id is None:
-            return
-        existing_target_id = self.action_label_map.get(action_label)
-        if existing_target_id is not None and existing_target_id != target_id:
-            raise ValueError(
-                f"duplicate action label '{_action_label_display(action_label)}' "
-                f"targets both {existing_target_id!r} and {target_id!r}"
-            )
-        self.action_label_map[action_label] = target_id
-        self.target_action_labels_by_id[target_id] = action_label
+        _record_action_label_target(
+            self.action_label_map,
+            self.target_action_labels_by_id,
+            action_label,
+            target_id,
+        )
 
     def _scaffold_label(self, action: DependsOn | CandidateRelation, action_index: int) -> str:
         return action.label or f"_anon_action_{action_index:03d}"
@@ -1864,8 +1894,12 @@ def compile_package_artifact(
         metadata_updates=bayes_lowered.metadata_updates,
         parameter_updates={},
     )
-    action_compiler.action_label_map.update(bayes_lowered.action_label_map)
-    action_compiler.target_action_labels_by_id.update(bayes_lowered.target_action_labels_by_id)
+    _merge_action_label_targets(
+        action_compiler.action_label_map,
+        action_compiler.target_action_labels_by_id,
+        bayes_lowered.action_label_map,
+        bayes_lowered.target_action_labels_by_id,
+    )
     _record_bayes_action_targets(
         pkg,
         action_labels_by_object,

--- a/gaia/lang/dsl/infer_verb.py
+++ b/gaia/lang/dsl/infer_verb.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import Any, cast
 
 from gaia.lang.runtime.action import Infer as InferAction
 from gaia.lang.runtime.knowledge import Claim, Knowledge
@@ -42,17 +42,10 @@ def _legacy_infer(
     return legacy_infer(list(premises), *args, **legacy_kwargs)
 
 
-def _resolve_evidence(
-    evidence_or_legacy: Claim | str | list[Knowledge] | tuple[Knowledge, ...] | None,
-    evidence: Claim | str | None,
-) -> Claim | str | None:
-    if evidence_or_legacy is None:
-        return evidence
-    if isinstance(evidence_or_legacy, (list, tuple)):
+def _resolve_evidence(evidence: Claim | str | None) -> Claim | str | None:
+    if isinstance(evidence, (list, tuple)):
         raise TypeError("legacy infer form must be handled before evidence resolution")
-    if evidence is not None:
-        raise TypeError("infer() got evidence both positionally and by keyword")
-    return evidence_or_legacy
+    return evidence
 
 
 def _validate_infer_claims(
@@ -105,10 +98,9 @@ def _infer_relation(
 
 
 def infer(
-    evidence_or_legacy: Claim | str | list[Knowledge] | tuple[Knowledge, ...] | None = None,
+    evidence: Claim | str | None = None,
     *args: Any,
     hypothesis: Claim | None = None,
-    evidence: Claim | str | None = None,
     given: Claim | tuple[Claim, ...] | list[Claim] | None = (),
     background: list[Knowledge] | None = None,
     p_e_given_h: float | Claim | None = None,
@@ -125,15 +117,16 @@ def infer(
     v5 ``infer([premises], conclusion, ...)`` form is preserved as a deprecated
     compatibility path.
     """
-    if isinstance(evidence_or_legacy, (list, tuple)):
-        return _legacy_infer(evidence_or_legacy, args, legacy_kwargs)
+    legacy_evidence = cast(Any, evidence)
+    if isinstance(legacy_evidence, (list, tuple)):
+        return _legacy_infer(legacy_evidence, args, legacy_kwargs)
 
     if args:
         raise TypeError("v6 infer() accepts only one positional evidence argument")
     if legacy_kwargs:
         unexpected = next(iter(legacy_kwargs))
         raise TypeError(f"infer() got an unexpected keyword argument: '{unexpected}'")
-    evidence = _resolve_evidence(evidence_or_legacy, evidence)
+    evidence = _resolve_evidence(evidence)
     evidence, hypothesis, given_tuple = _validate_infer_claims(
         hypothesis=hypothesis,
         evidence=evidence,

--- a/tests/gaia/lang/test_compiler_actions.py
+++ b/tests/gaia/lang/test_compiler_actions.py
@@ -4,6 +4,7 @@ from gaia.lang import (
     Claim,
     associate,
     candidate_relation,
+    compose,
     compute,
     contradict,
     depends_on,
@@ -479,4 +480,55 @@ def test_unrelated_knowledge_action_label_collision_still_raises():
         c.label = "c"
 
     with pytest.raises(ValueError, match="label collision"):
+        compile_package_artifact(pkg)
+
+
+def test_duplicate_strategy_action_label_raises():
+    with CollectedPackage("v6_actions") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        c1 = derive("C1.", given=a, rationale="A implies C1.", label="same_step")
+        c1.label = "c1"
+        c2 = derive("C2.", given=a, rationale="A implies C2.", label="same_step")
+        c2.label = "c2"
+
+    with pytest.raises(ValueError, match="duplicate action label 'same_step'"):
+        compile_package_artifact(pkg)
+
+
+def test_duplicate_operator_action_label_raises():
+    with CollectedPackage("v6_actions") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        b = Claim("B.")
+        b.label = "b"
+        c = Claim("C.")
+        c.label = "c"
+        first = contradict(a, b, rationale="A conflicts with B.", label="same_relation")
+        first.label = "first_conflict"
+        second = contradict(a, c, rationale="A conflicts with C.", label="same_relation")
+        second.label = "second_conflict"
+
+    with pytest.raises(ValueError, match="duplicate action label 'same_relation'"):
+        compile_package_artifact(pkg)
+
+
+def test_duplicate_compose_action_label_raises():
+    @compose(name="test:workflow:first", version="1.0", label="same_workflow")
+    def first_workflow(seed: Claim) -> Claim:
+        return derive("C1.", given=seed, rationale="First workflow.", label="first_child")
+
+    @compose(name="test:workflow:second", version="1.0", label="same_workflow")
+    def second_workflow(seed: Claim) -> Claim:
+        return derive("C2.", given=seed, rationale="Second workflow.", label="second_child")
+
+    with CollectedPackage("v6_actions") as pkg:
+        a = Claim("A.")
+        a.label = "a"
+        c1 = first_workflow(a)
+        c1.label = "c1"
+        c2 = second_workflow(a)
+        c2.label = "c2"
+
+    with pytest.raises(ValueError, match="duplicate action label 'same_workflow'"):
         compile_package_artifact(pkg)

--- a/tests/gaia/lang/test_compiler_actions.py
+++ b/tests/gaia/lang/test_compiler_actions.py
@@ -2,7 +2,9 @@ import pytest
 
 from gaia.lang import (
     Claim,
+    Variable,
     associate,
+    bayes,
     candidate_relation,
     compose,
     compute,
@@ -13,8 +15,12 @@ from gaia.lang import (
     exclusive,
     infer,
     observe,
+    parameter,
     predict,
     tension,
+)
+from gaia.lang import (
+    Probability as ProbabilityDomain,
 )
 from gaia.lang.compiler import compile_package_artifact
 from gaia.lang.runtime.package import CollectedPackage
@@ -531,4 +537,21 @@ def test_duplicate_compose_action_label_raises():
         c2.label = "c2"
 
     with pytest.raises(ValueError, match="duplicate action label 'same_workflow'"):
+        compile_package_artifact(pkg)
+
+
+def test_duplicate_bayes_and_core_action_label_raises():
+    with CollectedPackage("v6_actions") as pkg:
+        theta = Variable(symbol="theta", domain=ProbabilityDomain)
+        hypothesis = parameter(theta, 0.5, content="theta = 0.5.", prior=0.5, label="h")
+        bayes.model(
+            hypothesis,
+            observable=theta,
+            distribution=bayes.Beta(alpha=1, beta=1),
+            label="same_action",
+        )
+        conclusion = derive("C.", given=hypothesis, rationale="H implies C.", label="same_action")
+        conclusion.label = "c"
+
+    with pytest.raises(ValueError, match="duplicate action label 'same_action'"):
         compile_package_artifact(pkg)

--- a/tests/gaia/lang/test_infer.py
+++ b/tests/gaia/lang/test_infer.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 
 from gaia.lang import infer
@@ -168,6 +170,17 @@ def test_infer_registers_action_and_warrant():
     assert action in e.supports
     assert action.helper is not None
     assert action.warrants == [action.helper]
+
+
+def test_infer_public_signature_is_evidence_first_without_legacy_list_shape():
+    signature = inspect.signature(infer)
+    first_parameter = next(iter(signature.parameters.values()))
+
+    assert first_parameter.name == "evidence"
+    annotation = str(first_parameter.annotation)
+    assert "list" not in annotation
+    assert "tuple" not in annotation
+    assert "Knowledge" not in annotation
 
 
 @pytest.mark.legacy_dsl


### PR DESCRIPTION
## Summary
- reject duplicate Action labels before they can silently overwrite action_label_map targets
- make the public infer() signature evidence-first while preserving the deprecated legacy runtime path
- update predicate-logic docs to use claim(formula=...) plus observe(...) instead of nonexistent observation(...) sugar

Closes #555
Closes #556
Closes #557

## Tests
- python -m pytest tests/gaia/lang/test_infer.py tests/gaia/lang/test_compiler_actions.py --no-cov -q
- python -m ruff check .
- python -m ruff format --check .
- python -m pytest -q