### PR TITLE
docs(for-users): document gaia --version and slim language reference

### DIFF
--- a/docs/for-users/cli-commands.md
+++ b/docs/for-users/cli-commands.md
@@ -26,6 +26,34 @@ gaia trace    verify / review / show          ARM Trace tooling (independent)
 For the old-to-new verb mapping (and the related Python import-path
 changes), see [Migration to alpha 0](../migration.md).
 
+## Top-level options
+
+### `gaia --version`
+
+```bash
+gaia --version
+```
+
+Prints version, release channel, commit, and IR schema metadata, then exits:
+
+```text
+gaia-lang 0.5.0
+channel: stable
+commit: 84353aa3
+ir_schema: 7
+```
+
+| Field | Source | Meaning |
+|-------|--------|---------|
+| version | `gaia._meta.get_library_version()` | distribution version of `gaia-lang` |
+| channel | `gaia._meta.get_channel()` | `stable` / `alpha` / `beta` / `rc` / `dev` — release channel |
+| commit | `gaia._meta.get_commit()` | git short-SHA the wheel was built from |
+| ir_schema | `gaia._meta.IR_SCHEMA` | IR schema version this CLI consumes/emits |
+
+Use `--version` in CI logs and bug reports so the IR schema and channel
+are unambiguous when debugging registry / dependency mismatches. The
+`ir_schema` field is also visible in `.gaia/compile_metadata.json`.
+
 ## `gaia build`
 
 Create and validate a knowledge package.
@@ -306,14 +334,22 @@ gaia inquiry review [path] --mode publish --markdown --strict
 gaia inquiry review [path] --focus github:pkg::claim --depth 1
 gaia inquiry focus <target> --path .
 gaia inquiry focus --clear --path .
+gaia inquiry focus <target> --push --path .              # push current, set new
+gaia inquiry focus --pop --path .                        # pop saved focus
+gaia inquiry focus --stack --path .                      # print focus stack
 gaia inquiry obligation add <target-qid> --content "What must be shown" --kind other --path .
 gaia inquiry obligation list --path .
 gaia inquiry obligation close <obligation-qid> --path .
 gaia inquiry hypothesis add "Alternative mechanism" --path .
 gaia inquiry hypothesis list --path .
+gaia inquiry hypothesis remove <hypothesis-qid> --path .
 gaia inquiry reject <strategy-label-or-id> --content "Why this path is rejected" --path .
 gaia inquiry tactics log --path .
 ```
+
+`gaia inquiry focus` flags `--clear`, `--push`, `--pop`, and `--stack` are
+mutually exclusive. `--push` and a positional `<target>` together push the
+current frame and set a new focus; `--pop` restores the most recent frame.
 
 `gaia inquiry review` options:
 

--- a/docs/for-users/cli-commands.md
+++ b/docs/for-users/cli-commands.md
@@ -40,7 +40,7 @@ Prints version, release channel, commit, and IR schema metadata, then exits:
 gaia-lang 0.5.0
 channel: stable
 commit: 84353aa3
-ir_schema: 7
+ir_schema: ir-v1+<12hex>
 ```
 
 | Field | Source | Meaning |
@@ -51,8 +51,9 @@ ir_schema: 7
 | ir_schema | `gaia._meta.IR_SCHEMA` | IR schema version this CLI consumes/emits |
 
 Use `--version` in CI logs and bug reports so the IR schema and channel
