### PR TITLE
[codex] Remove inline prior parameters from probabilistic actions

### DIFF
--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -192,7 +192,7 @@ Action verbs are the v0.5 main path for connecting claims. Support verbs, `infer
 | `compute(ClaimType, *, fn=None, given=(), background=None, rationale="")` | A deterministic Python computation produces the conclusion |
 | `infer(evidence, *, hypothesis, given=(), p_e_given_h, p_e_given_not_h=0.5, rationale="")` | A probabilistic prediction/evidence link remains; returns the evidence claim and keeps an internal likelihood warrant |
 | `decompose(whole, *, parts, formula, rationale="")` | A composite claim's truth condition is a formula over atomic part claims; returns the whole claim |
-| `associate(a, b, *, p_a_given_b, p_b_given_a, prior_a=None, prior_b=None, rationale="")` | A symmetric probabilistic association remains; returns an association helper claim |
+| `associate(a, b, *, p_a_given_b, p_b_given_a, rationale="")` | A symmetric probabilistic association remains; returns an association helper claim |
 | `depends_on(conclusion, *, given, background=None, rationale="")` | A conclusion has load-bearing dependencies that still need formalization |
 | `candidate_relation(a, b, *, proposed, background=None, rationale="")` | Two claims may have a relation, but the relation is not formalized yet |
 | `tension(a, b, *, background=None, rationale="")` | Shorthand for a candidate scientific tension between two claims |

--- a/docs/foundations/gaia-lang/dsl.md
+++ b/docs/foundations/gaia-lang/dsl.md
@@ -250,9 +250,9 @@ Returns the evidence claim. The action still creates an internal likelihood help
 
 Without `given`, the compiled BP factor is `H -> E` with CPT `[P(E|not H), P(E|H)]`. With `given=G`, the compiled factor uses premises `[H, G]` and CPT `[0.5, 0.5, P(E|not H,G), P(E|H,G)]`, so the relation becomes neutral when `G` is false. `p_e_given_not_h` defaults to `0.5`, the soft-implication baseline.
 
-### `associate(a, b, *, p_a_given_b, p_b_given_a, prior_a=None, prior_b=None, background=None, rationale="", label=None)`
+### `associate(a, b, *, p_a_given_b, p_b_given_a, background=None, rationale="", label=None)`
 
-Symmetric probabilistic association between two claims. Returns a generated association helper claim and lowers to a pairwise potential between `a` and `b`. At least one marginal prior for `a` or `b` must be available, either from the claim/priors layer or from `prior_a` / `prior_b`.
+Symmetric probabilistic association between two claims. Returns a generated association helper claim and lowers to a pairwise potential between `a` and `b`. At least one independent marginal prior for `a` or `b` must resolve from the claim/priors layer. Statistical model-derived marginals should be represented through `gaia.lang.bayes` outputs, not inline `associate(...)` arguments.
 
 ### `decompose(whole, *, parts, formula, background=None, rationale="", label=None, metadata=None)`
 

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -159,9 +159,9 @@ Bayesian update: given a hypothesis Claim `H`, evidence Claim `E`, and explicit 
 
 Returns the evidence Claim. The author should prefer `bayes.model(...) + bayes.likelihood(...)` (see [§6 Bayes Module](#6-bayes-module)) when the probability is an instance of a predictive distribution.
 
-#### `associate(a, b, *, p_a_given_b, p_b_given_a, prior_a=None, prior_b=None, ...)`
+#### `associate(a, b, *, p_a_given_b, p_b_given_a, ...)`
 
-Symmetric pairwise potential between two Claims. At least one of `prior_a / prior_b` (or the priors already declared on `a` / `b`) must resolve so the joint table is well-defined. Returns the association warrant helper Claim.
+Symmetric pairwise potential between two Claims. At least one independent marginal prior declared on `a` / `b`, or supplied by the package priors layer, must resolve so the joint table is well-defined. `associate(...)` itself records only the two conditional constraints; model-derived marginals belong in `gaia.lang.bayes`. Returns the association warrant helper Claim.
 
 ### 3.3 Structural — hard constraint between Claims
 

--- a/docs/specs/2026-04-23-gaia-foundation-spec.md
+++ b/docs/specs/2026-04-23-gaia-foundation-spec.md
@@ -851,8 +851,6 @@ evidence_positive = infer(
     given=calibration_reliable, # OPTIONAL. Switch condition; enters BP as a gate.
     p_e_given_h=0.95,           # REQUIRED. Cromwell-clamped.
     p_e_given_not_h=0.10,       # OPTIONAL. Defaults to neutral 0.5.
-    prior_hypothesis=0.10,      # OPTIONAL. Population prevalence of disease in this context.
-    prior_evidence=None,        # OPTIONAL. Rarely needed — usually closes from the factor.
     background=[assumption_a, assumption_b],   # §13
     source_id="lab:test_T",
     data_id="patient_001.test_T.pass_1",
@@ -868,13 +866,12 @@ evidence_positive = infer(
 
 **Required arguments:** `p_e_given_h`. `p_e_given_not_h` defaults to `0.5`, the soft-implication neutral baseline. Cromwell clamp `(ε, 1-ε)` applies at compile time.
 
-**Optional prior arguments** (`prior_hypothesis`, `prior_evidence`). Authors writing an `infer` are often in the same epistemic context where the hypothesis's prior is being estimated — the paper, the cohort, the domain-expert judgment that justifies the CPT pair usually justifies the marginal too. Co-locating these numbers at the `infer` call site keeps related judgments together in the IR and in the reviewer's view.
+**No inline prior arguments.** `infer(...)` records the CPT constraint `P(E|H)` / `P(E|¬H)`. It does not accept `prior_hypothesis` or `prior_evidence`. Marginal priors belong to the Claim / package priors layer, or to a separate model object that makes the marginal explicit.
 
-These are **constraint contributions**, not overrides. Under the soft-constraint framework, a prior can be provided by any of:
+Under the soft-constraint framework, a prior can be provided by:
 
 - the Claim declaration (`Claim("disease", prior=0.10)`)
 - `priors.py` at package level
-- the `infer(..., prior_hypothesis=...)` argument
 - an earlier action whose output pins the marginal
 
 `gaia check` (§17 item 11e) reports the outcome across all providers:
@@ -887,7 +884,7 @@ Redundancy is **not a risk** — it is a natural consequence of authors capturin
 
 **Return value:** `infer()` returns the evidence Claim `E`. The action also creates a generated helper Claim whose `helper_kind` is `"likelihood"`; that helper remains attached as the reviewable warrant for the probability estimate. When a composition ends in `infer(...)`, `Compose.conclusion` points at the evidence Claim, not the helper.
 
-IR lowering follows the v0.5 shape — `type="infer"`, `premises=[H_qid]`, `conclusion=E_qid`, `conditional_probabilities=[P(E|¬H), P(E|H)]` inline. With `given=G`, lowering uses `premises=[H_qid, G_qid]` and `conditional_probabilities=[0.5, 0.5, P(E|¬H,G), P(E|H,G)]`, so the relation is neutral when the gate is false. Well-known metadata keys remain under `metadata["evidence"] = {source_id, data_id, data_hash, rationale}`. The optional priors, when provided, become additional entries in the package's prior-provider graph for `hypothesis` / `evidence`, with `source_id = "from:{infer_action_qid}"` so `gaia check` can attribute them.
+IR lowering follows the v0.5 shape — `type="infer"`, `premises=[H_qid]`, `conclusion=E_qid`, `conditional_probabilities=[P(E|¬H), P(E|H)]` inline. With `given=G`, lowering uses `premises=[H_qid, G_qid]` and `conditional_probabilities=[0.5, 0.5, P(E|¬H,G), P(E|H,G)]`, so the relation is neutral when the gate is false. Well-known metadata keys remain under `metadata["evidence"] = {source_id, data_id, data_hash, rationale}`.
 
 ### 11.3 Why forced CPT pair, no LR-only path
 
@@ -925,8 +922,6 @@ assoc_claim = associate(
     smoking, lung_cancer,
     p_a_given_b=0.75,           # P(smoker | lung_cancer, I)
     p_b_given_a=0.20,           # P(lung_cancer | smoker, I)
-    prior_a=0.25,               # OPTIONAL. P(smoker | I) — cohort-derived marginal.
-    prior_b=None,               # OPTIONAL. If None, closed from A's marginal + Bayes.
     background=[cohort],        # I
     rationale=(
         "From cohort study C, Table 2: in diagnosed cases, 75% were smokers; "
@@ -944,11 +939,10 @@ assoc_claim = associate(
 
 **Why both `p_a_given_b` and `p_b_given_a`, not just one?** Under Jaynesian framework, each of these is a legitimate conditional probability the author might have from data. Observational studies routinely report both directions (e.g., "in cases, 75% had exposure; in exposed, 20% developed outcome"). The data is symmetric in presentation; the signature reflects that.
 
-**Optional marginal priors (`prior_a`, `prior_b`).** The same context that provides the two conditionals often also provides marginal prevalences — the cohort paper that reports "75% of cases were smokers" usually also reports "25% smoking prevalence in the cohort". Authors can record that marginal at the `associate` call site, co-locating all related probabilistic context in one IR node.
+**No inline marginal priors.** `associate(...)` records only the two conditional constraints. It does not accept `prior_a` or `prior_b`. Independent marginal prevalences belong to `Claim(..., prior=...)`, `priors.py`, or another explicit provider. Model-derived marginals belong to a structured model in `gaia.lang.bayes`.
 
 **Soft-constraint semantics (auto + `gaia check`):** `associate` contributes two conditional constraints on the joint `φ(A, B | I)`, which has 3 free parameters (4 entries summing to 1). One more constraint — A's marginal, B's marginal, or one joint entry — closes the factor. That closing constraint can come from:
 
-- the optional `prior_a` / `prior_b` arguments on this call,
 - the Claim declaration (`Claim("smoking", prior=0.25)`),
 - `priors.py` at package level,
 - other actions whose outputs pin the marginals.
@@ -956,14 +950,14 @@ assoc_claim = associate(
 `gaia check` (§17 item 11e) reports the outcome across all providers:
 
 - **Hole** — no path provides the missing marginal; BP cannot form the factor. Hard error.
-- **Redundant** — multiple sources agree (e.g., `associate(..., prior_a=0.25)` plus `Claim("smoking", prior=0.25)`). Informational; author confirms intentional over-specification. **Not a risk** — the extra source is audit-friendly context, not a conflict.
+- **Redundant** — multiple sources agree (e.g., `Claim("smoking", prior=0.25)` plus `priors.py` with the same value). Informational; author confirms intentional over-specification. **Not a risk** — the extra source is audit-friendly context, not a conflict.
 - **Conflict** — multiple sources disagree (Bayes-violation). Hard error.
 
 These three categories apply to **any** probabilistic factor — not just `associate`. `gaia check` is the kernel's factor-graph coherence tool (§15.1 audit role).
 
 **BP factor lowering contract (normative).** To avoid ambiguity and double-counting, `associate` lowers to a **pairwise association potential**, not a full joint factor. The construction uses closed-form equations:
 
-1. **`gaia check` resolves one consistent marginal for each of A and B** from the prior-provider graph (Claim declaration, `priors.py`, `prior_a`/`prior_b` args on this or other actions, outputs of other actions). Let the resolved values be `P(A|I) = π_a`, `P(B|I) = π_b`. If more than one provider is consistent, any one is used (redundancy already reported by `gaia check`). If only one marginal is provided, the other is derived via Bayes: `π_b = π_a · p_b_given_a / p_a_given_b` (and vice versa).
+1. **`gaia check` resolves one consistent marginal for each of A and B** from the prior-provider graph (Claim declaration, `priors.py`, outputs of other actions). Let the resolved values be `P(A|I) = π_a`, `P(B|I) = π_b`. If more than one provider is consistent, any one is used (redundancy already reported by `gaia check`). If only one marginal is provided, the other is derived via Bayes: `π_b = π_a · p_b_given_a / p_a_given_b` (and vice versa).
 
 2. **Bayes-consistency gate** (compile-time check):
     ```
