### PR TITLE
fix(docs): align v0.5 docs with current code (Phase 1 P0)

### DIFF
--- a/docs/for-users/cli-commands.md
+++ b/docs/for-users/cli-commands.md
@@ -481,6 +481,12 @@ gaia pkg register . --registry-dir ../gaia-registry --create-pr      # 10. Publi
 
 ## Old flat verbs
 
-The historical `gaia build compile`, `gaia run infer`, `gaia inspect starmap`, etc. are
-tombstoned. Invoking them prints a redirect to stderr and exits with code 2.
-See [Migration to alpha 0](../migration.md) for the full mapping.
+The historical flat top-level verbs (`gaia compile`, `gaia infer`, `gaia check`,
+`gaia init`, `gaia render`, `gaia starmap`, `gaia starmap-replay`, `gaia add`,
+`gaia register`) are tombstoned in alpha 0. The grouped forms documented above
+(`gaia build compile`, `gaia run infer`, `gaia inspect starmap`, etc.) are the
+current canonical replacements.
+
+Invoking a tombstoned flat verb prints a redirect to stderr and exits with
+code 2 — no side effects, no partial work. See
+[Migration to alpha 0](../migration.md) for the full old-to-new mapping.

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -615,7 +615,7 @@ overloaded, and `Claim` objects intentionally reject truth-value checks such as
 
 ### Propositional analysis
 
-Compiled operator graphs can be analyzed with `gaia.engine.ir.logic`. The API keeps Gaia IR as the stored representation and uses a mature Boolean backend for normalization and checks:
+Compiled operator graphs can be analyzed with `gaia.engine.ir.logic`. The API keeps Gaia IR as the stored representation and uses a mature Boolean backend for normalization and checks. The snippet assumes `pkg` is an already-collected package object:
 
 ```python
 from gaia.engine.lang.compiler import compile_package_artifact

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -618,6 +618,7 @@ overloaded, and `Claim` objects intentionally reject truth-value checks such as
 Compiled operator graphs can be analyzed with `gaia.engine.ir.logic`. The API keeps Gaia IR as the stored representation and uses a mature Boolean backend for normalization and checks:
 
 ```python
