### PR TITLE
docs(specs): engine module reorganization design

### DIFF
--- a/docs/specs/2026-05-16-engine-module-reorg-design.md
+++ b/docs/specs/2026-05-16-engine-module-reorg-design.md
@@ -4,26 +4,34 @@
 **Date:** 2026-05-16
 **Branch:** off `v0.5`
 **Related PRs:** TBD (reorg PR a + reorg PR b)
-**Builds on:** `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` (BayesInference shape decision)
-**Scope:** Two coordinated reorganizations of first- and second-level modules under `gaia.engine`:
-  1. consolidate single-file packages (`engine.lang.types/`) and demote `engine.logic/` to `engine.ir.logic/` (PR a, small)
-  2. promote `engine.lang.bayes/` to peer `engine.bayes/` and align Bayes verb directory naming (PR b, medium)
+**Builds on:** alpha-0 engine facade split (PR #607); BayesInference shape decision in `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` is one of several catalysts but not the only one.
+**Scope:** Coordinated reorganization of first- and second-level modules under `gaia.engine`, sequenced as two PRs:
+  1. **PR a (small, low-risk)** — consolidate single-file packages and demote `engine.logic/` to `engine.ir.logic/`
+  2. **PR b (medium)** — promote `engine.lang.bayes/` to peer `engine.bayes/` and align the Bayes verb directory name with the lang convention
 
-**Non-goals:** Do not flatten the entire engine into a single layer. Do not rename `engine.lang/` to `engine.core/`. Do not move `lang.runtime/`, `lang.dsl/`, `lang.compiler/` out of `lang/`. Do not introduce a new IR data model. Do not change BP, inquiry, or trace top-level layout.
+**Non-goals:** Do not flatten the entire engine into a single layer. Do not rename `engine.lang/` to `engine.core/`. Do not move `lang.runtime/`, `lang.dsl/`, `lang.compiler/` out of `lang/`. Do not introduce a new IR data model. Do not change BP, inquiry, or trace top-level layout. Do not eliminate the existing `lang → bayes` module-import reverse links (deferred — see §13).
 
-## 1. Motivation
+## 1. Goal
 
-PR #606 + #609 landed `BayesInference(Reasoning)` as a runtime-level first-class concept (per `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` §4.2). The class hierarchy now treats Bayes as a top-level reasoning family. The Python module layout, however, still nests Bayes five levels deep at `gaia.engine.lang.bayes.*`. This is an **inconsistency between the runtime hierarchy decision and the module path** that should be resolved before more reasoning families (causal, statistics, ...) land and inherit the same layout.
+Align the `gaia.engine` module layout with the conceptual structure of the engine — applying cohesion, dependency direction, API surface, and evolution-pressure criteria (§3) — and set explicit precedents for future extension modules so they don't inherit accidental decisions.
 
-Three smaller issues compound:
+Since alpha-0 (PR #607) split engine code into `gaia.engine.{bp, ir, lang, logic, inquiry, trace, packaging}` sub-facades, four organizational issues have accumulated. They are independent in cause but share the same diagnostic framework:
 
-1. `gaia.engine.lang.types/` is a sub-package shell containing one file (`primitives.py`). It is over-structure: the four primitive types (Bool/Nat/Real/Probability) are formula-domain concepts and belong with the formula AST.
+| # | Issue | Affected path | Criterion violated |
+|---|---|---|---|
+| 1 | Single-file package shell with one file and no second contributor | `engine.lang.types/primitives.py` | Cohesion (§3 criterion 1) |
+| 2 | Top-level peer with no Gaia-native abstractions — pure sympy-on-IR adapter | `engine.logic/propositional.py` | Cohesion + dependency direction (§3 criteria 1, 2) |
+| 3 | Module path inconsistent with the runtime-class hierarchy | Bayes nested 5 levels deep at `engine.lang.bayes/*` despite `BayesInference(Reasoning)` being a first-class shape | Evolution pressure (§3 criterion 4) |
+| 4 | Naming asymmetry between core and extension verb directories | `engine.lang.dsl/` vs `engine.lang.bayes.verbs/` | API surface (§3 criterion 3) |
 
-2. `gaia.engine.logic/` is the only top-level engine peer that has no Gaia-native abstractions of its own — it is a thin sympy-on-IR analysis layer. By the same criterion that places `bp/`, `inquiry/`, `lang/`, `trace/` at the top level (each owns substantial concept layer), `logic/` belongs as an IR sub-module under `engine.ir.logic/`.
+None of these resolve themselves through normal feature work. Issue 3 in particular has accumulating cost — every future reasoning family (the speculative `CausalEdge` from `2026-05-15-causal-cleanup-reasoning-shapes.md` §6, potential statistics/frequentist extensions, ML / latent-variable extensions) will inherit either the deep-nesting precedent or get a one-off carve-out, neither of which is good.
 
-3. The Bayes verb directory is named `bayes.verbs/` while the core verb directory is named `lang.dsl/`. After Bayes is promoted to peer, the asymmetry surfaces in the public import path.
+The spec groups the four issues into two coordinated PRs by code-touch shape:
 
-This spec proposes the minimal coordinated reorg that resolves all four issues, frames `engine.lang/` as a host module with `engine.bayes/` as a peer extension, and sets a precedent for future extensions.
+- **PR a** (issues 1 + 2) — both are removals of top-level / sub-package shells. Pure path moves with tombstone shims; ~120 LoC; one ImportError test per old path.
+- **PR b** (issues 3 + 4) — both involve the Bayes subtree. PR b is the larger change because it touches every Bayes-using import in the repo plus the three `lang → bayes` reverse-import sites at `lang/__init__.py` / `lang/compiler/compile.py` / `lang/runtime/distribution.py` (see §6.2).
+
+The motivation is **structural, not feature-driven**. Issue 3 is the largest in code-touch and creates the most pressure because the runtime/module mismatch is the most explicit, but issues 1, 2, and 4 are independent organizational debts that this spec resolves in the same window because they share the diagnostic framework and tooling (tombstone machinery, facade contract test, doc reference layer).
 
 ## 2. Current Code Facts
 
@@ -125,7 +133,7 @@ The fix: rename `bayes.verbs/` → `bayes.dsl/`. Future Bayes-side sugar/factori
 
 - **`lang.runtime/`, `lang.dsl/`, `lang.compiler/` placement under `lang/`**: these form a tight cohesion triangle. Adding any new core reasoning verb requires touching all three. They must stay together. Promoting them to engine top-level breaks the triangle and increases coupling cost.
 
-- **`lang/` name as host module**: code-fact analysis shows `bayes` single-direction depends on `lang.runtime` (for `Reasoning` base class), `lang.compiler` (for compile-time helpers), and `lang.formula`/`refs`/`review` (shared services). `lang` is not a peer to `bayes`; it is the host that `bayes` plugs into. Renaming `lang` to `core` would imply a peer relation that doesn't match the actual import graph. Keep the `lang` name; document the host/extension boundary.
+- **`lang/` name as host module**: in the runtime-class hierarchy `bayes` extensions inherit from `lang.runtime` base classes and reuse `lang.compiler` / `lang.formula` / `lang.refs` / `lang.review` services. The `lang ↔ bayes` module-import graph is bidirectional today (§6.2), but the runtime-class direction is host-to-extension, not peer-to-peer. Renaming `lang` to `core` would imply a flat peer relation, which the runtime-class hierarchy does not have. Keep the `lang` name; §6 documents both the runtime-class host/extension semantics and the module-import reality.
 
 - **`compiler` co-location**: `lang.compiler/` and `bayes.compiler/` (post-promotion) stay separate per current code; they are cohesive within their own authoring layers and do not benefit from forced unification.
 

--- a/docs/specs/2026-05-16-engine-module-reorg-design.md
+++ b/docs/specs/2026-05-16-engine-module-reorg-design.md
@@ -35,7 +35,7 @@ The motivation is **structural, not feature-driven**. Issue 3 is the largest in 
 
 ## 2. Current Code Facts
 
-(based on `origin/codex/remove-excluded-foundation-dsl` head — i.e., v0.5 + PR #606 + PR #609)
+(based on current `origin/v0.5`, i.e. v0.5 after PR #606 and PR #609)
 
 ```
 gaia/engine/
@@ -201,7 +201,7 @@ This is what the BayesInference shape decision (`2026-05-15-causal-cleanup-reaso
 
 | Site | What it does |
 |---|---|
-| `gaia/engine/lang/__init__.py:138-142` `__getattr__("bayes")` | Lazy-imports `gaia.engine.lang.bayes` (or post-PR-b `gaia.engine.bayes`) so the documented public form `from gaia.engine.lang import bayes` keeps working |
+| `gaia/engine/lang/__init__.py::__getattr__("bayes")` | Lazy-imports `gaia.engine.lang.bayes` (or post-PR-b `gaia.engine.bayes`) so the documented public form `from gaia.engine.lang import bayes` keeps working |
 | `gaia/engine/lang/compiler/compile.py::_lower_bayes_actions` | Calls `from gaia.engine.lang.bayes.compiler import lower_bayes_claims` directly inside the core compile pipeline |
 | `gaia/engine/lang/runtime/distribution.py` (10+ sites) | Top-level distribution factories `Normal / LogNormal / Beta / Exponential / Gamma / StudentT / Cauchy / ChiSquared / Binomial / Poisson` lazy-import their backing implementations from `bayes.distributions.*` and `bayes.adapters.scipy_backend` |
 
@@ -226,8 +226,8 @@ PR b's scope is **path migration only**:
 
 - move the directory tree `engine/lang/bayes/` → `engine/bayes/`
 - update the three reverse-import sites above to point at the new path:
-  - `lang/__init__.py:140` `import_module("gaia.engine.lang.bayes")` → `import_module("gaia.engine.bayes")`
-  - `lang/compiler/compile.py:1826` `from gaia.engine.lang.bayes.compiler import …` → `from gaia.engine.bayes.compiler import …`
+  - `lang/__init__.py` `import_module("gaia.engine.lang.bayes")` → `import_module("gaia.engine.bayes")`
+  - `lang/compiler/compile.py::_lower_bayes_actions` `from gaia.engine.lang.bayes.compiler import …` → `from gaia.engine.bayes.compiler import …`
   - all `lang/runtime/distribution.py` `from gaia.engine.lang.bayes.{distributions,adapters} import …` → `from gaia.engine.bayes.{distributions,adapters} import …`
 - install the tombstone for `gaia.engine.lang.bayes` (see §9)
 
@@ -289,7 +289,7 @@ gaia/engine/
 └── trace/
 ```
 
-**Disappearing:** `engine.lang.types/`, `engine.logic/`, `engine.lang.bayes/`.
+**Disappearing as canonical implementation namespaces:** `engine.lang.types/`, `engine.logic/`, `engine.lang.bayes/` (old directories remain only as tombstone shims where needed).
 **Appearing:** `engine.bayes/`, `engine.ir.logic/`.
 **Renamed inside `bayes/`:** `verbs/` → `dsl/`.
 **Untouched:** `lang.runtime/`, `lang.dsl/`, `lang.compiler/`, `lang.refs/`, `lang.review/`, `ir/*` other than the new `logic/` subdir, `bp/`, `inquiry/`, `trace/`, `_stale_check.py`, `packaging.py`.
@@ -309,6 +309,7 @@ Two sequenced PRs to minimize blast radius and let reviewers focus on one struct
 | `gaia/engine/logic/propositional.py` | Move to `gaia/engine/ir/logic/propositional.py` |
 | `gaia/engine/logic/__init__.py` | **Replace contents** with the 4-line tombstone shim — directory kept |
 | `gaia/engine/ir/logic/__init__.py` | **New file** with explicit scope notes (see below) |
+| `gaia/logic/__init__.py` | **Retarget existing alpha-0 shim** from `gaia.engine.logic` to `gaia.engine.ir.logic` |
 
 The tombstone shim follows the alpha-0 convention used by `gaia/bp/__init__.py`, `gaia/lang/__init__.py`, etc.:
 
@@ -334,6 +335,13 @@ Existing entry updated:
 ```python
 # old: "gaia.logic": "gaia.engine.logic"
 "gaia.logic": "gaia.engine.ir.logic",
+```
+
+Existing top-level tombstone shim updated:
+
+```python
+# old: _tombstoned_namespace_getattr("gaia.logic", "gaia.engine.logic")
+__getattr__ = _tombstoned_namespace_getattr("gaia.logic", "gaia.engine.ir.logic")
 ```
 
 `gaia/engine/lang/__init__.py`: continue re-exporting `Bool, Nat, Real, Probability, PrimitiveType` so user-facing import `from gaia.engine.lang import Bool` keeps working unchanged.
@@ -392,9 +400,9 @@ Repo-wide import-path rewrites — three categories:
 2. **Internal cross-imports inside the moved subtree** — paths inside `bayes/*` referring to siblings need rewriting from `gaia.engine.lang.bayes.X` to `gaia.engine.bayes.X`.
 
 3. **Three `lang → bayes` reverse-import sites** (per §6.2) — these continue to exist after PR b but the path is updated:
-   - `gaia/engine/lang/__init__.py:140` `import_module("gaia.engine.lang.bayes")` → `import_module("gaia.engine.bayes")`
-   - `gaia/engine/lang/compiler/compile.py:1826` `from gaia.engine.lang.bayes.compiler import lower_bayes_claims` → `from gaia.engine.bayes.compiler import lower_bayes_claims`
-   - all `gaia/engine/lang/runtime/distribution.py` lazy imports — for example line 169 `from gaia.engine.lang.bayes.distributions.base import _BaseDistribution` → `from gaia.engine.bayes.distributions.base import _BaseDistribution`; same for `bayes.adapters.scipy_backend` and the 10 distribution factories `Normal / LogNormal / Beta / Exponential / Gamma / StudentT / Cauchy / ChiSquared / Binomial / Poisson`
+   - `gaia/engine/lang/__init__.py` `import_module("gaia.engine.lang.bayes")` → `import_module("gaia.engine.bayes")`
+   - `gaia/engine/lang/compiler/compile.py::_lower_bayes_actions` `from gaia.engine.lang.bayes.compiler import lower_bayes_claims` → `from gaia.engine.bayes.compiler import lower_bayes_claims`
+   - all `gaia/engine/lang/runtime/distribution.py` lazy imports — for example `from gaia.engine.lang.bayes.distributions.base import _BaseDistribution` → `from gaia.engine.bayes.distributions.base import _BaseDistribution`; same for `bayes.adapters.scipy_backend` and the 10 distribution factories `Normal / LogNormal / Beta / Exponential / Gamma / StudentT / Cauchy / ChiSquared / Binomial / Poisson`
 
 Note: the `verbs/ → dsl/` rename inside `bayes/` does not require its own namespace tombstone because `engine.lang.bayes.verbs` was an internal sub-package; the public `bayes.dsl/__init__.py` re-exports the same names (`model`, `likelihood`).
 
@@ -446,7 +454,7 @@ With both pieces in place, the three import forms are all covered:
 
 This is why §8.1 / §8.2 keep the old directories and **replace** their `__init__.py` with shim contents rather than deleting the directories.
 
-For PR a: two new tombstone shims (`engine/lang/types/`, `engine/logic/`); two new `TOMBSTONED_NAMESPACES` entries (`gaia.engine.lang.types`, `gaia.engine.logic`); one existing entry updated (`gaia.logic` retargeted to `gaia.engine.ir.logic`).
+For PR a: two new tombstone shims (`engine/lang/types/`, `engine/logic/`); two new `TOMBSTONED_NAMESPACES` entries (`gaia.engine.lang.types`, `gaia.engine.logic`); one existing registry entry updated (`gaia.logic` retargeted to `gaia.engine.ir.logic`); one existing top-level shim retargeted (`gaia/logic/__init__.py` points to `gaia.engine.ir.logic`).
 
 For PR b: one new tombstone shim (`engine/lang/bayes/`); one new `TOMBSTONED_NAMESPACES` entry (`gaia.engine.lang.bayes`).
 
@@ -510,9 +518,9 @@ assert bayes.__name__ == "gaia.engine.bayes"          # path migrated
 
 # 2. Top-level Distribution factories — proxy to the new bayes.distributions
 from gaia.engine.lang.runtime.distribution import Normal, Beta, Binomial
-n = Normal(mu=0.0, sigma=1.0)
-b = Beta(alpha=1.0, beta=1.0)
-bn = Binomial(n=10, p=0.5)
+n = Normal("x", mu=0.0, sigma=1.0)
+b = Beta("p", alpha=1.0, beta=1.0)
+bn = Binomial("k", n=10, p=0.5)
 # accessing them must not raise; their backing classes resolve from gaia.engine.bayes.distributions
 
 # 3. _lower_bayes_actions code path — exercise via end-to-end compile
@@ -559,7 +567,7 @@ User / foundations docs:
 
 Reference / facade docs (engine reference layer):
 
-- update `docs/reference/engine/index.md` — facade table (the canonical 7-submodule list that locks the engine surface): remove `gaia.engine.logic` from the top-level list; the demoted `engine.ir.logic` lives under the existing `gaia.engine.ir` reference page
+- update `docs/reference/engine/index.md` — facade table (the current top-level engine surface): remove `gaia.engine.logic` from the top-level list; the demoted `engine.ir.logic` lives under the existing `gaia.engine.ir` reference page
 - delete or redirect `docs/reference/engine/logic.md` — its content moves to a sub-section under `docs/reference/engine/ir.md` (or a new `docs/reference/engine/ir/logic.md` if the per-page convention prefers a separate page)
 - update `docs/reference/engine/ir.md` (or `lang/formula.md` / `lang/types.md`) — note that `Bool / Nat / Real / Probability / PrimitiveType` now canonically live at `gaia.engine.lang.formula.primitives`
 
@@ -570,14 +578,14 @@ Facade contract test:
   EXPECTED = {
       "gaia.engine.bp": 17,
       "gaia.engine.ir": 32,
-      "gaia.engine.lang": 127,
+      "gaia.engine.lang": 130,
       "gaia.engine.logic": 7,         # ← remove (logic demoted under ir)
       "gaia.engine.inquiry": 45,
       "gaia.engine.trace": 7,
       "gaia.engine.packaging": 9,
   }
   ```
-  Decide whether the 7 logic symbols are re-exported from `gaia.engine.ir` (so `gaia.engine.ir`'s count rises from 32 to ~39) or made internal-only under `gaia.engine.ir.logic` (so the `gaia.engine.ir` `__all__` is unchanged and the 7 symbols disappear from the locked facade total). This is a small but explicit policy decision the implementing PR has to make; update `tests/baseline/test_l2_facade.py` and the docstring in `engine-facade-final.md` accordingly.
+  The current pre-reorg grand total is 247. Decide whether the 7 logic symbols are re-exported from `gaia.engine.ir` (so `gaia.engine.ir`'s count rises from 32 to ~39 and the total stays near 247) or made internal-only under `gaia.engine.ir.logic` (so the `gaia.engine.ir` `__all__` is unchanged and the 7 symbols disappear from the locked facade total). This is a small but explicit policy decision the implementing PR has to make; update `tests/baseline/test_l2_facade.py` and its module docstring/header counts accordingly.
 
 ### PR b
 
@@ -599,7 +607,7 @@ Reference / facade docs:
 
 Facade contract test:
 
-- update `tests/baseline/test_l2_facade.py` — add `gaia.engine.bayes` to `EXPECTED` with its `__all__` count; total 244 will change; sync the docstring header counts
+- update `tests/baseline/test_l2_facade.py` — add `gaia.engine.bayes` to `EXPECTED` with its `__all__` count; the post-PR-a total will change again; sync the docstring header counts
 
 ### Both PRs
 

--- a/docs/specs/2026-05-16-engine-module-reorg-design.md
+++ b/docs/specs/2026-05-16-engine-module-reorg-design.md
@@ -1,0 +1,489 @@
+# `gaia.engine` Module Reorganization Design
+
+**Status:** Design proposal for v0.5 follow-up
+**Date:** 2026-05-16
+**Branch:** off `v0.5`
+**Related PRs:** TBD (reorg PR a + reorg PR b)
+**Builds on:** `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` (BayesInference shape decision)
+**Scope:** Two coordinated reorganizations of first- and second-level modules under `gaia.engine`:
+  1. consolidate single-file packages (`engine.lang.types/`) and demote `engine.logic/` to `engine.ir.logic/` (PR a, small)
+  2. promote `engine.lang.bayes/` to peer `engine.bayes/` and align Bayes verb directory naming (PR b, medium)
+
+**Non-goals:** Do not flatten the entire engine into a single layer. Do not rename `engine.lang/` to `engine.core/`. Do not move `lang.runtime/`, `lang.dsl/`, `lang.compiler/` out of `lang/`. Do not introduce a new IR data model. Do not change BP, inquiry, or trace top-level layout.
+
+## 1. Motivation
+
+PR #606 + #609 landed `BayesInference(Reasoning)` as a runtime-level first-class concept (per `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` §4.2). The class hierarchy now treats Bayes as a top-level reasoning family. The Python module layout, however, still nests Bayes five levels deep at `gaia.engine.lang.bayes.*`. This is an **inconsistency between the runtime hierarchy decision and the module path** that should be resolved before more reasoning families (causal, statistics, ...) land and inherit the same layout.
+
+Three smaller issues compound:
+
+1. `gaia.engine.lang.types/` is a sub-package shell containing one file (`primitives.py`). It is over-structure: the four primitive types (Bool/Nat/Real/Probability) are formula-domain concepts and belong with the formula AST.
+
+2. `gaia.engine.logic/` is the only top-level engine peer that has no Gaia-native abstractions of its own — it is a thin sympy-on-IR analysis layer. By the same criterion that places `bp/`, `inquiry/`, `lang/`, `trace/` at the top level (each owns substantial concept layer), `logic/` belongs as an IR sub-module under `engine.ir.logic/`.
+
+3. The Bayes verb directory is named `bayes.verbs/` while the core verb directory is named `lang.dsl/`. After Bayes is promoted to peer, the asymmetry surfaces in the public import path.
+
+This spec proposes the minimal coordinated reorg that resolves all four issues, frames `engine.lang/` as a host module with `engine.bayes/` as a peer extension, and sets a precedent for future extensions.
+
+## 2. Current Code Facts
+
+(based on `origin/codex/remove-excluded-foundation-dsl` head — i.e., v0.5 + PR #606 + PR #609)
+
+```
+gaia/engine/
+├── _stale_check.py
+├── packaging.py
+├── bp/                        # 10 modules — Belief Propagation engine
+├── inquiry/                   # 13 modules — goal-tree analysis
+├── ir/                        # 12 modules — Intermediate Representation
+├── lang/
+│   ├── runtime/               # 11 modules — Knowledge / Reasoning / Scaffold dataclasses
+│   ├── compiler/              # 5 modules — lang AST → IR
+│   ├── dsl/                   # 15 modules — public verbs (derive, equal, ...)
+│   ├── formula/               # 5 modules — predicate logic AST
+│   ├── bayes/                 # ← extension nested inside lang
+│   │   ├── runtime/
+│   │   ├── verbs/             # ← naming inconsistent with lang.dsl/
+│   │   ├── compiler/
+│   │   ├── distributions/
+│   │   └── adapters/
+│   ├── refs/                  # 6 modules — @label resolution
+│   ├── review/                # 3 modules — review manifest gen
+│   └── types/                 # ← single file (primitives.py)
+├── logic/                     # ← single file (propositional.py); only top-level peer with no own abstraction
+└── trace/                     # 9 modules
+```
+
+Tombstone infrastructure (`gaia/_legacy_imports.py`) is already in place for the alpha-0 `gaia.<old> → gaia.engine.<new>` migration:
+
+- `_tombstoned_namespace_getattr(old, new)` redirects attribute access
+- `TOMBSTONED_NAMESPACES` dict registers the redirects; meta-path finder picks them up for `import gaia.<old>.<sub>` style imports
+- `tests/baseline/test_l2_tombstones.py` enforces the registry contract
+
+This spec reuses that machinery for new tombstones.
+
+## 3. First-Principles Criteria
+
+A module organization is judged by how much it lowers three costs:
+
+- **Cognitive cost** — how much effort to find the right file
+- **Coupling cost** — how many files change together for one feature
+- **Boundary cost** — cross-module import / cyclic risk / dependency direction
+
+Four objective tests:
+
+1. **Cohesion** — files that change together must live together
+2. **Dependency direction** — imports form an acyclic, single-direction graph
+3. **API surface** — short, stable public import paths
+4. **Evolution pressure** — where does the next thing naturally go
+
+This spec applies these criteria to each diagnosed issue.
+
+## 4. Diagnosis
+
+### 4.1 Bayes nested under `lang/` violates evolution pressure (criterion 4)
+
+PR #606 + #609 established `BayesInference(Reasoning)` as a first-class runtime category (a sibling of `Directed`/`Relation`/`Decompose`/`Compose`). When future extensions land — e.g., causal (the speculative `CausalEdge` from `2026-05-15-causal-cleanup-reasoning-shapes.md` §6), or statistics — they should follow the same precedent. With the current layout that precedent says: nest under `engine.lang/`. That makes `engine.lang/` a perpetual junk drawer of "everything authoring-related" and implicitly contradicts the BayesInference decision (which carved Bayes out as runtime-first-class).
+
+The fix: promote `bayes/` to be a peer module under `engine/`. This sets a clean precedent — new reasoning families land as `engine.<family>/`, not `engine.lang.<family>/`.
+
+### 4.2 `engine.logic/` has no own abstraction; it is an IR consumer (criterion 1, 2)
+
+By the cohesion + dependency-direction criterion, top-level engine peers are characterized by owning their own data model:
+
+| Top-level peer | Own abstractions | Files |
+|---|---|---|
+| `engine.bp/` | `FactorGraph` / `Potential` / `JunctionTree` / `MeanFieldEngine` | 10 |
+| `engine.inquiry/` | `ProofState` / goal-tree / `ReviewTarget` / `Anchor` / `Snapshot` | 13 |
+| `engine.lang/` | `Knowledge` / `Reasoning` / `Scaffold` / formula AST | 50+ |
+| `engine.ir/` | (the data hub itself) | 12 |
+| `engine.trace/` | trace records / ranking / hashing | 9 |
+| `engine.logic/` | **none** — pure sympy-on-IR adapter | 1 |
+
+`engine.logic/` is the outlier. Its public functions all have signature `(graph: LocalCanonicalGraph, knowledge_id: str) → sympy.Expr`. It defines no Gaia data classes, persists nothing, and consumes IR exclusively. Structurally it is the same kind of module as `engine.ir.coarsen`, `engine.ir.linearize`, `engine.ir.validator` — IR analysis utilities — except it uses an external solver (sympy) as backend.
+
+The fix: demote `engine.logic/` to `engine.ir.logic/` (sub-package). The IR-consumer relationship becomes explicit; future solver backends (Z3, CVC5, ATP) join the same sub-package. If logic ever grows substantial own abstractions (e.g., a unified `Theory` data model spanning solvers, with caching and proof certificates), it can be promoted back to a top-level peer at that point. YAGNI says don't anticipate.
+
+### 4.3 `engine.lang.types/` is single-file over-structure (criterion 1)
+
+Contents: `primitives.py` exporting `Bool`, `Nat`, `Real`, `Probability`, `PrimitiveType`. These are formula-domain primitive types — used by `lang.formula.term.Variable.domain`, by `lang.formula.predicate` for term type checking, and by `Claim.formula` payloads. They have no second contributor in the package and no theoretical reason to sit in their own namespace.
+
+The fix: merge into `lang.formula/primitives.py`.
+
+### 4.4 `lang.dsl/` vs `bayes.verbs/` naming inconsistency (criterion 3)
+
+Both directories serve the same role: public verb entry. The current names diverge because `lang.dsl/` has historically held more than verbs (formula factories, sugar, legacy strategies) while `bayes.verbs/` has only `model.py` and `likelihood.py`. After Bayes promotes to peer, the asymmetry becomes visible in import paths:
+
+```python
+from gaia.engine.lang.dsl import derive
+from gaia.engine.bayes.verbs import model       # ← inconsistent
+```
+
+The fix: rename `bayes.verbs/` → `bayes.dsl/`. Future Bayes-side sugar/factories land in `bayes.dsl/sugar.py` etc., matching the lang convention.
+
+### 4.5 What is NOT diagnosed as a problem
+
+- **`lang.runtime/`, `lang.dsl/`, `lang.compiler/` placement under `lang/`**: these form a tight cohesion triangle. Adding any new core reasoning verb requires touching all three. They must stay together. Promoting them to engine top-level breaks the triangle and increases coupling cost.
+
+- **`lang/` name as host module**: code-fact analysis shows `bayes` single-direction depends on `lang.runtime` (for `Reasoning` base class), `lang.compiler` (for compile-time helpers), and `lang.formula`/`refs`/`review` (shared services). `lang` is not a peer to `bayes`; it is the host that `bayes` plugs into. Renaming `lang` to `core` would imply a peer relation that doesn't match the actual import graph. Keep the `lang` name; document the host/extension boundary.
+
+- **`compiler` co-location**: `lang.compiler/` and `bayes.compiler/` (post-promotion) stay separate per current code; they are cohesive within their own authoring layers and do not benefit from forced unification.
+
+## 5. Logic Layer Architecture
+
+The `engine.logic` demotion in §4.2 motivates an explicit articulation of how logical analysis is split across module boundaries. Three scopes coexist; they are not redundant.
+
+### 5.1 Three scopes of logical structure
+
+| Scope | What it is | Where the structure lives | Where the analysis goes |
+|---|---|---|---|
+| **A. Within-claim** | one-claim predicate logic: quantifiers, predicates, terms, arithmetic (`Forall(x, Greater(f(x), 0))` inside a single `Claim.formula`) | `lang.formula` AST + IR `formula_atom` metadata after lowering | (none today) — `engine.ir.logic.predicate` (future Z3-backed) |
+| **B. Between-claim** | propositional connectives linking claims (`claim_a ∧ claim_b → helper`), produced by IR Operator nodes | IR `LocalCanonicalGraph.operators` | `engine.ir.logic.propositional` (current sympy backend) |
+| **C. Cross-cutting** | analysis spanning A + B (e.g., `Forall(x, P(x))` claim contradicts `Lnot(P(b))` claim — needs both formula metadata and Operator graph) | both | (none today) — `engine.ir.logic.predicate` or `engine.ir.logic.smt` (future) |
+
+### 5.2 What the IR preserves vs collapses
+
+When `lang.compiler.lower_formula` lowers a `Claim` with `formula = Forall(x in Real, Greater(f(x), 0))`:
+
+- top-level connectives (`Land/Lor/Lnot/Implies/Iff` at the formula root) → lowered to IR `Operator` nodes between knowledge nodes (B-scope structure)
+- top-level quantifiers / predicates / arithmetic (`Forall/Exists/Equals/Greater/UserPredicate` at the root) → preserved as JSON metadata on the Knowledge node (`metadata["formula_atom"]`, `metadata["formula_bindings"]`); the Knowledge becomes opaque from the Operator graph's perspective (A-scope structure preserved but not active)
+
+The IR therefore contains **all the information needed for A and C scope analysis** — the metadata is complete. What is missing is the **active analyzer** that reads `formula_atom` metadata and feeds it to a first-order / SMT solver.
+
+The current `engine.logic.propositional` only walks `graph.operators` and ignores metadata. It covers scope B exhaustively and scope A/C not at all.
+
+### 5.3 Why all three scopes belong in `engine.ir.logic/`
+
+Scope A might naively appear to belong with `lang.formula/` (since `Forall/Equals/...` are formula AST nodes). But the analyzer's input is **not** the AST — by the time analysis runs, the formulas have been lowered to IR with metadata. The analyzer takes IR + metadata, not raw AST. Putting it in `lang.formula/` would force `lang.formula/` to depend on IR (wrong direction) and on Z3 (heavy dep on a data layer).
+
+Scope C inherently combines IR Operator graph with claim-internal metadata; it has nowhere to live except IR-level.
+
+Therefore: all three logic scopes' analyzers belong under `engine.ir.logic/` as additional backends. The current sympy `propositional.py` is the first; future FOL/SMT backends are siblings.
+
+### 5.4 What `lang.formula/` retains
+
+Pure AST utilities, not "logic analysis":
+
+- `is_formula(x)` (type check)
+- atom collection (walk `ClaimAtom` nodes)
+- variable binding extraction (used during lowering)
+- well-formedness checks (`_check_term`, decompose validation)
+
+These are syntactic helpers tied to AST structure. They do not need solvers; they live close to their callers (`lang.formula.predicate`, `lang.dsl.decompose`, `lang.compiler.lower_formula`).
+
+## 6. Host vs Extension Framing
+
+After PR b lands, `engine.lang/` and `engine.bayes/` are **not symmetric peers**. The dependency graph is:
+
+```
+bayes.runtime ─→ lang.runtime          (BayesInference inherits Reasoning)
+bayes.compiler ─→ lang.compiler         (compile-time helpers)
+bayes.runtime / verbs ─→ lang.formula   (predicate logic AST shared)
+bayes.* ─→ lang.refs / lang.review      (shared services)
+bayes.* ─→ engine.ir, engine.bp         (downstream)
+lang.* ↛ bayes.*                        (zero reverse imports)
+```
+
+`lang/` is the **host**: it defines the base `Reasoning` hierarchy, the formula AST, and shared services (refs, review). `bayes/` is an **extension**: it adds new `Reasoning` subclasses, new verbs, and a Bayes-specific compile path that all plug into the host.
+
+This framing answers two recurring naming questions:
+
+1. *"Should `lang/` be renamed `core/` for symmetry with `bayes/`?"* — No. `core/peer-bayes/peer-causal/...` would imply a flat peer hierarchy, but the import graph is hub-and-spoke. The `lang` name preserves "this is the language host module"; `bayes` (and future causal/statistics) extend it.
+
+2. *"Why does `bayes.runtime` mirror `lang.runtime` while `lang.runtime` does not have a `bayes/` subdirectory?"* — Because each extension owns its own Reasoning subclasses and verbs but reuses the host's base hierarchy. The mirror is structural, not hierarchical.
+
+Future extensions follow this contract:
+
+> Any new reasoning family that introduces its own runtime classes (e.g., `CausalEdge` per `2026-05-15-causal-cleanup-reasoning-shapes.md` §6) lands as a peer module under `gaia.engine.<family>/`, not under `gaia.engine.lang.<family>/`. The peer module follows the same internal layout as `gaia.engine.bayes/`: at minimum `runtime/` + `dsl/`; optionally `compiler/`, `distributions/`, `adapters/` as needed. The peer extension may freely import from `gaia.engine.lang.*` (host) and `gaia.engine.ir/` / `engine.bp/` (downstream); the host must not import from any extension.
+
+## 7. Target State
+
+After both PRs land:
+
+```
+gaia/engine/
+├── _stale_check.py
+├── packaging.py
+├── lang/                          # host: core authoring + shared services
+│   ├── runtime/
+│   ├── dsl/
+│   ├── compiler/
+│   ├── formula/
+│   │   ├── connective.py
+│   │   ├── predicate.py
+│   │   ├── primitives.py          # ← merged from engine.lang.types/
+│   │   ├── quantifier.py
+│   │   ├── symbols.py
+│   │   └── term.py
+│   ├── refs/
+│   └── review/
+├── bayes/                         # peer extension (promoted from engine.lang.bayes)
+│   ├── runtime/
+│   ├── dsl/                       # ← renamed from verbs/
+│   ├── compiler/
+│   ├── distributions/
+│   ├── adapters/
+│   └── README.md
+├── ir/
+│   ├── coarsen.py / linearize.py / validator.py / formalize.py / ...
+│   └── logic/                     # ← demoted from engine.logic/
+│       ├── __init__.py
+│       └── propositional.py       # current sympy backend; siblings (predicate/smt/...) added later
+├── bp/
+├── inquiry/
+└── trace/
+```
+
+**Disappearing:** `engine.lang.types/`, `engine.logic/`, `engine.lang.bayes/`.
+**Appearing:** `engine.bayes/`, `engine.ir.logic/`.
+**Renamed inside `bayes/`:** `verbs/` → `dsl/`.
+**Untouched:** `lang.runtime/`, `lang.dsl/`, `lang.compiler/`, `lang.refs/`, `lang.review/`, `ir/*` other than the new `logic/` subdir, `bp/`, `inquiry/`, `trace/`, `_stale_check.py`, `packaging.py`.
+
+## 8. Migration Plan
+
+Two sequenced PRs to minimize blast radius and let reviewers focus on one structural argument at a time.
+
+### 8.1 PR a — Single-file consolidation + logic demotion
+
+**Scope:** Two file moves, two new tombstones, three deleted shells, no semantic changes.
+
+| From | To |
+|---|---|
+| `gaia/engine/lang/types/primitives.py` | `gaia/engine/lang/formula/primitives.py` |
+| `gaia/engine/logic/propositional.py` | `gaia/engine/ir/logic/propositional.py` |
+
+Tombstones added to `TOMBSTONED_NAMESPACES`:
+
+```python
+"gaia.engine.lang.types": "gaia.engine.lang.formula",
+"gaia.engine.logic": "gaia.engine.ir.logic",
+```
+
+Existing entry updated:
+
+```python
+# old: "gaia.logic": "gaia.engine.logic"
+"gaia.logic": "gaia.engine.ir.logic",
+```
+
+Deleted (after tombstones install):
+
+- `gaia/engine/lang/types/__init__.py` (and the directory if no other contents)
+- `gaia/engine/logic/__init__.py` (and the directory)
+
+`gaia/engine/lang/__init__.py`: continue re-exporting `Bool, Nat, Real, Probability, PrimitiveType` so user-facing import `from gaia.engine.lang import Bool` keeps working unchanged.
+
+Update `gaia/engine/ir/logic/__init__.py` (new file) with explicit scope notes per §5:
+
+```python
+"""Logic backends for compiled Gaia IR.
+
+Provides solver-backed analysis of the IR's logical structure. Backends use
+external libraries (sympy, future Z3/CVC5) while keeping `gaia.engine.ir`
+data classes free of solver dependencies.
+
+Current scope:
+    propositional — sympy-based analysis of claim-level Operator graphs
+        (NEGATION/CONJUNCTION/DISJUNCTION/IMPLICATION/EQUIVALENCE/
+        CONTRADICTION/COMPLEMENT). Treats Knowledge nodes as atoms; does
+        not look inside Claim.formula metadata.
+
+Future (out of scope for this PR; tracked separately):
+    predicate — first-order / SMT backends consuming `formula_atom` metadata
+        for claim-internal predicate / quantifier / arithmetic analysis.
+    smt — cross-cutting analysis combining Operator graph with claim-internal
+        formula metadata.
+
+See docs/specs/2026-05-16-engine-module-reorg-design.md §5 for the three-scope
+taxonomy.
+"""
+```
+
+Estimated diff: ~120 lines (file moves + tombstone updates + new `__init__.py` + path rewrites in tests / examples / docs that use the old paths).
+
+### 8.2 PR b — Bayes promotion + verbs/dsl rename
+
+**Scope:** One subtree move, one rename, one tombstone, repo-wide import path updates.
+
+| From | To |
+|---|---|
+| `gaia/engine/lang/bayes/` (entire tree) | `gaia/engine/bayes/` |
+| `gaia/engine/bayes/verbs/*` (post-move) | `gaia/engine/bayes/dsl/*` |
+
+Tombstone added:
+
+```python
+"gaia.engine.lang.bayes": "gaia.engine.bayes",
+```
+
+Repo-wide import rewrites:
+
+- `from gaia.engine.lang.bayes import ...` → `from gaia.engine.bayes import ...`
+- `from gaia.engine.lang.bayes.runtime import ...` → `from gaia.engine.bayes.runtime import ...`
+- `from gaia.engine.lang.bayes.verbs import ...` → `from gaia.engine.bayes.dsl import ...`
+- internal cross-imports in `bayes/*` updated similarly
+
+Doc updates (see §11).
+
+Estimated diff: ~350-450 lines (mostly mechanical import path updates + tombstone install + docs sync).
+
+### 8.3 Sequencing rationale
+
+PR a first because it is contained, has minimal blast radius, and resolves unambiguous over-structure with no naming debate. Reviewers focus on the demotion argument (criterion 4.2) without being distracted by the Bayes promotion.
+
+PR b second because it depends on the BayesInference decision being settled (which happened in PR #606+#609) and has wider repo-touch. With PR a already merged, PR b's change set is purely the bayes-related moves.
+
+## 9. Tombstone Strategy
+
+Reuse the existing `gaia/_legacy_imports.py` machinery:
+
+- `TOMBSTONED_NAMESPACES` registers each old → new redirect
+- `_TombstonedSubmoduleFinder` (already installed at module load time) intercepts `import gaia.<old>.<sub>` style imports
+- `_tombstoned_namespace_getattr` handles `from gaia.<old> import X` style imports
+
+Each tombstone raises a clean `ImportError` (alpha-0 strict policy — not a deprecation warning):
+
+```
+gaia.engine.logic.propositional has moved to gaia.engine.ir.logic.propositional;
+this path was never public API and is removed in alpha 0. Update imports to
+`gaia.engine.ir.logic.propositional`.
+```
+
+The `tests/baseline/test_l2_tombstones.py` enforces that every entry in `TOMBSTONED_NAMESPACES` actually raises an `ImportError` with the right redirect.
+
+For PR a, two new entries added and one updated (see §8.1). For PR b, one new entry added.
+
+The `verbs/ → dsl/` rename inside `bayes/` does not need a separate tombstone because `engine.lang.bayes.verbs` only ever existed as an internal sub-package; the public API was always `engine.lang.bayes.<verb>` re-exported. Test that public verbs (`from gaia.engine.bayes import model, likelihood`) still resolve; internal `bayes.dsl/__init__.py` re-exports the same names.
+
+## 10. Test Plan
+
+### PR a tests
+
+Smoke imports (must pass):
+
+```python
+from gaia.engine.lang import Bool, Nat, Real, Probability, PrimitiveType    # public API unchanged
+from gaia.engine.lang.formula.primitives import Bool                          # new direct path
+from gaia.engine.ir.logic.propositional import is_satisfiable, are_equivalent # new direct path
+```
+
+Tombstone redirects (must raise ImportError):
+
+```python
+import pytest
+
+with pytest.raises(ImportError, match="moved to gaia.engine.lang.formula"):
+    from gaia.engine.lang.types.primitives import Bool
+
+with pytest.raises(ImportError, match="moved to gaia.engine.ir.logic"):
+    from gaia.engine.logic.propositional import is_satisfiable
+
+with pytest.raises(ImportError, match="moved to gaia.engine.ir.logic"):
+    import gaia.engine.logic.propositional
+```
+
+Existing test suites must continue to pass without changes:
+
+- `tests/baseline/test_l2_tombstones.py` (extended automatically when `TOMBSTONED_NAMESPACES` is updated)
+- `tests/gaia/lang/formula/test_predicate.py`
+- any test that exercises propositional analysis on compiled packages
+
+### PR b tests
+
+Smoke imports:
+
+```python
+from gaia.engine.bayes import model, likelihood                       # new public path
+from gaia.engine.bayes.runtime import BayesInference, PredictiveModel, Likelihood
+from gaia.engine.bayes.dsl import model                               # renamed verbs → dsl
+from gaia.engine.lang.runtime.action import Reasoning
+from gaia.engine.bayes.runtime.actions import BayesInference
+
+assert issubclass(BayesInference, Reasoning)                           # cross-module subclass
+```
+
+Tombstone redirect:
+
+```python
+with pytest.raises(ImportError, match="moved to gaia.engine.bayes"):
+    from gaia.engine.lang.bayes import model
+```
+
+Existing test suites must pass without semantic regressions:
+
+- `tests/gaia/lang/bayes/*` — Bayes runtime + verbs + lowering tests (paths updated as part of PR b)
+- `tests/gaia/lang/test_action_hierarchy.py::test_bayes_action_shapes_follow_reasoning_taxonomy` — verifies `BayesInference / PredictiveModel / Likelihood` subclass relations across module boundaries
+
+### Cross-PR test
+
+IR hash stability: compile a sample Gaia package (e.g., one of the existing `*-gaia` examples) before each PR and after; the resulting `.gaia/ir.json` and `.gaia/ir_hash` must be byte-identical. Module path changes must not perturb compiled IR.
+
+## 11. Doc Updates
+
+PR a:
+
+- update `docs/foundations/gaia-lang/predicate-logic.md` — fix any direct references to `gaia.engine.lang.types` import paths
+- update `docs/foundations/gaia-lang/knowledge-and-reasoning.md` — fix any references to `engine.logic.propositional`
+- new `gaia/engine/ir/logic/__init__.py` docstring per §8.1
+
+PR b:
+
+- update `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` §4.2 — replace `gaia.engine.lang.bayes.runtime` references with `gaia.engine.bayes.runtime`; add a host/extension paragraph per §6 of this spec
+- update `docs/foundations/gaia-lang/bayes.md` — update import examples
+- update `docs/foundations/gaia-lang/knowledge-and-reasoning.md` §6 (Bayes Module) — update path references
+- update `docs/for-users/language-reference.md` import-block example — update Bayes import
+- update `README.md` — update any Bayes-related import snippets
+- move `gaia/engine/lang/bayes/README.md` → `gaia/engine/bayes/README.md`; update its import examples
+
+Both PRs:
+
+- a paragraph in `docs/foundations/gaia-lang/package.md` (or a new `engine-architecture.md`) framing host vs extension per §6 of this spec, so future contributors reading the layout know why `lang/` and `bayes/` are not peers despite sitting at the same nesting depth
+
+## 12. Validation
+
+For each PR:
+
+```bash
+git diff --check
+uv run --extra dev ruff check .
+uv run --extra dev ruff format --check .
+uv run --extra dev pytest tests/ --no-cov
+uv run --extra dev pytest tests/baseline/test_l2_tombstones.py -v
+uv run --extra docs mkdocs build --strict
+```
+
+Smoke compile on a known package:
+
+```bash
+gaia compile <some-existing-package>
+gaia build check <some-existing-package>
+diff <package>/.gaia/ir.json <reference-ir.json>
+```
+
+## 13. Future Work
+
+Tracked separately, not part of this spec:
+
+- **First-order / SMT logic backends** — implement `engine.ir.logic.predicate` (Z3-backed) consuming `formula_atom` metadata for scope A and C analysis (§5.1). Promote `engine.ir.logic/` to top-level `engine.logic/` only if a unified `Theory` data model emerges (Gaia-native abstractions over multiple solvers).
+
+- **Causal extension module** — when the `CausalEdge` GaiaGraph record from `2026-05-15-causal-cleanup-reasoning-shapes.md` §6 is implemented, land it as `gaia.engine.causal/` per the precedent in §6 of this spec.
+
+- **Compose review consolidation** — `engine.lang.review/` (manifest gen), `engine.inquiry/` (consume manifest), `engine.trace/review.py` (post-execution review) all carry "review" but operate at different lifecycle stages. Worth a separate spec to clarify whether these should consolidate, rename, or stay split.
+
+- **`Action` alias retirement** — track in `2026-05-15-reasoning-claim-reference-boundary.md` §9 deferred work. Independent of this reorg.
+
+## 14. Out of Scope (Explicit)
+
+Items considered and deliberately rejected for this spec:
+
+- **Full hierarchy flattening** (promoting `lang.runtime` / `lang.dsl` / `lang.compiler` to engine top-level): rejected per §4.5. Cohesion triangle is real; flattening breaks it.
+
+- **Renaming `lang/` → `core/`**: rejected per §4.5 + §6. Code-fact dependency direction is host/extension, not peer.
+
+- **Splitting `lang.dsl/` into `verbs/`, `factories/`, `legacy/`**: orthogonal nesting, no current consumer. YAGNI.
+
+- **Promoting Bayes out of `engine/`** (e.g., to top-level `gaia.bayes/`): out of scope for v0.5; alpha-0 layout already commits engine code under `gaia.engine/` and Bayes is engine code.
+
+- **Adding `engine.causal/` / `engine.statistics/` as part of this PR**: the spec sets the precedent (§6) but does not implement extensions that don't yet exist. They land as separate PRs when the feature work is ready.
+
+- **Removing tombstones**: post-deprecation cleanup is independent of this reorg. Tombstones are alpha-0 hard-error redirects, not soft deprecation; they stay in place indefinitely as long as `gaia.<old>` paths could plausibly appear in user code.

--- a/docs/specs/2026-05-16-engine-module-reorg-design.md
+++ b/docs/specs/2026-05-16-engine-module-reorg-design.md
@@ -171,30 +171,77 @@ Pure AST utilities, not "logic analysis":
 
 These are syntactic helpers tied to AST structure. They do not need solvers; they live close to their callers (`lang.formula.predicate`, `lang.dsl.decompose`, `lang.compiler.lower_formula`).
 
-## 6. Host vs Extension Framing
+## 6. Host vs Extension — Two Layers, Different Today's Realities
 
-After PR b lands, `engine.lang/` and `engine.bayes/` are **not symmetric peers**. The dependency graph is:
+After PR b lands, `engine.lang/` and `engine.bayes/` are **not symmetric peers** in the runtime-class hierarchy, but **today's module-import graph is bidirectional**, not unidirectional. This section is precise about which layer carries the host/extension semantics and which layer does not, because PR b only addresses one of the two.
+
+### 6.1 Runtime-class layer (clean host/extension)
+
+`bayes.* → lang.*` (extension built on host):
+
+- `bayes.runtime.actions.BayesInference` inherits `lang.runtime.action.Reasoning`
+- `bayes.runtime.actions.PredictiveModel / Likelihood` inherit `BayesInference`
+- `bayes.compiler.*` uses helpers from `lang.compiler.*`
+- `bayes.runtime.actions.Likelihood` constructs `lang.runtime.action.Contradict / Exclusive` via the auto-structural mechanism
+- `bayes.*` consumes the formula AST in `lang.formula.*`
+
+This is what the BayesInference shape decision (`2026-05-15-causal-cleanup-reasoning-shapes.md` §4.2) sets up: a runtime-class hierarchy where Bayes records are formal extensions of the base `Reasoning` hierarchy. Nothing in `lang.runtime.action` inherits from anything in `bayes`.
+
+### 6.2 Module-import layer (bidirectional today)
+
+`lang.* → bayes.*` (host consuming extension; **persists after PR b**):
+
+| Site | What it does |
+|---|---|
+| `gaia/engine/lang/__init__.py:138-142` `__getattr__("bayes")` | Lazy-imports `gaia.engine.lang.bayes` (or post-PR-b `gaia.engine.bayes`) so the documented public form `from gaia.engine.lang import bayes` keeps working |
+| `gaia/engine/lang/compiler/compile.py::_lower_bayes_actions` | Calls `from gaia.engine.lang.bayes.compiler import lower_bayes_claims` directly inside the core compile pipeline |
+| `gaia/engine/lang/runtime/distribution.py` (10+ sites) | Top-level distribution factories `Normal / LogNormal / Beta / Exponential / Gamma / StudentT / Cauchy / ChiSquared / Binomial / Poisson` lazy-import their backing implementations from `bayes.distributions.*` and `bayes.adapters.scipy_backend` |
+
+So the import graph is:
 
 ```
-bayes.runtime ─→ lang.runtime          (BayesInference inherits Reasoning)
-bayes.compiler ─→ lang.compiler         (compile-time helpers)
-bayes.runtime / verbs ─→ lang.formula   (predicate logic AST shared)
-bayes.* ─→ lang.refs / lang.review      (shared services)
-bayes.* ─→ engine.ir, engine.bp         (downstream)
-lang.* ↛ bayes.*                        (zero reverse imports)
+bayes.runtime ─→ lang.runtime           (extension extends host runtime classes)
+bayes.compiler ─→ lang.compiler          (extension reuses host compile helpers)
+bayes.* ─→ lang.formula / lang.refs / lang.review   (shared services)
+bayes.* ─→ engine.ir / engine.bp        (downstream)
+
+lang.__init__ ─→ bayes                   (lazy attribute hook for public API)
+lang.compiler.compile ─→ bayes.compiler  (Bayes lowering hook)
+lang.runtime.distribution ─→ bayes.distributions / bayes.adapters
+                                        (top-level Distribution factories
+                                         delegate to Bayes implementations)
 ```
 
-`lang/` is the **host**: it defines the base `Reasoning` hierarchy, the formula AST, and shared services (refs, review). `bayes/` is an **extension**: it adds new `Reasoning` subclasses, new verbs, and a Bayes-specific compile path that all plug into the host.
+### 6.3 What PR b does (and does not) about the bidirectional layer
 
-This framing answers two recurring naming questions:
+PR b's scope is **path migration only**:
 
-1. *"Should `lang/` be renamed `core/` for symmetry with `bayes/`?"* — No. `core/peer-bayes/peer-causal/...` would imply a flat peer hierarchy, but the import graph is hub-and-spoke. The `lang` name preserves "this is the language host module"; `bayes` (and future causal/statistics) extend it.
+- move the directory tree `engine/lang/bayes/` → `engine/bayes/`
+- update the three reverse-import sites above to point at the new path:
+  - `lang/__init__.py:140` `import_module("gaia.engine.lang.bayes")` → `import_module("gaia.engine.bayes")`
+  - `lang/compiler/compile.py:1826` `from gaia.engine.lang.bayes.compiler import …` → `from gaia.engine.bayes.compiler import …`
+  - all `lang/runtime/distribution.py` `from gaia.engine.lang.bayes.{distributions,adapters} import …` → `from gaia.engine.bayes.{distributions,adapters} import …`
+- install the tombstone for `gaia.engine.lang.bayes` (see §9)
+
+PR b **does not** eliminate the reverse imports. The reasons:
+
+1. `from gaia.engine.lang import bayes` is documented public API in `docs/foundations/gaia-lang/bayes.md` and `docs/for-users/language-reference.md`. Removing or reshaping it requires a deprecation cycle and user-facing communication that is out of scope here.
+2. Top-level distribution factories `Normal / Beta / ...` under `lang.runtime.distribution` are part of the v0.5 documented surface; relocating them is its own Bayes-API design question (do they belong in `bayes.runtime.distribution`? do they stay in `lang.runtime` as type-aware wrappers? do they split?). Cannot be decided in a path-migration PR.
+3. `compile._lower_bayes_actions` is a hard-coded lowering hook into Bayes. Cleanly replacing it with a lang-only contract requires designing a plugin/registry mechanism — substantial follow-up work.
+
+PR b therefore preserves the **runtime-class** host/extension structure (clean, single-direction) while leaving the **module-import** structure bidirectional. The path migration is justified by the precedent argument in §4.1 (BayesInference is runtime-first-class; its module path should match) without overloading PR b with a decoupling refactor.
+
+### 6.4 Naming questions answered
+
+1. *"Should `lang/` be renamed `core/` for symmetry with `bayes/`?"* — No. The runtime-class direction is host/extension (§6.1) and `lang` accurately names the host. The module-import bidirectionality (§6.2) does not turn `lang/` into a peer of `bayes/`; lang is still the host that consumes (a few) extension-implemented services because that was the v0.5 design choice for distribution factories and the public `lang.bayes` namespace shortcut.
 
 2. *"Why does `bayes.runtime` mirror `lang.runtime` while `lang.runtime` does not have a `bayes/` subdirectory?"* — Because each extension owns its own Reasoning subclasses and verbs but reuses the host's base hierarchy. The mirror is structural, not hierarchical.
 
-Future extensions follow this contract:
+### 6.5 Future-extension contract
 
-> Any new reasoning family that introduces its own runtime classes (e.g., `CausalEdge` per `2026-05-15-causal-cleanup-reasoning-shapes.md` §6) lands as a peer module under `gaia.engine.<family>/`, not under `gaia.engine.lang.<family>/`. The peer module follows the same internal layout as `gaia.engine.bayes/`: at minimum `runtime/` + `dsl/`; optionally `compiler/`, `distributions/`, `adapters/` as needed. The peer extension may freely import from `gaia.engine.lang.*` (host) and `gaia.engine.ir/` / `engine.bp/` (downstream); the host must not import from any extension.
+> Any new reasoning family that introduces its own runtime classes (e.g., `CausalEdge` per `2026-05-15-causal-cleanup-reasoning-shapes.md` §6) lands as a peer module under `gaia.engine.<family>/`, not under `gaia.engine.lang.<family>/`. The peer module follows the same internal layout as `gaia.engine.bayes/`: at minimum `runtime/` + `dsl/`; optionally `compiler/`, `distributions/`, `adapters/` as needed. The peer extension freely imports from `gaia.engine.lang.*` (host) and `gaia.engine.ir/` / `engine.bp/` (downstream).
+>
+> Whether the host imports back from the new extension (mirroring today's `lang → bayes` reality for distribution factories and compile hooks) is a per-extension decision, not a default; it should be flagged explicitly when the extension's design spec is written, and a follow-up to §13's "Lang/Bayes import isolation" should consider the new extension's reverse-import sites.
 
 ## 7. Target State
 
@@ -245,12 +292,27 @@ Two sequenced PRs to minimize blast radius and let reviewers focus on one struct
 
 ### 8.1 PR a — Single-file consolidation + logic demotion
 
-**Scope:** Two file moves, two new tombstones, three deleted shells, no semantic changes.
+**Scope:** Two file moves, two new tombstone shims, two new namespace registry entries, no semantic changes.
 
-| From | To |
+| File | Action |
 |---|---|
-| `gaia/engine/lang/types/primitives.py` | `gaia/engine/lang/formula/primitives.py` |
-| `gaia/engine/logic/propositional.py` | `gaia/engine/ir/logic/propositional.py` |
+| `gaia/engine/lang/types/primitives.py` | Move to `gaia/engine/lang/formula/primitives.py` |
+| `gaia/engine/lang/types/__init__.py` | **Replace contents** with the 4-line tombstone shim (see below) — directory kept |
+| `gaia/engine/logic/propositional.py` | Move to `gaia/engine/ir/logic/propositional.py` |
+| `gaia/engine/logic/__init__.py` | **Replace contents** with the 4-line tombstone shim — directory kept |
+| `gaia/engine/ir/logic/__init__.py` | **New file** with explicit scope notes (see below) |
+
+The tombstone shim follows the alpha-0 convention used by `gaia/bp/__init__.py`, `gaia/lang/__init__.py`, etc.:
+
+```python
+"""Alpha 0 tombstone — gaia.engine.lang.types relocated to gaia.engine.lang.formula."""
+
+from gaia._legacy_imports import _tombstoned_namespace_getattr
+
+__getattr__ = _tombstoned_namespace_getattr(
+    "gaia.engine.lang.types", "gaia.engine.lang.formula"
+)
+```
 
 Tombstones added to `TOMBSTONED_NAMESPACES`:
 
@@ -265,11 +327,6 @@ Existing entry updated:
 # old: "gaia.logic": "gaia.engine.logic"
 "gaia.logic": "gaia.engine.ir.logic",
 ```
-
-Deleted (after tombstones install):
-
-- `gaia/engine/lang/types/__init__.py` (and the directory if no other contents)
-- `gaia/engine/logic/__init__.py` (and the directory)
 
 `gaia/engine/lang/__init__.py`: continue re-exporting `Bool, Nat, Real, Probability, PrimitiveType` so user-facing import `from gaia.engine.lang import Bool` keeps working unchanged.
 
@@ -303,29 +360,39 @@ Estimated diff: ~120 lines (file moves + tombstone updates + new `__init__.py` +
 
 ### 8.2 PR b — Bayes promotion + verbs/dsl rename
 
-**Scope:** One subtree move, one rename, one tombstone, repo-wide import path updates.
+**Scope:** One subtree move, one internal rename, one tombstone shim, repo-wide import-path updates including the three known reverse-import sites in `lang/`.
 
-| From | To |
+| File / Directory | Action |
 |---|---|
-| `gaia/engine/lang/bayes/` (entire tree) | `gaia/engine/bayes/` |
-| `gaia/engine/bayes/verbs/*` (post-move) | `gaia/engine/bayes/dsl/*` |
+| `gaia/engine/lang/bayes/` (entire subtree) | Move to `gaia/engine/bayes/` |
+| `gaia/engine/bayes/verbs/` (post-move) | Rename to `gaia/engine/bayes/dsl/` |
+| `gaia/engine/lang/bayes/__init__.py` (the now-empty old location) | **Replace contents** with tombstone shim (see §8.1 pattern) — directory kept |
 
-Tombstone added:
+Tombstone added to `TOMBSTONED_NAMESPACES`:
 
 ```python
 "gaia.engine.lang.bayes": "gaia.engine.bayes",
 ```
 
-Repo-wide import rewrites:
+Repo-wide import-path rewrites — three categories:
 
-- `from gaia.engine.lang.bayes import ...` → `from gaia.engine.bayes import ...`
-- `from gaia.engine.lang.bayes.runtime import ...` → `from gaia.engine.bayes.runtime import ...`
-- `from gaia.engine.lang.bayes.verbs import ...` → `from gaia.engine.bayes.dsl import ...`
-- internal cross-imports in `bayes/*` updated similarly
+1. **External callers** (tests, examples, package code, docs):
+   - `from gaia.engine.lang.bayes import ...` → `from gaia.engine.bayes import ...`
+   - `from gaia.engine.lang.bayes.runtime import ...` → `from gaia.engine.bayes.runtime import ...`
+   - `from gaia.engine.lang.bayes.verbs import ...` → `from gaia.engine.bayes.dsl import ...`
+
+2. **Internal cross-imports inside the moved subtree** — paths inside `bayes/*` referring to siblings need rewriting from `gaia.engine.lang.bayes.X` to `gaia.engine.bayes.X`.
+
+3. **Three `lang → bayes` reverse-import sites** (per §6.2) — these continue to exist after PR b but the path is updated:
+   - `gaia/engine/lang/__init__.py:140` `import_module("gaia.engine.lang.bayes")` → `import_module("gaia.engine.bayes")`
+   - `gaia/engine/lang/compiler/compile.py:1826` `from gaia.engine.lang.bayes.compiler import lower_bayes_claims` → `from gaia.engine.bayes.compiler import lower_bayes_claims`
+   - all `gaia/engine/lang/runtime/distribution.py` lazy imports — for example line 169 `from gaia.engine.lang.bayes.distributions.base import _BaseDistribution` → `from gaia.engine.bayes.distributions.base import _BaseDistribution`; same for `bayes.adapters.scipy_backend` and the 10 distribution factories `Normal / LogNormal / Beta / Exponential / Gamma / StudentT / Cauchy / ChiSquared / Binomial / Poisson`
+
+Note: the `verbs/ → dsl/` rename inside `bayes/` does not require its own namespace tombstone because `engine.lang.bayes.verbs` was an internal sub-package; the public `bayes.dsl/__init__.py` re-exports the same names (`model`, `likelihood`).
 
 Doc updates (see §11).
 
-Estimated diff: ~350-450 lines (mostly mechanical import path updates + tombstone install + docs sync).
+Estimated diff: ~400-500 lines (mostly mechanical import path updates including the lang→bayes lazy imports + tombstone install + docs sync).
 
 ### 8.3 Sequencing rationale
 
@@ -335,25 +402,49 @@ PR b second because it depends on the BayesInference decision being settled (whi
 
 ## 9. Tombstone Strategy
 
-Reuse the existing `gaia/_legacy_imports.py` machinery:
+Reuse the existing `gaia/_legacy_imports.py` machinery, but be careful about which import form the meta-path finder actually intercepts. The finder logic is:
 
-- `TOMBSTONED_NAMESPACES` registers each old → new redirect
-- `_TombstonedSubmoduleFinder` (already installed at module load time) intercepts `import gaia.<old>.<sub>` style imports
-- `_tombstoned_namespace_getattr` handles `from gaia.<old> import X` style imports
-
-Each tombstone raises a clean `ImportError` (alpha-0 strict policy — not a deprecation warning):
-
+```python
+# gaia/_legacy_imports.py:91-107 (paraphrased)
+def find_spec(self, fullname, path, target=None):
+    for old_ns, new_ns in TOMBSTONED_NAMESPACES.items():
+        prefix = f"{old_ns}."
+        if fullname.startswith(prefix):           # ← exact match excluded
+            ...
+            return ModuleSpec(...)
+    return None
 ```
-gaia.engine.logic.propositional has moved to gaia.engine.ir.logic.propositional;
-this path was never public API and is removed in alpha 0. Update imports to
-`gaia.engine.ir.logic.propositional`.
+
+So the finder only intercepts **strict-prefix** submodule imports (`import gaia.engine.logic.propositional`). It does **not** intercept the bare namespace import (`import gaia.engine.logic`) because `fullname == "gaia.engine.logic"` does not pass `startswith("gaia.engine.logic.")`.
+
+The way alpha-0 covers all three import forms is by also keeping the old directory's `__init__.py` as a 4-line shim that installs a module-level `__getattr__`:
+
+```python
+# gaia/bp/__init__.py — alpha-0 reference shim
+"""Alpha 0 tombstone — gaia.bp relocated to gaia.engine.bp."""
+
+from gaia._legacy_imports import _tombstoned_namespace_getattr
+
+__getattr__ = _tombstoned_namespace_getattr("gaia.bp", "gaia.engine.bp")
 ```
 
-The `tests/baseline/test_l2_tombstones.py` enforces that every entry in `TOMBSTONED_NAMESPACES` actually raises an `ImportError` with the right redirect.
+With both pieces in place, the three import forms are all covered:
 
-For PR a, two new entries added and one updated (see §8.1). For PR b, one new entry added.
+| Import form | Mechanism | Result |
+|---|---|---|
+| `from gaia.engine.logic import X` | shim `__getattr__("X")` | `ImportError(... has moved to gaia.engine.ir.logic ...)` |
+| `import gaia.engine.logic.propositional` | `_TombstonedSubmoduleFinder.find_spec` matches prefix | `ImportError(... has moved to gaia.engine.ir.logic.propositional ...)` |
+| `import gaia.engine.logic` (exact) | resolves to the shim module (which is empty except for `__getattr__`) — subsequent attribute access raises | `ImportError` on first attribute access |
 
-The `verbs/ → dsl/` rename inside `bayes/` does not need a separate tombstone because `engine.lang.bayes.verbs` only ever existed as an internal sub-package; the public API was always `engine.lang.bayes.<verb>` re-exported. Test that public verbs (`from gaia.engine.bayes import model, likelihood`) still resolve; internal `bayes.dsl/__init__.py` re-exports the same names.
+This is why §8.1 / §8.2 keep the old directories and **replace** their `__init__.py` with shim contents rather than deleting the directories.
+
+For PR a: two new tombstone shims (`engine/lang/types/`, `engine/logic/`); two new `TOMBSTONED_NAMESPACES` entries (`gaia.engine.lang.types`, `gaia.engine.logic`); one existing entry updated (`gaia.logic` retargeted to `gaia.engine.ir.logic`).
+
+For PR b: one new tombstone shim (`engine/lang/bayes/`); one new `TOMBSTONED_NAMESPACES` entry (`gaia.engine.lang.bayes`).
+
+The `verbs/ → dsl/` rename inside `bayes/` does not need a separate tombstone because `engine.lang.bayes.verbs` only ever existed as an internal sub-package; the public API was always `engine.lang.bayes.<verb>` re-exported. Internal `bayes.dsl/__init__.py` re-exports the same names (`model`, `likelihood`).
+
+`tests/baseline/test_l2_tombstones.py` enforces that every entry in `TOMBSTONED_NAMESPACES` actually raises an `ImportError` with the right redirect; it must be extended to cover the new entries (or, if it auto-discovers from the registry, will pick them up automatically — confirm during PR a implementation).
 
 ## 10. Test Plan
 
@@ -390,7 +481,7 @@ Existing test suites must continue to pass without changes:
 
 ### PR b tests
 
-Smoke imports:
+Smoke imports — new canonical paths:
 
 ```python
 from gaia.engine.bayes import model, likelihood                       # new public path
@@ -402,17 +493,47 @@ from gaia.engine.bayes.runtime.actions import BayesInference
 assert issubclass(BayesInference, Reasoning)                           # cross-module subclass
 ```
 
+Smoke imports — surviving `lang → bayes` reverse-import sites (per §6.2 these continue to work after PR b updates the path):
+
+```python
+# 1. Lazy submodule attribute on lang/__init__.py
+from gaia.engine.lang import bayes
+assert bayes.__name__ == "gaia.engine.bayes"          # path migrated
+
+# 2. Top-level Distribution factories — proxy to the new bayes.distributions
+from gaia.engine.lang.runtime.distribution import Normal, Beta, Binomial
+n = Normal(mu=0.0, sigma=1.0)
+b = Beta(alpha=1.0, beta=1.0)
+bn = Binomial(n=10, p=0.5)
+# accessing them must not raise; their backing classes resolve from gaia.engine.bayes.distributions
+
+# 3. _lower_bayes_actions code path — exercise via end-to-end compile
+from gaia.engine.lang.runtime.package import CollectedPackage
+from gaia.engine.lang import claim, bayes as bayes_module
+from gaia.engine.lang.compiler import compile_package_artifact
+
+with CollectedPackage("smoke_bayes") as pkg:
+    h = claim("Hypothesis.", prior=0.5)
+    obs = ...  # build a tiny bayes.model + bayes.likelihood
+artifact = compile_package_artifact(pkg)
+# compile must complete without ImportError on the lang→bayes hook path
+```
+
 Tombstone redirect:
 
 ```python
 with pytest.raises(ImportError, match="moved to gaia.engine.bayes"):
     from gaia.engine.lang.bayes import model
+
+with pytest.raises(ImportError, match="moved to gaia.engine.bayes"):
+    import gaia.engine.lang.bayes.compiler
 ```
 
 Existing test suites must pass without semantic regressions:
 
 - `tests/gaia/lang/bayes/*` — Bayes runtime + verbs + lowering tests (paths updated as part of PR b)
 - `tests/gaia/lang/test_action_hierarchy.py::test_bayes_action_shapes_follow_reasoning_taxonomy` — verifies `BayesInference / PredictiveModel / Likelihood` subclass relations across module boundaries
+- `tests/baseline/test_l2_facade.py` — facade contract; `EXPECTED` must include the new `gaia.engine.bayes` entry and the total updated
 
 ### Cross-PR test
 
@@ -420,24 +541,61 @@ IR hash stability: compile a sample Gaia package (e.g., one of the existing `*-g
 
 ## 11. Doc Updates
 
-PR a:
+### PR a
+
+User / foundations docs:
 
 - update `docs/foundations/gaia-lang/predicate-logic.md` — fix any direct references to `gaia.engine.lang.types` import paths
 - update `docs/foundations/gaia-lang/knowledge-and-reasoning.md` — fix any references to `engine.logic.propositional`
 - new `gaia/engine/ir/logic/__init__.py` docstring per §8.1
 
-PR b:
+Reference / facade docs (engine reference layer):
 
-- update `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` §4.2 — replace `gaia.engine.lang.bayes.runtime` references with `gaia.engine.bayes.runtime`; add a host/extension paragraph per §6 of this spec
-- update `docs/foundations/gaia-lang/bayes.md` — update import examples
+- update `docs/reference/engine/index.md` — facade table (the canonical 7-submodule list that locks the engine surface): remove `gaia.engine.logic` from the top-level list; the demoted `engine.ir.logic` lives under the existing `gaia.engine.ir` reference page
+- delete or redirect `docs/reference/engine/logic.md` — its content moves to a sub-section under `docs/reference/engine/ir.md` (or a new `docs/reference/engine/ir/logic.md` if the per-page convention prefers a separate page)
+- update `docs/reference/engine/ir.md` (or `lang/formula.md` / `lang/types.md`) — note that `Bool / Nat / Real / Probability / PrimitiveType` now canonically live at `gaia.engine.lang.formula.primitives`
+
+Facade contract test:
+
+- update `tests/baseline/test_l2_facade.py` — the `EXPECTED` dict is currently:
+  ```python
+  EXPECTED = {
+      "gaia.engine.bp": 17,
+      "gaia.engine.ir": 32,
+      "gaia.engine.lang": 127,
+      "gaia.engine.logic": 7,         # ← remove (logic demoted under ir)
+      "gaia.engine.inquiry": 45,
+      "gaia.engine.trace": 7,
+      "gaia.engine.packaging": 9,
+  }
+  ```
+  Decide whether the 7 logic symbols are re-exported from `gaia.engine.ir` (so `gaia.engine.ir`'s count rises from 32 to ~39) or made internal-only under `gaia.engine.ir.logic` (so the `gaia.engine.ir` `__all__` is unchanged and the 7 symbols disappear from the locked facade total). This is a small but explicit policy decision the implementing PR has to make; update `tests/baseline/test_l2_facade.py` and the docstring in `engine-facade-final.md` accordingly.
+
+### PR b
+
+User / foundations docs:
+
+- update `docs/specs/2026-05-15-causal-cleanup-reasoning-shapes.md` §4.2 — replace `gaia.engine.lang.bayes.runtime` references with `gaia.engine.bayes.runtime`; add a paragraph cross-referencing §6 of this spec for the runtime-class vs module-import distinction
+- update `docs/foundations/gaia-lang/bayes.md` — update import examples to `from gaia.engine.bayes import ...`
 - update `docs/foundations/gaia-lang/knowledge-and-reasoning.md` §6 (Bayes Module) — update path references
 - update `docs/for-users/language-reference.md` import-block example — update Bayes import
 - update `README.md` — update any Bayes-related import snippets
 - move `gaia/engine/lang/bayes/README.md` → `gaia/engine/bayes/README.md`; update its import examples
+- decide whether to keep `from gaia.engine.lang import bayes` documented (recommended: keep, with a doc note that `gaia.engine.bayes` is the canonical path and `gaia.engine.lang.bayes` is a documented compatibility shortcut backed by `lang/__init__.py:__getattr__`)
 
-Both PRs:
+Reference / facade docs:
 
-- a paragraph in `docs/foundations/gaia-lang/package.md` (or a new `engine-architecture.md`) framing host vs extension per §6 of this spec, so future contributors reading the layout know why `lang/` and `bayes/` are not peers despite sitting at the same nesting depth
+- new `docs/reference/engine/bayes.md` (or `bayes/index.md` if the existing convention prefers package-style with sub-pages mirroring `docs/reference/engine/lang/*.md`) — Bayes facade reference page
+- update `docs/reference/engine/index.md` — facade table: add `gaia.engine.bayes` row
+- update `docs/reference/engine/lang/*.md` if any sub-page references `engine.lang.bayes` directly
+
+Facade contract test:
+
+- update `tests/baseline/test_l2_facade.py` — add `gaia.engine.bayes` to `EXPECTED` with its `__all__` count; total 244 will change; sync the docstring header counts
+
+### Both PRs
+
+- a paragraph in `docs/foundations/gaia-lang/package.md` (or a new `engine-architecture.md`) framing the runtime-class / module-import two-layer distinction per §6 of this spec, so future contributors reading the layout know why `lang/` is the host on the runtime-class layer but still imports back from `bayes/` on the module layer.
 
 ## 12. Validation
 
@@ -455,7 +613,7 @@ uv run --extra docs mkdocs build --strict
 Smoke compile on a known package:
 
 ```bash
-gaia compile <some-existing-package>
+gaia build compile <some-existing-package>
 gaia build check <some-existing-package>
 diff <package>/.gaia/ir.json <reference-ir.json>
 ```
@@ -464,9 +622,11 @@ diff <package>/.gaia/ir.json <reference-ir.json>
 
 Tracked separately, not part of this spec:
 
+- **Lang/Bayes import isolation** — design a plugin/registry hook so `lang.compiler` does not directly import `bayes.compiler` (replacing today's `_lower_bayes_actions` direct import with a registered hook); decide whether `from gaia.engine.lang import bayes` stays as a documented compatibility shortcut or is tombstoned in favor of `from gaia.engine.bayes import ...`; decide where the top-level `Normal / LogNormal / Beta / Exponential / Gamma / StudentT / Cauchy / ChiSquared / Binomial / Poisson` distribution factories live (under `lang.runtime.distribution` as today, or relocated to `bayes.runtime.distribution`, or split between user-facing wrappers in `lang` and implementations in `bayes`). Independent of the path migration in this spec; landing requires its own design spec because it touches public API surface.
+
 - **First-order / SMT logic backends** — implement `engine.ir.logic.predicate` (Z3-backed) consuming `formula_atom` metadata for scope A and C analysis (§5.1). Promote `engine.ir.logic/` to top-level `engine.logic/` only if a unified `Theory` data model emerges (Gaia-native abstractions over multiple solvers).
 
-- **Causal extension module** — when the `CausalEdge` GaiaGraph record from `2026-05-15-causal-cleanup-reasoning-shapes.md` §6 is implemented, land it as `gaia.engine.causal/` per the precedent in §6 of this spec.
+- **Causal extension module** — when the `CausalEdge` GaiaGraph record from `2026-05-15-causal-cleanup-reasoning-shapes.md` §6 is implemented, land it as `gaia.engine.causal/` per the precedent in §6 of this spec. Per §6.5, decide explicitly whether `lang/` will reverse-import any causal-specific service (mirroring today's `lang → bayes` reality) or whether the new extension is fully decoupled from day one.
 
 - **Compose review consolidation** — `engine.lang.review/` (manifest gen), `engine.inquiry/` (consume manifest), `engine.trace/review.py` (post-execution review) all carry "review" but operate at different lifecycle stages. Worth a separate spec to clarify whether these should consolidate, rename, or stay split.
 


### PR DESCRIPTION
## Summary

Adds `docs/specs/2026-05-16-engine-module-reorg-design.md`, a design spec for two coordinated reorganizations of the `gaia.engine` module tree. Spec only — no code moves in this PR; implementation will follow as PR a + PR b.

**PR a (small, low-risk):** consolidate single-file packages and demote `engine.logic/` to `engine.ir.logic/`.

| From | To |
|---|---|
| `gaia/engine/lang/types/primitives.py` | `gaia/engine/lang/formula/primitives.py` |
| `gaia/engine/logic/propositional.py` | `gaia/engine/ir/logic/propositional.py` |

**PR b (medium):** promote Bayes to a peer extension and align verb directory naming.

| From | To |
|---|---|
| `gaia/engine/lang/bayes/` (whole subtree) | `gaia/engine/bayes/` |
| `gaia/engine/bayes/verbs/` (post-move) | `gaia/engine/bayes/dsl/` |

## Why

PR #606 + #609 landed `BayesInference(Reasoning)` as a runtime-first-class shape, but the module path still nests Bayes five levels deep at `gaia.engine.lang.bayes.*`. This is an inconsistency between the runtime hierarchy decision and the module path that should be resolved before more reasoning families (causal, statistics, …) inherit the same nested layout.

Three smaller cleanups ride along because they share the same first-principles judgment criteria:

- `engine.lang.types/` is a sub-package shell with one file; its primitives belong with the formula AST.
- `engine.logic/` is the only top-level engine peer with no Gaia-native abstractions — pure sympy-on-IR adapter — so it belongs as an IR sub-module like `engine.ir.coarsen / linearize / validator`.
- `lang.dsl/` vs `bayes.verbs/` naming asymmetry surfaces in public import paths once Bayes promotes.

## What the spec covers

- **First-principles framework** (§3) — four objective criteria for module placement: cohesion, dependency direction, API surface, evolution pressure.
- **Diagnosis** (§4) — applies the criteria to each issue, including explicit non-issues (don't flatten the lang triangle, don't rename `lang/` → `core/`).
- **Logic layer architecture** (§5) — three scopes (within-claim / between-claim / cross-cutting), explanation of why all three solver backends belong under `engine.ir.logic/` rather than `lang.formula/`.
- **Host vs extension framing** (§6) — `lang/` is the host, `bayes/` is an extension; sets the precedent for future causal / statistics modules.
- **Target state, migration plan, tombstone strategy, test plan, validation, doc updates, future work, and explicit out-of-scope items** (§7–§14).

## Validation

- `git diff --check`
- `uv run --extra docs mkdocs build --strict` (spec page renders cleanly)

This PR adds documentation only; no Python code is changed and no tests run differently.

Made with [Cursor](https://cursor.com)