@@ -990,9 +984,8 @@ These three categories apply to **any** probabilistic factor — not just `assoc
 
 6. **No double-counting invariant**: `associate`'s factor contributes only the **normalised pairwise interaction**, not any marginal mass. The joint that BP reconstructs is `P(A, B | I) = P(A|I) · P(B|I) · ψ(A, B | I)`, which by construction equals the closed-form joint from step 3.
 
-This rule has two consequences worth calling out:
+This rule has one consequence worth calling out:
 
-- **`prior_a` / `prior_b` on the `associate` call contribute to the prior-provider graph like any other prior source** — they are resolved through the same `gaia check` path as `Claim.prior` / `priors.py`, not injected directly into BP as a second unary factor. Any one resolved provider is consumed by step 1 above; additional consistent providers show up as `redundant`.
 - **Two `associate` actions sharing a Claim do not double-count that Claim's marginal** — each uses the resolved `π_a` from the prior-provider graph for its own ψ computation. Multiple pairwise ψ factors and one unary prior factor per Claim is the canonical BP decomposition.
 
 Future **Causal family** verbs (§18 open point) will use an analogous lowering contract with do-calculus / interventional semantics, factored through unary priors and interventional pairwise factors to preserve the same no-double-counting invariant.
@@ -1341,7 +1334,7 @@ IR schema changes belong in change-controlled PRs against `docs/foundations/gaia
 
 11c. **`[new]`** Introduce the Correlate action family per §11. Add abstract base class `Correlate(Action)` in `gaia/lang/runtime/action.py`. Migrate `Infer` to subclass `Correlate` (from current direct `Action` subclass). This creates a shared home for shared concerns across probabilistic 2-Claim actions — parameter validation, `gaia check` hooks, audit metadata conventions — without altering existing Infer semantics.
 