+from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.ir.logic import (
     are_equivalent,
     is_satisfiable,

--- a/docs/foundations/bp/belief-state.md
+++ b/docs/foundations/bp/belief-state.md
@@ -28,28 +28,36 @@ BeliefState:
 
     # ── 诊断 ──
     converged:            bool
-    iterations:           int
-    max_residual:         float
+    iterations_run:       int
+    max_change_at_stop:   float
 ```
 
 ## Local CLI Beliefs Format
 
-本地 CLI `gaia run infer` 写入的 `.gaia/beliefs.json` 使用不同的 schema，针对本地包优化：
+本地 CLI `gaia run infer` 写入的 `.gaia/beliefs.json` 使用不同的 schema，针对本地包优化。
+载体形状由 `gaia/cli/commands/infer.py::_beliefs_payload` 直接构造，`diagnostics`
+字段是 `result.diagnostics` 的 `dataclasses.asdict()` 结果，所以字段名与
+`gaia/engine/bp/{bp,trw_bp,mean_field,junction_tree}.py` 中各 `*Diagnostics` 的
+dataclass 字段一一对应：
 
 ```json
 {
-  "ir_hash": "...",
-  "gaia_lang_version": "...",
+  "ir_hash": "sha256:...",
+  "gaia_lang_version": "0.5.0",
   "beliefs": [
     {"knowledge_id": "github:pkg::label", "label": "label", "belief": 0.73}
   ],
   "diagnostics": {
     "converged": true,
-    "iterations": 42,
-    "max_residual": 0.0001
+    "iterations_run": 42,
+    "max_change_at_stop": 0.0001
   }
 }
 ```
+
+不同后端会附加各自的诊断字段（例如 JT 的 `treewidth`、loopy BP 的
+`belief_history` / `direction_changes`）；权威示例见
+[`cli/inference.md` §Output Format](../cli/inference.md#beliefsjson)。
 
 **与 BeliefState 的区别**：
 - `beliefs` 是 list of records，不是 `dict[str, float]`
@@ -79,11 +87,14 @@ BeliefState:
 ## 诊断字段
 
 - `converged`：BP 是否在容差内收敛
-- `iterations`：实际运行的迭代数
-- `max_residual`：停止时的最大消息变化量
+- `iterations_run`：实际运行的迭代数（exact JT 固定为 2，对应 collect + distribute 两次扫描）
+- `max_change_at_stop`：停止时的最大消息变化量
 - `compilation_summary`：每个 Strategy 的 BP 编译路径（direct / composite / formal_expr），便于诊断推理链路
 
 这些字段用于判断 belief 的可靠性。未收敛的 BeliefState 仍然有效，但应标记为近似值。
+不同后端会另外携带各自的诊断字段（例如 JT 的 `treewidth`、TRW-BP / Mean Field
+特有的内部统计），都按 `dataclasses.asdict()` 序列化，对照各自模块的
+`*Diagnostics` 定义即可。
 
 ## 源代码
 

--- a/docs/foundations/bp/formal-strategy-lowering.md
+++ b/docs/foundations/bp/formal-strategy-lowering.md
@@ -348,15 +348,10 @@ for op in formal_expr.operators:
 
 判定规则：conclusion 的 $P(H\!=\!1)$ 能否从 $\pi(\text{variables})$ 推导出来？能 → 0.5（计算型）；不能 → $1-\varepsilon$（断言型）。
 
-### 7.3 `potentials.md` 对齐
+### 7.3 与势函数和推理文档的关系
 
-`potentials.md` 应按当前实现保留专门 deterministic FactorType，并说明
-deterministic potential 是 strict 0/1；Cromwell clamp 属于 unary
-evidence/prior 和 soft probability 参数。
-
-### 7.4 `inference.md` 更新
-
-删除 gate_var 机制的描述。Relation operator 的 conclusion 通过 $\pi = 1-\varepsilon$ 自然激活约束，不需要门控变量。
+- 势函数细节见 [`potentials.md`](potentials.md)：每种 deterministic FactorType 的势函数是 strict 0/1；Cromwell clamp 仅作用于 unary evidence/prior 和 soft probability 参数（例如 ↝ 的 `p₁ / p₂`），不出现在 deterministic potential 中。
+- Relation operator 的 conclusion 通过 §7.2 的 $\pi = 1-\varepsilon$ 先验自然激活约束，没有单独的门控变量；推理流程见 [`inference.md`](inference.md)。
 
 ## 参考
 

--- a/docs/foundations/cli/inference.md
+++ b/docs/foundations/cli/inference.md
@@ -307,7 +307,8 @@ is returned with `diagnostics.converged = False`.
 The `diagnostics` object in `beliefs.json` records:
 
 - `converged` — whether inference reached the convergence threshold
-- `iterations_run` — number of complete iterations (0 for JT exact)
+- `iterations_run` — number of complete iterations or exact-pass count (JT
+  exact records `2`, for collect + distribute)
 - `max_change_at_stop` — maximum belief change in the final iteration
 - `treewidth` — estimated treewidth of the factor graph (-1 if not computed)
 - `belief_history` — `{var_id: [belief_at_iter_0, ...]}` per variable

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -99,6 +99,10 @@ gaia build check [PATH]
 gaia build check --brief [PATH]
 gaia build check --show <module|label> [PATH]
 gaia build check --hole [PATH]
+gaia build check --warrants [PATH]
+gaia build check --warrants --blind [PATH]
+gaia build check --inquiry [PATH]
+gaia build check --gate [PATH]
 ```
 
 | Argument | Default | Description |
@@ -110,6 +114,10 @@ gaia build check --hole [PATH]
 | `--brief`, `-b` | Show per-module warrant structure overview |
 | `--show`, `-s` | Expand a specific module or claim/strategy label |
 | `--hole` | Show detailed prior contract report for independent degrees of freedom |
+| `--warrants` | Show v6 `ReviewManifest` warrants and audit questions for reviewable actions |
+| `--blind` | With `--warrants`, hide status values and prior diagnostics to reduce reviewer anchoring |
+| `--inquiry` | Show goal-oriented reasoning progress and review status |
+| `--gate` | Run quality-gate checks and exit non-zero when the package is not publishable |
 
 **What it does:**
 
@@ -126,6 +134,8 @@ printed but do not fail the check.
 **Default output:** Prints pass/fail summary with knowledge diagnostics. Each independent boundary premise is annotated with `prior=X` or `no external prior (MaxEnt)`. Shows a "MaxEnt (no external prior): N" count when any load-bearing boundary claims lack external priors. If deterministic operators constrain those MaxEnt claims, the output also reports the effective feasible state space and entropy in bits. It also reports the induced MaxEnt entropy from the current full joint distribution, which is the Jaynes-style answer to "how many independent bits are really left after the graph's existing constraints and explicit priors are applied?"
 
 **`--hole` output:** Detailed report splitting all load-bearing boundary claims into MaxEnt degrees of freedom (no external prior, with content and QID) and covered claims (with prior value and justification). Use during prior review to identify which independent claims intentionally rely on MaxEnt, which are constrained by deterministic logic, what their induced entropy is under the current graph, and which still need `priors.py` entries.
+
+**`--warrants` / `--blind` / `--inquiry` / `--gate`:** Per-action review and gating views, layered on top of the merged `ReviewManifest`. See [CLI Commands § `gaia build check`](../../for-users/cli-commands.md#gaia-build-check) for the full review-loop semantics, and [`review-pipeline.md`](../review/review-pipeline.md) for the manifest contract and gate criteria.
 
 **Prior contract:** External priors belong only on independent probabilistic inputs to exported goals that are not already pinned by a zero-premise `observe(...)`. A zero-premise `observe(...)` sets its conclusion to `1 - CROMWELL_EPS`; claims concluded by `derive(...)`, `compute(...)`, or `observe(..., given=...)` get their belief from the graph and should not receive manual priors. Structural/helper claims from propositional expressions, `infer(...)`, `associate(...)`, relation verbs (`equal`, `contradict`, `exclusive`), and generated formalization internals also carry no independent prior. If an independent input is intentionally left without an external prior, Gaia uses the Jaynes maximum-entropy distribution over the remaining independent degrees of freedom subject to declared hard constraints.
 

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -294,7 +294,7 @@ The v5 strategy DSL remains available for backward compatibility under `gaia.eng
 
 | Legacy verb | v0.5 replacement |
 |---|---|
-| `support([P], C, prior=...)` | `derive(C, given=[P])` (deterministic) or `infer(C, hypothesis=P, p_e_given_h=..., p_e_given_not_h=...)` (probabilistic) |
+| `support([P], C, prior=...)` | `derive(C, given=[P])` (deterministic) or `infer(P, hypothesis=C, p_e_given_h=..., p_e_given_not_h=...)` (probabilistic — `P` is the evidence we observe, `C` is the hypothesis whose belief we want to update). For exclusive model comparison, prefer `bayes.likelihood(...)`. |
 | `deduction([P], C)` | `derive(C, given=[P])` |
 | `infer([premises], conclusion, ...)` | `infer(evidence, hypothesis=..., given=..., p_e_given_h=..., p_e_given_not_h=...)` |
 | `compare(pred_h, pred_alt, observation, ...)` | author the equivalences and implication explicitly, or use `bayes.likelihood(...)` |

--- a/docs/foundations/review/review-pipeline.md
+++ b/docs/foundations/review/review-pipeline.md
@@ -79,7 +79,7 @@ manifest; it previews the compiled graph numerically.
 
 ## 4. CLI: `gaia inquiry review`
 
-Source: `gaia/cli/commands/inquiry.py`, `gaia/inquiry/review.py:run_review`.
+Source: `gaia/cli/commands/inquiry.py`, `gaia/engine/inquiry/review.py:run_review`.
 
 `gaia inquiry review` runs the local review loop in a single step:
 
@@ -120,7 +120,10 @@ None of these sub-commands mutate `.py` source, IR, priors, or beliefs — they 
 
 ## 5. Manifest Merging
 
-Source: `gaia/cli/commands/_review_manifest.py`.
+Source: `gaia/engine/inquiry/review_manifest.py`. `gaia inquiry review` and
+`gaia build check` import these helpers from
+`gaia.engine.inquiry.review_manifest`; `gaia/cli/commands/_review_manifest.py`
+is a tombstone left in place to redirect any pre-alpha-0 callers.
 
 ```python
 def load_or_generate_review_manifest(pkg_path: Path | str, compiled) -> ReviewManifest
@@ -159,7 +162,7 @@ change the gate result.
 
 ## 6. CLI: `gaia trace verify / review / show`
 
-Source: `gaia/cli/commands/trace.py`, `gaia/trace/review.py:run_trace_review`. Spec: `docs/specs/2026-...` ARM Trace Reviewer (PR #491).
+Source: `gaia/cli/commands/trace.py`, `gaia/engine/trace/review.py:run_trace_review`. Spec: `docs/specs/2026-...` ARM Trace Reviewer (PR #491).
 
 The trace pipeline records every reasoning event emitted during `gaia run infer` and other agent-side workflows into a hash-chained `.json` / `.jsonl` file. The trace is independent of the inference numerical result — its purpose is to make the *reasoning process* itself auditable.
 
@@ -215,13 +218,13 @@ and the [Gaia IR parameterization contract](../gaia-ir/06-parameterization.md).
 | `Review` / `ReviewManifest` / `ReviewStatus` schema | `gaia/engine/ir/review.py` |
 | Manifest generator (per-action audit questions) | `gaia/engine/lang/review/manifest.py` |
 | Audit-question templates | `gaia/engine/lang/review/templates.py` |
-| CLI manifest load / merge | `gaia/cli/commands/_review_manifest.py` |
+| Manifest load / merge helpers | `gaia/engine/inquiry/review_manifest.py` |
 | `gaia inquiry` CLI sub-app | `gaia/cli/commands/inquiry.py` |
-| Inquiry review loop | `gaia/inquiry/review.py` |
-| Inquiry state, focus, obligations | `gaia/inquiry/state.py`, `focus.py`, `proof_state.py` |
+| Inquiry review loop | `gaia/engine/inquiry/review.py` |
+| Inquiry state, focus, obligations | `gaia/engine/inquiry/state.py`, `focus.py`, `proof_state.py` |
 | `gaia trace` CLI sub-app | `gaia/cli/commands/trace.py` |
-| Trace review (eight sections + diagnostics) | `gaia/trace/review.py` |
-| Trace schema and hash chain | `gaia/trace/schema.py`, `gaia/trace/hashing.py` |
+| Trace review (eight sections + diagnostics) | `gaia/engine/trace/review.py` |
+| Trace schema and hash chain | `gaia/engine/trace/schema.py`, `gaia/engine/trace/hashing.py` |
 
 ## 9. Future Work
 

--- a/docs/foundations/review/review-pipeline.md
+++ b/docs/foundations/review/review-pipeline.md
@@ -123,7 +123,8 @@ None of these sub-commands mutate `.py` source, IR, priors, or beliefs — they 
 Source: `gaia/engine/inquiry/review_manifest.py`. `gaia inquiry review` and
 `gaia build check` import these helpers from
 `gaia.engine.inquiry.review_manifest`; `gaia/cli/commands/_review_manifest.py`
-is a tombstone left in place to redirect any pre-alpha-0 callers.
+is a narrow tombstone for the pre-alpha-0 `load_or_generate_review_manifest`
+entry point.
 
 ```python
 def load_or_generate_review_manifest(pkg_path: Path | str, compiled) -> ReviewManifest

--- a/docs/foundations/theory/03-propositional-operators.md
+++ b/docs/foundations/theory/03-propositional-operators.md
@@ -411,7 +411,7 @@ p₁ = 1, p₂ = 0.5
 
 ### 4.7 与现有粗推理算子的关系
 
-此前的粗推理算子（已归档至 [`docs/archive/foundations-v3/theory/03-coarse-reasoning.md`](../../archive/foundations-v3/theory/03-coarse-reasoning.md)）使用单参数 p，其条件概率表为：
+此前的粗推理算子（历史文件位于 `docs/archive/foundations-v3/theory/03-coarse-reasoning.md`，不作为站点页面发布）使用单参数 p，其条件概率表为：
 
 | M | C | 行为 |
 |---|---|------|

--- a/docs/foundations/theory/03-propositional-operators.md
+++ b/docs/foundations/theory/03-propositional-operators.md
@@ -411,7 +411,7 @@ p₁ = 1, p₂ = 0.5
 
 ### 4.7 与现有粗推理算子的关系
 
-此前的粗推理算子（已归档至 `archive/foundations-v3/theory/03-coarse-reasoning.md`）使用单参数 p，其条件概率表为：
+此前的粗推理算子（已归档至 [`docs/archive/foundations-v3/theory/03-coarse-reasoning.md`](../../archive/foundations-v3/theory/03-coarse-reasoning.md)）使用单参数 p，其条件概率表为：
 
 | M | C | 行为 |
 |---|---|------|


### PR DESCRIPTION
## Summary

**Phase 1 (P0) of a 6-PR stacked series that aligns the v0.5 docs to current code.** Pure correctness fixes across user-facing and foundation docs; no design changes. **Two commits**: original P0 fix + a codex review pass on top.

### Original commit — 8 P0 corrections

- **`for-users/cli-commands.md` § Old flat verbs** — invert the wording. The previous text claimed `gaia build compile / gaia run infer / gaia inspect starmap` were tombstoned, which is the **opposite** of what `gaia.cli.commands._flat_tombstones` actually does. Fixed to list the real flat verbs that exit 2.
- **`foundations/review/review-pipeline.md`** — replace 6+ tombstoned source paths (`gaia/inquiry/*`, `gaia/trace/*`, `gaia/cli/commands/_review_manifest.py`) with their canonical engine homes.
- **`foundations/cli/workflow.md` `gaia build check` flag table** — add the missing `--warrants / --blind / --inquiry / --gate` to match `gaia/cli/commands/check.py`.
- **`foundations/bp/belief-state.md`** — rename diagnostic fields to `iterations_run / max_change_at_stop` to match `gaia/cli/commands/infer.py` via `dataclasses.asdict`.
- **`foundations/gaia-lang/knowledge-and-reasoning.md` § 7** — fix the legacy `support([P], C)` → `infer(...)` mapping (positional polarity was reversed).
- **`foundations/bp/formal-strategy-lowering.md` § 7.3 / § 7.4** — rewrite leftover editing notes into a positive cross-reference.
- **`for-users/language-reference.md`** — add the missing `from gaia.engine.lang.compiler import compile_package_artifact` import.
- **`foundations/theory/03-propositional-operators.md`** — fix the archive link to v3 coarse-reasoning.

### Codex review pass — 4 follow-up corrections

- `for-users/language-reference.md` — clarify the propositional-analysis snippet assumes `pkg` is an already-collected package object (the snippet does not show how `pkg` is bound).
- **`foundations/cli/inference.md` `beliefs.json` diagnostics description** (out-of-original-scope but legitimate fix): the original text said \`iterations_run — 0 for JT exact\` but \`gaia/engine/bp/junction_tree.py:701\` actually sets \`diag.iterations_run = 2\` (collect + distribute). Corrected.
- `foundations/review/review-pipeline.md` — narrow the description of \`gaia/cli/commands/_review_manifest.py\` to a tombstone for the single \`load_or_generate_review_manifest\` public entry point (other helpers are engine-internal).
- `foundations/theory/03-propositional-operators.md` — restate the v3 archive pointer as inline path with explicit "not published as a site page" note instead of a markdown link, eliminating the pre-existing mkdocs INFO about an excluded archive link.

## Stacked-PR series

This PR is **#1 of 6**; the next five build on top of this one.

| # | Branch | Base | Status |
|---|--------|------|--------|
| 1 | \`kun/docs-v05-p0-fixes\` (this PR) | \`v0.5\` | this |
| 2 | \`kun/docs-v05-p2-user-framing\` | \`kun/docs-v05-p0-fixes\` | #635 |
| 3 | \`kun/docs-v05-p2-cli-and-lang-ref\` | \`kun/docs-v05-p2-user-framing\` | #636 |
| 4 | \`kun/docs-v05-p3a-ir-contract\` | \`kun/docs-v05-p2-cli-and-lang-ref\` | #637 |
| 5 | \`kun/docs-v05-p3b-lang-bp-refresh\` | \`kun/docs-v05-p3a-ir-contract\` | #638 |
| 6 | \`kun/docs-v05-p3c-theory-ecosystem\` | \`kun/docs-v05-p3b-lang-bp-refresh\` | #639 |

Recommended merge order: 634 → 635 → 636 → 637 → 638 → 639. Each PR's diff is a single self-contained commit pair (original fix + codex review pass).

## Test plan

- [x] \`mkdocs build --strict\` clean on the stack tip
- [x] \`git diff --check\` clean on both commits in this PR
- [x] \`ruff check .\` + \`ruff format --check .\` clean
- [ ] CI: ruff + mypy + ir-schema bump + pytest baseline+cli slice