### PR TITLE
[codex] Enable Pages for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
@@ -30,6 +32,8 @@ jobs:
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/v0.5'
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/v0.5'


### PR DESCRIPTION
## Summary

- grant the Docs workflow the Pages/OIDC permissions needed for Pages setup
- enable repository Pages automatically during the `configure-pages` step on `v0.5` pushes

## Root Cause

After PR #579 merged, the push-triggered Docs workflow successfully built the MkDocs site but failed in `actions/configure-pages@v5` with:

> Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions

The workflow attempted to configure a Pages site before Pages had been enabled for the repository.

## Validation

- `make docs-build`
- `git diff --check`
