### PR TITLE
fix(packaging): include trace package in v0.5 wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,16 @@ requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["gaia", "gaia.ir*", "gaia.lang*", "gaia.logic*", "gaia.bp*", "gaia.cli*", "gaia.inquiry*"]
+include = [
+    "gaia",
+    "gaia.bp*",
+    "gaia.cli*",
+    "gaia.inquiry*",
+    "gaia.ir*",
+    "gaia.lang*",
+    "gaia.logic*",
+    "gaia.trace*",
+]
 
 [tool.setuptools.package-data]
 "gaia.cli.templates.pages" = ["**/*"]


### PR DESCRIPTION
## Summary

This is the v0.5 follow-up for #552.

`v0.5` already includes `gaia.inquiry*` in `[tool.setuptools.packages.find].include`, but it still omitted `gaia.trace*`. Non-editable wheels therefore dropped the `gaia/trace/` package even though the CLI imports trace modules.

This PR adds only `gaia.trace*` and formats the include list so the v0.5 diff stays minimal and does not pull in unrelated `main` changes.

## Verification

```bash
python -m pip wheel . --no-deps --no-build-isolation -w /private/tmp/gaia-v05-wheel.ZcmjPc
unzip -l /private/tmp/gaia-v05-wheel.ZcmjPc/gaia_lang-0.5.0-py3-none-any.whl gaia/trace/__init__.py gaia/trace/review.py gaia/inquiry/__init__.py
python -m pip install /private/tmp/gaia-v05-wheel.ZcmjPc/gaia_lang-0.5.0-py3-none-any.whl --no-deps --target /private/tmp/gaia-v05-wheel-install.z2KnOi
PYTHONPATH=/private/tmp/gaia-v05-wheel-install.z2KnOi python -c "import gaia.trace, gaia.inquiry; print(gaia.trace.__name__, gaia.inquiry.__name__)"
git diff --check
```

The wheel now contains `gaia/trace/__init__.py`, `gaia/trace/review.py`, and the already-present `gaia/inquiry/__init__.py`; the import smoke test prints `gaia.trace gaia.inquiry`.
