### PR TITLE
[codex] Add BetaBinomial Bayes distribution

### DIFF
--- a/docs/foundations/gaia-lang/bayes.md
+++ b/docs/foundations/gaia-lang/bayes.md
@@ -62,9 +62,9 @@ Bayes models are authored through `bayes.model(...)`. There is no
 v0.5; use `derive(...)` for ordinary support steps and `bayes.model(...)` when
 declaring a predictive distribution for a hypothesis.
 
-The v1 distribution set is:
+The v1 hypothesis-comparison distribution set is:
 
-- `Binomial`, `Poisson`
+- `Binomial`, `BetaBinomial`, `Poisson`
 - `Normal`, `Beta`, `Exponential`, `LogNormal`, `StudentT`, `Cauchy`, `Gamma`,
   `ChiSquared`
 
@@ -72,6 +72,13 @@ Each distribution delegates numeric evaluation to `scipy.stats`. Parameters may
 be concrete numbers or `Variable` objects (PR #505). Deferred variable parameters
 are resolved by the compiler from hypothesis formulas; their serialized
 descriptors are audit metadata, not identity keys.
+
+`BetaBinomial(n, alpha, beta)` delegates to `scipy.stats.betabinom`. It is the
+minimal wrapper for a common model-comparison pattern: integrate
+`Binomial(n, p)` over `p ~ Beta(alpha, beta)` instead of hand-writing a
+precomputed likelihood. The Mendel example package uses
+`BetaBinomial(n=395, alpha=1, beta=1)` for the diffuse `p ~ Uniform[0, 1]`
+alternative, where every exact count has marginal likelihood `1 / (n + 1)`.
 
 ## Verbs at a Glance
 
@@ -494,6 +501,9 @@ non-fatal — packages compile successfully.
 
 ### Source code
 
+- `gaia/lang/bayes/distributions/` — hypothesis-comparison distribution
+  literals (`Binomial`, `BetaBinomial`, `Poisson`, continuous families) backed
+  by `scipy.stats`
 - `gaia/lang/runtime/distribution.py` — Distribution Knowledge wrapper
   + family factories (`Normal`, `LogNormal`, `Beta`, `Gamma`, `Exponential`,
   `StudentT`, `Cauchy`, `ChiSquared`, `Binomial`, `Poisson`)

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/__init__.py
@@ -10,56 +10,25 @@ Two theories compete for the same single-factor cross:
 * ``blending_inheritance_model`` — continuous averaging of parental traits;
   denies that discrete dominant/recessive classes exist in F2 at all.
 
-These two theories differ in **kind**, and that difference is reflected in
-how they engage with the data:
+The quantitative count comparison is expressed through ``gaia.lang.bayes``:
 
-* Mendel participates **probabilistically**: it is a generative model and
-  therefore engages with the observed F2 count through a single ``associate``
-  that uses the pointwise binomial PMF as its likelihood.
-* Blending participates **categorically**: it denies the very framework in
-  which one would count dominant vs. recessive individuals, so its conflicts
-  with the data are expressed through ``contradict`` edges at the qualitative
-  framework level, not through a binomial likelihood it cannot produce.
+* Mendel is represented by ``bayes.Binomial(n=395, p=3/4)``.
+* The diffuse alternative is represented by
+  ``bayes.BetaBinomial(n=395, alpha=1, beta=1)``, which is the predictive
+  distribution obtained by integrating ``Binomial(n, p)`` over
+  ``p ~ Uniform[0, 1]``.
 
-Every probability in this package is traceable to two well-defined settings:
-``MENDELIAN_DOMINANT_PROBABILITY = 3/4`` and a uniform prior ``p ~ U[0, 1]``
-as the diffuse alternative (see ``probabilities.py``).
-
-Why an intermediate ``f2_dominant_count_specific`` node exists
---------------------------------------------------------------
-
-Semantically the ``associate`` below should relate ``mendelian_segregation_model``
-directly to ``f2_count_observation``. In v0.5 that triggers a framework-level
-collision: ``metadata.prior`` on a Claim is asked to encode two genuinely
-different quantities at once —
-
-* the **reliability / subjective prior** of the observation (0.95, meaning "I
-  trust Mendel's record"), supplied via the ``PRIORS`` dict;
-* the **Bayesian marginal** ``P(count) = Σ_H P(count | H) P(H)`` of the count
-  event (≈ 0.024 for the 295/395 outcome under the {Mendel, diffuse}
-  mixture), supplied through the ``PRIORS`` entry for a separate count-event
-  claim.
-
-These are two different concepts living on the same field, so the inference
-engine sees them as "conflicting marginal providers" and refuses to compile.
-
-As a workaround this package introduces ``f2_dominant_count_specific`` — a
-plain ``derive`` node that carries only the specific numerical event and is
-entered into ``PRIORS`` with the Bayes marginal — and routes the ``associate``
-through it.
-This leaves the observation's ``reliability`` prior untouched on
-``f2_count_observation`` and lets the Bayesian marginal live cleanly on the
-derived node. This is a v0.5 compatibility workaround, not the long-term
-authoring pattern for model-derived marginals; new structured model-data
-comparisons should use ``gaia.lang.bayes``. No other semantic is introduced by
-this node. See issue #485 for the design discussion.
+The observed count remains a normal observation with a reliability prior. The
+Bayes likelihood values are attached as structured metadata by the Bayes
+lowering pass, not placed in the observation's content or hidden behind an
+intermediate count-event claim.
 """
 
 from gaia.lang import (
     Constant,
     Nat,
     Variable,
-    associate,
+    bayes,
     claim,
     contradict,
     derive,
@@ -73,12 +42,10 @@ from gaia.lang import (
 
 from .probabilities import (
     DOMINANT_COUNT,
+    MENDELIAN_DOMINANT_PROBABILITY,
     RECESSIVE_COUNT,
     TOTAL_COUNT,
-    mendel_count_association_parameters,
 )
-
-association_parameters = mendel_count_association_parameters()
 
 f2_total_count = Variable(symbol="n_f2", domain=Nat, value=TOTAL_COUNT)
 f2_dominant_count = Variable(symbol="k_dominant", domain=Nat, value=DOMINANT_COUNT)
@@ -226,53 +193,56 @@ mendel_predicts_three_to_one_ratio = derive(
 )
 
 # -----------------------------------------------------------------------------
-# A single derived data event carrying the specific count for the probabilistic
-# comparison. This is deliberately NOT a tolerance window around the observed
-# ratio; it is just the specific observed value, reified as a proposition.
-#
-# The node exists only to carry the Bayesian marginal ``P(count = 295/395)``
-# on a separate Claim from ``f2_count_observation``, which already carries the
-# reliability prior 0.95 via ``PRIORS``. See the module docstring above, and
-# issue #485, for the underlying framework design (``metadata.prior`` doing
-# double duty as both "reliability" and "marginal"). New structured
-# model-derived marginals should move to ``gaia.lang.bayes`` rather than using
-# this workaround.
+# Quantitative count comparison via gaia.lang.bayes
 # -----------------------------------------------------------------------------
 
-f2_dominant_count_specific = derive(
-    f"F2 显性表型计数的具体数值为 {DOMINANT_COUNT} / {DOMINANT_COUNT + RECESSIVE_COUNT}。",
-    given=f2_count_observation,
-    background=[monohybrid_cross_setup, finite_sample_background],
-    rationale="把定性观测中的具体计数提取为一个命题，作为 Mendel 与数据进行"
-    "概率比较时使用的数据事件；这里也起到把 Bayes 边际和观测可靠性两个概念"
-    "分开存放在两个不同 Claim 上的作用，规避 v0.5 framework 中 metadata.prior"
-    "的一号多用。",
-    label="f2_dominant_count_specific",
+mendel_count_model = bayes.model(
+    mendelian_segregation_model,
+    observable=f2_dominant_count,
+    distribution=bayes.Binomial(
+        n=TOTAL_COUNT,
+        p=MENDELIAN_DOMINANT_PROBABILITY,
+    ),
+    background=[monohybrid_cross_setup, dominance_background, finite_sample_background],
+    rationale=(
+        "孟德尔分离模型给出 F2 每个个体以概率 3/4 表现显性的生成模型，"
+        "因此显性计数服从 Binomial(N, 3/4)。"
+    ),
+    label="mendel_count_model",
 )
 
-# -----------------------------------------------------------------------------
-# Mendel: the one quantitative link — associate(model, count) via pointwise PMF
-# -----------------------------------------------------------------------------
-
-mendel_count_association = associate(
-    mendelian_segregation_model,
-    f2_dominant_count_specific,
-    background=[monohybrid_cross_setup, finite_sample_background],
-    p_a_given_b=association_parameters.p_mendelian_given_count,
-    p_b_given_a=association_parameters.p_count_given_mendelian,
-    rationale=(
-        "用在观测计数处的点似然 Binomial(N, 3/4).pmf(295) 作为 p(count | Mendel)；"
-        "对照项用 p ~ Uniform[0, 1] 的 diffuse 先验，其任意单点计数的边际概率"
-        "为解析解 1 / (N + 1)。这样所有参数都来自两个明确的假设，"
-        "既没有 tolerance 窗口，也没有人为指定的替代二项参数。"
+diffuse_count_model = bayes.model(
+    blending_inheritance_model,
+    observable=f2_dominant_count,
+    distribution=bayes.BetaBinomial(
+        n=TOTAL_COUNT,
+        alpha=1.0,
+        beta=1.0,
     ),
-    label="mendel_count_association",
+    background=[monohybrid_cross_setup, finite_sample_background],
+    rationale=(
+        "把对照项写成 p ~ Uniform[0, 1] 下的 BetaBinomial(N, 1, 1) 预测分布；"
+        "它给出任意具体计数的边际概率 1 / (N + 1)，不人为指定第二个二项参数。"
+    ),
+    label="diffuse_count_model",
+)
+
+mendel_count_likelihood = bayes.likelihood(
+    f2_count_observation,
+    model=mendel_count_model,
+    against=[diffuse_count_model],
+    background=[monohybrid_cross_setup, finite_sample_background],
+    rationale=(
+        "直接比较观测到的 F2 显性计数在 Mendel 点模型和 diffuse 参考模型下的"
+        "log likelihood；观测可靠性仍留在 f2_count_observation 的 prior 中。"
+    ),
+    exclusivity="none",
+    label="mendel_count_likelihood",
 )
 
 # -----------------------------------------------------------------------------
 # Blending: three qualitative predictions, each clashing with a qualitative
-# observation via contradict. Blending does NOT participate in associate, by
-# design: it is not a generative model for the dominant/recessive count.
+# observation via contradict.
 # -----------------------------------------------------------------------------
 
 blending_predicts_intermediate_f1 = derive(
@@ -333,18 +303,19 @@ __all__ = [
     "blending_predicts_intermediate_f1",
     "blending_predicts_no_recessive_reappearance",
     "competing_models",
+    "diffuse_count_model",
     "f1_blending_conflict",
     "f1_mendel_match",
     "f1_uniform_dominant_observation",
     "f2_count_observation",
     "f2_discrete_classes_blending_conflict",
     "f2_discrete_classes_mendel_match",
-    "f2_dominant_count_specific",
     "f2_has_discrete_classes_observation",
     "f2_reappearance_blending_conflict",
     "f2_reappearance_mendel_match",
     "f2_recessive_reappears_observation",
-    "mendel_count_association",
+    "mendel_count_likelihood",
+    "mendel_count_model",
     "mendel_predicts_discrete_classes",
     "mendel_predicts_f1_dominance",
     "mendel_predicts_recessive_reappearance",

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/priors.py
@@ -13,15 +13,11 @@ from mendel_v0_5 import (
     blending_inheritance_model,
     f1_uniform_dominant_observation,
     f2_count_observation,
-    f2_dominant_count_specific,
     f2_has_discrete_classes_observation,
     f2_recessive_reappears_observation,
-    mendel_count_association_parameters,
     mendelian_segregation_model,
 )
 from mendel_v0_5.probabilities import PRIOR_MENDELIAN_MODEL
-
-association_parameters = mendel_count_association_parameters()
 
 register_prior(
     mendelian_segregation_model,
@@ -52,12 +48,4 @@ register_prior(
     f2_count_observation,
     value=0.95,
     justification="把 F2 显性/隐性计数作为可靠的实验观察。",
-)
-register_prior(
-    f2_dominant_count_specific,
-    value=association_parameters.prior_count,
-    justification=(
-        "把具体计数事件在 {Mendel, diffuse} 混合模型下的 Bayes 边际作为"
-        "该中间命题的 prior；它不是观测报告可靠性。"
-    ),
 )

--- a/examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py
+++ b/examples/mendel-v0-5-gaia/src/mendel_v0_5/probabilities.py
@@ -12,8 +12,8 @@ The statistical comparison is between two clearly identified alternatives:
 Every number produced by this module is therefore traceable to ``MENDELIAN_P``
 and the uniform-over-``p`` reference measure. There is no tolerance window,
 no post-hoc ratio band, and no strawman binomial with an arbitrary second
-``p``. The likelihood handed to ``associate`` is the pointwise binomial PMF
-evaluated at the observed count.
+``p``. The point hypothesis is represented by ``bayes.Binomial`` and the
+diffuse alternative by ``bayes.BetaBinomial(n, 1, 1)`` in the example package.
 """
 
 from __future__ import annotations
@@ -29,8 +29,8 @@ MENDELIAN_DOMINANT_PROBABILITY = 3 / 4
 PRIOR_MENDELIAN_MODEL = 0.5
 
 
-class MendelCountAssociation(NamedTuple):
-    """Bayesian association parameters for Mendel's dominant-count observation."""
+class MendelCountLikelihood(NamedTuple):
+    """Bayesian likelihood parameters for Mendel's dominant-count observation."""
 
     p_count_given_mendelian: float
     p_count_given_diffuse: float
@@ -54,8 +54,8 @@ def diffuse_count_marginal(*, n: int) -> float:
     return 1.0 / (n + 1)
 
 
-def mendel_count_association_parameters() -> MendelCountAssociation:
-    """Compute Bayes-consistent ``associate`` parameters for the Mendel ↔ count relation.
+def mendel_count_likelihood_parameters() -> MendelCountLikelihood:
+    """Compute reference likelihoods for the Mendel count comparison.
 
     The posterior is formed by marginalising over the Mendelian point hypothesis
     and the diffuse alternative:
@@ -75,7 +75,7 @@ def mendel_count_association_parameters() -> MendelCountAssociation:
     )
     p_mendelian_given_count = PRIOR_MENDELIAN_MODEL * p_count_given_mendelian / prior_count
 
-    return MendelCountAssociation(
+    return MendelCountLikelihood(
         p_count_given_mendelian=p_count_given_mendelian,
         p_count_given_diffuse=p_count_given_diffuse,
         prior_mendelian=PRIOR_MENDELIAN_MODEL,

--- a/gaia/lang/bayes/__init__.py
+++ b/gaia/lang/bayes/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from gaia.lang.bayes.distributions import (
     Beta,
+    BetaBinomial,
     Binomial,
     Cauchy,
     ChiSquared,
@@ -49,6 +50,7 @@ _register_bayes_roles()
 
 __all__ = [
     "Beta",
+    "BetaBinomial",
     "Binomial",
     "Cauchy",
     "ChiSquared",

--- a/gaia/lang/bayes/adapters/scipy_backend.py
+++ b/gaia/lang/bayes/adapters/scipy_backend.py
@@ -10,6 +10,7 @@ import scipy.stats as stats
 
 _BUILDERS: dict[str, Callable[[dict[str, float]], Any]] = {
     "beta": lambda p: stats.beta(a=p["alpha"], b=p["beta"]),
+    "betabinomial": lambda p: stats.betabinom(n=int(p["n"]), a=p["alpha"], b=p["beta"]),
     "binomial": lambda p: stats.binom(n=int(p["n"]), p=p["p"]),
     "cauchy": lambda p: stats.cauchy(loc=p["mu"], scale=p["gamma"]),
     "chisquared": lambda p: stats.chi2(df=p["df"]),

--- a/gaia/lang/bayes/compiler/lower.py
+++ b/gaia/lang/bayes/compiler/lower.py
@@ -350,7 +350,7 @@ def _log_likelihood(distribution: Any, value: Any, data_claim: Claim) -> float:
     noise_payload = ((data_claim.metadata or {}).get("bayes") or {}).get("noise")
     if noise_payload:
         return _log_likelihood_with_noise(distribution, value, noise_payload)
-    if distribution.kind in {"binomial", "poisson"}:
+    if distribution.kind in {"betabinomial", "binomial", "poisson"}:
         return float(distribution.logpmf(value))
     return float(distribution.logpdf(float(value)))
 
@@ -364,7 +364,7 @@ def _log_likelihood_with_noise(
 
     noise = Normal(**noise_payload.get("params", {}))
     low, high = distribution.support()
-    if distribution.kind in {"binomial", "poisson"}:
+    if distribution.kind in {"betabinomial", "binomial", "poisson"}:
         if not math.isfinite(high):
             high = max(int(value + 10 * noise.params["sigma"]), int(value) + 50)
         terms = []

--- a/gaia/lang/bayes/distributions/__init__.py
+++ b/gaia/lang/bayes/distributions/__init__.py
@@ -12,7 +12,7 @@ from gaia.lang.bayes.distributions.continuous import (
     Normal,
     StudentT,
 )
-from gaia.lang.bayes.distributions.discrete import Binomial, Poisson
+from gaia.lang.bayes.distributions.discrete import BetaBinomial, Binomial, Poisson
 from gaia.lang.bayes.distributions.protocol import (
     DistParam,
     Distribution,
@@ -21,6 +21,7 @@ from gaia.lang.bayes.distributions.protocol import (
 
 __all__ = [
     "Beta",
+    "BetaBinomial",
     "Binomial",
     "Cauchy",
     "ChiSquared",

--- a/gaia/lang/bayes/distributions/discrete.py
+++ b/gaia/lang/bayes/distributions/discrete.py
@@ -54,6 +54,50 @@ class Binomial(_BaseDistribution):
         return (0, int(resolved["n"]))
 
 
+class BetaBinomial(_BaseDistribution):
+    """Beta-binomial distribution literal for integer success counts."""
+
+    kind: str = "betabinomial"
+
+    def __init__(self, *, n: Any, alpha: Any, beta: Any) -> None:
+        """Create a BetaBinomial distribution literal."""
+        super().__init__(kind="betabinomial", params={"n": n, "alpha": alpha, "beta": beta})
+
+    @model_validator(mode="after")
+    def _validate_betabinomial(self) -> BetaBinomial:
+        n = self.params["n"]
+        if _is_concrete_number(n):
+            if isinstance(n, float) and not n.is_integer():
+                raise ValueError(f"BetaBinomial n must be an integer, got {n!r}")
+            if int(n) < 0:
+                raise ValueError(f"BetaBinomial n must be >= 0, got {n!r}")
+        for name in ("alpha", "beta"):
+            value = self.params[name]
+            if _is_concrete_number(value) and float(value) <= 0.0:
+                raise ValueError(f"BetaBinomial {name} must be > 0, got {value!r}")
+        return self
+
+    def logpmf(self, k: int) -> float:
+        """Evaluate the log probability mass at integer count ``k``."""
+        if not isinstance(k, int) or isinstance(k, bool):
+            raise TypeError(f"BetaBinomial.logpmf(k): k must be integer, got {type(k).__name__}")
+        resolved = self._resolved_params()
+        n = int(resolved["n"])
+        if k < 0 or k > n:
+            return -math.inf
+        return float(_to_scipy_dist(self.kind, resolved).logpmf(k))
+
+    def logpdf(self, x: float) -> float:
+        """Reject density evaluation for the discrete BetaBinomial distribution."""
+        del x
+        raise TypeError("BetaBinomial is a discrete distribution; use .logpmf()")
+
+    def support(self) -> tuple[int, int]:
+        """Return the inclusive integer support bounds."""
+        resolved = self._resolved_params()
+        return (0, int(resolved["n"]))
+
+
 class Poisson(_BaseDistribution):
     """Poisson distribution literal for non-negative integer counts."""
 

--- a/gaia/lang/bayes/distributions/discrete.py
+++ b/gaia/lang/bayes/distributions/discrete.py
@@ -55,7 +55,16 @@ class Binomial(_BaseDistribution):
 
 
 class BetaBinomial(_BaseDistribution):
-    """Beta-binomial distribution literal for integer success counts."""
+    """Beta-binomial distribution literal for integer success counts.
+
+    Predictive distribution obtained by integrating ``Binomial(n, p)`` over
+    ``p ~ Beta(alpha, beta)``. Useful as a model-comparison reference when
+    the success probability has a Beta prior rather than a fixed value.
+
+    The special case ``BetaBinomial(n, alpha=1, beta=1)`` corresponds to
+    ``p ~ Uniform[0, 1]`` and gives the closed-form uniform marginal
+    ``P(k) = 1 / (n + 1)`` for every ``k ∈ [0, n]``.
+    """
 
     kind: str = "betabinomial"
 

--- a/tests/gaia/lang/bayes/test_distributions.py
+++ b/tests/gaia/lang/bayes/test_distributions.py
@@ -18,10 +18,11 @@ class Deferred:
 
 def test_public_distribution_surface_imports_from_gaia_lang_namespace():
     from gaia.lang import bayes
-    from gaia.lang.bayes import Binomial, Normal
+    from gaia.lang.bayes import BetaBinomial, Binomial, Normal
 
     required = {
         "Beta",
+        "BetaBinomial",
         "Binomial",
         "Cauchy",
         "ChiSquared",
@@ -33,8 +34,12 @@ def test_public_distribution_surface_imports_from_gaia_lang_namespace():
         "StudentT",
     }
     assert required.issubset(set(bayes.__all__))
+    assert BetaBinomial is bayes.BetaBinomial
     assert Binomial is bayes.Binomial
     assert Normal is bayes.Normal
+    assert bayes.BetaBinomial(n=10, alpha=1, beta=1).logpmf(5) == pytest.approx(
+        stats.betabinom.logpmf(5, n=10, a=1, b=1)
+    )
     assert bayes.Binomial(n=10, p=0.5).logpmf(5) == pytest.approx(stats.binom.logpmf(5, 10, 0.5))
     assert bayes.Normal(mu=0.0, sigma=1.0).logpdf(0.0) == pytest.approx(stats.norm.logpdf(0.0))
 
@@ -48,6 +53,13 @@ def test_public_distribution_surface_imports_from_gaia_lang_namespace():
             "logpmf",
             295,
             stats.binom.logpmf(295, 395, 0.75),
+        ),
+        (
+            lambda bayes: bayes.BetaBinomial(n=395, alpha=1.0, beta=1.0),
+            "betabinomial",
+            "logpmf",
+            295,
+            stats.betabinom.logpmf(295, n=395, a=1.0, b=1.0),
         ),
         (
             lambda bayes: bayes.Poisson(rate=3.0),
@@ -146,8 +158,12 @@ def test_distribution_validation_rejects_invalid_parameters():
 
     with pytest.raises(ValueError, match=r"Binomial.*p.*\[0, 1\]"):
         bayes.Binomial(n=10, p=1.1)
+    with pytest.raises(ValueError, match=r"BetaBinomial.*alpha.*> 0"):
+        bayes.BetaBinomial(n=10, alpha=0.0, beta=1.0)
     with pytest.raises(ValueError, match=r"Normal.*sigma.*> 0"):
         bayes.Normal(mu=0.0, sigma=0.0)
+    with pytest.raises(TypeError, match="discrete"):
+        bayes.BetaBinomial(n=10, alpha=1.0, beta=1.0).logpdf(5)
     with pytest.raises(TypeError, match="discrete"):
         bayes.Binomial(n=10, p=0.5).logpdf(5)
     with pytest.raises(TypeError, match="continuous"):

--- a/tests/gaia/lang/bayes/test_distributions.py
+++ b/tests/gaia/lang/bayes/test_distributions.py
@@ -168,3 +168,25 @@ def test_distribution_validation_rejects_invalid_parameters():
         bayes.Binomial(n=10, p=0.5).logpdf(5)
     with pytest.raises(TypeError, match="continuous"):
         bayes.Normal(mu=0.0, sigma=1.0).logpmf(0)
+
+
+def test_betabinomial_uniform_alpha_beta_equals_one_over_n_plus_one():
+    """BetaBinomial(n, 1, 1) recovers the integrate-over-Uniform[0, 1] marginal 1/(n+1).
+
+    This identity is the mathematical foundation of the Mendel example's
+    diffuse alternative: the closed-form uniform marginal ``P(k) = 1/(n+1)``
+    is exactly ``BetaBinomial(n, alpha=1, beta=1)`` evaluated at any
+    ``k ∈ [0, n]``. Pin the invariant here so future scipy / numerical
+    changes cannot silently break the example's stated derivation.
+    """
+    from gaia.lang import bayes
+
+    for n in (10, 100, 395):
+        bb = bayes.BetaBinomial(n=n, alpha=1.0, beta=1.0)
+        expected_logpmf = -math.log(n + 1)
+        for k in (0, n // 3, n // 2, n - 1, n):
+            assert bb.logpmf(k) == pytest.approx(expected_logpmf), (
+                f"BetaBinomial({n}, 1, 1).logpmf({k}) should equal -log({n + 1})"
+            )
+        assert bb.logpmf(n + 1) == -math.inf
+        assert bb.logpmf(-1) == -math.inf

--- a/tests/test_mendel_v05_example.py
+++ b/tests/test_mendel_v05_example.py
@@ -8,6 +8,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+import scipy.stats as stats
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
@@ -60,26 +61,26 @@ def _load_probability_module(package: Path):
     return module
 
 
-def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Path):
+def test_mendel_fixture_models_competing_theories_with_bayes_likelihood(tmp_path: Path):
     package = _copy_mendel_example(tmp_path)
     probabilities = _load_probability_module(package)
 
     compile_result = runner.invoke(app, ["compile", str(package)])
     assert compile_result.exit_code == 0, compile_result.output
 
-    association_parameters = probabilities.mendel_count_association_parameters()
+    likelihood_parameters = probabilities.mendel_count_likelihood_parameters()
 
     ir = json.loads((package / ".gaia" / "ir.json").read_text())
     knowledge_by_label = {item["label"]: item for item in ir["knowledges"] if item.get("label")}
     strategy_types = {item["type"] for item in ir["strategies"]}
-    association = knowledge_by_label["mendel_count_association"]
     count_observation = knowledge_by_label["f2_count_observation"]
-    count_specific = knowledge_by_label["f2_dominant_count_specific"]
+    likelihood = knowledge_by_label["mendel_count_likelihood"]
 
-    # The package uses a single associate (Mendel ↔ count) and three qualitative
-    # contradict edges against blending. It declares no `infer` strategy of its own.
-    assert "infer" not in strategy_types
-    assert "associate" in strategy_types
+    # The package uses the Bayes module for the quantitative count comparison,
+    # not the old associate workaround node that conflated observation
+    # reliability with the count marginal.
+    assert "associate" not in strategy_types
+    assert "infer" in strategy_types
 
     # Core claims and observations are present.
     for label in (
@@ -93,7 +94,9 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
         "mendel_predicts_discrete_classes",
         "mendel_predicts_recessive_reappearance",
         "mendel_predicts_three_to_one_ratio",
-        "f2_dominant_count_specific",
+        "mendel_count_model",
+        "diffuse_count_model",
+        "mendel_count_likelihood",
         "f1_mendel_match",
         "f2_discrete_classes_mendel_match",
         "f2_reappearance_mendel_match",
@@ -106,27 +109,24 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     ):
         assert label in knowledge_by_label, f"missing knowledge {label}"
 
-    # The Mendel↔count associate stores only the conditional link parameters.
-    # Node priors live in the priors layer instead of on the associate call.
-    assert association["metadata"]["helper_kind"] == "association"
-    assert association["metadata"]["relation"]["p_a_given_b"] == pytest.approx(
-        association_parameters.p_mendelian_given_count
-    )
-    assert association["metadata"]["relation"]["p_b_given_a"] == pytest.approx(
-        association_parameters.p_count_given_mendelian
-    )
-    assert "prior_a" not in association["metadata"]["relation"]
-    assert "prior_b" not in association["metadata"]["relation"]
+    assert "f2_dominant_count_specific" not in knowledge_by_label
+    assert "mendel_count_association" not in knowledge_by_label
+
+    # The quantitative comparison stores executable Bayes likelihood metadata.
+    assert likelihood["metadata"]["helper_kind"] == "model_preference"
+    likelihoods = likelihood["metadata"]["bayes"]["likelihoods"]
+    mendel_id = knowledge_by_label["mendelian_segregation_model"]["id"]
+    blending_id = knowledge_by_label["blending_inheritance_model"]["id"]
+    assert likelihoods[mendel_id] == pytest.approx(stats.binom.logpmf(295, n=395, p=3 / 4))
+    assert likelihoods[blending_id] == pytest.approx(stats.betabinom.logpmf(295, n=395, a=1, b=1))
     assert count_observation["metadata"]["prior"] == pytest.approx(0.95)
-    assert count_specific["metadata"]["prior"] == pytest.approx(association_parameters.prior_count)
 
     # The diffuse alternative has the closed-form marginal 1/(N+1).
-    assert association_parameters.p_count_given_diffuse == pytest.approx(1.0 / (295 + 100 + 1))
+    assert likelihood_parameters.p_count_given_diffuse == pytest.approx(1.0 / (295 + 100 + 1))
     # Sanity-check direction: a point likelihood peaked near the Mendelian mode
     # must beat a Uniform(p) reference measure at the same count.
     assert (
-        association_parameters.p_count_given_mendelian
-        > association_parameters.p_count_given_diffuse
+        likelihood_parameters.p_count_given_mendelian > likelihood_parameters.p_count_given_diffuse
     )
 
     assert {
@@ -151,10 +151,8 @@ def test_mendel_fixture_models_competing_theories_with_association(tmp_path: Pat
     # Directional belief checks: Mendel should rise above its prior and dominate
     # blending. We avoid hard-coded posterior values to stay robust to future
     # changes in the inference engine's numerical details.
-    assert beliefs["mendelian_segregation_model"] > association_parameters.prior_mendelian
+    assert beliefs["mendelian_segregation_model"] > likelihood_parameters.prior_mendelian
     assert beliefs["mendelian_segregation_model"] > 0.8
     assert beliefs["blending_inheritance_model"] < 0.2
     assert beliefs["mendelian_segregation_model"] > beliefs["blending_inheritance_model"]
-    # The specific count event is the marginal provider for the associate; the
-    # observation itself keeps its independent reliability prior.
-    assert beliefs["f2_dominant_count_specific"] > association_parameters.prior_count
+    assert beliefs["mendel_count_likelihood"] > 0.99


### PR DESCRIPTION
## Motivation

This PR is a follow-up cleanup enabled by recently-merged infrastructure:

- **PR #588** ([feat(ir,lang,cli)!: multi-source prior pipeline via register_prior](https://github.com/SiliconEinstein/Gaia/pull/588), closed #582) — gives every claim a multi-source `PriorRecord` with `ResolutionPolicy` arbitration, so engine-derived marginals no longer need to ride on the same `metadata.prior` field as observation reliability.
- **PR #590** ([feat(continuous): Distribution as first-class Knowledge with predicate claims (#581 PR1)](https://github.com/SiliconEinstein/Gaia/pull/590), partially closed #581) — promotes `Distribution` to a first-class Knowledge subclass with `BoolExpr`-based predicate claims.

Together they retire the Mendel v0.5 example's `f2_dominant_count_specific` workaround — a v0.5 compatibility node introduced specifically to sidestep the `metadata.prior` field-overload problem documented in **#485** (the old docstring even says so explicitly). The example can now express the quantitative count comparison through the long-term `bayes.model + bayes.likelihood` flow that `docs/foundations/gaia-lang/bayes.md` documents as the supported pattern, with the Bayes likelihood values attached as structured metadata by the lowering pass instead of hand-wired into a workaround claim's prior.

`BetaBinomial` is the missing piece: the diffuse alternative was previously a hand-derived `1/(n+1)` marginal in `mendel_count_association_parameters()`. `BetaBinomial(n, alpha=1, beta=1)` is mathematically equivalent (the closed-form integrate-over-Uniform[0, 1] case — pinned by a new test in the second commit) and strictly more expressive (any Beta prior, not just Uniform).

Refs #485, #581, #582.

## Summary

- add a minimal `bayes.BetaBinomial` wrapper over `scipy.stats.betabinom`, with class docstring explaining it as the integrate-over-`Beta` predictive distribution and calling out the `BetaBinomial(n, 1, 1) = 1/(n+1)` special case
- route beta-binomial likelihoods through the existing Bayes `logpmf` lowering path (parallel to `binomial` / `poisson`)
- migrate the Mendel v0.5 example from the old `associate` + `f2_dominant_count_specific` count-event workaround to `bayes.model` + `bayes.likelihood`, removing the workaround node and its `register_prior` entry; update module docstring and `MendelCountLikelihood` namedtuple to match
- document the new distribution surface in `docs/foundations/gaia-lang/bayes.md` and cover the Mendel compile / infer path in tests
- pin the `BetaBinomial(n, 1, 1) ≡ 1/(n+1)` identity in `tests/gaia/lang/bayes/test_distributions.py` so future scipy / numerical changes cannot silently break the Mendel diffuse alternative's stated derivation

## Validation

- `python -m pytest --no-cov tests/gaia/lang/bayes tests/test_mendel_v05_example.py -q` → 34 passed (33 original + 1 new equivalence test)
- `python -m ruff check gaia/lang/bayes/adapters/scipy_backend.py gaia/lang/bayes/distributions/discrete.py gaia/lang/bayes/distributions/__init__.py gaia/lang/bayes/__init__.py gaia/lang/bayes/compiler/lower.py examples/mendel-v0-5-gaia/src/mendel_v0_5 tests/gaia/lang/bayes/test_distributions.py tests/test_mendel_v05_example.py` → passed
- `python -m ruff format --check ...` (same paths) → passed
- `git diff --check` → clean
