### PR TITLE
refactor(pyproject): remove all jaynes_ref references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ build-backend = "setuptools.build_meta"
 include = [
     "gaia",
     "gaia.bp*",
-    "gaia.jaynes_ref*",
     "gaia.cli*",
     "gaia.inquiry*",
     "gaia.ir*",
@@ -92,11 +91,6 @@ markers = [
 
 [project.scripts]
 gaia = "gaia.cli.main:app"
-
-[tool.coverage.run]
-omit = [
-    "gaia/jaynes_ref/*",
-]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -130,7 +124,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "tests.*",
-    "gaia.jaynes_ref.*",
 ]
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
@@ -197,8 +190,6 @@ ignore = [
     "RUF002",
     "RUF003",
 ]
-"jaynes_ref/tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107", "RUF001", "RUF002", "RUF003", "E741"]
-"gaia/jaynes_ref/tests/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107", "RUF001", "RUF002", "RUF003", "E741"]
 "gaia/trace/**/*.py" = ["RUF001", "RUF002", "RUF003"]
 "gaia/bp/*.py" = ["RUF001", "RUF002", "RUF003"]
 "gaia/inquiry/**/*.py" = ["RUF001", "RUF002", "RUF003"]


### PR DESCRIPTION
## 问题

PR #601 删除了 `gaia/jaynes_ref/` 目录，但 `pyproject.toml` 中还有 5 处引用，导致配置不一致。

## 改动

从 `pyproject.toml` 删除所有 `jaynes_ref` 引用：
- `[tool.setuptools.packages.find]` 的 `"gaia.jaynes_ref*"`
- `[tool.coverage.run]` 整个 `omit` section
- `[[tool.mypy.overrides]]` 的 `"gaia.jaynes_ref.*"`
- `[tool.ruff.lint.per-file-ignores]` 的 2 条规则

## 验证

```bash
grep jaynes_ref pyproject.toml  # 无输出
```