### PR TITLE
chore(hooks): install pre-commit stubs into per-worktree .githooks/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ coverage.xml
 # Worktrees
 .worktrees/
 
+# Per-worktree git hooks (populated by `make bootstrap` via core.hooksPath)
+.githooks/
+
 # Logs
 logs/
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,19 +30,23 @@ Key entry points:
 Use `uv` for all dependency management. Do not install repo dependencies with `pip`.
 
 ```bash
-uv sync --extra dev
-uv run pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg
-```
-
-The same setup is available through:
-
-```bash
 make bootstrap
 ```
 
-`make bootstrap` installs all three hook stages — `pre-commit`, `pre-push`, and `commit-msg`.
-The pre-push hook runs the CI-byte-aligned gate locally so red CI is caught before the push
+`make bootstrap` runs `uv sync --extra dev`, enables `extensions.worktreeConfig`, installs
+all three hook stages — `pre-commit`, `pre-push`, and `commit-msg` — into the worktree-local
+`.githooks/` directory, and sets `core.hooksPath` per worktree so git picks them up. The
+pre-push hook runs the CI-byte-aligned gate locally so red CI is caught before the push
 leaves your machine; the commit-msg hook enforces Conventional Commits on every commit.
+
+Hooks live in `<worktree>/.githooks/` rather than the shared `.git/hooks/` directory, and
+the convention applies whether or not you use additional worktrees — single clones get their
+own `.githooks/` just the same. The rationale is that in a bare-hub-with-worktrees setup
+`.git/hooks/` is shared across every worktree, while `pre-commit install` stubs hardcode the
+installing worktree's `.venv/bin/python`. Per-worktree `.githooks/` makes each worktree's
+hooks point at its own venv, so removing one worktree never leaves stale stubs that break
+commits in another. Existing contributors migrate by re-running `make bootstrap` once; the
+target is idempotent.
 
 ## Quality Gates
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,15 @@ PYTEST_ARGS ?=
 
 bootstrap:
 	$(UV) sync --extra dev
+	git config extensions.worktreeConfig true
+	-git config --worktree --unset core.hooksPath
+	mkdir -p .githooks
 	$(UV) run pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg
+	@hooks_src="$$(git rev-parse --git-path hooks)"; \
+		for h in pre-commit pre-push commit-msg; do \
+			if [ -f "$$hooks_src/$$h" ]; then mv -f "$$hooks_src/$$h" ".githooks/$$h"; fi; \
+		done
+	git config --worktree core.hooksPath .githooks
 
 lint:
 	$(UV) run pre-commit run --all-files


### PR DESCRIPTION
## Summary

Switch `make bootstrap` to install pre-commit hooks into a worktree-local `.githooks/` directory via `core.hooksPath` set per worktree (under `extensions.worktreeConfig`). Eliminates the failure mode where removing a worktree leaves stale hook stubs in the shared `.git/hooks/` pointing at a dead venv, breaking commits in every other worktree (hit on 2026-05-13 — a `collab-refactor` worktree cleanup left the shared `commit-msg` stub pointing at a dead Python interpreter, blocking a fresh commit in `security-trim`).

Transparent for single-clone users: same `make bootstrap`, same `git commit`, hooks just live in `.githooks/` rather than `.git/hooks/`. CI is unaffected — CI invokes `uv run pre-commit run --all-files` directly, never via git client-side hooks.

## Type

- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [x] chore / build / ci / test
- [ ] Breaking change (describe migration below)

## Notes for reviewers

- **Implementation detail.** pre-commit 4.6 refuses to install when `core.hooksPath` is set ("Cowardly refusing"). The Makefile installs hooks to the default location first, then moves the three stubs (`pre-commit`, `pre-push`, `commit-msg`) into `.githooks/`, then sets `core.hooksPath`. Idempotent — verified across consecutive `make bootstrap` runs.
- **End-to-end validation.** This PR's own commit and push went through hooks installed in the new `.githooks/` path (pre-commit ran, commitizen check ran, pre-push CI-byte-aligned gate ran). The mechanism works under load.
- **Migration.** Existing contributors re-run `make bootstrap` once. The Makefile target is idempotent; any leftover stubs in `.git/hooks/` become inert when `core.hooksPath` is set — no manual cleanup needed.
- **Custom hooks caveat.** Anyone with hand-edited non-pre-commit hooks in `.git/hooks/<name>` would see them stop firing after the migration; they'd need to move to `.githooks/`. The repo itself ships no such hooks.