### PR TITLE
docs(security): drop supported-versions and response-time sections

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,20 +13,3 @@ Instead, use GitHub's private vulnerability reporting:
    or impact analysis you can share.
 
 Reports are received privately by the maintainers and are not disclosed until a fix is ready.
-
-## Supported Versions
-
-Only the current minor release line receives security updates. Older minor lines are not
-patched.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.5.x   | :white_check_mark: |
-| < 0.5   | :x:                |
-
-## Response Time
-
-- Acknowledgement within **7 days** of the report.
-- Status updates at least **weekly** until the issue is resolved or closed.
-- Coordinated disclosure: the fix, advisory, and (where applicable) CVE are published through
-  **GitHub Security Advisories** once a release containing the fix is available.


### PR DESCRIPTION
## Summary

Trim `SECURITY.md` to keep only the title and the private-reporting instructions. Removes the "Supported Versions" table and the "Response Time" commitments (acknowledgement window, weekly status updates, coordinated-disclosure language).

## Type

- [ ] feat
- [ ] fix
- [ ] refactor
- [x] docs
- [ ] chore / build / ci / test
- [ ] Breaking change (describe migration below)

## Notes for reviewers

Docs-only; no code paths touched. The remaining `## Reporting a Vulnerability` section is unchanged.