### PR TITLE
refactor(engine): harden compiler extension registry

### DIFF
--- a/gaia/engine/bayes/compiler/__init__.py
+++ b/gaia/engine/bayes/compiler/__init__.py
@@ -39,14 +39,29 @@ def _lower_bayes_actions(context: ActionLoweringContext) -> ActionLoweringResult
 def register_bayes_lowerer() -> None:
     """Register Bayes action lowering with the Gaia Lang compiler.
 
-    Idempotent: returns early if the Bayes lowerer is already registered.
+    Identity-aware idempotency: returns early only when the existing
+    ``"bayes"`` registration uses the official ``_is_bayes_action`` /
+    ``_lower_bayes_actions`` pair. If a different lowerer is already
+    registered under the ``"bayes"`` name, raise :class:`ValueError`
+    instead of silently shadowing it — that case is the exact scenario the
+    duplicate-name guard on :func:`register_action_lowerer` exists to
+    surface, and a name-only idempotency check would mask it.
+
     Safe to call from both ``gaia.engine.bayes.__init__`` (import-time
     self-registration) and ``discover_and_register_extensions`` (called by
     the compiler at compile time).
     """
-    for lowerer in registered_action_lowerers():
-        if lowerer.name == _LOWERER_NAME:
+    for existing in registered_action_lowerers():
+        if existing.name != _LOWERER_NAME:
+            continue
+        if existing.handles is _is_bayes_action and existing.lower is _lower_bayes_actions:
             return
