### PR TITLE
docs(skills): remove stale gaia-ir-authoring index entry

### DIFF
--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -54,12 +54,6 @@ Usage notes:
 </skill>
 
 <skill>
-<name>gaia-ir-authoring</name>
-<description>Use when constructing a Gaia knowledge package or LocalCanonicalGraph — teaches Python DSL authoring, compilation, validation, registration, and BP inference using gaia.lang + gaia.ir + gaia.bp</description>
-<location>project</location>
-</skill>
-
-<skill>
 <name>meeting</name>
 <description>Use when a decision needs structured multi-party deliberation with external AI agents before the user decides. Triggers include architecture discussions, design trade-offs, naming decisions, or any topic where independent perspectives improve decision quality.</description>
 <location>project</location>


### PR DESCRIPTION
## Summary

Follow-up from a self-review of #566.

#566 removed the stale `.claude/skills/gaia-ir-authoring/SKILL.md` body, but the project skill catalog still listed `gaia-ir-authoring` in `.claude/skills.md`. That left AGENTS-aware skill discovery pointing at a deleted skill body.

This PR removes the dangling catalog entry.

## Verification

```bash
rg -n "gaia-ir-authoring" .claude AGENTS.md CLAUDE.md skills docs/foundations README.md pyproject.toml
git diff --check
```

The active skill entrypoints no longer reference `gaia-ir-authoring`, and the diff has no whitespace errors.