-11d. **`[new]`** Add `associate()` DSL function + `Associate(Correlate)` runtime dataclass + `AssociateStrategy` IR node (§11.4). DSL: `associate(a, b, *, p_a_given_b, p_b_given_a, prior_a=None, prior_b=None, background, rationale, label) -> Claim`. Runtime: `Associate` inherits from `Correlate` with `a`, `b`, `p_a_given_b`, `p_b_given_a`, `prior_a`, `prior_b`, `helper` fields. DSL returns a generated helper Claim with `metadata["helper_kind"] = "association"`. IR lowering: `type="associate"`, `premises=[A_qid, B_qid]` (no directional premise/conclusion split — both symmetric premises), the two conditionals stored in a dedicated schema field. BP factor lowering: 2×2 symmetric factor, parameters derived from `(p_a_given_b, p_b_given_a)` plus marginals obtained via graph closure (`gaia check` validates coherence; see item 11e). Optional `prior_a` / `prior_b` contribute to the prior-provider graph for A and B as additional sources, source-tagged `"from:{associate_action_qid}"`. Similarly, `infer()` accepts optional `prior_hypothesis` / `prior_evidence` arguments that contribute to the hypothesis's / evidence's prior-provider graph (§11.2); this is an authoring ergonomics feature, not a separate mechanism — the soft-constraint model treats all prior providers uniformly.
+11d. **`[new]`** Add `associate()` DSL function + `Associate(Correlate)` runtime dataclass + `AssociateStrategy` IR node (§11.4). DSL: `associate(a, b, *, p_a_given_b, p_b_given_a, background, rationale, label) -> Claim`. Runtime: `Associate` inherits from `Correlate` with `a`, `b`, `p_a_given_b`, `p_b_given_a`, `helper` fields. DSL returns a generated helper Claim with `metadata["helper_kind"] = "association"`. IR lowering: `type="associate"`, `premises=[A_qid, B_qid]` (no directional premise/conclusion split — both symmetric premises), the two conditionals stored in a dedicated schema field. BP factor lowering: 2×2 symmetric factor, parameters derived from `(p_a_given_b, p_b_given_a)` plus marginals obtained via graph closure (`gaia check` validates coherence; see item 11e). `associate()` and `infer()` do not accept inline prior arguments; they record soft probabilistic constraints, while independent marginals remain Claim / `priors.py` responsibilities and model-derived marginals belong in `gaia.lang.bayes`.
 
 11e. **`[new]`** Extend `gaia check` to report factor-graph coherence for any probabilistic factor (Infer, Associate, and future Correlate / Causal members). Three outcomes to surface:
     - **Hole** — factor parameter has no provider (no constraint path supplies the needed marginal or joint entry). Hard error.

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
@@ -37,19 +37,22 @@ different quantities at once —
   trust Mendel's record"), supplied via the ``PRIORS`` dict;
 * the **Bayesian marginal** ``P(count) = Σ_H P(count | H) P(H)`` of the count
   event (≈ 0.024 for the 295/395 outcome under the {Mendel, diffuse}
-  mixture), supplied via ``associate(..., prior_b=...)``.
+  mixture), supplied through the ``PRIORS`` entry for a separate count-event
+  claim.
 
 These are two different concepts living on the same field, so the inference
 engine sees them as "conflicting marginal providers" and refuses to compile.
 
 As a workaround this package introduces ``f2_dominant_count_specific`` — a
 plain ``derive`` node that carries only the specific numerical event and is
-**not** entered into ``PRIORS`` — and routes the ``associate`` through it.
+entered into ``PRIORS`` with the Bayes marginal — and routes the ``associate``
+through it.
 This leaves the observation's ``reliability`` prior untouched on
 ``f2_count_observation`` and lets the Bayesian marginal live cleanly on the
