### PR TITLE
[codex] Rename claim action backref to from_actions

### DIFF
--- a/docs/specs/2026-04-21-gaia-lang-v6-design.md
+++ b/docs/specs/2026-04-21-gaia-lang-v6-design.md
@@ -255,7 +255,7 @@ s = derive("Energy is quantized.", given=(A, B), rationale="...", label="planck_
 
 At compile time, the label is stored in the compiled target's `metadata.action_label`. Strategy targets retain hash-based `strategy_id` values (`lcs_...`); Operator targets retain hash-based `operator_id` values (`lco_...`). The compiler maintains a bidirectional `action_label ↔ target_id` mapping.
 
-Actions are registered in the collected package when created. `Claim.supports` is a convenience index for InquiryState and user inspection, not the compiler's only source of truth.
+Actions are registered in the collected package when created. `Claim.from_actions` is a convenience index for InquiryState and user inspection, not the compiler's only source of truth.
 
 **Warrants:** `warrants` tracks the helper Claims that explain what a reviewer is accepting (e.g., `Implies(AllTrue(A,B), C)` for derive). ReviewManifest entries are generated for reviewable action targets such as the compiled Strategy or Operator; those entries may reference helper Claims as warrants.
 
@@ -271,7 +271,7 @@ Claim("AllTrue(A, B).", metadata={"generated": True, "helper_kind": "conjunction
 
 No subclass hierarchy for helpers — the `metadata.review` flag distinguishes warrants from mechanical helpers. Only `metadata.review == True` helper Claims go into `Action.warrants`; ReviewManifest entries are generated per reviewable Action target and may reference those helper Claims in the audit question.
 
-### 4.3 Claim.supports
+### 4.3 Claim.from_actions
 
 Each Claim tracks which Actions support it:
 
@@ -279,7 +279,7 @@ Each Claim tracks which Actions support it:
 class Claim(Knowledge):
     content: str
     prior: float | None = None
-    supports: list[Action] = []    # Actions that support this Claim
+    from_actions: list[Action] = []  # Actions that produced/support this Claim
 ```
 
 A Claim can have multiple support paths:
@@ -289,10 +289,10 @@ quantum_hyp = Claim("Energy exchange is quantized.")
 derive(quantum_hyp, given=(planck_result, uv_data), rationale="Planck resolves UV catastrophe.")
 derive(quantum_hyp, given=(photoelectric,), rationale="Photoelectric effect confirms.")
 
-len(quantum_hyp.supports)  # 2
+len(quantum_hyp.from_actions)  # 2
 ```
 
-InquiryState traverses `claim.supports` to build the dependency tree.
+InquiryState traverses `claim.from_actions` to build the dependency tree.
 
 ### 4.4 Lowering
 

--- a/docs/specs/2026-05-05-bayes-actions-design.md
+++ b/docs/specs/2026-05-05-bayes-actions-design.md
@@ -138,7 +138,7 @@ class Likelihood(Probabilistic):
 
 `helper` (inherited from `Probabilistic`) carries the Bayes judgment: `"Given <data summary>, <model.label> is preferred over <against labels> (BF≈…)"`. Its `metadata["helper_kind"] = "model_preference"` and `metadata["relation"]` carry the structured comparison record (per-model log-likelihoods, pairwise BFs, exclusivity mode). This mirrors `infer()`'s helper convention exactly.
 
-**Field types are `Claim`, not `PredictiveModel`.** Following `Infer`'s storage pattern (which stores `hypothesis: Claim`, `evidence: Claim`), `Likelihood` stores the **helper Claims** returned by `bayes.model(...)`. The owning `PredictiveModel` Action is reachable via `Claim.supports`. This keeps the `roles.py` projection uniform — Bayes fields are Claim references like every other Action — and lets `roles_for_claim(M_3to1_helper, pkg)` naturally surface its `compared_model` role inside `Likelihood`.
+**Field types are `Claim`, not `PredictiveModel`.** Following `Infer`'s storage pattern (which stores `hypothesis: Claim`, `evidence: Claim`), `Likelihood` stores the **helper Claims** returned by `bayes.model(...)`. The owning `PredictiveModel` Action is reachable via `Claim.from_actions`. This keeps the `roles.py` projection uniform — Bayes fields are Claim references like every other Action — and lets `roles_for_claim(M_3to1_helper, pkg)` naturally surface its `compared_model` role inside `Likelihood`.
 
 ---
 
@@ -197,7 +197,7 @@ bayes.likelihood(
 ) -> Claim       # returns helper Claim ("M_a is preferred over M_b given D")
 ```
 
-Note: `model=` and `against=` are typed as `Claim` because what the user passes is the **return value** of `bayes.model(...)` — which is the PredictiveModel Action's helper Claim. The Likelihood lowering walks back from the helper Claim to its owning `PredictiveModel` Action via `Claim.supports`. Type-checking that this Claim was produced by a `PredictiveModel` (and not, say, a plain `Predict`) is enforced at compile time, not by Python's static type system.
+Note: `model=` and `against=` are typed as `Claim` because what the user passes is the **return value** of `bayes.model(...)` — which is the PredictiveModel Action's helper Claim. The Likelihood lowering walks back from the helper Claim to its owning `PredictiveModel` Action via `Claim.from_actions`. Type-checking that this Claim was produced by a `PredictiveModel` (and not, say, a plain `Predict`) is enforced at compile time, not by Python's static type system.
 
 `precomputed=` is still keyed by the original **hypothesis Claims**, not by the
 model-helper Claims passed through `model=` / `against=`. The new Action shape
@@ -268,7 +268,7 @@ Step 2: Build the helper Claim ("M_a preferred over M_b given D"), populate
         helper.metadata["helper_kind"] = "model_preference".
 
 Step 3: Construct the Likelihood Action with helper, model, against, data,
-        log_likelihoods. Append to data[0].supports (and to the package).
+        log_likelihoods. Append to data[0].from_actions (and to the package).
 
 Step 4: Per H_i, emit an IR `infer` strategy with
         StrategyParamRecord.conditional_probabilities = [0.5, p1_i]
@@ -423,7 +423,7 @@ cmp = bayes.likelihood(
 # (unclamped BF≈7e21); the existing BP CPT clamp yields posterior odds≈498.
 # cmp.metadata["helper_kind"] == "model_preference"
 # cmp.metadata["relation"]    == { log_likelihoods, pairwise_bf, exclusivity, ... }
-# cmp.supports                == [Likelihood Action]
+# cmp.from_actions           == [Likelihood Action]
 ```
 
 Auto-generated `Exclusive` between H_3to1 and H_null is appended to the package
@@ -524,8 +524,8 @@ The design is implemented when:
 2. `from gaia.lang import bayes` exposes `bayes.model`, `bayes.likelihood`, and the distribution literals, while importing `gaia.lang` alone does not eagerly import `gaia.lang.bayes` or scipy.
 3. `gaia.lang.runtime.action.Predict` exists; `gaia.lang.runtime.action` imports nothing from `gaia.lang.bayes`.
 4. `gaia.lang.bayes.runtime.actions.PredictiveModel` and `Likelihood` exist and pass `isinstance(_, Action)` checks; `Likelihood` additionally passes `isinstance(_, Probabilistic)`.
-5. `bayes.model(...)` returns a Claim whose `.supports` contains a `PredictiveModel` Action with populated `hypothesis / observable / distribution / helper`.
-6. `bayes.likelihood(...)` returns a Claim whose `.metadata["helper_kind"] == "model_preference"` and whose `.supports` contains a `Likelihood` Action with populated `model / against / data / log_likelihoods`.
+5. `bayes.model(...)` returns a Claim whose `.from_actions` contains a `PredictiveModel` Action with populated `hypothesis / observable / distribution / helper`.
+6. `bayes.likelihood(...)` returns a Claim whose `.metadata["helper_kind"] == "model_preference"` and whose `.from_actions` contains a `Likelihood` Action with populated `model / against / data / log_likelihoods`.
 7. `Predict` compiles with `pattern="prediction"` and the generated review prompt is a prediction-specific prompt, not the derive prompt.
 8. `roles_for_package(pkg)` surfaces all six Bayes role names from §9 for the canonical Mendel package.
 9. The Mendel golden pipeline (per #523 §7.4) passes in both documented modes: illustrative `precomputed={H_a: -1.2, H_b: -5.1}` recovers odds≈47, and the real Binomial(395, p) pipeline records raw log-likelihoods in metadata while BP posterior odds are clamp-limited around 498.

--- a/gaia/lang/bayes/compiler/lower.py
+++ b/gaia/lang/bayes/compiler/lower.py
@@ -123,7 +123,7 @@ def _prediction_metadata(
 
 
 def _model_action(helper: Claim) -> PredictiveModel:
-    for action in helper.supports:
+    for action in helper.from_actions:
         if isinstance(action, PredictiveModel) and action.helper is helper:
             return action
     raise ValueError(f"{helper.label or helper.content!r} is not a bayes.model() helper")

--- a/gaia/lang/bayes/verbs/likelihood.py
+++ b/gaia/lang/bayes/verbs/likelihood.py
@@ -35,7 +35,7 @@ def _as_claim_tuple(
 
 
 def _model_action(helper: Claim) -> PredictiveModel:
-    for action in helper.supports:
+    for action in helper.from_actions:
         if isinstance(action, PredictiveModel) and action.helper is helper:
             return action
     raise TypeError("likelihood() model entries must be Claims returned by bayes.model()")
@@ -251,5 +251,5 @@ def likelihood(
         precomputed=dict(precomputed) if precomputed is not None else None,
         log_likelihoods=log_likelihoods,
     )
-    helper.supports.append(action)
+    helper.from_actions.append(action)
     return helper

--- a/gaia/lang/bayes/verbs/model.py
+++ b/gaia/lang/bayes/verbs/model.py
@@ -62,5 +62,5 @@ def model(
         distribution=distribution,
         helper=helper,
     )
-    helper.supports.append(action)
+    helper.from_actions.append(action)
     return helper

--- a/gaia/lang/dsl/decompose.py
+++ b/gaia/lang/dsl/decompose.py
@@ -25,7 +25,7 @@ def _claim_atoms(formula: Any) -> tuple[Claim, ...]:
 
 
 def _existing_decompose(whole: Claim) -> Decompose | None:
-    for action in whole.supported_by:
+    for action in whole.from_actions:
         if isinstance(action, Decompose) and action.whole is whole:
             return action
     return None
@@ -38,7 +38,7 @@ def _decomposition_reaches(start: Claim, target: Claim, seen: set[int]) -> bool:
     if start_id in seen:
         return False
     seen.add(start_id)
-    for action in start.supported_by:
+    for action in start.from_actions:
         if not isinstance(action, Decompose) or action.whole is not start:
             continue
         if any(_decomposition_reaches(part, target, seen) for part in action.parts):
@@ -96,5 +96,5 @@ def decompose(
         parts=part_tuple,
         formula=formula,
     )
-    whole.supported_by.append(action)
+    whole.from_actions.append(action)
     return whole

--- a/gaia/lang/dsl/infer_verb.py
+++ b/gaia/lang/dsl/infer_verb.py
@@ -166,5 +166,5 @@ def infer(
         helper=helper,
     )
     action.warrants.append(helper)
-    evidence.supported_by.append(action)
+    evidence.from_actions.append(action)
     return evidence

--- a/gaia/lang/dsl/scaffold.py
+++ b/gaia/lang/dsl/scaffold.py
@@ -49,7 +49,7 @@ def depends_on(
         conclusion=conclusion,
         given=given_tuple,
     )
-    conclusion.supported_by.append(action)
+    conclusion.from_actions.append(action)
     return conclusion
 
 

--- a/gaia/lang/dsl/support.py
+++ b/gaia/lang/dsl/support.py
@@ -79,7 +79,7 @@ def derive(
         conclusion=conclusion,
         given=given_tuple,
     )
-    conclusion.supported_by.append(action)
+    conclusion.from_actions.append(action)
     return conclusion
 
 
@@ -113,7 +113,7 @@ def observe(
     )
     if not given_tuple:
         _pin_observed_claim(conclusion)
-    conclusion.supported_by.append(action)
+    conclusion.from_actions.append(action)
     return conclusion
 
 
@@ -166,7 +166,7 @@ def _compute_call(
         given=given_tuple,
         fn=fn,
     )
-    conclusion.supported_by.append(action)
+    conclusion.from_actions.append(action)
     return conclusion
 
 
@@ -211,7 +211,7 @@ def compute(
                 given=given_tuple,
                 fn=wrapped_fn,
             )
-            conclusion.supported_by.append(action)
+            conclusion.from_actions.append(action)
             return conclusion
 
         return wrapper

--- a/gaia/lang/runtime/knowledge.py
+++ b/gaia/lang/runtime/knowledge.py
@@ -193,7 +193,7 @@ class Claim(Knowledge):
     """Proposition with prior. Participates in BP."""
 
     prior: float | None = None
-    supported_by: list[Action] = field(default_factory=list)
+    from_actions: list[Action] = field(default_factory=list)
     formula: Any = None
     kind: ClaimKind = ClaimKind.GENERAL
     _param_fields: ClassVar[dict[str, Any]] = {}
@@ -213,6 +213,7 @@ class Claim(Knowledge):
             "label",
             "strategy",
             "prior",
+            "from_actions",
             "supported_by",
             "supports",
             "targets",
@@ -261,8 +262,7 @@ class Claim(Knowledge):
         content: str | None = None,
         *,
         prior: float | None = None,
-        supported_by: list[Any] | None = None,
-        supports: list[Any] | None = None,
+        from_actions: list[Any] | None = None,
         formula: Any = None,
         kind: ClaimKind = ClaimKind.GENERAL,
         **kwargs: Any,
@@ -291,21 +291,10 @@ class Claim(Knowledge):
             parameters=params or knowledge_kwargs.pop("parameters", []),
             **knowledge_kwargs,
         )
-        if supported_by is not None and supports is not None:
-            raise TypeError("Pass either supported_by or legacy supports, not both")
         self.prior = prior
-        self.supported_by = list(supported_by if supported_by is not None else supports or [])
+        self.from_actions = list(from_actions or [])
         self.formula = formula
         self.kind = kind
-
-    @property
-    def supports(self) -> list[Action]:
-        """Compatibility alias for the renamed action back-reference."""
-        return self.supported_by
-
-    @supports.setter
-    def supports(self, value: list[Action]) -> None:
-        self.supported_by = value
 
 
 @dataclass(init=False, eq=False)

--- a/tests/gaia/lang/bayes/test_runtime_and_lowering.py
+++ b/tests/gaia/lang/bayes/test_runtime_and_lowering.py
@@ -99,7 +99,7 @@ def test_bayes_module_does_not_extend_factor_or_operator_enums():
 def test_model_and_likelihood_are_action_backed_helper_claims():
     pkg, h_31, _h_null, data, model_31, model_null, cmp_result = _compiled_mendel_bayes()
 
-    model_action = model_31.supports[0]
+    model_action = model_31.from_actions[0]
     assert isinstance(model_action, PredictiveModel)
     assert model_action.hypothesis is h_31
     assert model_action.observable.symbol == "k"
@@ -107,7 +107,7 @@ def test_model_and_likelihood_are_action_backed_helper_claims():
     assert model_31.metadata["helper_kind"] == "predictive_model"
     assert model_31.metadata["bayes"]["role"] == "prediction"
 
-    cmp_action = cmp_result.supports[0]
+    cmp_action = cmp_result.from_actions[0]
     assert isinstance(cmp_action, Likelihood)
     assert cmp_action.model is model_31
     assert cmp_action.against == (model_null,)
@@ -148,7 +148,7 @@ def test_observation_noise_metadata_serializes_distribution_literal():
 
 def test_likelihood_compiles_to_reviewable_infer_strategies_and_exhaustive_complement():
     pkg, h_31, h_null, _data, _model_31, _model_null, cmp_result = _compiled_mendel_bayes()
-    cmp_result.supports[0].precomputed = {h_31: -1.2, h_null: -5.1}
+    cmp_result.from_actions[0].precomputed = {h_31: -1.2, h_null: -5.1}
 
     compiled = compile_package_artifact(pkg)
     graph = compiled.graph
@@ -240,7 +240,7 @@ def test_likelihood_precomputed_requires_every_model_hypothesis():
     finally:
         _current_package.reset(token)
 
-    _cmp_result.supports[0].precomputed = {h_31: -1.0}
+    _cmp_result.from_actions[0].precomputed = {h_31: -1.0}
     with pytest.raises(ValueError, match="precomputed likelihoods must cover"):
         compile_package_artifact(pkg)
 

--- a/tests/gaia/lang/test_compute_v6.py
+++ b/tests/gaia/lang/test_compute_v6.py
@@ -25,9 +25,9 @@ def test_compute_function():
     )
     assert isinstance(result, SumResult)
     assert result.value == 7
-    assert len(result.supports) == 1
-    assert isinstance(result.supports[0], Compute)
-    assert result.supports[0].given == (a, b)
+    assert len(result.from_actions) == 1
+    assert isinstance(result.from_actions[0], Compute)
+    assert result.from_actions[0].given == (a, b)
 
 
 def test_compute_decorator():
@@ -41,9 +41,9 @@ def test_compute_decorator():
     result = add(a, b)
     assert isinstance(result, SumResult)
     assert result.value == 7
-    assert len(result.supports) == 1
-    assert isinstance(result.supports[0], Compute)
-    assert result.supports[0].rationale == "Add two integers."
+    assert len(result.from_actions) == 1
+    assert isinstance(result.from_actions[0], Compute)
+    assert result.from_actions[0].rationale == "Add two integers."
 
 
 def test_compute_decorator_keyword_args_record_given_claims():
@@ -60,7 +60,7 @@ def test_compute_decorator_keyword_args_record_given_claims():
         result = add(a=a, b=b)
         result.label = "sum"
 
-    assert result.supports[0].given == (a, b)
+    assert result.from_actions[0].given == (a, b)
 
     compiled = compile_package_artifact(pkg)
     strategy = compiled.graph.strategies[0]
@@ -76,7 +76,7 @@ def test_compute_creates_reviewable_implication_warrant():
         given=(a, b),
         rationale="Addition.",
     )
-    action = result.supports[0]
+    action = result.from_actions[0]
     assert len(action.warrants) == 1
     warrant = action.warrants[0]
     assert warrant.metadata["generated"] is True

--- a/tests/gaia/lang/test_derive.py
+++ b/tests/gaia/lang/test_derive.py
@@ -23,8 +23,8 @@ def test_derive_attaches_to_supports():
     a = Claim("Premise.")
     c = Claim("Conclusion.")
     derive(c, given=a, rationale="Test.")
-    assert len(c.supports) == 1
-    assert isinstance(c.supports[0], Derive)
+    assert len(c.from_actions) == 1
+    assert isinstance(c.from_actions[0], Derive)
 
 
 def test_derive_multiple_supports():
@@ -33,40 +33,40 @@ def test_derive_multiple_supports():
     c = Claim("C.")
     derive(c, given=a, rationale="From A.")
     derive(c, given=b, rationale="From B.")
-    assert len(c.supports) == 2
+    assert len(c.from_actions) == 2
 
 
 def test_derive_single_given_not_tuple():
     a = Claim("Premise.")
     c = derive("Conclusion.", given=a, rationale="Test.")
-    assert isinstance(c.supports[0].given, tuple)
-    assert len(c.supports[0].given) == 1
+    assert isinstance(c.from_actions[0].given, tuple)
+    assert len(c.from_actions[0].given) == 1
 
 
 def test_derive_with_label():
     a = Claim("Premise.")
     c = derive("Conclusion.", given=a, rationale="Test.", label="my_step")
-    assert c.supports[0].label == "my_step"
+    assert c.from_actions[0].label == "my_step"
 
 
 def test_derive_with_background():
     a = Claim("Premise.")
     bg = Setting("Lab conditions.")
     c = derive("Conclusion.", given=a, background=[bg], rationale="Test.")
-    assert c.supports[0].background == [bg]
+    assert c.from_actions[0].background == [bg]
 
 
 def test_derive_registers_action_with_package():
     with CollectedPackage("v6_test") as pkg:
         a = Claim("Premise.")
         c = derive("Conclusion.", given=a, rationale="Test.")
-    assert pkg.actions == [c.supports[0]]
+    assert pkg.actions == [c.from_actions[0]]
 
 
 def test_derive_creates_reviewable_implication_warrant():
     a = Claim("Premise.")
     c = derive("Conclusion.", given=a, rationale="A implies C.")
-    action = c.supports[0]
+    action = c.from_actions[0]
     assert len(action.warrants) == 1
     warrant = action.warrants[0]
     assert warrant.metadata["generated"] is True

--- a/tests/gaia/lang/test_equal.py
+++ b/tests/gaia/lang/test_equal.py
@@ -44,4 +44,4 @@ def test_equal_helper_usable_as_premise():
     b = Claim("Obs.")
     helper = equal(a, b, rationale="Match.")
     c = derive("Theory valid.", given=helper, rationale="Matches imply valid.")
-    assert c.supports[0].given == (helper,)
+    assert c.from_actions[0].given == (helper,)

--- a/tests/gaia/lang/test_infer.py
+++ b/tests/gaia/lang/test_infer.py
@@ -28,7 +28,7 @@ def test_infer_returns_evidence_and_keeps_likelihood_warrant_on_action():
     assert action.hypothesis is h
     assert action.prior_hypothesis == 0.4
     assert action.prior_evidence == 0.3
-    assert action in e.supports
+    assert action in e.from_actions
     assert action.helper is not None
     assert action.helper is not e
     assert action.helper.metadata.get("generated") is True
@@ -59,7 +59,7 @@ def test_infer_returns_evidence_claim_and_defaults_not_h_to_neutral():
 
     action = pkg.actions[0]
     assert result is e
-    assert action in e.supports
+    assert action in e.from_actions
     assert action.evidence is e
     assert action.hypothesis is h
     assert action.p_e_given_h == 0.8
@@ -100,7 +100,7 @@ def test_infer_keyword_evidence_also_returns_evidence():
         p_e_given_not_h=0.05,
         rationale="Strong evidence.",
     )
-    action = result.supports[0]
+    action = result.from_actions[0]
     assert action.evidence is e
     assert action.helper is not None
     assert action.helper.metadata["helper_kind"] == "likelihood"
@@ -126,7 +126,7 @@ def test_infer_string_evidence_creates_and_returns_evidence():
     action = pkg.actions[0]
     assert action.evidence.content == "Planck spectrum observed."
     assert action.hypothesis is h
-    assert action in action.evidence.supports
+    assert action in action.evidence.from_actions
     assert action.helper is not None
     assert action.helper.metadata["helper_kind"] == "likelihood"
     assert (
@@ -167,7 +167,7 @@ def test_infer_registers_action_and_warrant():
     assert action.background == [bg]
     assert action.p_e_given_h == 0.8
     assert action.p_e_given_not_h == 0.2
-    assert action in e.supports
+    assert action in e.from_actions
     assert action.helper is not None
     assert action.warrants == [action.helper]
 

--- a/tests/gaia/lang/test_knowledge_v6.py
+++ b/tests/gaia/lang/test_knowledge_v6.py
@@ -32,7 +32,7 @@ def test_claim_creation():
     assert c.type == "claim"
     assert c.format == "markdown"
     assert c.prior == 0.5
-    assert c.supports == []
+    assert c.from_actions == []
 
 
 def test_claim_accepts_format():
@@ -45,10 +45,34 @@ def test_claim_no_prior():
     assert c.prior is None
 
 
-def test_claim_supports_is_legacy_alias_for_supported_by():
+def test_claim_from_actions_is_the_canonical_action_backref():
     c = Claim("UV data.")
-    assert c.supported_by == []
-    assert c.supports is c.supported_by
+    assert c.from_actions == []
+    assert not hasattr(c, "supported_by")
+    assert not hasattr(c, "supports")
+
+
+def test_claim_rejects_legacy_supports_kwarg():
+    with pytest.raises(TypeError, match="supports"):
+        Claim("UV data.", supports=[])
+
+
+def test_claim_rejects_legacy_supported_by_kwarg():
+    with pytest.raises(TypeError, match="supported_by"):
+        Claim("UV data.", supported_by=[])
+
+
+def test_claim_subclasses_cannot_reintroduce_legacy_action_backrefs():
+    class LegacyNamesClaim(Claim):
+        """Legacy names should not become templated claim parameters."""
+
+        supports: str
+        supported_by: str
+
+    with pytest.raises(TypeError, match="supports"):
+        LegacyNamesClaim(supports="old")
+    with pytest.raises(TypeError, match="supported_by"):
+        LegacyNamesClaim(supported_by="old")
 
 
 def test_claim_is_hashable_for_priors_dict():

--- a/tests/gaia/lang/test_observe.py
+++ b/tests/gaia/lang/test_observe.py
@@ -8,17 +8,17 @@ def test_observe_with_given():
     calibrated = Claim("Calibration OK.", prior=0.95)
     data = observe("UV spectrum data.", given=calibrated, rationale="Measured.")
     assert isinstance(data, Claim)
-    assert len(data.supports) == 1
-    assert isinstance(data.supports[0], Observe)
-    assert data.supports[0].given == (calibrated,)
+    assert len(data.from_actions) == 1
+    assert isinstance(data.from_actions[0], Observe)
+    assert data.from_actions[0].given == (calibrated,)
 
 
 def test_observe_root_fact_pins_prior_and_adds_reviewable_action():
     data = observe("UV spectrum data.", rationale="Measured at 5 points.")
     assert data.prior == 1.0 - CROMWELL_EPS
-    assert len(data.supports) == 1
-    assert isinstance(data.supports[0], Observe)
-    assert data.supports[0].given == ()
+    assert len(data.from_actions) == 1
+    assert isinstance(data.from_actions[0], Observe)
+    assert data.from_actions[0].given == ()
 
 
 def test_observe_root_fact_rejects_conflicting_prior():
@@ -34,7 +34,7 @@ def test_observe_root_fact_rejects_conflicting_prior():
 def test_observe_creates_reviewable_implication_warrant():
     calibrated = Claim("Calibration OK.", prior=0.95)
     data = observe("UV spectrum data.", given=calibrated, rationale="Measured.")
-    action = data.supports[0]
+    action = data.from_actions[0]
     assert len(action.warrants) == 1
     warrant = action.warrants[0]
     assert warrant.metadata["generated"] is True


### PR DESCRIPTION
## Summary
- Rename the runtime Claim action back-reference from supported_by/supports to from_actions.
- Update core, scaffold, decompose, infer, and Bayes action paths to use from_actions internally.
- Remove the legacy supports alias/constructor path and update tests/spec wording to the canonical runtime name.
- Keep compiled/review metadata["supported_by"] unchanged as the IR-facing support surface.

## Test Plan
- python -m ruff check gaia/lang/runtime/knowledge.py tests/gaia/lang/test_knowledge_v6.py tests/gaia/lang/test_derive.py tests/gaia/lang/test_observe.py tests/gaia/lang/test_compute_v6.py tests/gaia/lang/test_equal.py tests/gaia/lang/test_infer.py tests/gaia/lang/bayes/test_runtime_and_lowering.py
- python -m ruff format --check gaia/lang/runtime/knowledge.py tests/gaia/lang/test_knowledge_v6.py tests/gaia/lang/test_derive.py tests/gaia/lang/test_observe.py tests/gaia/lang/test_compute_v6.py tests/gaia/lang/test_equal.py tests/gaia/lang/test_infer.py tests/gaia/lang/bayes/test_runtime_and_lowering.py
- python -m pytest tests/gaia/lang -q --no-cov
- python -m pytest tests/cli/test_compile_v6_actions.py -q --no-cov