-are unambiguous when debugging registry / dependency mismatches. The
-`ir_schema` field is also visible in `.gaia/compile_metadata.json`.
+are unambiguous when debugging registry / dependency mismatches.
+`.gaia/compile_metadata.json` records the compiled `ir_hash` and
+`gaia_lang_version`; use `gaia --version` for the schema string.
 
 ## `gaia build`
 

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -53,20 +53,21 @@ from .s3_results import *
 
 ```python
 from gaia.engine.lang import (
-    claim, note, question,                                 # Knowledge
-    Variable, Nat, Real, Probability, Bool,                # Formula terms
-    parameter,                                             # Structured formula claims
-    ClaimAtom, land, lnot, lor, implies,                  # Formula AST helpers
-    contradict, equal, exclusive,                         # Reviewable relations
-    depends_on, candidate_relation, materialize,          # Scaffold annotations
-    observe, derive, compute, infer, decompose,            # Recommended actions
-    register_prior,                                       # External prior records
-    Normal, LogNormal, Beta, Exponential, Gamma,          # Distribution factories
+    claim, note, question,                                  # Knowledge
+    Variable, Nat, Real, Probability, Bool,                 # Formula terms
+    parameter,                                              # Structured formula claims
+    ClaimAtom, land, lnot, lor, implies, iff,               # Propositional formula helpers
+    forall, exists,                                         # First-order quantifiers
+    contradict, equal, exclusive,                           # Reviewable relations
+    depends_on, candidate_relation, materialize,            # Scaffold annotations
+    observe, derive, compute, infer, decompose,             # Recommended actions
+    register_prior,                                         # External prior records
+    Normal, LogNormal, Beta, Exponential, Gamma,            # Distribution factories
     StudentT, Cauchy, ChiSquared, Binomial, Poisson,
-    Distribution, BoolExpr, DerivedDistribution,           # Continuous helpers
+    Distribution, BoolExpr, DerivedDistribution,            # Continuous helpers
 )
 
-import gaia.engine.bayes as bayes                          # Bayes helpers
+import gaia.engine.bayes as bayes                           # Bayes hypothesis comparison
 ```
 
 For unit-aware continuous quantities, import quantities from `gaia.unit`:
@@ -74,6 +75,12 @@ For unit-aware continuous quantities, import quantities from `gaia.unit`:
 ```python
 from gaia.unit import q
 ```
+
+For the full enumerated public surface (every symbol, with signatures and
+docstrings), see the auto-generated [`gaia.engine.lang` API reference](../reference/engine/lang.md).
+This page focuses on **how to choose** the right action and **what each one
+compiles to**; the reference page is the source of truth for parameter names
+and types.
 
 ## Knowledge Types
 
@@ -613,6 +620,31 @@ The legacy shortcuts `~a`, `a & b`, `a | b`, `not_(a)`, `and_(...)`, and
 overloaded, and `Claim` objects intentionally reject truth-value checks such as
 `if claim:`.
 
+### First-order quantifiers
+
+`forall(...)` and `exists(...)` build quantified formula nodes for
+predicate-logic claims. Use them inside `claim(..., formula=...)` when the
+proposition ranges over a `Variable` rather than over named claim atoms:
+
+```python
+from gaia.engine.lang import Bool, Variable, claim, exists, forall, implies
+
+x = Variable(symbol="x", domain=Bool)
+universal = claim(
+    "All systems satisfy P implies Q.",
+    formula=forall(x, implies(P(x), Q(x))),
+)
+witness = claim(
+    "There exists a system that satisfies P.",
+    formula=exists(x, P(x)),
+)
+```
+
+For the full predicate-logic surface (variables, domains, predicates,
+ground/lower boundary semantics), see
+[`gaia-lang/predicate-logic.md`](../foundations/gaia-lang/predicate-logic.md)
+and the [formula AST API reference](../reference/engine/lang/formula.md).
+
 ### Propositional analysis
 
 Compiled operator graphs can be analyzed with `gaia.engine.ir.logic`. The API keeps Gaia IR as the stored representation and uses a mature Boolean backend for normalization and checks. The snippet assumes `pkg` is an already-collected package object:
