### PR TITLE
Fix package source module discovery

### DIFF
--- a/gaia/cli/_packages.py
+++ b/gaia/cli/_packages.py
@@ -85,15 +85,35 @@ def _import_fresh(import_name: str) -> ModuleType:
         sys.dont_write_bytecode = previous
 
 
-def _assign_labels(module: ModuleType, pkg: CollectedPackage) -> None:
+def _source_module_for_loaded_module(module_name: str, pkg: CollectedPackage) -> str | None:
+    if module_name == pkg.name or module_name.endswith(".__init__"):
+        return None
+    return module_name.removeprefix(f"{pkg.name}.")
+
+
+def _is_assignable_name(name: str) -> bool:
+    return not (name.startswith("__") and name.endswith("__"))
+
+
+def _assign_labels(module: ModuleType, pkg: CollectedPackage, source_module: str | None) -> None:
     local_knowledge_ids = {id(k) for k in pkg.knowledge}
     local_strategy_ids = {id(s) for s in pkg.strategies}
-    all_names = [name for name in dir(module) if not name.startswith("_")]
-    for attr in all_names:
-        obj = getattr(module, attr, None)
-        if isinstance(obj, Knowledge) and id(obj) in local_knowledge_ids and obj.label is None:
+    for attr, obj in vars(module).items():
+        if not _is_assignable_name(attr):
+            continue
+        if (
+            isinstance(obj, Knowledge)
+            and id(obj) in local_knowledge_ids
+            and obj.label is None
+            and getattr(obj, "_source_module", None) == source_module
+        ):
             obj.label = attr
-        if isinstance(obj, Strategy) and id(obj) in local_strategy_ids and obj.label is None:
+        if (
+            isinstance(obj, Strategy)
+            and id(obj) in local_strategy_ids
+            and obj.label is None
+            and getattr(obj, "_source_module", None) == source_module
+        ):
             obj.label = attr
 
 
@@ -107,7 +127,45 @@ def _assign_labels_for_loaded_modules() -> None:
         pkg = get_inferred_package(pyproject)
         if pkg is None:
             continue
-        _assign_labels(module, pkg)
+        source_module = _source_module_for_loaded_module(module_name, pkg)
+        _assign_labels(module, pkg, source_module)
+
+
+def _is_auxiliary_source_module(parts: tuple[str, ...]) -> bool:
+    if "reviews" in parts:
+        return True
+    return len(parts) == 1 and parts[0] in {"priors", "review"}
+
+
+def _source_module_name(import_name: str, package_dir: Path, path: Path) -> str | None:
+    relative = path.relative_to(package_dir)
+    if relative.name == "__init__.py":
+        if relative.parent == Path("."):
+            return None
+        parts = relative.parent.parts
+    else:
+        parts = relative.with_suffix("").parts
+    if _is_auxiliary_source_module(parts):
+        return None
+    return f"{import_name}.{'.'.join(parts)}"
+
+
+def _import_package_source_modules(import_name: str, package_dir: Path) -> None:
+    module_names = [
+        module_name
+        for path in sorted(package_dir.rglob("*.py"))
+        if (module_name := _source_module_name(import_name, package_dir, path)) is not None
+    ]
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        for module_name in module_names:
+            try:
+                importlib.import_module(module_name)
+            except Exception as exc:
+                raise GaiaCliError(f"Error importing package module {module_name}: {exc}") from exc
+    finally:
+        sys.dont_write_bytecode = previous
 
 
 def _load_pyproject_config(pkg_path: Path) -> dict[str, Any]:
@@ -218,6 +276,8 @@ def load_gaia_package(path: str | Path = ".") -> LoadedGaiaPackage:
         sys.path.insert(0, source_root_str)
 
     module = _import_package_module(import_name)
