### PR TITLE
refactor(engine): register compiler action lowerers

### DIFF
--- a/gaia/engine/bayes/__init__.py
+++ b/gaia/engine/bayes/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from gaia.engine.bayes.compiler import register_bayes_lowerer as _register_bayes_lowerer
 from gaia.engine.bayes.distributions import (
     Beta,
     BetaBinomial,
@@ -47,6 +48,8 @@ def _register_bayes_roles() -> None:
 
 
 _register_bayes_roles()
+
+_register_bayes_lowerer()
 
 __all__ = [
     "BayesInference",

--- a/gaia/engine/bayes/compiler/__init__.py
+++ b/gaia/engine/bayes/compiler/__init__.py
@@ -1,5 +1,41 @@
 """Bayes compiler lowering."""
 
 from gaia.engine.bayes.compiler.lower import BayesLoweringResult, lower_bayes_claims
+from gaia.engine.bayes.runtime import BayesInference
+from gaia.engine.lang.compiler.extensions import (
+    ActionLoweringContext,
+    ActionLoweringResult,
+    register_action_lowerer,
+)
+
+
+def _is_bayes_action(action: object) -> bool:
+    return isinstance(action, BayesInference)
+
+
+def _lower_bayes_actions(context: ActionLoweringContext) -> ActionLoweringResult:
+    lowered = lower_bayes_claims(
+        context.knowledge_nodes,
+        actions=context.actions,
+        namespace=context.namespace,
+        package_name=context.package_name,
+        knowledge_map=context.knowledge_map,
+        action_labels_by_object=context.action_labels_by_object,
+        existing_operators=context.existing_operators,
+    )
+    return ActionLoweringResult(
+        knowledges=lowered.knowledges,
+        operators=lowered.operators,
+        strategies=lowered.strategies,
+        metadata_updates=lowered.metadata_updates,
+        action_label_map=lowered.action_label_map,
+        target_action_labels_by_id=lowered.target_action_labels_by_id,
+    )
+
+
+def register_bayes_lowerer() -> None:
+    """Register Bayes action lowering with the Gaia Lang compiler."""
+    register_action_lowerer("bayes", handles=_is_bayes_action, lower=_lower_bayes_actions)
+
 
 __all__ = ["BayesLoweringResult", "lower_bayes_claims"]

--- a/gaia/engine/lang/compiler/compile.py
+++ b/gaia/engine/lang/compiler/compile.py
@@ -50,6 +50,12 @@ from gaia.engine.ir import (
 from gaia.engine.ir.knowledge import KnowledgeType
 from gaia.engine.ir.operator import OperatorType
 from gaia.engine.ir.strategy import StrategyType
+from gaia.engine.lang.compiler.extensions import (
+    ActionLoweringContext,
+    ActionLoweringResult,
+    is_registered_action,
+    lower_registered_actions,
+)
 from gaia.engine.lang.compiler.lower_formula import lower_claim_formula
 from gaia.engine.lang.refs import (
     ReferenceError,
@@ -834,7 +840,7 @@ class _ActionCompiler:
         strategy_target_ids_by_object: dict[int, str],
         operator_target_ids_by_object: dict[int, str],
     ) -> list[IrCompose]:
-        """Lower Compose actions after child actions and Bayes actions have targets."""
+        """Lower Compose actions after child and extension actions have targets."""
         return [
             self._compile_compose_action(
                 action,
@@ -1335,7 +1341,7 @@ class _ActionCompiler:
         """Lower one non-scaffold action into its IR target."""
         if isinstance(action, DependsOn | CandidateRelation):
             return None
-        if _is_bayes_action(action):
+        if is_registered_action(action):
             return None
         if isinstance(action, Support):
             return self._compile_support_action(action, action_index)
@@ -1437,19 +1443,19 @@ class _ReferenceScanner:
     ir_knowledges: list[IrKnowledge]
     generated_knowledges: list[IrKnowledge]
     formula_generated_knowledges: list[IrKnowledge]
-    bayes_lowered_knowledges: list[IrKnowledge]
+    extension_lowered_knowledges: list[IrKnowledge]
     ir_strategies: list[IrStrategy]
     formula_generated_strategies: list[IrStrategy]
-    bayes_strategies: list[IrStrategy]
+    extension_strategies: list[IrStrategy]
     ir_operators: list[IrOperator]
     action_operators: list[IrOperator]
     formula_generated_operators: list[IrOperator]
-    bayes_operators: list[IrOperator]
+    extension_operators: list[IrOperator]
     ir_composes: list[IrCompose]
     refs_by_knowledge: dict[int, tuple[set[str], set[str]]] = field(default_factory=dict)
 
     def scan(self) -> list[IrKnowledge]:
-        """Scan package text and return updated Bayes-generated knowledge nodes."""
+        """Scan package text and return updated extension-generated knowledge nodes."""
         label_to_id, knowledge_label_ids = self._build_knowledge_label_tables()
         label_to_id.update(self._build_action_short_labels(knowledge_label_ids))
         check_collisions(label_to_id, self.references)
@@ -1607,7 +1613,7 @@ class _ReferenceScanner:
         for strategy in [
             *self.ir_strategies,
             *self.formula_generated_strategies,
-            *self.bayes_strategies,
+            *self.extension_strategies,
         ]:
             if strategy.strategy_id != target_id:
                 continue
@@ -1622,7 +1628,7 @@ class _ReferenceScanner:
             *self.ir_operators,
             *self.action_operators,
             *self.formula_generated_operators,
-            *self.bayes_operators,
+            *self.extension_operators,
         ]
         for operator in all_operators:
             if operator.operator_id != target_id:
@@ -1647,7 +1653,7 @@ class _ReferenceScanner:
             *self.ir_knowledges,
             *self.generated_knowledges,
             *self.formula_generated_knowledges,
-            *self.bayes_lowered_knowledges,
+            *self.extension_lowered_knowledges,
         ]
 
     def _apply_knowledge_refs(self, all_ir_knowledges: list[IrKnowledge]) -> None:
@@ -1822,13 +1828,6 @@ def _infer_conditional_probabilities(
     return cpt
 
 
-def _is_bayes_action(action: Any) -> bool:
-    bayes_meta = dict(getattr(action, "metadata", {}) or {}).get("bayes")
-    if not isinstance(bayes_meta, dict):
-        return False
-    return bayes_meta.get("action") in {"predictive_model", "likelihood"}
-
-
 def _lower_formula_claims(
     pkg: CollectedPackage,
     knowledge_nodes: list[Knowledge],
@@ -1866,51 +1865,14 @@ def _build_action_labels_by_object(pkg: CollectedPackage) -> dict[int, str]:
     }
 
 
-def _lower_bayes_actions(
-    pkg: CollectedPackage,
-    knowledge_nodes: list[Knowledge],
-    knowledge_map: dict[int, str],
-    action_labels_by_object: dict[int, str],
-    existing_operators: list[IrOperator],
-) -> Any:
-    from gaia.engine.bayes.compiler import lower_bayes_claims
-
-    return lower_bayes_claims(
-        knowledge_nodes,
-        actions=tuple(getattr(pkg, "actions", ())),
-        namespace=pkg.namespace,
-        package_name=pkg.name,
-        knowledge_map=knowledge_map,
-        action_labels_by_object=action_labels_by_object,
-        existing_operators=existing_operators,
-    )
-
-
-def _record_bayes_action_targets(
-    pkg: CollectedPackage,
-    action_labels_by_object: dict[int, str],
-    bayes_action_label_map: dict[str, str],
-    action_target_ids_by_object: dict[int, str],
-) -> None:
-    for action in getattr(pkg, "actions", []):
-        if not _is_bayes_action(action):
-            continue
-        bayes_action_label = action_labels_by_object.get(id(action))
-        if bayes_action_label is None:
-            continue
-        target_id = bayes_action_label_map.get(bayes_action_label)
-        if target_id is not None:
-            action_target_ids_by_object[id(action)] = target_id
-
-
 def _build_graph(
     pkg: CollectedPackage,
     *,
     ir_knowledges: list[IrKnowledge],
     generated_knowledges: list[IrKnowledge],
     formula_generated: _FormulaLoweringResult,
-    bayes_lowered: Any,
-    bayes_lowered_knowledges_updated: list[IrKnowledge],
+    extension_lowered: ActionLoweringResult,
+    extension_lowered_knowledges_updated: list[IrKnowledge],
     ir_operators: list[IrOperator],
     action_operators: list[IrOperator],
     ir_strategies: list[IrStrategy],
@@ -1925,15 +1887,19 @@ def _build_graph(
             *ir_knowledges,
             *generated_knowledges,
             *formula_generated.knowledges,
-            *bayes_lowered_knowledges_updated,
+            *extension_lowered_knowledges_updated,
         ],
         operators=[
             *ir_operators,
             *action_operators,
             *formula_generated.operators,
-            *bayes_lowered.operators,
+            *extension_lowered.operators,
         ],
-        strategies=[*ir_strategies, *formula_generated.strategies, *bayes_lowered.strategies],
+        strategies=[
+            *ir_strategies,
+            *formula_generated.strategies,
+            *extension_lowered.strategies,
+        ],
         composes=ir_composes,
         module_order=module_order,
         module_titles=module_titles if module_titles else None,
@@ -1993,29 +1959,34 @@ def compile_package_artifact(
         pkg, knowledge_collection.nodes, knowledge_map, ir_knowledges
     )
     action_labels_by_object = _build_action_labels_by_object(pkg)
-    bayes_lowered = _lower_bayes_actions(
-        pkg,
-        knowledge_collection.nodes,
-        knowledge_map,
-        action_labels_by_object,
-        [*ir_operators, *action_compiler.action_operators, *formula_generated.operators],
+    extension_lowered = lower_registered_actions(
+        ActionLoweringContext(
+            knowledge_nodes=knowledge_collection.nodes,
+            actions=tuple(getattr(pkg, "actions", ())),
+            namespace=pkg.namespace,
+            package_name=pkg.name,
+            knowledge_map=knowledge_map,
+            action_labels_by_object=action_labels_by_object,
+            existing_operators=[
+                *ir_operators,
+                *action_compiler.action_operators,
+                *formula_generated.operators,
+            ],
+        )
     )
     _apply_formula_knowledge_updates(
         ir_knowledges,
-        metadata_updates=bayes_lowered.metadata_updates,
+        metadata_updates=extension_lowered.metadata_updates,
         parameter_updates={},
     )
     _merge_action_label_targets(
         action_compiler.action_label_map,
         action_compiler.target_action_labels_by_id,
-        bayes_lowered.action_label_map,
-        bayes_lowered.target_action_labels_by_id,
+        extension_lowered.action_label_map,
+        extension_lowered.target_action_labels_by_id,
     )
-    _record_bayes_action_targets(
-        pkg,
-        action_labels_by_object,
-        bayes_lowered.action_label_map,
-        action_compiler.action_target_ids_by_object,
+    action_compiler.action_target_ids_by_object.update(
+        extension_lowered.action_target_ids_by_object
     )
 
     ir_composes = action_compiler.compile_compose_actions(
@@ -2023,7 +1994,7 @@ def compile_package_artifact(
         operator_target_ids_by_object=operator_target_ids_by_object,
     )
     action_compiler.compile_materializations()
-    bayes_lowered_knowledges_updated = _ReferenceScanner(
+    extension_lowered_knowledges_updated = _ReferenceScanner(
         pkg=pkg,
         references=references,
         knowledge_nodes=knowledge_collection.nodes,
@@ -2033,14 +2004,14 @@ def compile_package_artifact(
         ir_knowledges=ir_knowledges,
         generated_knowledges=generated_knowledges,
         formula_generated_knowledges=formula_generated.knowledges,
-        bayes_lowered_knowledges=bayes_lowered.knowledges,
+        extension_lowered_knowledges=extension_lowered.knowledges,
         ir_strategies=ir_strategies,
         formula_generated_strategies=formula_generated.strategies,
-        bayes_strategies=bayes_lowered.strategies,
+        extension_strategies=extension_lowered.strategies,
         ir_operators=ir_operators,
         action_operators=action_compiler.action_operators,
         formula_generated_operators=formula_generated.operators,
-        bayes_operators=bayes_lowered.operators,
+        extension_operators=extension_lowered.operators,
         ir_composes=ir_composes,
     ).scan()
 
@@ -2049,8 +2020,8 @@ def compile_package_artifact(
         ir_knowledges=ir_knowledges,
         generated_knowledges=generated_knowledges,
         formula_generated=formula_generated,
-        bayes_lowered=bayes_lowered,
-        bayes_lowered_knowledges_updated=bayes_lowered_knowledges_updated,
+        extension_lowered=extension_lowered,
+        extension_lowered_knowledges_updated=extension_lowered_knowledges_updated,
         ir_operators=ir_operators,
         action_operators=action_compiler.action_operators,
         ir_strategies=ir_strategies,

--- a/gaia/engine/lang/compiler/extensions.py
+++ b/gaia/engine/lang/compiler/extensions.py
@@ -1,0 +1,141 @@
+"""Extension lowering hooks for Gaia Lang compilation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from gaia.engine.ir import Knowledge as IrKnowledge
+from gaia.engine.ir import Operator as IrOperator
+from gaia.engine.ir import Strategy as IrStrategy
+
+ActionPredicate = Callable[[Any], bool]
+
+
+@dataclass(frozen=True)
+class ActionLoweringContext:
+    """Inputs shared with registered action lowerers."""
+
+    knowledge_nodes: list[Any]
+    actions: tuple[Any, ...]
+    namespace: str
+    package_name: str
+    knowledge_map: dict[int, str]
+    action_labels_by_object: dict[int, str]
+    existing_operators: list[IrOperator]
+
+
+@dataclass
+class ActionLoweringResult:
+    """IR additions and action-target mappings emitted by extension lowerers."""
+
+    knowledges: list[IrKnowledge] = field(default_factory=list)
+    operators: list[IrOperator] = field(default_factory=list)
+    strategies: list[IrStrategy] = field(default_factory=list)
+    metadata_updates: dict[str, dict[str, Any]] = field(default_factory=dict)
+    action_label_map: dict[str, str] = field(default_factory=dict)
+    target_action_labels_by_id: dict[str, str] = field(default_factory=dict)
+    action_target_ids_by_object: dict[int, str] = field(default_factory=dict)
+
+
+ActionLowerer = Callable[[ActionLoweringContext], ActionLoweringResult]
+
+
+@dataclass(frozen=True)
+class RegisteredActionLowerer:
+    """Registered compiler extension for one family of runtime actions."""
+
+    name: str
+    handles: ActionPredicate
+    lower: ActionLowerer
+
+
+_ACTION_LOWERERS: dict[str, RegisteredActionLowerer] = {}
+
+
+def register_action_lowerer(
+    name: str,
+    *,
+    handles: ActionPredicate,
+    lower: ActionLowerer,
+) -> None:
+    """Register an extension lowerer by stable name."""
+    if not name:
+        raise ValueError("action lowerer name must not be empty")
+    _ACTION_LOWERERS[name] = RegisteredActionLowerer(name=name, handles=handles, lower=lower)
+
+
+def registered_action_lowerers() -> tuple[RegisteredActionLowerer, ...]:
+    """Return registered action lowerers in registration order."""
+    return tuple(_ACTION_LOWERERS.values())
+
+
+def is_registered_action(action: Any) -> bool:
+    """Return whether any registered lowerer owns this action."""
+    return any(lowerer.handles(action) for lowerer in _ACTION_LOWERERS.values())
+
+
+def lower_registered_actions(context: ActionLoweringContext) -> ActionLoweringResult:
+    """Run registered action lowerers and merge their IR additions."""
+    combined = ActionLoweringResult()
+    existing_operators = list(context.existing_operators)
+    for lowerer in _ACTION_LOWERERS.values():
+        if not any(lowerer.handles(action) for action in context.actions):
+            continue
+        scoped_context = replace(context, existing_operators=list(existing_operators))
+        result = lowerer.lower(scoped_context)
+        _merge_result(combined, result, context=context, lowerer=lowerer)
+        existing_operators.extend(result.operators)
+    return combined
+
+
+def _merge_result(
+    combined: ActionLoweringResult,
+    result: ActionLoweringResult,
+    *,
+    context: ActionLoweringContext,
+    lowerer: RegisteredActionLowerer,
+) -> None:
+    combined.knowledges.extend(result.knowledges)
+    combined.operators.extend(result.operators)
+    combined.strategies.extend(result.strategies)
+    combined.metadata_updates.update(result.metadata_updates)
+    _merge_action_labels(combined, result, lowerer=lowerer)
+    combined.action_target_ids_by_object.update(result.action_target_ids_by_object)
+    _record_owned_action_targets(combined, result, context=context, lowerer=lowerer)
+
+
+def _merge_action_labels(
+    combined: ActionLoweringResult,
+    result: ActionLoweringResult,
+    *,
+    lowerer: RegisteredActionLowerer,
+) -> None:
+    for action_label, target_id in result.action_label_map.items():
+        existing = combined.action_label_map.get(action_label)
+        if existing is not None and existing != target_id:
+            raise ValueError(
+                f"extension lowerer {lowerer.name!r} changed action label "
+                f"{action_label!r} target from {existing!r} to {target_id!r}"
+            )
+        combined.action_label_map[action_label] = target_id
+    combined.target_action_labels_by_id.update(result.target_action_labels_by_id)
+
+
+def _record_owned_action_targets(
+    combined: ActionLoweringResult,
+    result: ActionLoweringResult,
+    *,
+    context: ActionLoweringContext,
+    lowerer: RegisteredActionLowerer,
+) -> None:
+    for action in context.actions:
+        if not lowerer.handles(action):
+            continue
+        action_label = context.action_labels_by_object.get(id(action))
+        if action_label is None:
+            continue
+        target_id = result.action_label_map.get(action_label)
+        if target_id is not None:
+            combined.action_target_ids_by_object[id(action)] = target_id

--- a/tests/gaia/lang/compiler/test_extension_lowering.py
+++ b/tests/gaia/lang/compiler/test_extension_lowering.py
@@ -1,0 +1,49 @@
+"""Compiler extension lowering stays out of Gaia Lang core."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import gaia.engine.bayes as bayes
+from gaia.engine.lang import Nat, Probability, Variable, parameter
+from gaia.engine.lang.compiler.compile import compile_package_artifact
+from gaia.engine.lang.runtime.package import CollectedPackage
+
+
+def test_lang_compiler_has_no_direct_bayes_import_or_hook() -> None:
+    compile_module = importlib.import_module("gaia.engine.lang.compiler.compile")
+    source = inspect.getsource(compile_module)
+
+    assert "gaia.engine.bayes" not in source
+    assert "_lower_bayes_actions" not in source
+
+
+def test_bayes_registers_compiler_extension_when_imported() -> None:
+    from gaia.engine.lang.compiler.extensions import registered_action_lowerers
+
+    registered = {lowerer.name for lowerer in registered_action_lowerers()}
+
+    assert "bayes" in registered
+
+
+def test_bayes_actions_compile_through_registered_extension() -> None:
+    with CollectedPackage(name="extension_bayes_pkg", namespace="t") as pkg:
+        theta = Variable(symbol="theta", domain=Probability)
+        k = Variable(symbol="k", domain=Nat)
+        hypothesis = parameter(theta, 0.75, content="theta = 0.75.", prior=0.5, label="h")
+        model_helper = bayes.model(
+            hypothesis,
+            observable=k,
+            distribution=bayes.Binomial(n=10, p=theta),
+            label="theta_model",
+        )
+
+    compiled = compile_package_artifact(pkg)
+    helper_id = compiled.knowledge_ids_by_object[id(model_helper)]
+    helper_ir = next(
+        knowledge for knowledge in compiled.graph.knowledges if knowledge.id == helper_id
+    )
+
+    assert helper_ir.metadata["bayes"]["role"] == "prediction"
+    assert compiled.action_label_map["t:extension_bayes_pkg::action::theta_model"] == helper_id


### PR DESCRIPTION
## Summary
- add a small Gaia Lang compiler extension registry for runtime action lowerers
- move Bayes compiler lowering behind a Bayes-registered lowerer instead of a hard-coded `lang.compiler -> bayes.compiler` import
- rename the compiler plumbing from Bayes-specific to extension-generic while preserving compiled IR behavior

## Stacking
- stacked on #626 / `codex/engine-reorg-pr-b`
- addresses the Lang/Bayes compiler import-isolation follow-up discussed after #617

## Validation
- `git diff --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run mypy`
- `uv run --extra dev pytest tests/gaia/lang/compiler/test_extension_lowering.py -q --no-cov`
- `uv run --extra dev pytest tests/gaia/bayes tests/gaia/lang/compiler/test_extension_lowering.py tests/gaia/lang/test_action_hierarchy.py tests/gaia/lang/test_review_manifest.py tests/gaia/bp/test_review_gating.py tests/cli/test_inquiry.py -q --no-cov`
- `uv run --extra dev pytest tests/ --no-cov`
- `uv run --extra docs mkdocs build --strict`