### PR TITLE
chore(hooks): keep pre-push hook read-only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,19 +5,26 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-merge-conflict
+        stages: [pre-commit]
       - id: check-yaml
+        stages: [pre-commit]
       - id: end-of-file-fixer
         files: ^(\.pre-commit-config\.yaml|pyproject\.toml|uv\.lock|README\.md|AGENTS\.md|CLAUDE\.md|gaia/|tests/(?!fixtures/storage/)|examples/)
+        stages: [pre-commit]
       - id: trailing-whitespace
         files: ^(\.pre-commit-config\.yaml|pyproject\.toml|uv\.lock|README\.md|AGENTS\.md|CLAUDE\.md|gaia/|tests/(?!fixtures/storage/)|examples/)
+        stages: [pre-commit]
       - id: detect-private-key
+        stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.5
     hooks:
       - id: ruff-check
         args: [--fix, --select=E4,E7,E9,F]
+        stages: [pre-commit]
       - id: ruff-format
+        stages: [pre-commit]
 
   - repo: local
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,13 +74,13 @@ while still requiring true decomposition of high-complexity functions.
 ## Push Pre-flight
 
 The pre-push hook runs the CI-byte-aligned gate (full ruff + format check + mypy + pytest
---cov) on every `git push`. This guarantees that if the hook is green, CI on the corresponding
-PR will be green for the same reasons.
+--cov) on every `git push`. If the hook is green, local state has passed the same commands
+that CI runs; GitHub may still catch environment, branch-protection, or service-side issues.
 
-**Do not bypass the pre-push hook** with `--no-verify`, `--no-gpg-sign`, or any other skip
-flag. If the hook fails, fix the underlying issue and create a new commit — do not skip the
-hook to "ship now, fix later". Bypassing produces silent drift between local and CI state and
-defeats the entire point of byte-aligning the gates.
+**Do not bypass the pre-push hook** with `--no-verify` or any other hook-skip flag. If the hook
+fails, fix the underlying issue and create a new commit — do not skip the hook to "ship now,
+fix later". Bypassing produces silent drift between local and CI state and defeats the entire
+point of byte-aligning the gates.
 
 This applies equally to in-repo agents (Claude Code, Cursor, Codex, etc.). Agents must not
 push without a green pre-push gate. Only the human contributor can override the hook in


### PR DESCRIPTION
## Summary
- limit auto-fixing pre-commit hooks to the pre-commit stage so pre-push stays read-only
- soften the AGENTS.md pre-push guarantee wording to account for GitHub-side/environment failures
- remove the misleading no-gpg-sign bypass example

Follow-up to #564 after it was merged.

## Validation
- uv run --extra dev pre-commit validate-config
- git diff --check origin/v0.5...HEAD
- uv run --extra dev pre-commit run ruff-check --hook-stage pre-push --all-files --verbose (expected: no ruff-check hook in pre-push stage)