### PR TITLE
docs(for-users): correct visitor framing and quick-start scaffolding

### DIFF
--- a/docs/for-users/cli-commands.md
+++ b/docs/for-users/cli-commands.md
@@ -481,6 +481,12 @@ gaia pkg register . --registry-dir ../gaia-registry --create-pr      # 10. Publi
 
 ## Old flat verbs
 
-The historical `gaia build compile`, `gaia run infer`, `gaia inspect starmap`, etc. are
-tombstoned. Invoking them prints a redirect to stderr and exits with code 2.
-See [Migration to alpha 0](../migration.md) for the full mapping.
+The historical flat top-level verbs (`gaia compile`, `gaia infer`, `gaia check`,
+`gaia init`, `gaia render`, `gaia starmap`, `gaia starmap-replay`, `gaia add`,
+`gaia register`) are tombstoned in alpha 0. The grouped forms documented above
+(`gaia build compile`, `gaia run infer`, `gaia inspect starmap`, etc.) are the
+current canonical replacements.
+
+Invoking a tombstoned flat verb prints a redirect to stderr and exits with
+code 2 — no side effects, no partial work. See
+[Migration to alpha 0](../migration.md) for the full old-to-new mapping.

--- a/docs/for-users/hole-bridge-tutorial.md
+++ b/docs/for-users/hole-bridge-tutorial.md
@@ -38,7 +38,7 @@ Those results are written into:
 name = "paper-a-gaia"
 version = "1.0.0"
 dependencies = [
-  "gaia-lang>=0.1.0",
+  "gaia-lang>=0.5",
 ]
 
 [tool.gaia]