@@ -714,159 +746,54 @@ at_least_one = disjunction(mech_a, mech_b, mech_c,
 
 ## Legacy / Experimental Strategy APIs
 
-The APIs below remain available for older packages and for experiments with named reasoning patterns. New v0.5 packages should normally use `observe(...)`, `derive(...)`, `compute(...)`, `infer(...)`, and the relation verbs above. In particular, do not use `abduction(...)` or `induction(...)` as a shortcut for uncertainty that has not been made explicit; extract the uncertain assumptions as claims first.
+The v5 named-strategy DSL is preserved for backward compatibility under
+`gaia.engine.lang.compat` while existing packages migrate. **New v0.5 packages
+should not use these helpers.** Top-level fallback access (e.g.
+`from gaia.engine.lang import support`) emits a `DeprecationWarning`; the
+explicit `gaia.engine.lang.compat.<name>` import is what migrating packages
+should use until they finish moving off them.
 
-Import these helpers explicitly only when migrating or testing legacy package
-behavior:
+For the full migration table (every legacy verb mapped to its v0.5 replacement),
+see [Migration to alpha 0 §Layer 3](../migration.md#layer-3-legacy-dsl-verb-migration).
+For per-symbol signatures, the auto-generated
+[`gaia.engine.lang` reference](../reference/engine/lang.md) renders the compat
+surface alongside the canonical exports.
 
 ```python
 from gaia.engine.lang.compat import (
+    # background-context aliases (replaced by note)
     setting, context,
+    # operator helpers (replaced by relation verbs and formula AST)
     contradiction, equivalence, complement, disjunction,
+    # named-strategy DSL (replaced by derive / infer / bayes.likelihood)
     support, compare, deduction, abduction, induction,
     analogy, extrapolation, elimination, case_analysis,
-    mathematical_induction, composite, fills,
+    mathematical_induction, composite,
+    # cross-package bridging (still in use; will be promoted in a later release)
+    fills,
 )
 ```
 
-### `support(premises, conclusion, *, reason, prior, background=None)`
+### Notable migration rows
 
-Legacy soft support. Premises jointly support a conclusion through a probabilistic implication warrant. `reason` and `prior` must be paired. Prefer `derive(...)` when the step is deterministic; prefer `infer(...)` when you really need an explicit probabilistic evidence link.
+| Legacy helper | v0.5 replacement | Notes |
+|---|---|---|
+| `setting(...)` / `context(...)` | `note(...)` | Background context only; never participates in BP. |
+| `support([P], C, prior=...)` | `derive(C, given=[P])` (deterministic) or `infer(P, hypothesis=C, p_e_given_h=..., p_e_given_not_h=...)` / `bayes.likelihood(...)` (probabilistic) | `P` is the evidence; `C` is the hypothesis whose belief gets updated. |
+| `deduction([P], C)` | `derive(C, given=[P])` | Strict logical entailment lowers to a hard conditional implication. |
+| `compare / abduction / induction / analogy / extrapolation / elimination / case_analysis / mathematical_induction` | Author the deterministic skeleton with `derive(...)` + relation verbs, or `bayes.likelihood(...)` for explicit Bayesian comparisons | Do not use these as shortcuts for uncertainty that hasn't been spelled out as claims. |
+| `composite(..., sub_strategies=[...])` | Plain `derive(...)` chains plus `@compose` for the workflow boundary | Sub-strategy priors are no longer the v0.5 surface for soft leaves; use `infer(...)` / `bayes.likelihood(...)` instead. |
+| `infer([premises], conclusion, ...)` (legacy positional) | `infer(evidence, hypothesis=..., given=..., p_e_given_h=..., p_e_given_not_h=...)` | The legacy positional form is preserved as a deprecated path; the keyword form is the v0.5 contract. |
+| `contradiction(a, b)` / `equivalence(a, b)` / `complement(a, b)` | `contradict(a, b)` / `equal(a, b)` / `exclusive(a, b)` | The relation-verb forms appear in review manifests and emit reviewable warrant helpers. |
+| `disjunction(*claims)` / `and_(...)` / `or_(...)` / `not_(...)` | `lor(...)` / `land(...)` / `lnot(...)` formula helpers, or explicit `Operator(disjunction, ...)` | Formula AST is the v0.5 way to express structural Boolean expressions. |
+| `noisy_and(...)` | `derive(...)` for deterministic conjunction; `infer(...)` / `bayes.likelihood(...)` for probabilistic evidence aggregation | Currently delegates to legacy `support()`. |
 
-```python
-support(
-    [evidence_a, evidence_b],
-    conclusion,
-    reason="Two independent lines of evidence converge.",
-    prior=0.85,
-)
-```
-
-### `deduction(premises, conclusion, *, reason, prior=None, background=None)`
-
-Legacy strict logical entailment. In new packages, prefer `derive(...)` for this role.
-
-**Key test:** "If all premises are definitely true, is the conclusion **necessarily** true?" Yes -> deduction. No -> support.
-
-`prior` is legacy-only for deduction. Current BP lowering treats deduction as a
-hard conditional implication. Review decides whether the warrant satisfies
-publication-quality gates; it does not set a numeric prior for the proof step,
-and it does not suppress `gaia run infer` local preview output.
-
-```python
-deduction(
-    [bounded_above, monotonically_increasing],
-    theorem,
-    reason="Monotone convergence theorem.",
-)
-```
-
-### `compare(pred_h, pred_alt, observation, *, reason, prior, background=None)`
-
-Compare two competing predictions against an observation. Auto-generates a comparison claim as the conclusion.
-
-```python
-comp = compare(pred_h, pred_alt, obs,
-    reason="H matches observation much better.", prior=0.9)
-# comp.conclusion is the auto-generated comparison claim
-```
-
-### `abduction(support_h, support_alt, comparison, *, reason, background=None)`
-
-Experimental named pattern for inference to best explanation. Takes three **Strategy** objects (not claims): two `support` strategies and one `compare` strategy. For v0.5 authoring, this is not the recommended way to model abductive scientific reasoning; express the competing models, predictions, observations, matches, and alternative explanations as explicit claims/actions instead.
-
-```python
-s_h = support([hypothesis], obs, reason="H explains obs.", prior=0.9)
-s_alt = support([alternative], obs, reason="Alt weakly explains obs.", prior=0.4)
-comp = compare(pred_h, pred_alt, obs, reason="H matches better.", prior=0.9)
-
-abd = abduction(s_h, s_alt, comp,
-    reason="Both attempt to explain the same observation.")
-```
-
-### `induction(support_1, support_2, law, *, reason, background=None)`
-
-Experimental composite pattern: two support strategies jointly confirm a general law. Chainable. For v0.5 authoring, prefer explicit repeated observations/predictions plus reviewable relations, then let BP combine the graph.
-
-```python
-s1 = support([law], obs1, reason="Law predicts obs1.", prior=0.9)
-s2 = support([law], obs2, reason="Law predicts obs2.", prior=0.9)
-s3 = support([law], obs3, reason="Law predicts obs3.", prior=0.9)
-
-ind_12 = induction(s1, s2, law=law, reason="Samples A, B independent.")
-ind_123 = induction(ind_12, s3, law=law, reason="Sample C independent.")
-```
-
-### `analogy(source, target, bridge, *, reason, background=None)`
-
-`bridge` asserts structural similarity between source and target domains.
-
-```python
-analogy(source, target, bridge, reason="Same mechanism, different material.")
-```
-
-### `extrapolation(source, target, continuity, *, reason, background=None)`
-
-`continuity` asserts conditions remain similar when extending a result.
-
-```python
-extrapolation(source, target, continuity, reason="Smooth pressure dependence.")
-```
-
-### `elimination(exhaustiveness, excluded, survivor, *, reason, background=None)`
-
-Process of elimination. `excluded` is a list of `(candidate, evidence_against)` tuples.
-
-```python
-elimination(
-    exhaustive,
-    excluded=[(magnon, no_magnon), (plasmon, no_plasmon)],
-    survivor=phonon,
-    reason="Only phonon mechanism remains.",
-)
-```
-
-### `case_analysis(exhaustiveness, cases, conclusion, *, reason, background=None)`
-
-`cases` is a list of `(case_condition, case_implies_conclusion)` tuples.
-
-```python
-case_analysis(
-    exhaustive,
-    cases=[(above_tc, above_implies), (below_tc, below_implies)],
-    conclusion=conclusion,
-    reason="Covers all temperature regimes.",
-)
-```
-
-### `composite(premises, conclusion, *, sub_strategies, reason, background=None)`
-
-Legacy hierarchical composition. Soft leaf sub-strategies may carry legacy warrant priors; derived conclusions themselves do not receive external priors.
-
-```python
-s1 = deduction([axiom_a, axiom_b], intermediate, reason="From axioms.")
-s2 = support([intermediate, data], final, reason="Combined evidence.", prior=0.85)
-
-composite(
-    [axiom_a, axiom_b, data], final,
-    sub_strategies=[s1, s2],
-    reason="Two-stage argument.",
-)
-```
-
-### `infer(premises, conclusion, *, reason, background=None)`
-
-Legacy general CPT strategy. Prefer the current `infer(evidence, hypothesis=..., given=..., p_e_given_h=..., p_e_given_not_h=0.5)` action form. The old sidecar-based parameterization path has been removed from the authoring surface.
-
-### `fills(source, target, *, mode=None, strength="exact", reason="", background=None)`
-
-Cross-package interface bridging. `strength` is `"exact"` | `"partial"` |
-`"conditional"`. `mode` is optional legacy metadata (`"deduction"` or
-`"infer"` when used).
-
-```python
-fills(local_evidence, imported_claim, strength="exact")
-```
+`fills(...)` (cross-package interface bridging) is still the v0.5 surface for
+declaring `local_hole`-resolving relations between packages. See
+[Hole and Bridge Tutorial](hole-bridge-tutorial.md) for the end-to-end
+walkthrough; the per-parameter signature is rendered in the
+[`gaia.engine.lang` reference](../reference/engine/lang.md) alongside the rest
+of the compat surface.
 
 ## Module Organization
 

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -627,16 +627,31 @@ predicate-logic claims. Use them inside `claim(..., formula=...)` when the
 proposition ranges over a `Variable` rather than over named claim atoms:
 
 ```python
-from gaia.engine.lang import Bool, Variable, claim, exists, forall, implies
+from gaia.engine.lang import (
+    ClaimKind,
+    Domain,
+    PredicateSymbol,
+    UserPredicate,
+    Variable,
+    claim,
+    exists,
+    forall,
+    implies,
+)
 
-x = Variable(symbol="x", domain=Bool)
+System = Domain(content="Systems in this package", members=["s1", "s2"])
+x = Variable(symbol="x", domain=System)
+P = PredicateSymbol(name="P", arg_domains=(System,))
+Q = PredicateSymbol(name="Q", arg_domains=(System,))
 universal = claim(
     "All systems satisfy P implies Q.",
-    formula=forall(x, implies(P(x), Q(x))),
+    formula=forall(x, implies(UserPredicate(P, (x,)), UserPredicate(Q, (x,)))),
+    kind=ClaimKind.QUANTIFIED,
 )
 witness = claim(
     "There exists a system that satisfies P.",
-    formula=exists(x, P(x)),
+    formula=exists(x, UserPredicate(P, (x,))),
+    kind=ClaimKind.QUANTIFIED,
 )
 ```
 
@@ -755,9 +770,11 @@ should use until they finish moving off them.
 
 For the full migration table (every legacy verb mapped to its v0.5 replacement),
 see [Migration to alpha 0 §Layer 3](../migration.md#layer-3-legacy-dsl-verb-migration).
-For per-symbol signatures, the auto-generated
-[`gaia.engine.lang` reference](../reference/engine/lang.md) renders the compat
-surface alongside the canonical exports.
+For per-symbol signatures of the canonical replacements, use the auto-generated
+[`gaia.engine.lang` reference](../reference/engine/lang.md) and focused
+[`gaia.engine.lang.dsl` reference](../reference/engine/lang/dsl.md). The compat
+facade is a deprecated migration import, not a separate generated authoring
+contract.
 
 ```python
 from gaia.engine.lang.compat import (
@@ -791,9 +808,9 @@ from gaia.engine.lang.compat import (
 `fills(...)` (cross-package interface bridging) is still the v0.5 surface for
 declaring `local_hole`-resolving relations between packages. See
 [Hole and Bridge Tutorial](hole-bridge-tutorial.md) for the end-to-end
-walkthrough; the per-parameter signature is rendered in the
-[`gaia.engine.lang` reference](../reference/engine/lang.md) alongside the rest
-of the compat surface.
+walkthrough. Until it is promoted out of `compat`, treat
+`gaia.engine.lang.compat.fills` as a compatibility import rather than a
+top-level generated reference entry.
 
 ## Module Organization
 


### PR DESCRIPTION
## Summary

**Phase 2 part 2 (PR #3 of 6) of the v0.5 doc-vs-code alignment series.** User-facing reference cleanup; no behavior changes. **Two commits**: original cleanup + a codex review pass that fixed two factual errors and rewrote the predicate-logic example.

Stacked on top of \`kun/docs-v05-p2-user-framing\` (#635). Merge #634 → #635 first.

### Original commit

**\`for-users/cli-commands.md\`**
- Add a top-level "\`gaia --version\`" section documenting the version, channel, commit, and ir_schema lines.
- Document \`gaia inquiry focus --push / --pop / --stack\` flags so the reference matches \`gaia/cli/commands/inquiry.py::focus_command\`.
- Add \`gaia inquiry hypothesis remove\` to the inquiry sub-command list.
- Note that \`--clear / --push / --pop / --stack\` on \`inquiry focus\` are mutually exclusive.

**\`for-users/language-reference.md\`** (Q19/Q20 split — keep design narrative, push API enumeration to docstrings + auto-generated reference)
- Add \`forall\`, \`exists\`, and \`iff\` to the imports cheat sheet.
- Add a "First-order quantifiers" subsection with a worked example.
- **Slim the "Legacy / Experimental Strategy APIs" appendix** from ~150 lines of per-function micro-tutorials down to a focused migration table plus pointers to \`migration.md\` Layer 3 and the auto-generated \`gaia.engine.lang\` reference (net: +119 / −156 lines).
- Add a banner near the imports cheat sheet pointing at the auto-generated \`lang.md\` reference.

### Codex review pass — 5 corrections (2 factual errors)

- **\`for-users/cli-commands.md\` \`ir_schema\` example value (factual error)** — original used \`ir_schema: 7\`. Actual format from \`gaia/_meta.py:83\` is \`f"{IR_SCHEMA_VERSION}+{compute_current_ir_hash()}"\` → \`ir-v1+<12hex>\`. Corrected.
- **\`for-users/cli-commands.md\` \`compile_metadata.json\` claim (factual error)** — original said "\`ir_schema\` field is also visible in \`.gaia/compile_metadata.json\`". Actual payload from \`gaia/engine/packaging.py:_render_compile_metadata\` is \`{gaia_lang_version, compiled_at, ir_hash}\` — no \`ir_schema\`. Corrected to "use \`gaia --version\` for the schema string".
- **\`for-users/language-reference.md\` first-order quantifiers example** — original used placeholder \`P(x)\` / \`Q(x)\` over \`Bool\` domain that would not run. Codex rewrote with the actual v0.5 API: \`Domain(content=..., members=[...])\`, \`PredicateSymbol(name=..., arg_domains=...)\`, \`UserPredicate(P, (x,))\`, \`kind=ClaimKind.QUANTIFIED\` — all symbols verified in \`gaia.engine.lang.__all__\`.
- **\`for-users/language-reference.md\` compat reference pointer** — original said the auto-generated \`gaia.engine.lang\` reference renders the compat surface alongside canonical exports. Codex clarified that compat is a deprecated migration import, not a separate generated authoring contract; updated link to point at both \`lang.md\` and \`lang/dsl.md\` for canonical replacements.
- **\`for-users/language-reference.md\` \`fills\` cross-reference** — same correction: \`compat.fills\` is a compatibility import until it is promoted, not a top-level generated reference entry.

## Stacked-PR series

PR **#3 of 6**. Series root: #634.

## Test plan

- [x] \`mkdocs build --strict\` clean
- [x] \`git diff --check\` clean
- [ ] CI