### PR TITLE
ci(codecov): drop project gate already enforced by pytest

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,5 @@
 coverage:
   status:
-    project:
-      default:
-        # CI already enforces --cov-fail-under=90; keep Codecov aligned.
-        target: 90%
-        threshold: 0%
     patch:
       default:
         target: 80%


### PR DESCRIPTION
## Summary

- `pytest --cov-fail-under=90` is set in `pyproject.toml` `[tool.pytest.ini_options].addopts` and already fails CI when total `gaia/` coverage drops below 90%.
- Coverage scope covers the full `gaia/` tree: no `[tool.coverage.run] omit`, no `.coveragerc`/`setup.cfg`/`tox.ini`, only 4 `pragma: no cover` (all defensive `except` branches) and the standard `if TYPE_CHECKING:` idiom in 11 modules.
- Codecov's `project: target 90%, threshold 0%` rule duplicated the same project-aggregate check. Dropping it.
- Keeping `patch: 80%`, which pytest cannot enforce — `--cov-fail-under` is project-aggregate only and cannot gate per-PR new-line coverage.

After this change: pytest owns the project floor (90% aggregate over `gaia/`); codecov owns the patch floor (80% on new lines per PR). Each side has exactly one job.

## Test plan

- [x] Pre-push gate green locally (ruff full select + format check + mypy --strict + `pytest --cov-report=xml tests -v -m "not integration_api"`).
- [ ] CI re-runs the same suite on this branch.
- [ ] Codecov reports only the `patch` status on this PR after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)