### PR TITLE
chore(hooks): add pre-push CI-byte-aligned gate + CLAUDE.md symlink check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 .pytest_cache/
 htmlcov/
 .coverage
+coverage.xml
 
 # Worktrees
 .worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,37 @@ repos:
 
   - repo: local
     hooks:
+      - id: claude-md-symlink
+        name: CLAUDE.md must be a symlink to AGENTS.md
+        entry: "bash -c 'test -L CLAUDE.md && [ \"$(readlink CLAUDE.md)\" = \"AGENTS.md\" ] || { echo \"CLAUDE.md must be a symlink to AGENTS.md (run: ln -sf AGENTS.md CLAUDE.md)\"; exit 1; }'"
+        language: system
+        pass_filenames: false
+        stages: [pre-commit, pre-push]
+
       - id: mypy
-        name: mypy strict (manual until Phase 2)
+        name: mypy --strict
         entry: uv run mypy
         language: system
         pass_filenames: false
-        stages: [manual]
+        stages: [pre-commit, pre-push]
+
+      - id: ruff-check-full
+        name: ruff check . (full 15-cat select, CI byte-aligned)
+        entry: uv run ruff check .
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: ruff-format-check
+        name: ruff format --check . (CI byte-aligned)
+        entry: uv run ruff format --check .
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: pytest-cov
+        name: pytest --cov (CI byte-aligned)
+        entry: uv run pytest --cov-report=xml tests -v -m "not integration_api"
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Use `uv` for all dependency management. Do not install repo dependencies with `p
 
 ```bash
 uv sync --extra dev
-uv run pre-commit install
+uv run pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 
 The same setup is available through:
@@ -39,30 +39,64 @@ The same setup is available through:
 make bootstrap
 ```
 
+Install **both** the pre-commit and pre-push hooks (as `make bootstrap` does). The pre-push
+hook runs the CI-byte-aligned gate locally so red CI is caught before the push leaves your
+machine.
+
 ## Quality Gates
 
-Before committing normal development work, run:
+Local hooks split work between commit time and push time:
+
+- **pre-commit** (fast, per commit): hygiene hooks (trailing whitespace / EOF newline /
+  merge-conflict / detect-private-key), `ruff check` narrow select + `--fix`, `ruff format`,
+  `mypy --strict`, and the `CLAUDE.md` symlink check.
+- **pre-push** (CI-byte-aligned, per push): `ruff check .` full 15-cat select,
+  `ruff format --check .`, `mypy`, `pytest --cov-report=xml tests -v -m "not integration_api"`,
+  plus the symlink check again.
+
+For ad-hoc runs:
 
 ```bash
-make check
-```
-
-`make check` runs `uv run pre-commit run --all-files` and `uv run pytest`. Pytest is configured
-with strict markers, coverage for `gaia`, and `--cov-fail-under=90`.
-
-Additional focused commands:
-
-```bash
+make check       # pre-commit (all files) + pytest with the configured coverage gate
 make lint        # pre-commit over all files
 make test        # pytest with the configured coverage gate
 make typecheck   # strict mypy over gaia and tests
 ```
+
+Pytest is configured with strict markers, coverage for `gaia`, and `--cov-fail-under=90`.
 
 Ruff's mccabe complexity limit is set to 12. The earlier limit of 9 was inherited from
 `lbg-cli`, a CLI-utility repo with much less algorithmic weight; Gaia mixes CLI workflows with
 BP message passing, IR coarsening, DSL compile/lower/link passes, and inquiry orchestration. A
 limit of 12 is a mainstream Python threshold for mixed CLI + library + algorithmic codebases
 while still requiring true decomposition of high-complexity functions.
+
+## Push Pre-flight
+
+The pre-push hook runs the CI-byte-aligned gate (full ruff + format check + mypy + pytest
+--cov) on every `git push`. This guarantees that if the hook is green, CI on the corresponding
+PR will be green for the same reasons.
+
+**Do not bypass the pre-push hook** with `--no-verify`, `--no-gpg-sign`, or any other skip
+flag. If the hook fails, fix the underlying issue and create a new commit — do not skip the
+hook to "ship now, fix later". Bypassing produces silent drift between local and CI state and
+defeats the entire point of byte-aligning the gates.
+
+This applies equally to in-repo agents (Claude Code, Cursor, Codex, etc.). Agents must not
+push without a green pre-push gate. Only the human contributor can override the hook in
+genuinely exceptional circumstances, and the override should be called out explicitly in the
+PR description.
+
+### CLAUDE.md ↔ AGENTS.md sync
+
+`CLAUDE.md` is a symlink to `AGENTS.md`. The pre-commit + pre-push hooks both verify this
+relationship. Editing `AGENTS.md` is the canonical action; `CLAUDE.md` is never edited as a
+separate file. If you ever find the two diverging (the symlink replaced by a real file copy),
+restore with:
+
+```bash
+rm CLAUDE.md && ln -sf AGENTS.md CLAUDE.md
+```
 
 ## Engineering Rules
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTEST_ARGS ?=
 
 bootstrap:
 	$(UV) sync --extra dev
-	$(UV) run pre-commit install
+	$(UV) run pre-commit install --hook-type pre-commit --hook-type pre-push
 
 lint:
 	$(UV) run pre-commit run --all-files


### PR DESCRIPTION
## Summary

Closes the local→CI gap where \`make check\` was green but CI could still red on \`ruff\` full select, \`mypy --strict\`, or \`pytest --cov\`.

- **pre-commit hook**: adds \`mypy --strict\` (was \`stages: [manual]\`, never auto-ran) + CLAUDE.md ↔ AGENTS.md symlink integrity check
- **pre-push hook (new)**: runs the exact CI close-out gate locally — \`uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest --cov-report=xml tests -v -m "not integration_api"\`
- **Makefile bootstrap**: installs both \`pre-commit\` and \`pre-push\` hook types
- **AGENTS.md**: new "Push Pre-flight" section explicitly forbidding bypass (\`--no-verify\`, \`--no-gpg-sign\`); includes CLAUDE.md ↔ AGENTS.md sync subsection
- **.gitignore**: \`coverage.xml\` (generated by the new pre-push pytest step)

If the pre-push hook is green, CI for the same commit will be green for the same reasons.

## Test plan

- [x] \`uv run pre-commit run --all-files\` green on this branch (9 hooks)
- [x] \`uv run pre-commit run --hook-stage pre-push --all-files\` green on this branch (12 hooks incl. full ruff + mypy + pytest --cov)
- [x] \`git push\` actually triggered the pre-push hook on this branch — full gate passed before the push completed
- [ ] CI on this PR comes back green (auto-verified by branch protection)