@@ -63,6 +63,13 @@ deduction(
 
 __all__ = ["main_theorem"]
 ```
+
+> **Why `compat.deduction`?** `deduction` is the v5 named-strategy verb; in v0.5
+> the canonical replacement is `derive(main_theorem, given=[missing_lemma])`,
+> which is functionally equivalent. We use `compat.deduction` here only because
+> the tutorial deliberately walks you through the *legacy authoring shape* that
+> exposes a missing premise as a `local_hole`. New v0.5 packages should prefer
+> `derive(...)`; see [Migration to alpha 0 §Layer 3](../migration.md#layer-3-legacy-dsl-verb-migration).
 
 Compile and inspect:
 
@@ -99,7 +106,7 @@ path; it installs the pinned package version and caches any release beliefs.
 name = "paper-b-gaia"
 version = "1.0.0"
 dependencies = [
-  "gaia-lang>=0.1.0",
+  "gaia-lang>=0.5",
   "paper-a-gaia>=1.0.0,<2.0.0",
 ]
 

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -615,7 +615,7 @@ overloaded, and `Claim` objects intentionally reject truth-value checks such as
 
 ### Propositional analysis
 
-Compiled operator graphs can be analyzed with `gaia.engine.ir.logic`. The API keeps Gaia IR as the stored representation and uses a mature Boolean backend for normalization and checks:
+Compiled operator graphs can be analyzed with `gaia.engine.ir.logic`. The API keeps Gaia IR as the stored representation and uses a mature Boolean backend for normalization and checks. The snippet assumes `pkg` is an already-collected package object:
 
 ```python
 from gaia.engine.lang.compiler import compile_package_artifact

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -618,6 +618,7 @@ overloaded, and `Claim` objects intentionally reject truth-value checks such as
 Compiled operator graphs can be analyzed with `gaia.engine.ir.logic`. The API keeps Gaia IR as the stored representation and uses a mature Boolean backend for normalization and checks:
 
 ```python
+from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.ir.logic import (
     are_equivalent,
     is_satisfiable,

--- a/docs/for-users/quick-start.md
+++ b/docs/for-users/quick-start.md
@@ -55,14 +55,14 @@ The name **must** end with `-gaia`. The command:
 3. Renames `src/my_first_gaia/` → `src/my_first/` (the import name strips the `-gaia` suffix and replaces hyphens with underscores).
 4. Writes a minimal DSL template into `src/my_first/__init__.py`.
 5. Adds `.gaia/beliefs.json` and `.gaia/dep_beliefs/` to `.gitignore` (`.gaia/ir.json` and `.gaia/ir_hash` stay tracked so the registry can verify them).
-6. Runs `uv add gaia-lang` to record the dependency in `pyproject.toml` / `uv.lock`.
+6. Attempts `uv add gaia-lang` to record the dependency in `pyproject.toml` / `uv.lock`. If that step warns, run `uv add gaia-lang` manually inside the package.
 
 The resulting layout:
 
 ```
 my-first-gaia/
   pyproject.toml              # [project], [tool.hatch.build.targets.wheel], [tool.gaia]
-  uv.lock                     # pinned dependency tree
+  uv.lock                     # pinned dependency tree, present after uv dependency resolution succeeds
   src/my_first/
     __init__.py               # DSL declarations (template)
   .gitignore                  # ignores .gaia/beliefs.json, .gaia/dep_beliefs/

--- a/docs/for-users/quick-start.md
+++ b/docs/for-users/quick-start.md
@@ -11,7 +11,8 @@ Create, build, and publish your first Gaia knowledge package in 10 minutes.
 | Python | 3.12+ | [python.org](https://www.python.org/downloads/) |
 | uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 
-Verify both are available:
+`uv` is required: `gaia build init` calls `uv init --lib` and `uv add gaia-lang` under
+the hood, so the CLI errors out with an actionable message if `uv` is missing. Verify:
 
 ```bash
 python3 --version   # 3.12+
@@ -20,13 +21,24 @@ uv --version
 
 ## Install Gaia
 
+Pick whichever installer you already use; both are supported.
+
 ```bash
+# Option A: pip (works on any Python environment)
 pip install gaia-lang
+
+# Option B: uv (recommended if you already work in uv-managed projects)
+uv tool install gaia-lang
 ```
 
-Verify:
+Verify the version, release channel, commit, and IR schema metadata:
 
 ```bash
+gaia --version
+# gaia-lang 0.5.0
+# channel: stable
+# commit: ...
+# ir_schema: ...
 gaia --help
 ```
 
@@ -36,14 +48,24 @@ gaia --help
 gaia build init my-first-gaia
 ```
 
-The name **must** end with `-gaia`. This creates:
+The name **must** end with `-gaia`. The command:
+
+1. Runs `uv init --lib my-first-gaia` to create the package skeleton.
+2. Patches `pyproject.toml` with `[tool.hatch.build.targets.wheel]` (so the package builds as a wheel) and `[tool.gaia]` (`type = "knowledge-package"`, freshly generated `uuid`).
+3. Renames `src/my_first_gaia/` → `src/my_first/` (the import name strips the `-gaia` suffix and replaces hyphens with underscores).
+4. Writes a minimal DSL template into `src/my_first/__init__.py`.
+5. Adds `.gaia/beliefs.json` and `.gaia/dep_beliefs/` to `.gitignore` (`.gaia/ir.json` and `.gaia/ir_hash` stay tracked so the registry can verify them).
+6. Runs `uv add gaia-lang` to record the dependency in `pyproject.toml` / `uv.lock`.
+
+The resulting layout:
 
 ```
 my-first-gaia/
-  pyproject.toml              # [tool.gaia] metadata
+  pyproject.toml              # [project], [tool.hatch.build.targets.wheel], [tool.gaia]
+  uv.lock                     # pinned dependency tree
   src/my_first/
-    __init__.py               # DSL declarations
-  .gitignore
+    __init__.py               # DSL declarations (template)
+  .gitignore                  # ignores .gaia/beliefs.json, .gaia/dep_beliefs/
 ```
 
 ## Edit Your Package
@@ -215,8 +237,21 @@ gaia run render . --target docs
 
 This produces `docs/detailed-reasoning.md` with per-module Mermaid reasoning graphs.
 
+## Inspect (optional)
+
+Visualize the compiled package as an interactive graph:
+
+```bash
+gaia inspect starmap .
+# writes .gaia/starmap.html (open in a browser)
+gaia inspect starmap . --format dot --out starmap.dot
+```
+
+This is read-only — it never mutates IR, priors, or beliefs.
+
 ## Next Steps
 
 - [Language Reference](language-reference.md) — full cheat sheet for all knowledge types, operators, and strategies
-- [CLI Commands](cli-commands.md) — complete reference for all `gaia` commands
+- [CLI Commands](cli-commands.md) — complete reference for all `gaia` commands (verb groups, options, exit codes)
 - [Hole And Bridge Tutorial](hole-bridge-tutorial.md) — cross-package dependency resolution with `fills()`
+- [Migration to alpha 0](../migration.md) — if you have a pre-alpha-0 package, the import-path and CLI-verb migration table

--- a/docs/for-visitors/what-is-gaia.md
+++ b/docs/for-visitors/what-is-gaia.md
@@ -12,7 +12,7 @@ Today, no system tracks this. Scientists do it in their heads, in literature rev
 
 Gaia represents scientific knowledge as a structured graph and computes how trust flows through it. Each claim, each experimental setup, each reasoning step is a node or a link. Every claim carries a posterior between 0 and 1 representing how much we should trust it given the evidence currently in the system.
 
-When new evidence arrives — a new package, a new experiment, a contradiction — beliefs are recomputed across the entire connected graph. Claims that lose support drop in credibility; claims that gain new evidence rise. The graph stays internally consistent without anyone having to manually trace every dependency.
+When authors run inference after adding new evidence — a package update, a new experiment, a contradiction — Gaia recomputes beliefs for the local package and, when requested, installed dependency graphs. Claims that lose support drop in credibility; claims that gain new evidence rise. Global corpus-wide recomputation belongs to the registry / LKM layer, not to a hidden automatic step in the local CLI.
 
 ## How It Works
 
@@ -22,7 +22,7 @@ Authors (or AI agents) write **knowledge packages** — small structured descrip
 2. The author writes `claim(...)`, `note(...)`, `derive(...)`, `infer(...)`, relation verbs (`contradict`, `equal`, `exclusive`), and propositional formulas in Python.
 3. `gaia build compile` lowers the DSL into Gaia IR (`Knowledge / Operator / Strategy / Compose` records).
 4. `gaia run infer` lowers the IR into a factor graph and runs belief propagation locally.
-5. `gaia pkg register` publishes the package into a git-backed registry, where downstream packages can depend on its exported claims.
+5. `gaia pkg register` checks the release artifacts and prepares or writes git-backed registry metadata, where downstream packages can depend on exported claims.
 
 Knowledge extraction itself is **author-side or agent-side work**, not an automated pipeline inside Gaia. Gaia's contribution is the **executable contract** (compile, validate, infer, gate, register) that turns those declarations into a graph whose beliefs are reproducible and machine-checkable.
 

--- a/docs/for-visitors/what-is-gaia.md
+++ b/docs/for-visitors/what-is-gaia.md
@@ -10,13 +10,21 @@ Today, no system tracks this. Scientists do it in their heads, in literature rev
 
 ## What Gaia Does
 
-Gaia reads scientific papers and extracts their knowledge as a structured graph. Each claim, each experimental setup, each reasoning step becomes a node or link in the graph. Every claim carries a number between 0 and 1 representing how much we should trust it, given all the evidence in the system.
+Gaia represents scientific knowledge as a structured graph and computes how trust flows through it. Each claim, each experimental setup, each reasoning step is a node or a link. Every claim carries a posterior between 0 and 1 representing how much we should trust it given the evidence currently in the system.
 
-When new evidence arrives -- a new paper, a new experiment, a contradiction -- Gaia automatically recalculates trust across the entire graph. Claims that were well-supported might drop in credibility. Claims that gain new evidence rise. The whole graph stays internally consistent without anyone having to manually trace every dependency.
+When new evidence arrives — a new package, a new experiment, a contradiction — beliefs are recomputed across the entire connected graph. Claims that lose support drop in credibility; claims that gain new evidence rise. The graph stays internally consistent without anyone having to manually trace every dependency.
 
 ## How It Works
 
-Authors (or AI agents) write knowledge packages -- structured descriptions of a paper's claims, experimental settings, and reasoning chains. Gaia compiles each package into a factor graph, a mathematical structure that encodes how claims support or contradict each other. It then runs belief propagation, an algorithm that passes messages between nodes until the graph reaches a stable set of beliefs. When a new package enters the system, beliefs update automatically across every connected claim.
+Authors (or AI agents) write **knowledge packages** — small structured descriptions of a paper's claims, settings, and reasoning chains. They use a Python authoring DSL (`gaia.engine.lang`) and the `gaia` command-line toolchain:
+
+1. `gaia build init <name>-gaia` scaffolds a package.
+2. The author writes `claim(...)`, `note(...)`, `derive(...)`, `infer(...)`, relation verbs (`contradict`, `equal`, `exclusive`), and propositional formulas in Python.
+3. `gaia build compile` lowers the DSL into Gaia IR (`Knowledge / Operator / Strategy / Compose` records).
+4. `gaia run infer` lowers the IR into a factor graph and runs belief propagation locally.
+5. `gaia pkg register` publishes the package into a git-backed registry, where downstream packages can depend on its exported claims.
+
+Knowledge extraction itself is **author-side or agent-side work**, not an automated pipeline inside Gaia. Gaia's contribution is the **executable contract** (compile, validate, infer, gate, register) that turns those declarations into a graph whose beliefs are reproducible and machine-checkable.
 
 ## What Gaia Is NOT
 
@@ -24,7 +32,7 @@ Authors (or AI agents) write knowledge packages -- structured descriptions of a 
 - **Not a chatbot.** It does not generate text or answer questions in natural language.
 - **Not a citation manager.** It does not track who cited whom -- it tracks which claims depend on which evidence and how much each claim should be trusted.
 
-Gaia is a **reasoning engine for scientific knowledge**.
+Gaia is a **reasoning engine for scientific knowledge**, with a Python authoring DSL on the input side and belief propagation on the output side.
 
 ## Key Concepts
 

--- a/docs/foundations/bp/belief-state.md
+++ b/docs/foundations/bp/belief-state.md
@@ -28,28 +28,36 @@ BeliefState:
 
     # ── 诊断 ──
     converged:            bool
-    iterations:           int
-    max_residual:         float
+    iterations_run:       int
+    max_change_at_stop:   float
 ```
 
 ## Local CLI Beliefs Format
 
-本地 CLI `gaia run infer` 写入的 `.gaia/beliefs.json` 使用不同的 schema，针对本地包优化：
+本地 CLI `gaia run infer` 写入的 `.gaia/beliefs.json` 使用不同的 schema，针对本地包优化。
+载体形状由 `gaia/cli/commands/infer.py::_beliefs_payload` 直接构造，`diagnostics`
+字段是 `result.diagnostics` 的 `dataclasses.asdict()` 结果，所以字段名与
+`gaia/engine/bp/{bp,trw_bp,mean_field,junction_tree}.py` 中各 `*Diagnostics` 的
+dataclass 字段一一对应：
 
 ```json
 {
-  "ir_hash": "...",
-  "gaia_lang_version": "...",
+  "ir_hash": "sha256:...",
+  "gaia_lang_version": "0.5.0",
   "beliefs": [
     {"knowledge_id": "github:pkg::label", "label": "label", "belief": 0.73}
   ],
   "diagnostics": {
     "converged": true,
-    "iterations": 42,
-    "max_residual": 0.0001
+    "iterations_run": 42,
+    "max_change_at_stop": 0.0001
   }
 }
 ```
+
+不同后端会附加各自的诊断字段（例如 JT 的 `treewidth`、loopy BP 的
+`belief_history` / `direction_changes`）；权威示例见
+[`cli/inference.md` §Output Format](../cli/inference.md#beliefsjson)。
 
 **与 BeliefState 的区别**：
 - `beliefs` 是 list of records，不是 `dict[str, float]`
@@ -79,11 +87,14 @@ BeliefState:
 ## 诊断字段
 
 - `converged`：BP 是否在容差内收敛
-- `iterations`：实际运行的迭代数
-- `max_residual`：停止时的最大消息变化量
+- `iterations_run`：实际运行的迭代数（exact JT 固定为 2，对应 collect + distribute 两次扫描）
+- `max_change_at_stop`：停止时的最大消息变化量
 - `compilation_summary`：每个 Strategy 的 BP 编译路径（direct / composite / formal_expr），便于诊断推理链路
 
 这些字段用于判断 belief 的可靠性。未收敛的 BeliefState 仍然有效，但应标记为近似值。
+不同后端会另外携带各自的诊断字段（例如 JT 的 `treewidth`、TRW-BP / Mean Field
+特有的内部统计），都按 `dataclasses.asdict()` 序列化，对照各自模块的
+`*Diagnostics` 定义即可。
 
 ## 源代码
 

--- a/docs/foundations/bp/formal-strategy-lowering.md
+++ b/docs/foundations/bp/formal-strategy-lowering.md
@@ -348,15 +348,10 @@ for op in formal_expr.operators:
 
 判定规则：conclusion 的 $P(H\!=\!1)$ 能否从 $\pi(\text{variables})$ 推导出来？能 → 0.5（计算型）；不能 → $1-\varepsilon$（断言型）。
 
-### 7.3 `potentials.md` 对齐
+### 7.3 与势函数和推理文档的关系
 
-`potentials.md` 应按当前实现保留专门 deterministic FactorType，并说明
-deterministic potential 是 strict 0/1；Cromwell clamp 属于 unary
-evidence/prior 和 soft probability 参数。
-
-### 7.4 `inference.md` 更新
-
-删除 gate_var 机制的描述。Relation operator 的 conclusion 通过 $\pi = 1-\varepsilon$ 自然激活约束，不需要门控变量。
+- 势函数细节见 [`potentials.md`](potentials.md)：每种 deterministic FactorType 的势函数是 strict 0/1；Cromwell clamp 仅作用于 unary evidence/prior 和 soft probability 参数（例如 ↝ 的 `p₁ / p₂`），不出现在 deterministic potential 中。
+- Relation operator 的 conclusion 通过 §7.2 的 $\pi = 1-\varepsilon$ 先验自然激活约束，没有单独的门控变量；推理流程见 [`inference.md`](inference.md)。
 
 ## 参考
 

--- a/docs/foundations/cli/inference.md
+++ b/docs/foundations/cli/inference.md
@@ -307,7 +307,8 @@ is returned with `diagnostics.converged = False`.
 The `diagnostics` object in `beliefs.json` records:
 
 - `converged` — whether inference reached the convergence threshold
-- `iterations_run` — number of complete iterations (0 for JT exact)
+- `iterations_run` — number of complete iterations or exact-pass count (JT
+  exact records `2`, for collect + distribute)
 - `max_change_at_stop` — maximum belief change in the final iteration
 - `treewidth` — estimated treewidth of the factor graph (-1 if not computed)
 - `belief_history` — `{var_id: [belief_at_iter_0, ...]}` per variable

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -99,6 +99,10 @@ gaia build check [PATH]
 gaia build check --brief [PATH]
 gaia build check --show <module|label> [PATH]
 gaia build check --hole [PATH]
+gaia build check --warrants [PATH]
+gaia build check --warrants --blind [PATH]
+gaia build check --inquiry [PATH]
+gaia build check --gate [PATH]
 ```
 
 | Argument | Default | Description |
@@ -110,6 +114,10 @@ gaia build check --hole [PATH]
 | `--brief`, `-b` | Show per-module warrant structure overview |
 | `--show`, `-s` | Expand a specific module or claim/strategy label |
 | `--hole` | Show detailed prior contract report for independent degrees of freedom |
+| `--warrants` | Show v6 `ReviewManifest` warrants and audit questions for reviewable actions |
+| `--blind` | With `--warrants`, hide status values and prior diagnostics to reduce reviewer anchoring |
+| `--inquiry` | Show goal-oriented reasoning progress and review status |
+| `--gate` | Run quality-gate checks and exit non-zero when the package is not publishable |
 
 **What it does:**
 
@@ -126,6 +134,8 @@ printed but do not fail the check.
 **Default output:** Prints pass/fail summary with knowledge diagnostics. Each independent boundary premise is annotated with `prior=X` or `no external prior (MaxEnt)`. Shows a "MaxEnt (no external prior): N" count when any load-bearing boundary claims lack external priors. If deterministic operators constrain those MaxEnt claims, the output also reports the effective feasible state space and entropy in bits. It also reports the induced MaxEnt entropy from the current full joint distribution, which is the Jaynes-style answer to "how many independent bits are really left after the graph's existing constraints and explicit priors are applied?"
 
 **`--hole` output:** Detailed report splitting all load-bearing boundary claims into MaxEnt degrees of freedom (no external prior, with content and QID) and covered claims (with prior value and justification). Use during prior review to identify which independent claims intentionally rely on MaxEnt, which are constrained by deterministic logic, what their induced entropy is under the current graph, and which still need `priors.py` entries.
+
+**`--warrants` / `--blind` / `--inquiry` / `--gate`:** Per-action review and gating views, layered on top of the merged `ReviewManifest`. See [CLI Commands § `gaia build check`](../../for-users/cli-commands.md#gaia-build-check) for the full review-loop semantics, and [`review-pipeline.md`](../review/review-pipeline.md) for the manifest contract and gate criteria.
 
 **Prior contract:** External priors belong only on independent probabilistic inputs to exported goals that are not already pinned by a zero-premise `observe(...)`. A zero-premise `observe(...)` sets its conclusion to `1 - CROMWELL_EPS`; claims concluded by `derive(...)`, `compute(...)`, or `observe(..., given=...)` get their belief from the graph and should not receive manual priors. Structural/helper claims from propositional expressions, `infer(...)`, `associate(...)`, relation verbs (`equal`, `contradict`, `exclusive`), and generated formalization internals also carry no independent prior. If an independent input is intentionally left without an external prior, Gaia uses the Jaynes maximum-entropy distribution over the remaining independent degrees of freedom subject to declared hard constraints.
 

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -294,7 +294,7 @@ The v5 strategy DSL remains available for backward compatibility under `gaia.eng
 
 | Legacy verb | v0.5 replacement |
 |---|---|
-| `support([P], C, prior=...)` | `derive(C, given=[P])` (deterministic) or `infer(C, hypothesis=P, p_e_given_h=..., p_e_given_not_h=...)` (probabilistic) |
+| `support([P], C, prior=...)` | `derive(C, given=[P])` (deterministic) or `infer(P, hypothesis=C, p_e_given_h=..., p_e_given_not_h=...)` (probabilistic — `P` is the evidence we observe, `C` is the hypothesis whose belief we want to update). For exclusive model comparison, prefer `bayes.likelihood(...)`. |
 | `deduction([P], C)` | `derive(C, given=[P])` |
 | `infer([premises], conclusion, ...)` | `infer(evidence, hypothesis=..., given=..., p_e_given_h=..., p_e_given_not_h=...)` |
 | `compare(pred_h, pred_alt, observation, ...)` | author the equivalences and implication explicitly, or use `bayes.likelihood(...)` |

--- a/docs/foundations/review/review-pipeline.md
+++ b/docs/foundations/review/review-pipeline.md
@@ -79,7 +79,7 @@ manifest; it previews the compiled graph numerically.
 
 ## 4. CLI: `gaia inquiry review`
 
-Source: `gaia/cli/commands/inquiry.py`, `gaia/inquiry/review.py:run_review`.
+Source: `gaia/cli/commands/inquiry.py`, `gaia/engine/inquiry/review.py:run_review`.
 
 `gaia inquiry review` runs the local review loop in a single step:
 
@@ -120,7 +120,10 @@ None of these sub-commands mutate `.py` source, IR, priors, or beliefs — they 
 
 ## 5. Manifest Merging
 
-Source: `gaia/cli/commands/_review_manifest.py`.
+Source: `gaia/engine/inquiry/review_manifest.py`. `gaia inquiry review` and
+`gaia build check` import these helpers from
+`gaia.engine.inquiry.review_manifest`; `gaia/cli/commands/_review_manifest.py`
+is a tombstone left in place to redirect any pre-alpha-0 callers.
 
 ```python
 def load_or_generate_review_manifest(pkg_path: Path | str, compiled) -> ReviewManifest
@@ -159,7 +162,7 @@ change the gate result.
 
 ## 6. CLI: `gaia trace verify / review / show`
 
-Source: `gaia/cli/commands/trace.py`, `gaia/trace/review.py:run_trace_review`. Spec: `docs/specs/2026-...` ARM Trace Reviewer (PR #491).
+Source: `gaia/cli/commands/trace.py`, `gaia/engine/trace/review.py:run_trace_review`. Spec: `docs/specs/2026-...` ARM Trace Reviewer (PR #491).
 
 The trace pipeline records every reasoning event emitted during `gaia run infer` and other agent-side workflows into a hash-chained `.json` / `.jsonl` file. The trace is independent of the inference numerical result — its purpose is to make the *reasoning process* itself auditable.
 
@@ -215,13 +218,13 @@ and the [Gaia IR parameterization contract](../gaia-ir/06-parameterization.md).
 | `Review` / `ReviewManifest` / `ReviewStatus` schema | `gaia/engine/ir/review.py` |
 | Manifest generator (per-action audit questions) | `gaia/engine/lang/review/manifest.py` |
 | Audit-question templates | `gaia/engine/lang/review/templates.py` |
-| CLI manifest load / merge | `gaia/cli/commands/_review_manifest.py` |
+| Manifest load / merge helpers | `gaia/engine/inquiry/review_manifest.py` |
 | `gaia inquiry` CLI sub-app | `gaia/cli/commands/inquiry.py` |
-| Inquiry review loop | `gaia/inquiry/review.py` |
-| Inquiry state, focus, obligations | `gaia/inquiry/state.py`, `focus.py`, `proof_state.py` |
+| Inquiry review loop | `gaia/engine/inquiry/review.py` |
+| Inquiry state, focus, obligations | `gaia/engine/inquiry/state.py`, `focus.py`, `proof_state.py` |
 | `gaia trace` CLI sub-app | `gaia/cli/commands/trace.py` |
-| Trace review (eight sections + diagnostics) | `gaia/trace/review.py` |
-| Trace schema and hash chain | `gaia/trace/schema.py`, `gaia/trace/hashing.py` |
+| Trace review (eight sections + diagnostics) | `gaia/engine/trace/review.py` |
+| Trace schema and hash chain | `gaia/engine/trace/schema.py`, `gaia/engine/trace/hashing.py` |
 
 ## 9. Future Work
 

--- a/docs/foundations/review/review-pipeline.md
+++ b/docs/foundations/review/review-pipeline.md
@@ -123,7 +123,8 @@ None of these sub-commands mutate `.py` source, IR, priors, or beliefs — they 
 Source: `gaia/engine/inquiry/review_manifest.py`. `gaia inquiry review` and
 `gaia build check` import these helpers from
 `gaia.engine.inquiry.review_manifest`; `gaia/cli/commands/_review_manifest.py`
-is a tombstone left in place to redirect any pre-alpha-0 callers.
+is a narrow tombstone for the pre-alpha-0 `load_or_generate_review_manifest`
+entry point.
 
 ```python
 def load_or_generate_review_manifest(pkg_path: Path | str, compiled) -> ReviewManifest

--- a/docs/foundations/theory/03-propositional-operators.md
+++ b/docs/foundations/theory/03-propositional-operators.md
@@ -411,7 +411,7 @@ p₁ = 1, p₂ = 0.5
 
 ### 4.7 与现有粗推理算子的关系
 
-此前的粗推理算子（已归档至 [`docs/archive/foundations-v3/theory/03-coarse-reasoning.md`](../../archive/foundations-v3/theory/03-coarse-reasoning.md)）使用单参数 p，其条件概率表为：
+此前的粗推理算子（历史文件位于 `docs/archive/foundations-v3/theory/03-coarse-reasoning.md`，不作为站点页面发布）使用单参数 p，其条件概率表为：
 
 | M | C | 行为 |
 |---|---|------|

--- a/docs/foundations/theory/03-propositional-operators.md
+++ b/docs/foundations/theory/03-propositional-operators.md
@@ -411,7 +411,7 @@ p₁ = 1, p₂ = 0.5
 
 ### 4.7 与现有粗推理算子的关系
 
-此前的粗推理算子（已归档至 `archive/foundations-v3/theory/03-coarse-reasoning.md`）使用单参数 p，其条件概率表为：
+此前的粗推理算子（已归档至 [`docs/archive/foundations-v3/theory/03-coarse-reasoning.md`](../../archive/foundations-v3/theory/03-coarse-reasoning.md)）使用单参数 p，其条件概率表为：
 
 | M | C | 行为 |
 |---|---|------|


### PR DESCRIPTION
## Summary

**Phase 2 part 1 (PR #2 of 6) of the v0.5 doc-vs-code alignment series.** User-facing framing fixes; no behavior changes. **Two commits**: original framing fix + a codex review pass that tightens overclaims.

Stacked on top of \`kun/docs-v05-p0-fixes\` (#634). Merge that first.

### Original commit — visitor + quick-start + hole-bridge

- **\`for-visitors/what-is-gaia.md\`** — rewrite "What Gaia Does" / "How It Works" so the v0.5 reality is visible. Gaia v0.5 does **not** auto-extract knowledge from papers; authors or AI agents write Python DSL packages and Gaia compiles + lowers + runs BP. The new section walks through the actual \`gaia build init / compile / run infer / pkg register\` pipeline with grouped CLI verbs.

- **\`for-users/quick-start.md\`**
  - Note that \`gaia build init\` requires \`uv\` (it calls \`uv init --lib\` and \`uv add gaia-lang\` internally).
  - Document both \`pip install gaia-lang\` and \`uv tool install gaia-lang\` install paths.
  - Add \`gaia --version\` (channel / commit / ir_schema metadata) to the verify step.
  - Match the directory layout to what \`init.py\` actually emits.
  - Add an "Inspect (optional)" section pointing at \`gaia inspect starmap\` and a Migration cross-link.

- **\`for-users/hole-bridge-tutorial.md\`** — add a callout at \`compat.deduction\` noting it is the legacy v5 surface; the canonical v0.5 replacement is \`derive(C, given=[P])\`. Bump dependency \`gaia-lang>=0.1.0\` → \`gaia-lang>=0.5\` in both example packages.

### Codex review pass — 4 overclaim corrections

- **\`for-users/quick-start.md\`** — \`gaia build init\` step 6 was overclaiming: I wrote "Runs \`uv add gaia-lang\`" but \`gaia/cli/commands/init.py:131-137\` wraps the call in try/except and only warns on failure. Codex changed to "**Attempts** \`uv add gaia-lang\` ... If that step warns, run \`uv add gaia-lang\` manually". Also marked \`uv.lock\` as "present after uv dependency resolution succeeds" instead of unconditional.

- **\`for-visitors/what-is-gaia.md\` (significant)** — original "When new evidence arrives ... beliefs are recomputed across the entire connected graph" implied automatic global recomputation. Codex made it explicit that recomputation only happens when authors run \`gaia run infer\` on the local package (and optional dep graphs), and that **global corpus-wide recomputation belongs to the registry / LKM layer, not to a hidden automatic step in the local CLI**. This is exactly the v0.5-reality framing this PR was supposed to enforce.

- **\`for-visitors/what-is-gaia.md\`** — \`gaia pkg register\` description was over-strong ("publishes the package into a git-backed registry"). Codex narrowed to "checks the release artifacts and prepares or writes git-backed registry metadata" — the default mode of \`gaia pkg register\` is dry-run; full publish requires \`--registry-dir --create-pr\`.

## Stacked-PR series

PR **#2 of 6**. Series root: #634.

## Test plan

- [x] \`mkdocs build --strict\` clean
- [x] \`git diff --check\` clean
- [ ] CI