+    _import_package_source_modules(import_name, source_root / import_name)
+
     pkg = get_inferred_package(pyproject)
     if pkg is None:
         raise GaiaCliError(

--- a/gaia/lang/runtime/nodes.py
+++ b/gaia/lang/runtime/nodes.py
@@ -35,15 +35,18 @@ class Strategy:
     formal_expr: list[Any] | None = None
     sub_strategies: list[Strategy] = field(default_factory=list)
     composition_warrant: Knowledge | None = None
+    _source_module: str | None = field(default=None, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         """Register the strategy with the active or inferred package."""
         pkg = _current_package.get()
+        source_module = None
         if pkg is None:
-            from gaia.lang.runtime.package import infer_package_from_callstack
+            from gaia.lang.runtime.package import infer_package_and_module
 
-            pkg = infer_package_from_callstack()
+            pkg, source_module = infer_package_and_module()
         if pkg is not None:
+            self._source_module = source_module
             pkg._register_strategy(self)
 
 

--- a/tests/cli/test_module_compile.py
+++ b/tests/cli/test_module_compile.py
@@ -79,3 +79,61 @@ def test_compile_multi_file_module_order(tmp_path):
     assert by_label["z"]["exported"] is True
     assert by_label["x"]["exported"] is False
     assert ir["module_order"] == ["sec_a", "sec_b"]
+
+
+def test_compile_discovers_source_modules_without_root_imports(tmp_path):
+    """Source modules are declarations, not a byproduct of __init__ re-exports."""
+    pkg_dir = tmp_path / "discovery_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "discovery-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "discovery_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "claims.py").write_text(
+        "from gaia.lang import claim, support\n\n"
+        'evidence = claim("Evidence from an unimported module.")\n'
+        'result = claim("Result from an unimported module.")\n'
+        "_strat_result = support(\n"
+        '    [evidence], result, reason="Evidence supports result.", prior=0.9\n'
+        ")\n"
+    )
+    (pkg_src / "__init__.py").write_text('__all__ = ["result"]\n')
+
+    result = runner.invoke(app, ["compile", str(pkg_dir)])
+    assert result.exit_code == 0, f"Failed: {result.output}"
+
+    ir = json.loads((pkg_dir / ".gaia" / "ir.json").read_text())
+    by_label = {k["label"]: k for k in ir["knowledges"] if "label" in k}
+
+    assert by_label["evidence"]["module"] == "claims"
+    assert by_label["result"]["module"] == "claims"
+    assert by_label["result"]["exported"] is True
+    assert ir["module_order"] == ["claims"]
+
+
+def test_load_labels_private_strategy_names_from_declaring_module(tmp_path):
+    """Underscore-prefixed strategy variables still get stable internal labels."""
+    from gaia.cli._packages import load_gaia_package
+
+    pkg_dir = tmp_path / "private_strategy_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "private-strategy-pkg-gaia"\nversion = "1.0.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "private_strategy_pkg"
+    pkg_src.mkdir()
+    (pkg_src / "logic.py").write_text(
+        "from gaia.lang import claim, support\n\n"
+        'premise = claim("Premise.")\n'
+        'result = claim("Result.")\n'
+        '_strat_result = support([premise], result, reason="Premise entails result.", prior=0.9)\n'
+    )
+    (pkg_src / "__init__.py").write_text('from .logic import result\n__all__ = ["result"]\n')
+
+    loaded = load_gaia_package(pkg_dir)
+
+    assert len(loaded.package.strategies) == 1
+    assert loaded.package.strategies[0].label == "_strat_result"


### PR DESCRIPTION
## Summary
- import package source modules during Gaia package loading so declarations are discovered without root __init__.py re-exports
- assign labels from the declaring module, including underscore-prefixed strategy names, while keeping __all__ as export-only metadata
- skip auxiliary priors/review modules during source discovery

Closes #351

## Tests
- python -m ruff check gaia/cli/_packages.py gaia/lang/runtime/nodes.py tests/cli/test_module_compile.py
- python -m pytest tests/cli/test_module_compile.py tests/cli/test_compile.py -q --no-cov
- python -m pytest -q