-derived node. No other semantic is introduced by this node; it would go away
-once the framework separates the ``reliability`` / ``marginal`` / ``belief``
-roles on a Claim. See issue #485 for the design discussion.
+derived node. This is a v0.5 compatibility workaround, not the long-term
+authoring pattern for model-derived marginals; new structured model-data
+comparisons should use ``gaia.lang.bayes``. No other semantic is introduced by
+this node. See issue #485 for the design discussion.
 """
 
 from gaia.lang import (
@@ -231,9 +234,9 @@ mendel_predicts_three_to_one_ratio = derive(
 # on a separate Claim from ``f2_count_observation``, which already carries the
 # reliability prior 0.95 via ``PRIORS``. See the module docstring above, and
 # issue #485, for the underlying framework design (``metadata.prior`` doing
-# double duty as both "reliability" and "marginal"). Once the framework
-# separates those two semantics, this intermediate node can be deleted and
-# ``associate`` can target ``f2_count_observation`` directly.
+# double duty as both "reliability" and "marginal"). New structured
+# model-derived marginals should move to ``gaia.lang.bayes`` rather than using
+# this workaround.
 # -----------------------------------------------------------------------------
 
 f2_dominant_count_specific = derive(
@@ -257,8 +260,6 @@ mendel_count_association = associate(
     background=[monohybrid_cross_setup, finite_sample_background],
     p_a_given_b=association_parameters.p_mendelian_given_count,
     p_b_given_a=association_parameters.p_count_given_mendelian,
-    prior_a=association_parameters.prior_mendelian,
-    prior_b=association_parameters.prior_count,
     rationale=(
         "用在观测计数处的点似然 Binomial(N, 3/4).pmf(295) 作为 p(count | Mendel)；"
         "对照项用 p ~ Uniform[0, 1] 的 diffuse 先验，其任意单点计数的边际概率"

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
@@ -4,11 +4,15 @@ from mendel_v0_5 import (
     blending_inheritance_model,
     f1_uniform_dominant_observation,
     f2_count_observation,
+    f2_dominant_count_specific,
     f2_has_discrete_classes_observation,
     f2_recessive_reappears_observation,
+    mendel_count_association_parameters,
     mendelian_segregation_model,
 )
 from mendel_v0_5.probabilities import PRIOR_MENDELIAN_MODEL
+
+association_parameters = mendel_count_association_parameters()
 
 PRIORS = {
     mendelian_segregation_model: (
@@ -34,5 +38,10 @@ PRIORS = {
     f2_count_observation: (
         0.95,
         "把 F2 显性/隐性计数作为可靠的实验观察。",
+    ),
+    f2_dominant_count_specific: (
+        association_parameters.prior_count,
+        "把具体计数事件在 {Mendel, diffuse} 混合模型下的 Bayes 边际作为"
+        "该中间命题的 prior；它不是观测报告可靠性。",
     ),
 }

--- a/gaia/bp/lowering.py
+++ b/gaia/bp/lowering.py
@@ -315,7 +315,6 @@ def _clamp_probability(value: float) -> float:
 def _resolve_associate_marginal(
     *,
     variable_id: str,
-    action_prior: float | None,
     priors: dict[str, float],
     metadata_priors: dict[str, float],
     strategy_id: str | None,
@@ -325,8 +324,6 @@ def _resolve_associate_marginal(
         providers.append(("node_priors", _clamp_probability(priors[variable_id])))
     if variable_id in metadata_priors:
         providers.append(("metadata.prior", _clamp_probability(metadata_priors[variable_id])))
-    if action_prior is not None:
-        providers.append(("associate prior", _clamp_probability(action_prior)))
 
     if not providers:
         return None
@@ -339,33 +336,6 @@ def _resolve_associate_marginal(
                 f"{variable_id!r}: {first_source}={first_value:g}, {source}={value:g}"
             )
     return first_value
-
-
-def _apply_inline_prior_provider(
-    fg: FactorGraph,
-    *,
-    variable_id: str,
-    inline_prior: float | None,
-    priors: dict[str, float],
-    metadata_priors: dict[str, float],
-    strategy_id: str | None,
-    field_name: str,
-) -> None:
-    if inline_prior is None:
-        return
-    inline = _clamp_probability(inline_prior)
-    providers: list[tuple[str, float]] = []
-    if variable_id in priors:
-        providers.append(("node_priors", _clamp_probability(priors[variable_id])))
-    if variable_id in metadata_priors:
-        providers.append(("metadata.prior", _clamp_probability(metadata_priors[variable_id])))
-    for source, value in providers:
-        if abs(value - inline) > _ASSOCIATE_TOLERANCE:
-            raise ValueError(
-                f"infer strategy {strategy_id}: conflicting prior providers for "
-                f"{variable_id!r}: {source}={value:g}, {field_name}={inline:g}"
-            )
-    fg.add_variable(variable_id, inline)
 
 
 def _associate_pairwise_weights(
@@ -385,14 +355,12 @@ def _associate_pairwise_weights(
     p_b_given_a = _clamp_probability(s.p_b_given_a)
     pi_a = _resolve_associate_marginal(
         variable_id=a,
-        action_prior=s.prior_a,
         priors=priors,
         metadata_priors=metadata_priors,
         strategy_id=s.strategy_id,
     )
     pi_b = _resolve_associate_marginal(
         variable_id=b,
-        action_prior=s.prior_b,
         priors=priors,
         metadata_priors=metadata_priors,
         strategy_id=s.strategy_id,
@@ -649,32 +617,11 @@ def _lower_infer_strategy(
     s: Strategy,
     conc: str,
     strategy_id: str,
-    priors: dict[str, float],
     strat_params: dict[str, list[float]],
-    metadata_priors: dict[str, float],
     infer_degraded: bool,
     ctr: list[int],
 ) -> None:
     """Lower an ``infer`` strategy to conditional or degraded soft-entailment factors."""
-    if s.premises:
-        _apply_inline_prior_provider(
-            fg,
-            variable_id=s.premises[0],
-            inline_prior=s.prior_hypothesis,
-            priors=priors,
-            metadata_priors=metadata_priors,
-            strategy_id=strategy_id,
-            field_name="prior_hypothesis",
-        )
-    _apply_inline_prior_provider(
-        fg,
-        variable_id=conc,
-        inline_prior=s.prior_evidence,
-        priors=priors,
-        metadata_priors=metadata_priors,
-        strategy_id=strategy_id,
-        field_name="prior_evidence",
-    )
     cpt = (
         s.conditional_probabilities
         or strat_params.get(strategy_id)
@@ -852,9 +799,7 @@ def _lower_leaf_strategy(
     """Lower a non-composite, non-formal strategy."""
     conc, strategy_id = _prepare_leaf_strategy_variables(fg, s, priors, claim_ids)
     if s.type == StrategyType.INFER:
-        _lower_infer_strategy(
-            fg, s, conc, strategy_id, priors, strat_params, metadata_priors, infer_degraded, ctr
-        )
+        _lower_infer_strategy(fg, s, conc, strategy_id, strat_params, infer_degraded, ctr)
         return
     if s.type == StrategyType.NOISY_AND:
         _lower_noisy_and_strategy(fg, s, conc, strategy_id, strat_params, ctr)

--- a/gaia/ir/strategy.py
+++ b/gaia/ir/strategy.py
@@ -16,7 +16,7 @@ import math
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from gaia.ir.operator import Operator, OperatorType
 
@@ -191,24 +191,6 @@ def _validate_conditional_probabilities(strategy: Strategy) -> None:
     object.__setattr__(strategy, "conditional_probabilities", probabilities)
 
 
-def _validate_infer_priors(strategy: Strategy) -> None:
-    """Validate optional infer prior metadata for non-composite strategies."""
-    if strategy.type != StrategyType.INFER or strategy.__class__.__name__ == "CompositeStrategy":
-        return
-    if strategy.prior_hypothesis is not None:
-        object.__setattr__(
-            strategy,
-            "prior_hypothesis",
-            _probability(strategy.prior_hypothesis, "prior_hypothesis"),
-        )
-    if strategy.prior_evidence is not None:
-        object.__setattr__(
-            strategy,
-            "prior_evidence",
-            _probability(strategy.prior_evidence, "prior_evidence"),
-        )
-
-
 def _validate_associate_parameters(strategy: Strategy) -> None:
     """Validate pairwise association parameters for non-composite strategies."""
     if (
@@ -224,10 +206,6 @@ def _validate_associate_parameters(strategy: Strategy) -> None:
         raise ValueError("associate strategy requires p_a_given_b and p_b_given_a")
     object.__setattr__(strategy, "p_a_given_b", _probability(strategy.p_a_given_b, "p_a_given_b"))
     object.__setattr__(strategy, "p_b_given_a", _probability(strategy.p_b_given_a, "p_b_given_a"))
-    if strategy.prior_a is not None:
-        object.__setattr__(strategy, "prior_a", _probability(strategy.prior_a, "prior_a"))
-    if strategy.prior_b is not None:
-        object.__setattr__(strategy, "prior_b", _probability(strategy.prior_b, "prior_b"))
 
 
 class Strategy(BaseModel):
@@ -235,6 +213,8 @@ class Strategy(BaseModel):
 
     Can be instantiated directly for basic strategies (infer, noisy_and).
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     strategy_id: str | None = None
     scope: str  # "local"
@@ -248,12 +228,8 @@ class Strategy(BaseModel):
     # local layer
     steps: list[Step] | None = None  # reasoning process (local only, None at global)
     conditional_probabilities: list[float] | None = None  # infer/noisy_and CPT parameters
-    prior_hypothesis: float | None = None
-    prior_evidence: float | None = None
     p_a_given_b: float | None = None
     p_b_given_a: float | None = None
-    prior_a: float | None = None
-    prior_b: float | None = None
 
     # traceability
     metadata: dict[str, Any] | None = None
@@ -299,7 +275,6 @@ class Strategy(BaseModel):
         _validate_strategy_scope_and_id(self)
         _assign_strategy_id(self)
         _validate_conditional_probabilities(self)
-        _validate_infer_priors(self)
         _validate_associate_parameters(self)
         return self
 

--- a/gaia/lang/compiler/compile.py
+++ b/gaia/lang/compiler/compile.py
@@ -1177,8 +1177,6 @@ class _ActionCompiler:
                 p_e_given_not_h=p_e_given_not_h,
                 given_count=len(given_ids),
             ),
-            prior_hypothesis=action.prior_hypothesis,
-            prior_evidence=action.prior_evidence,
             metadata=metadata,
         )
         self._record_action_target(action_label, strategy.strategy_id)
@@ -1205,8 +1203,6 @@ class _ActionCompiler:
             steps=_action_steps(action.rationale),
             p_a_given_b=action.p_a_given_b,
             p_b_given_a=action.p_b_given_a,
-            prior_a=action.prior_a,
-            prior_b=action.prior_b,
             metadata=metadata,
         )
         self._record_action_target(action_label, strategy.strategy_id)

--- a/gaia/lang/dsl/associate_verb.py
+++ b/gaia/lang/dsl/associate_verb.py
@@ -18,8 +18,6 @@ def associate(
     *,
     p_a_given_b: float,
     p_b_given_a: float,
-    prior_a: float | None = None,
-    prior_b: float | None = None,
     background: list[Knowledge] | None = None,
     rationale: str = "",
     label: str | None = None,
@@ -42,8 +40,6 @@ def associate(
                 "b": b,
                 "p_a_given_b": p_a_given_b,
                 "p_b_given_a": p_b_given_a,
-                "prior_a": prior_a,
-                "prior_b": prior_b,
             },
         },
     )
@@ -55,8 +51,6 @@ def associate(
         b=b,
         p_a_given_b=p_a_given_b,
         p_b_given_a=p_b_given_a,
-        prior_a=prior_a,
-        prior_b=prior_b,
         helper=helper,
     )
     action.warrants.append(helper)

--- a/gaia/lang/dsl/infer_verb.py
+++ b/gaia/lang/dsl/infer_verb.py
@@ -80,8 +80,6 @@ def _infer_relation(
     given_tuple: tuple[Claim, ...],
     p_e_given_h: float | Claim | None,
     p_e_given_not_h: float | Claim | None,
-    prior_hypothesis: float | None,
-    prior_evidence: float | None,
 ) -> dict[str, Any]:
     relation: dict[str, Any] = {
         "type": "infer",
@@ -89,8 +87,6 @@ def _infer_relation(
         "evidence": evidence,
         "p_e_given_h": p_e_given_h,
         "p_e_given_not_h": p_e_given_not_h,
-        "prior_hypothesis": prior_hypothesis,
-        "prior_evidence": prior_evidence,
     }
     if given_tuple:
         relation["given"] = given_tuple
@@ -105,8 +101,6 @@ def infer(
     background: list[Knowledge] | None = None,
     p_e_given_h: float | Claim | None = None,
     p_e_given_not_h: float | Claim | None = 0.5,
-    prior_hypothesis: float | None = None,
-    prior_evidence: float | None = None,
     rationale: str = "",
     label: str | None = None,
     **legacy_kwargs: Any,
@@ -140,8 +134,6 @@ def infer(
         given_tuple=given_tuple,
         p_e_given_h=p_e_given_h,
         p_e_given_not_h=p_e_given_not_h,
-        prior_hypothesis=prior_hypothesis,
-        prior_evidence=prior_evidence,
     )
     helper = Claim(
         f"{_claim_ref(evidence)} statistically supports {_claim_ref(hypothesis)}.",
@@ -161,8 +153,6 @@ def infer(
         given=given_tuple,
         p_e_given_h=p_e_given_h,
         p_e_given_not_h=p_e_given_not_h,
-        prior_hypothesis=prior_hypothesis,
-        prior_evidence=prior_evidence,
         helper=helper,
     )
     action.warrants.append(helper)

--- a/gaia/lang/runtime/action.py
+++ b/gaia/lang/runtime/action.py
@@ -142,8 +142,6 @@ class Infer(Probabilistic):
     given: tuple[Claim, ...] = ()
     p_e_given_h: float | Claim = 0.5
     p_e_given_not_h: float | Claim | None = 0.5
-    prior_hypothesis: float | None = None
-    prior_evidence: float | None = None
 
 
 @dataclass
@@ -154,8 +152,6 @@ class Associate(Probabilistic):
     b: Claim | None = None
     p_a_given_b: float = 0.5
     p_b_given_a: float = 0.5
-    prior_a: float | None = None
-    prior_b: float | None = None
 
 
 @dataclass

--- a/tests/gaia/lang/test_compiler_actions.py
+++ b/tests/gaia/lang/test_compiler_actions.py
@@ -166,8 +166,6 @@ def test_compile_infer_action_to_strategy_cpt():
             background=[bg],
             p_e_given_h=0.8,
             p_e_given_not_h=0.2,
-            prior_hypothesis=0.4,
-            prior_evidence=0.3,
             rationale="Bayes.",
             label="bayes_update",
         )
@@ -185,8 +183,6 @@ def test_compile_infer_action_to_strategy_cpt():
     assert strategy.metadata["action_label"] == "github:v6_actions::action::bayes_update"
     assert strategy.steps[0].reasoning == "Bayes."
     assert strategy.conditional_probabilities == [0.2, 0.8]
-    assert strategy.prior_hypothesis == 0.4
-    assert strategy.prior_evidence == 0.3
     assert not hasattr(compiled, "strategy_param_records")
 
     stat_support = _knowledge_by_label(compiled)["likelihood_helper"]
@@ -198,8 +194,6 @@ def test_compile_infer_action_to_strategy_cpt():
         "evidence": "github:v6_actions::e",
         "p_e_given_h": 0.8,
         "p_e_given_not_h": 0.2,
-        "prior_hypothesis": 0.4,
-        "prior_evidence": 0.3,
     }
 
 
@@ -283,8 +277,6 @@ def test_compile_associate_action_to_association_strategy():
             b,
             p_a_given_b=0.75,
             p_b_given_a=0.20,
-            prior_a=0.25,
-            prior_b=1 / 15,
             rationale="Observed cohort association.",
             label="assoc_ab",
         )
@@ -295,8 +287,6 @@ def test_compile_associate_action_to_association_strategy():
             "b": b,
             "p_a_given_b": 0.75,
             "p_b_given_a": 0.20,
-            "prior_a": 0.25,
-            "prior_b": 1 / 15,
         }
 
     compiled = compile_package_artifact(pkg)
@@ -306,8 +296,6 @@ def test_compile_associate_action_to_association_strategy():
     assert strategy.conclusion == "github:v6_actions::association_helper"
     assert strategy.p_a_given_b == 0.75
     assert strategy.p_b_given_a == 0.20
-    assert strategy.prior_a == 0.25
-    assert strategy.prior_b == 1 / 15
     assert strategy.metadata["action_label"] == "github:v6_actions::action::assoc_ab"
     assert strategy.metadata["pattern"] == "association"
 
@@ -320,9 +308,30 @@ def test_compile_associate_action_to_association_strategy():
         "b": "github:v6_actions::b",
         "p_a_given_b": 0.75,
         "p_b_given_a": 0.20,
-        "prior_a": 0.25,
-        "prior_b": 1 / 15,
     }
+
+
+def test_associate_rejects_inline_prior_keywords():
+    a = Claim("A.", prior=0.25)
+    b = Claim("B.", prior=1 / 15)
+
+    with pytest.raises(TypeError, match="prior_a"):
+        associate(
+            a,
+            b,
+            p_a_given_b=0.75,
+            p_b_given_a=0.20,
+            prior_a=0.25,
+        )
+
+    with pytest.raises(TypeError, match="prior_b"):
+        associate(
+            a,
+            b,
+            p_a_given_b=0.75,
+            p_b_given_a=0.20,
+            prior_b=1 / 15,
+        )
 
 
 def test_compile_depends_on_action_to_formalization_manifest_only():

--- a/tests/gaia/lang/test_composition.py
+++ b/tests/gaia/lang/test_composition.py
@@ -135,8 +135,6 @@ def test_compose_keeps_own_background_and_warrants_separate_from_child_warrants(
                 right,
                 p_a_given_b=0.75,
                 p_b_given_a=0.25,
-                prior_a=0.5,
-                prior_b=1 / 6,
                 label="assoc_ab",
             )
 

--- a/tests/gaia/lang/test_infer.py
+++ b/tests/gaia/lang/test_infer.py
@@ -17,8 +17,6 @@ def test_infer_returns_evidence_and_keeps_likelihood_warrant_on_action():
             hypothesis=h,
             p_e_given_h=0.9,
             p_e_given_not_h=0.05,
-            prior_hypothesis=0.4,
-            prior_evidence=0.3,
             rationale="Strong evidence.",
         )
 
@@ -26,8 +24,6 @@ def test_infer_returns_evidence_and_keeps_likelihood_warrant_on_action():
     assert result is e
     assert action.evidence is e
     assert action.hypothesis is h
-    assert action.prior_hypothesis == 0.4
-    assert action.prior_evidence == 0.3
     assert action in e.from_actions
     assert action.helper is not None
     assert action.helper is not e
@@ -40,10 +36,29 @@ def test_infer_returns_evidence_and_keeps_likelihood_warrant_on_action():
         "evidence": e,
         "p_e_given_h": 0.9,
         "p_e_given_not_h": 0.05,
-        "prior_hypothesis": 0.4,
-        "prior_evidence": 0.3,
     }
     assert action.warrants == [action.helper]
+
+
+def test_infer_rejects_inline_prior_keywords():
+    h = Claim("H.")
+    e = Claim("E.")
+
+    with pytest.raises(TypeError, match="prior_hypothesis"):
+        infer(
+            e,
+            hypothesis=h,
+            p_e_given_h=0.9,
+            prior_hypothesis=0.4,
+        )
+
+    with pytest.raises(TypeError, match="prior_evidence"):
+        infer(
+            e,
+            hypothesis=h,
+            p_e_given_h=0.9,
+            prior_evidence=0.3,
+        )
 
 
 def test_infer_returns_evidence_claim_and_defaults_not_h_to_neutral():

--- a/tests/ir/test_strategy.py
+++ b/tests/ir/test_strategy.py
@@ -116,13 +116,9 @@ class TestStrategyCreation:
             premises=["github:test::h"],
             conclusion="github:test::e",
             conditional_probabilities=[0.0, 1.0],
-            prior_hypothesis=0.0,
-            prior_evidence=1.0,
         )
 
         assert s.conditional_probabilities == [0.0, 1.0]
-        assert s.prior_hypothesis == 0.0
-        assert s.prior_evidence == 1.0
 
     def test_infer_rejects_out_of_range_author_probability(self):
         with pytest.raises(ValueError, match="conditional_probabilities"):
@@ -134,6 +130,7 @@ class TestStrategyCreation:
                 conditional_probabilities=[-0.1, 0.8],
             )
 
+    def test_infer_rejects_inline_prior_fields(self):
         with pytest.raises(ValueError, match="prior_hypothesis"):
             Strategy(
                 scope="local",
@@ -141,7 +138,7 @@ class TestStrategyCreation:
                 premises=["github:test::h"],
                 conclusion="github:test::e",
                 conditional_probabilities=[0.2, 0.8],
-                prior_hypothesis=1.2,
+                prior_hypothesis=0.5,
             )
 
     def test_associate_preserves_author_probability_bounds(self):
@@ -152,14 +149,10 @@ class TestStrategyCreation:
             conclusion="github:test::assoc",
             p_a_given_b=1.0,
             p_b_given_a=0.0,
-            prior_a=0.0,
-            prior_b=1.0,
         )
 
         assert s.p_a_given_b == 1.0
         assert s.p_b_given_a == 0.0
-        assert s.prior_a == 0.0
-        assert s.prior_b == 1.0
 
     def test_associate_rejects_out_of_range_author_probability(self):
         with pytest.raises(ValueError, match="p_a_given_b"):
@@ -172,6 +165,7 @@ class TestStrategyCreation:
                 p_b_given_a=0.5,
             )
 
+    def test_associate_rejects_inline_prior_fields(self):
         with pytest.raises(ValueError, match="prior_b"):
             Strategy(
                 scope="local",
@@ -180,7 +174,7 @@ class TestStrategyCreation:
                 conclusion="github:test::assoc",
                 p_a_given_b=0.5,
                 p_b_given_a=0.5,
-                prior_b=-0.1,
+                prior_b=0.5,
             )
 
     def test_invalid_scope_rejected(self):

--- a/tests/test_lowering.py
+++ b/tests/test_lowering.py
@@ -106,7 +106,7 @@ def test_associate_lowers_to_pairwise_potential_without_double_counting_marginal
     helper = "github:lowertest::assoc"
     g = _lg(
         knowledges=[
-            Knowledge(id=a, type="claim", content="A"),
+            Knowledge(id=a, type="claim", content="A", metadata={"prior": 0.25}),
             Knowledge(id=b, type="claim", content="B"),
             Knowledge(id=helper, type="claim", content="A is associated with B"),
         ],
@@ -118,7 +118,6 @@ def test_associate_lowers_to_pairwise_potential_without_double_counting_marginal
                 conclusion=helper,
                 p_a_given_b=0.75,
                 p_b_given_a=0.20,
-                prior_a=0.25,
             )
         ],
     )
@@ -159,8 +158,8 @@ def test_associate_lowering_rejects_bayes_inconsistent_marginals():
     helper = "github:lowertest::assoc"
     g = _lg(
         knowledges=[
-            Knowledge(id=a, type="claim", content="A"),
-            Knowledge(id=b, type="claim", content="B"),
+            Knowledge(id=a, type="claim", content="A", metadata={"prior": 0.25}),
+            Knowledge(id=b, type="claim", content="B", metadata={"prior": 0.50}),
             Knowledge(id=helper, type="claim", content="A is associated with B"),
         ],
         strategies=[
@@ -171,8 +170,6 @@ def test_associate_lowering_rejects_bayes_inconsistent_marginals():
                 conclusion=helper,
                 p_a_given_b=0.75,
                 p_b_given_a=0.20,
-                prior_a=0.25,
-                prior_b=0.50,
             )
         ],
     )
@@ -181,13 +178,13 @@ def test_associate_lowering_rejects_bayes_inconsistent_marginals():
         lower_local_graph(g)
 
 
-def test_infer_inline_priors_lower_as_unary_providers():
+def test_infer_claim_metadata_priors_lower_as_unary_providers():
     h = "github:lowertest::h"
     e = "github:lowertest::e"
     g = _lg(
         knowledges=[
-            Knowledge(id=h, type="claim", content="H"),
-            Knowledge(id=e, type="claim", content="E"),
+            Knowledge(id=h, type="claim", content="H", metadata={"prior": 0.25}),
+            Knowledge(id=e, type="claim", content="E", metadata={"prior": 0.1}),
         ],
         strategies=[
             Strategy(
@@ -196,8 +193,6 @@ def test_infer_inline_priors_lower_as_unary_providers():
                 premises=[h],
                 conclusion=e,
                 conditional_probabilities=[0.2, 0.8],
-                prior_hypothesis=0.25,
-                prior_evidence=0.1,
             )
         ],
     )
@@ -206,30 +201,6 @@ def test_infer_inline_priors_lower_as_unary_providers():
 
     assert fg.unary_factors[h] == pytest.approx(0.25)
     assert fg.unary_factors[e] == pytest.approx(0.1)
-
-
-def test_infer_inline_prior_conflicts_with_existing_prior():
-    h = "github:lowertest::h"
-    e = "github:lowertest::e"
-    g = _lg(
-        knowledges=[
-            Knowledge(id=h, type="claim", content="H", metadata={"prior": 0.6}),
-            Knowledge(id=e, type="claim", content="E"),
-        ],
-        strategies=[
-            Strategy(
-                scope="local",
-                type="infer",
-                premises=[h],
-                conclusion=e,
-                conditional_probabilities=[0.2, 0.8],
-                prior_hypothesis=0.25,
-            )
-        ],
-    )
-
-    with pytest.raises(ValueError, match="conflicting prior providers"):
-        lower_local_graph(g)
 
 
 def test_infer_given_switch_cpt_is_neutral_when_gate_unlikely():

--- a/tests/test_mendel_v05_example.py
+++ b/tests/test_mendel_v05_example.py
@@ -74,6 +74,7 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     strategy_types = {item["type"] for item in ir["strategies"]}
     association = knowledge_by_label["mendel_count_association"]
     count_observation = knowledge_by_label["f2_count_observation"]
+    count_specific = knowledge_by_label["f2_dominant_count_specific"]
 
     # The package uses a single associate (Mendel ↔ count) and three qualitative
     # contradict edges against blending. It declares no `infer` strategy of its own.
@@ -105,9 +106,8 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     ):
         assert label in knowledge_by_label, f"missing knowledge {label}"
 
-    # The Mendel↔count associate uses the pointwise binomial PMF on one side and
-    # the Bayes-consistent posterior on the other. All four numbers are fully
-    # determined by ``MENDELIAN_DOMINANT_PROBABILITY`` and a uniform prior on p.
+    # The Mendel↔count associate stores only the conditional link parameters.
+    # Node priors live in the priors layer instead of on the associate call.
     assert association["metadata"]["helper_kind"] == "association"
     assert association["metadata"]["relation"]["p_a_given_b"] == pytest.approx(
         association_parameters.p_mendelian_given_count
@@ -115,12 +115,10 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     assert association["metadata"]["relation"]["p_b_given_a"] == pytest.approx(
         association_parameters.p_count_given_mendelian
     )
-    assert association["metadata"]["relation"]["prior_a"] == pytest.approx(
-        association_parameters.prior_mendelian
-    )
-    assert association["metadata"]["relation"]["prior_b"] == pytest.approx(
-        association_parameters.prior_count
-    )
+    assert "prior_a" not in association["metadata"]["relation"]
+    assert "prior_b" not in association["metadata"]["relation"]
+    assert count_observation["metadata"]["prior"] == pytest.approx(0.95)
+    assert count_specific["metadata"]["prior"] == pytest.approx(association_parameters.prior_count)
 
     # The diffuse alternative has the closed-form marginal 1/(N+1).
     assert association_parameters.p_count_given_diffuse == pytest.approx(1.0 / (295 + 100 + 1))
@@ -157,6 +155,6 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     assert beliefs["mendelian_segregation_model"] > 0.8
     assert beliefs["blending_inheritance_model"] < 0.2
     assert beliefs["mendelian_segregation_model"] > beliefs["blending_inheritance_model"]
-    # The count observation's belief is driven upward by the associate and by
-    # the prior we placed on it.
-    assert beliefs["f2_count_observation"] > association_parameters.prior_count
+    # The specific count event is the marginal provider for the associate; the
+    # observation itself keeps its independent reliability prior.
+    assert beliefs["f2_dominant_count_specific"] > association_parameters.prior_count


### PR DESCRIPTION
## Summary

- Remove inline prior/marginal parameters from `infer(...)` and `associate(...)` across runtime actions, DSL metadata, IR strategies, compiler lowering, and BP lowering.
- Make old inline-prior fields fail explicitly at the DSL/IR boundary instead of silently becoming marginal providers.
- Update Mendel v0.5 example and docs so probabilistic actions provide soft constraints while priors/marginals resolve through the prior layer or Bayes workflows.

## Validation

- `python -m pytest --no-cov tests`
- `python -m ruff check gaia/lang/runtime/action.py gaia/lang/dsl/infer_verb.py gaia/lang/dsl/associate_verb.py gaia/lang/compiler/compile.py gaia/ir/strategy.py gaia/bp/lowering.py tests/gaia/lang/test_infer.py tests/gaia/lang/test_compiler_actions.py tests/ir/test_strategy.py tests/test_lowering.py tests/gaia/lang/test_composition.py tests/test_mendel_v05_example.py examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py`
- `python -m ruff format --check gaia/lang/runtime/action.py gaia/lang/dsl/infer_verb.py gaia/lang/dsl/associate_verb.py gaia/lang/compiler/compile.py gaia/ir/strategy.py gaia/bp/lowering.py tests/gaia/lang/test_infer.py tests/gaia/lang/test_compiler_actions.py tests/ir/test_strategy.py tests/test_lowering.py tests/gaia/lang/test_composition.py tests/test_mendel_v05_example.py examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py`
- `git diff --check`