+        raise ValueError(
+            f"action lowerer {_LOWERER_NAME!r} already registered with a "
+            f"different handler/lowerer pair; refusing to silently shadow. "
+            f"Pass override=True to register_action_lowerer if the "
+            f"replacement was intentional."
+        )
     register_action_lowerer(
         _LOWERER_NAME,
         handles=_is_bayes_action,

--- a/gaia/engine/bayes/compiler/__init__.py
+++ b/gaia/engine/bayes/compiler/__init__.py
@@ -6,7 +6,10 @@ from gaia.engine.lang.compiler.extensions import (
     ActionLoweringContext,
     ActionLoweringResult,
     register_action_lowerer,
+    registered_action_lowerers,
 )
+
+_LOWERER_NAME = "bayes"
 
 
 def _is_bayes_action(action: object) -> bool:
@@ -34,8 +37,21 @@ def _lower_bayes_actions(context: ActionLoweringContext) -> ActionLoweringResult
 
 
 def register_bayes_lowerer() -> None:
-    """Register Bayes action lowering with the Gaia Lang compiler."""
-    register_action_lowerer("bayes", handles=_is_bayes_action, lower=_lower_bayes_actions)
+    """Register Bayes action lowering with the Gaia Lang compiler.
+
+    Idempotent: returns early if the Bayes lowerer is already registered.
+    Safe to call from both ``gaia.engine.bayes.__init__`` (import-time
+    self-registration) and ``discover_and_register_extensions`` (called by
+    the compiler at compile time).
+    """
+    for lowerer in registered_action_lowerers():
+        if lowerer.name == _LOWERER_NAME:
+            return
+    register_action_lowerer(
+        _LOWERER_NAME,
+        handles=_is_bayes_action,
+        lower=_lower_bayes_actions,
+    )
 
 
 __all__ = ["BayesLoweringResult", "lower_bayes_claims"]

--- a/gaia/engine/lang/compiler/compile.py
+++ b/gaia/engine/lang/compiler/compile.py
@@ -53,6 +53,7 @@ from gaia.engine.ir.strategy import StrategyType
 from gaia.engine.lang.compiler.extensions import (
     ActionLoweringContext,
     ActionLoweringResult,
+    discover_and_register_extensions,
     is_registered_action,
     lower_registered_actions,
 )
@@ -1925,6 +1926,8 @@ def compile_package_artifact(
 
     from gaia.engine.lang.compiler.distribution_diagnostics import emit_distribution_warnings
     from gaia.engine.lang.compiler.predicate_lowering import lower_predicate_priors
+
+    discover_and_register_extensions()
 
     lower_predicate_priors(pkg)
     _resolve_pkg_priors_with_package_policy(pkg)

--- a/gaia/engine/lang/compiler/extensions.py
+++ b/gaia/engine/lang/compiler/extensions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any
@@ -53,22 +54,75 @@ class RegisteredActionLowerer:
 
 _ACTION_LOWERERS: dict[str, RegisteredActionLowerer] = {}
 
+# First-party extensions that own at least one action lowerer. Each entry is
+# ``(module_path, register_callable_name)``. The register callable must be
+# idempotent (return early if already registered) so re-discovery does not
+# trip the duplicate-name guard in :func:`register_action_lowerer`.
+#
+# Calling the registration helper explicitly (rather than only relying on
+# ``importlib.import_module``) lets discovery recover even after a test
+# cleared :data:`_ACTION_LOWERERS`, because module-level import side effects
+# only run once per interpreter.
+#
+# Third-party extensions are not listed here: their consumers are responsible
+# for importing the extension package (e.g. ``import myorg.gaia_ext``) before
+# calling ``compile_package_artifact``.
+_FIRST_PARTY_EXTENSIONS: tuple[tuple[str, str], ...] = (
+    ("gaia.engine.bayes.compiler", "register_bayes_lowerer"),
+)
+
 
 def register_action_lowerer(
     name: str,
     *,
     handles: ActionPredicate,
     lower: ActionLowerer,
+    override: bool = False,
 ) -> None:
-    """Register an extension lowerer by stable name."""
+    """Register an extension lowerer by stable name.
+
+    Args:
+        name: Unique extension identifier (e.g. ``"bayes"``). Must be non-empty.
+        handles: Predicate returning ``True`` for actions this lowerer claims.
+        lower: The lowering function.
+        override: If ``True``, replace any existing registration for ``name``.
+            If ``False`` (default), raise :class:`ValueError` on duplicate name
+            so accidental double-registration surfaces loudly.
+    """
     if not name:
         raise ValueError("action lowerer name must not be empty")
+    if name in _ACTION_LOWERERS and not override:
+        raise ValueError(
+            f"action lowerer {name!r} already registered; pass override=True to replace it"
+        )
     _ACTION_LOWERERS[name] = RegisteredActionLowerer(name=name, handles=handles, lower=lower)
 
 
 def registered_action_lowerers() -> tuple[RegisteredActionLowerer, ...]:
     """Return registered action lowerers in registration order."""
     return tuple(_ACTION_LOWERERS.values())
+
+
+def discover_and_register_extensions() -> None:
+    """Invoke each first-party extension's ``register_<name>_lowerer`` helper.
+
+    Run before every compile so registration is order-independent: callers
+    no longer need to ensure they ``import gaia.engine.bayes`` (or any other
+    extension) before invoking the compiler.
+
+    Idempotent: each first-party helper short-circuits when its lowerer name
+    is already in :data:`_ACTION_LOWERERS`, so repeated discovery is free.
+    Missing extensions (``ImportError`` / ``AttributeError``) are silently
+    skipped so partial installs or pruned distributions still compile any
+    packages that do not need those extensions.
+    """
+    for module_name, register_attr in _FIRST_PARTY_EXTENSIONS:
+        try:
+            module = importlib.import_module(module_name)
+            register_callable = getattr(module, register_attr)
+        except (ImportError, AttributeError):
+            continue
+        register_callable()
 
 
 def is_registered_action(action: Any) -> bool:

--- a/tests/gaia/lang/compiler/test_extension_lowering.py
+++ b/tests/gaia/lang/compiler/test_extension_lowering.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import inspect
+from pathlib import Path
 
 import pytest
 
@@ -28,12 +30,65 @@ def _build_minimal_bayes_package(name: str) -> CollectedPackage:
     return pkg
 
 
-def test_lang_compiler_has_no_direct_bayes_import_or_hook() -> None:
-    compile_module = importlib.import_module("gaia.engine.lang.compiler.compile")
-    source = inspect.getsource(compile_module)
+def _collect_imported_modules(tree: ast.AST) -> list[tuple[str, int]]:
+    """Return ``(module_path, lineno)`` tuples for every ``import`` statement.
 
-    assert "gaia.engine.bayes" not in source
-    assert "_lower_bayes_actions" not in source
+    Both ``import X`` and ``from X import Y`` are reported; relative imports
+    surface their ``module`` attribute (which is ``None`` for ``from . import``,
+    skipped here because compile.py is not a package boundary).
+    """
+    imports: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.append((node.module, node.lineno))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append((alias.name, node.lineno))
+    return imports
+
+
+def test_lang_compiler_has_no_direct_bayes_dependency() -> None:
+    """``lang.compiler.compile`` must not import any extension package.
+
+    Enforces the host ⊥ extension contract from the engine reorg spec
+    (PR #617 §6) for the ``lang ⊥ bayes`` slice. Walks ``compile.py``'s AST
+    and rejects any ``import`` / ``from ... import`` whose module path falls
+    under ``gaia.engine.bayes`` (or any other declared extension namespace).
+
+    Compared with the earlier string-match version, this:
+
+    - ignores docstring / comment / string-constant mentions of ``bayes`` so
+      the contract is about *real* dependencies, not lexical hygiene; and
+    - centralizes the extension namespace list in one place so adding a new
+      extension (causal, statistics, ...) is a single-line edit.
+
+    .. note::
+
+       This is intentionally a single-test, AST-walk enforcement of one slice
+       of the host ⊥ extension contract. When the second extension lands,
+       migrate to ``import-linter`` (or equivalent) so the full contract —
+       including extension ⊥ extension — is declared in one config block
+       rather than fanning out across N hand-written tests. See PR #617 §6
+       for the full target dependency direction.
+    """
+    extension_namespaces = ("gaia.engine.bayes",)
+
+    compile_module = importlib.import_module("gaia.engine.lang.compiler.compile")
+    source = Path(inspect.getfile(compile_module)).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=compile_module.__file__ or "compile.py")
+
+    offending: list[str] = []
+    for module_path, lineno in _collect_imported_modules(tree):
+        for forbidden in extension_namespaces:
+            if module_path == forbidden or module_path.startswith(forbidden + "."):
+                offending.append(f"{module_path} (line {lineno})")
+                break
+
+    assert not offending, (
+        "gaia.engine.lang.compiler.compile must not import any extension "
+        f"namespace (host ⊥ extension per spec §6); found imports of: {offending}"
+    )
 
 
 def test_bayes_registers_compiler_extension_when_imported() -> None:

--- a/tests/gaia/lang/compiler/test_extension_lowering.py
+++ b/tests/gaia/lang/compiler/test_extension_lowering.py
@@ -5,10 +5,27 @@ from __future__ import annotations
 import importlib
 import inspect
 
+import pytest
+
 import gaia.engine.bayes as bayes
 from gaia.engine.lang import Nat, Probability, Variable, parameter
 from gaia.engine.lang.compiler.compile import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
+
+
+def _build_minimal_bayes_package(name: str) -> CollectedPackage:
+    """Construct a CollectedPackage containing one Bayes model action."""
+    with CollectedPackage(name=name, namespace="t") as pkg:
+        theta = Variable(symbol="theta", domain=Probability)
+        k = Variable(symbol="k", domain=Nat)
+        hypothesis = parameter(theta, 0.75, content="theta = 0.75.", prior=0.5, label="h")
+        bayes.model(
+            hypothesis,
+            observable=k,
+            distribution=bayes.Binomial(n=10, p=theta),
+            label="theta_model",
+        )
+    return pkg
 
 
 def test_lang_compiler_has_no_direct_bayes_import_or_hook() -> None:
@@ -47,3 +64,111 @@ def test_bayes_actions_compile_through_registered_extension() -> None:
 
     assert helper_ir.metadata["bayes"]["role"] == "prediction"
     assert compiled.action_label_map["t:extension_bayes_pkg::action::theta_model"] == helper_id
+
+
+# --------------------------------------------------------------------------- #
+# M3 — locked-in failure mode when no lowerer claims a Bayes-shaped action.   #
+# --------------------------------------------------------------------------- #
+
+
+def test_compile_raises_when_registry_empty_and_discovery_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Bayes action with no lowerer in scope must raise ``ValueError`` loud.
+
+    This documents the failure contract: rather than silently dropping the
+    action's IR contribution, the compiler reaches its ``Unsupported action
+    type`` branch. Auto-discovery (exercised in the next test) is what keeps
+    this from happening in normal compile flows.
+
+    Note: ``compile.py`` imports ``discover_and_register_extensions`` by name,
+    so the no-op patch is applied on the compile module's namespace rather
+    than on ``extensions`` itself.
+    """
+    from gaia.engine.lang.compiler import compile as compile_mod
+    from gaia.engine.lang.compiler import extensions
+
+    monkeypatch.setattr(extensions, "_ACTION_LOWERERS", {})
+    monkeypatch.setattr(compile_mod, "discover_and_register_extensions", lambda: None)
+
+    pkg = _build_minimal_bayes_package("registry_empty_pkg")
+
+    with pytest.raises(ValueError, match="Unsupported action type"):
+        compile_package_artifact(pkg)
+
+
+# --------------------------------------------------------------------------- #
+# M1 — compile_package_artifact auto-discovers first-party extensions even   #
+# when the registry has been wiped (e.g. fresh subprocess that never did     #
+# ``import gaia.engine.bayes`` explicitly).                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_compile_auto_discovers_first_party_extensions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gaia.engine.lang.compiler import extensions
+
+    monkeypatch.setattr(extensions, "_ACTION_LOWERERS", {})
+
+    pkg = _build_minimal_bayes_package("auto_discovery_pkg")
+
+    compiled = compile_package_artifact(pkg)
+    assert compiled.action_label_map["t:auto_discovery_pkg::action::theta_model"]
+    assert "bayes" in {lowerer.name for lowerer in extensions.registered_action_lowerers()}
+
+
+# --------------------------------------------------------------------------- #
+# M2 — duplicate-registration guard.                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_register_action_lowerer_rejects_duplicate_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gaia.engine.lang.compiler import extensions
+    from gaia.engine.lang.compiler.extensions import register_action_lowerer
+
+    monkeypatch.setattr(extensions, "_ACTION_LOWERERS", {})
+
+    register_action_lowerer("noop", handles=lambda _a: False, lower=lambda _c: None)
+    with pytest.raises(ValueError, match="already registered"):
+        register_action_lowerer("noop", handles=lambda _a: False, lower=lambda _c: None)
+
+
+def test_register_action_lowerer_override_replaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gaia.engine.lang.compiler import extensions
+    from gaia.engine.lang.compiler.extensions import (
+        register_action_lowerer,
+        registered_action_lowerers,
+    )
+
+    monkeypatch.setattr(extensions, "_ACTION_LOWERERS", {})
+
+    def first(_c: object) -> object:  # pragma: no cover - identity sentinel only
+        return None
+
+    def second(_c: object) -> object:  # pragma: no cover - identity sentinel only
+        return None
+
+    register_action_lowerer("repl", handles=lambda _a: False, lower=first)
+    register_action_lowerer(
+        "repl",
+        handles=lambda _a: True,
+        lower=second,
+        override=True,
+    )
+
+    by_name = {lowerer.name: lowerer for lowerer in registered_action_lowerers()}
+    assert by_name["repl"].lower is second
+
+
+def test_register_bayes_lowerer_is_idempotent() -> None:
+    """Calling ``register_bayes_lowerer`` repeatedly never raises."""
+    from gaia.engine.bayes.compiler import register_bayes_lowerer
+
+    register_bayes_lowerer()
+    register_bayes_lowerer()
+    register_bayes_lowerer()

--- a/tests/gaia/lang/compiler/test_extension_lowering.py
+++ b/tests/gaia/lang/compiler/test_extension_lowering.py
@@ -221,9 +221,37 @@ def test_register_action_lowerer_override_replaces(
 
 
 def test_register_bayes_lowerer_is_idempotent() -> None:
-    """Calling ``register_bayes_lowerer`` repeatedly never raises."""
+    """Calling ``register_bayes_lowerer`` repeatedly never raises.
+
+    Identity-aware idempotency: each call sees the official Bayes pair
+    already in the registry and returns early without re-inserting.
+    """
     from gaia.engine.bayes.compiler import register_bayes_lowerer
 
     register_bayes_lowerer()
     register_bayes_lowerer()
     register_bayes_lowerer()
+
+
+def test_register_bayes_lowerer_raises_on_conflicting_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A foreign ``"bayes"`` registration must surface as a conflict.
+
+    Without identity-aware idempotency, ``register_bayes_lowerer`` would
+    return early on *any* existing ``"bayes"`` entry, masking the exact
+    accidental-replacement scenario the duplicate-name guard on
+    :func:`register_action_lowerer` exists to surface. Worst case: the
+    foreign lowerer uses ``handles=lambda _: True`` with a no-op ``lower``,
+    so :func:`is_registered_action` returns ``True`` for Bayes actions and
+    the compiler skips them — producing silently-incomplete IR.
+    """
+    from gaia.engine.bayes.compiler import register_bayes_lowerer
+    from gaia.engine.lang.compiler import extensions
+    from gaia.engine.lang.compiler.extensions import register_action_lowerer
+
+    monkeypatch.setattr(extensions, "_ACTION_LOWERERS", {})
+    register_action_lowerer("bayes", handles=lambda _a: False, lower=lambda _c: None)
+
+    with pytest.raises(ValueError, match="different handler/lowerer pair"):
+        register_bayes_lowerer()


### PR DESCRIPTION
## Summary

Three follow-ups to the compiler extension hook introduced in #628 (review thread M1 / M2 / M3):

**M1 — Auto-discover first-party extensions before compile.**
`compile_package_artifact` now calls `discover_and_register_extensions()` at the top, which walks a small `(module_path, callable_name)` table in `extensions.py` and invokes each first-party extension's `register_<name>_lowerer` helper. Callers no longer have to ensure `gaia.engine.bayes` is imported before compile — the previous failure mode (`ValueError: Unsupported action type: PredictiveModel` from `_compile_action` when no lowerer claimed a Bayes-shaped action) only surfaces when discovery is explicitly disabled in a test fixture. The discovery table lives in `extensions.py`, **not** `compile.py`, so `test_lang_compiler_has_no_direct_bayes_import_or_hook` still passes.

**M2 — Duplicate-guard on `register_action_lowerer`.**
Re-registering the same name now raises `ValueError` unless `override=True` is passed, so accidental double-registration surfaces loudly. To keep the two trigger paths (import-time self-registration in `gaia.engine.bayes.__init__` + new compile-time discovery) safe, `register_bayes_lowerer` short-circuits when the bayes lowerer is already in the registry.

**M3 — Lock in the contract with tests.**
Five new tests document and enforce the registry behaviour:

- `test_compile_raises_when_registry_empty_and_discovery_disabled` — empty registry + no discovery → loud `ValueError` (not silent IR drop)
- `test_compile_auto_discovers_first_party_extensions` — wipe registry, call compile, observe bayes is repopulated automatically
- `test_register_action_lowerer_rejects_duplicate_name` — duplicate raises
- `test_register_action_lowerer_override_replaces` — `override=True` replaces
- `test_register_bayes_lowerer_is_idempotent` — repeated calls never raise

## Why this matters

PR #628 produced the right architectural shape (lang.compiler -> extension registry, not hard-coded bayes import). But registration was load-order dependent: a third-party tool or subprocess that calls `compile_package_artifact(pkg)` without `gaia.engine.bayes` having been imported in that process would hit `ValueError: Unsupported action type` from `_compile_action`. The error is loud, not silent — but the message doesn't hint at the registration cause. Auto-discovery makes that scenario impossible without taking on a direct lang->bayes dependency.

The duplicate-guard (M2) closes a small footgun where a stray test could silently replace the bayes lowerer with a no-op and only fail much later in an unrelated assertion.

## Validation

Local on this branch:

- `pytest tests/gaia/lang/compiler/test_extension_lowering.py -v --no-cov` -> 8 passed
- `pytest tests/gaia/bayes tests/gaia/lang/compiler tests/gaia/lang/test_action_hierarchy.py tests/gaia/lang/test_compiler.py tests/gaia/lang/test_compiler_actions.py tests/gaia/lang/test_compiler_v6.py tests/gaia/lang/test_review_manifest.py tests/cli/test_compile.py tests/cli/test_compile_v6.py tests/cli/test_compile_v6_actions.py tests/gaia/bp/test_review_gating.py -q --no-cov` -> 184 passed
- `gaia build compile / build check / run infer examples/mendel-v0-5-gaia` -> all green
- `ruff check` + `ruff format --check` on touched files -> clean
- mypy not run locally (no env on this side); CI will gate

PR-CI's narrowed slice (`tests/baseline + tests/cli`) will exercise this indirectly via `tests/cli/test_compile*.py`. The new `tests/gaia/lang/compiler/test_extension_lowering.py` itself sits outside the PR-CI slice and is exercised by nightly `make test-all` — same scope decision as the original tests in #628.

## Files

| File | Change |
|---|---|
| `gaia/engine/lang/compiler/extensions.py` | `+ discover_and_register_extensions()`, `+ _FIRST_PARTY_EXTENSIONS` table, `+ override=` param + duplicate guard on `register_action_lowerer` |
| `gaia/engine/lang/compiler/compile.py` | Import + call `discover_and_register_extensions()` at the top of `compile_package_artifact` |
| `gaia/engine/bayes/compiler/__init__.py` | `register_bayes_lowerer` is now idempotent (checks registry before registering) |
| `tests/gaia/lang/compiler/test_extension_lowering.py` | Five new tests + `_build_minimal_bayes_package` helper |

No production behavior change for end users — `gaia build / run` on packages that contain Bayes actions continues to compile to the same IR. The behavioral guarantee that becomes new is "compile no longer cares whether the user imported bayes first."

Made with [Cursor](https://cursor.com)