### PR TITLE
docs(foundations): slim gaia-lang and refresh bp/contracts (Phase 3b)

### DIFF
--- a/docs/foundations/bp/inference.md
+++ b/docs/foundations/bp/inference.md
@@ -27,15 +27,17 @@ FactorGraph 是一个**概念**，不绑定特定的存储或运行方式：
 - **`gaia/engine/bp/junction_tree.py`** — Junction Tree exact inference，用于 treewidth ≤ 20 的图
 - **`gaia/engine/bp/mean_field.py`** — Mean Field Variational Inference (CAVI)，大图（n > 2000）的 fallback，硬约束图精度不足（详见「推理算法 / Mean Field VI」）
 - **`gaia/engine/bp/exact.py`** — 小图 brute-force，用于测试和验证
-- **`gaia/engine/bp/engine.py`** — `InferenceEngine`：根据 n 和 treewidth 自动选择算法
-- **`gaia/engine/bp/__init__.py`** — `infer(graph, method=auto)`：统一推理入口
+- **`gaia/engine/bp/engine.py`** — `InferenceEngine`：CLI 主路径；根据 n 和 treewidth 自动选择算法
+- **`gaia/engine/bp/__init__.py`** — `infer(graph, method=auto)`：legacy 便利封装；阈值与 `InferenceEngine` **不一致**，仅用于不需要 CLI parity 的旧调用（详见下方“两条路径的差异”）
 - **`gaia/engine/bp/lowering.py`** — `lower_local_graph()`：Gaia IR → FactorGraph 的入口
 
-**算法选择策略（`method=auto`）：**
+**算法选择策略（CLI `gaia run infer` → `InferenceEngine.run` → `EngineConfig`）：**
 1. 如果 n > 2000 → **fallback 到 Mean Field VI 并发出 `UserWarning`**。大图推理仍在调研中，MF 在 Gaia 硬约束图上有 30%~79% 系统误差，不是生产级；显式 `method="trw_bp"` 可绕过（慢但准确）。
 2. 否则估计 treewidth：
    - treewidth ≤ 20 → Junction Tree（精确）
    - treewidth > 20 → TRW-BP（近似）
+
+> **⚠️ 两条路径的差异 — 不要混用 `gaia.engine.bp.infer()` 和 `InferenceEngine`。** 模块下方的 `infer(graph, method="auto")` 是为了兼容旧调用而保留的便利函数，它的 large-graph fallback 路由到 **loopy BP**（`gaia/engine/bp/__init__.py` `_LOOPY_BP_NODE_LIMIT = 2000`），而 CLI 的 `gaia run infer` 走 `InferenceEngine.run`，n > 2000 时改用 **Mean Field VI**。两者其它阈值相同（treewidth ≤ 20 用 Junction Tree，否则 TRW-BP）。**新代码或希望与 CLI 输出一致的代码应直接使用 `InferenceEngine`**；`infer()` 仅在不关心 CLI parity 的小图测试中用。
 
 ### 从 Gaia IR 构建
 

--- a/docs/foundations/bp/potentials.md
+++ b/docs/foundations/bp/potentials.md
@@ -32,6 +32,8 @@ evidence / priors 和 soft 概率参数；确定性 operator potential 本身保
 
 所有确定性算子在因子图中保留专门的 `FactorType`。Conclusion 的先验决定其角色：**relation operator**（EQUIVALENCE / CONTRADICTION / COMPLEMENT / IMPLICATION）的 conclusion 是断言（通过 `add_evidence(1)` 激活约束）；**expression operator**（NEGATION / CONJUNCTION / DISJUNCTION）的 conclusion 是计算输出（$\pi = 0.5$，belief 由 variables 决定）。详见 [formal-strategy-lowering.md §2](formal-strategy-lowering.md)。
 
+> **Note — IMPLICATION 在 connective formula 下的特例：** 默认情况下 `lower_local_graph` 把顶层 `Operator(implication, ...)` 视作 relation 断言，按 §2 的 `add_evidence(1)` 路径激活；但当 implication 是某个 claim formula 内部连接词的下沉产物（即 lowering 调用站点把 `formula_lowering="connective"` 传入 `gaia.engine.bp.lowering`）时，IMPLICATION 保留为表达式形式不再 pin conclusion——这避免了 formula 内部连接词与外部 relation assertion 双重激活同一个 helper claim。源码：`gaia/engine/bp/lowering.py::_lower_one_operator` (`_OPERATOR_MAP` + connective 短路分支)。
+
 ## SOFT_ENTAILMENT（软蕴含 ↝）
 
 `variables=[M]`（单前提），`conclusion=C`，参数 `p1`, `p2`（须满足 `p1 + p2 > 1`）。

--- a/docs/foundations/bp/potentials.md
+++ b/docs/foundations/bp/potentials.md
@@ -32,7 +32,7 @@ evidence / priors 和 soft 概率参数；确定性 operator potential 本身保
 
 所有确定性算子在因子图中保留专门的 `FactorType`。Conclusion 的先验决定其角色：**relation operator**（EQUIVALENCE / CONTRADICTION / COMPLEMENT / IMPLICATION）的 conclusion 是断言（通过 `add_evidence(1)` 激活约束）；**expression operator**（NEGATION / CONJUNCTION / DISJUNCTION）的 conclusion 是计算输出（$\pi = 0.5$，belief 由 variables 决定）。详见 [formal-strategy-lowering.md §2](formal-strategy-lowering.md)。
 
-> **Note — IMPLICATION 在 connective formula 下的特例：** 默认情况下 `lower_local_graph` 把顶层 `Operator(implication, ...)` 视作 relation 断言，按 §2 的 `add_evidence(1)` 路径激活；但当 implication 是某个 claim formula 内部连接词的下沉产物（即 lowering 调用站点把 `formula_lowering="connective"` 传入 `gaia.engine.bp.lowering`）时，IMPLICATION 保留为表达式形式不再 pin conclusion——这避免了 formula 内部连接词与外部 relation assertion 双重激活同一个 helper claim。源码：`gaia/engine/bp/lowering.py::_lower_one_operator` (`_OPERATOR_MAP` + connective 短路分支)。
+> **Note — IMPLICATION 在 connective formula 下的特例：** 默认情况下 `lower_local_graph` 把顶层 `Operator(implication, ...)` 视作 relation 断言，按 §2 的 `add_evidence(1)` 路径激活；但当 implication 是某个 claim formula 内部连接词的下沉产物（compiler 写入 `metadata["formula_lowering"] == "connective"`）时，IMPLICATION 保留为表达式形式不再 pin conclusion——这避免了 formula 内部连接词与外部 relation assertion 双重激活同一个 helper claim。源码：`gaia/engine/bp/lowering.py::_operator_asserts_relation` 与 `_lower_operators`。
 
 ## SOFT_ENTAILMENT（软蕴含 ↝）
 

--- a/docs/foundations/contracts/rebuttal-report.md
+++ b/docs/foundations/contracts/rebuttal-report.md
@@ -1,6 +1,8 @@
 # 反驳报告契约
 
-> **Status:** Target design
+> **Status:** Target design — **not implemented in v0.5 CLI**.
+>
+> v0.5 没有任何代码生成 `RebuttalReport` / `RebuttalEntry` 或读写 `.gaia/review/rebuttal.json`；这是为未来 ReviewService（多 agent 同行评审 + 反驳周期）准备的合约草案。本文档保留作为下游设计输入，但不应被解读为 `gaia inquiry review` / `gaia run infer` 当前会执行的流程。当前本地 review 路径见 [../review/review-pipeline.md](../review/review-pipeline.md)。
 
 本文档定义反驳报告（RebuttalReport）的数据契约。当审查发现阻塞性问题时，作者或 agent 提交反驳，ReviewService 据此重新评估。
 

--- a/docs/foundations/gaia-lang/bayes.md
+++ b/docs/foundations/gaia-lang/bayes.md
@@ -14,13 +14,15 @@ since: v0.5
 >   It is what `bayes.model` / `bayes.likelihood` ship today. Treat these
 >   sections as the authoring contract.
 > - **Quantity-with-predicate surface (`Distribution` + `claim(content,
->   predicate)` + `observe(dist, value, error)`, marked `(v0.6+)`) is target
->   design**, planned for the v0.6 release line. The behavior described there
->   is **not** the v0.5 contract; do not rely on it from existing packages.
->   Each v0.6+ subsection carries its own callout where relevant.
+>   predicate)` + `observe(dist, value, error)`) is current in v0.5 but
+>   partial.** Inequality predicates get generated CDF priors and measurement
+>   events are recorded in IR. Observation-aware posterior CDF updates, richer
+>   equation constraint lowering, and distribution-vs-distribution predicates
+>   remain follow-up work.
 >
-> If you are reading this on a v0.5 install, treat anything inside the
-> "Quantity-With-Predicate Surface (v0.6+)" section as a roadmap reference.
+> If you are reading this on a v0.5 install, both surfaces below are usable;
+> check each section's "not yet" notes before relying on posterior-updating or
+> equation-propagation behavior.
 
 Gaia provides **two complementary mental models** for handling continuous
 parameters and observations. Pick the one that matches your scientific
@@ -29,7 +31,7 @@ question:
 | You want to … | Use this surface | Status | Mental model |
 |---|---|---|---|
 | Compare competing parameter-value hypotheses (Mendel 3:1 vs 1:1, Galileo Model A vs Model B) | `gaia.engine.bayes` (this module) — `bayes.model` + `bayes.likelihood` | **v0.5 canonical** | **Hypothesis comparison** via likelihood ratios |
-| Estimate a single uncertain quantity and ask threshold / simple equation questions about it (`T_c > 100 K`, `y == baseline + slope * x`) | `Distribution` + `claim(content, predicate)` + `observe(dist, value, error)` | **v0.6+ target design** | **Quantity with predicates** via generated prior records and equation metadata |
+| Estimate a single uncertain quantity and ask threshold / simple equation questions about it (`T_c > 100 K`, `y == baseline + slope * x`) | `Distribution` + `claim(content, predicate)` + `observe(dist, value, error)` | **v0.5 current, partial** | **Quantity with predicates** via generated prior records and equation metadata |
 
 Both surfaces ride on the same scipy-backed distribution machinery
 (``gaia.engine.bayes.distributions``); the difference is the authoring shape
@@ -274,18 +276,17 @@ compiled IR. `gaia build check` applies `priors.py` before compilation, so sidec
 priors are visible to this rule once injected into metadata. Hypotheses with no
 Claim prior and no `priors.py` entry contribute `0.5` to the sum.
 
-## Quantity-With-Predicate Surface (v0.6+)
+## Quantity-With-Predicate Surface
 
-> **Roadmap (v0.6+) — not current contract.** Everything from this section
-> down to the next top-level `##` heading describes target design that has not
-> shipped in v0.5. The behavior, syntax, and diagnostics are subject to change
-> before release; do not author new v0.5 packages against these names. The
-> hypothesis-comparison surface above is the v0.5 source of truth.
+> **Current but partial.** The API names in this section ship in v0.5.
+> Predicate priors are computed from the prior distribution. Measurement events
+> are recorded, but they do not yet update those predicate priors through a
+> posterior CDF.
 
 The hypothesis-comparison surface above is verbose for a common scientific
 pattern: *"I have one continuous parameter with prior uncertainty, and I want
 to ask threshold or equation questions about it"*. The
-**quantity-with-predicate** surface planned for v0.6+ collapses that pattern
+**quantity-with-predicate** surface collapses that pattern
 into three concepts:
 
 1. **Distribution** — a named continuous (or discrete) quantity with a prior
@@ -369,7 +370,7 @@ linear_response_loose = claim(
 
 The author's prior reflects belief in the *law/model* itself. The
 distributions on each operand carry marginal uncertainty of the parameters.
-Current PR1 lowering preserves the equation and optional tolerance in
+Current v0.5 lowering preserves the equation and optional tolerance in
 metadata and registers a neutral 0.5 default when no prior source is present;
 it does not yet propagate constraints between operands or derive a prior from
 the equation.
@@ -396,7 +397,7 @@ custom_noise = Normal("Bayesian-fit measurement noise", mu=0, sigma=4.5)
 m3 = observe(T_c, value=204, error=custom_noise)
 ```
 
-PR1 v0.6 stores observation events; the posterior CDF used for predicate
+Current v0.5 stores observation events; the posterior CDF used for predicate
 claim priors still uses the prior distribution (observation-aware posterior
 update is a follow-up PR — see `gaia/engine/lang/compiler/predicate_lowering.py`
 ``PREDICATE_LOWERING_SOURCE_ID`` docstring). Until then, predicate priors
@@ -416,8 +417,8 @@ Distribution factories accept ``gaia.unit.Quantity`` values via
 | ``Poisson`` | n/a | ``rate`` (lambda is the dimensionless expected count for the interval implied by the content string) | n/a |
 | ``LogNormal``, ``Beta``, ``ChiSquared``, ``Binomial`` | n/a | All — pass bare scalars; encode the random variable's unit in the content string | n/a |
 
-> **Migration (v0.6 breaking change for Poisson):** ``Poisson(rate=q(2, "1/s"))``
-> from earlier v0.5/v0.6 snapshots is no longer accepted. Poisson's ``rate``
+> **Migration note for earlier snapshots:** ``Poisson(rate=q(2, "1/s"))``
+> is no longer accepted. Poisson's ``rate``
 > parameter is the dimensionless expected count for whatever observation
 > interval is implied by the content string. Use
 > ``Poisson("events per second", rate=2)`` instead, encoding the interval in

--- a/docs/foundations/gaia-lang/bayes.md
+++ b/docs/foundations/gaia-lang/bayes.md
@@ -1,19 +1,35 @@
 ---
-status: current-canonical
+status: mixed
 layer: gaia-lang
 since: v0.5
 ---
 
 # Bayes Module And Continuous Quantities
 
+> **Status — read this first.** This document covers two surfaces with
+> different release status:
+>
+> - **Hypothesis-comparison surface (`gaia.engine.bayes`, sections "Hypothesis
+>   comparison surface" through "Check Rules") is current canonical in v0.5.**
+>   It is what `bayes.model` / `bayes.likelihood` ship today. Treat these
+>   sections as the authoring contract.
+> - **Quantity-with-predicate surface (`Distribution` + `claim(content,
+>   predicate)` + `observe(dist, value, error)`, marked `(v0.6+)`) is target
+>   design**, planned for the v0.6 release line. The behavior described there
+>   is **not** the v0.5 contract; do not rely on it from existing packages.
+>   Each v0.6+ subsection carries its own callout where relevant.
+>
+> If you are reading this on a v0.5 install, treat anything inside the
+> "Quantity-With-Predicate Surface (v0.6+)" section as a roadmap reference.
+
 Gaia provides **two complementary mental models** for handling continuous
 parameters and observations. Pick the one that matches your scientific
 question:
 
-| You want to … | Use this surface | Mental model |
-|---|---|---|
-| Compare competing parameter-value hypotheses (Mendel 3:1 vs 1:1, Galileo Model A vs Model B) | `gaia.engine.bayes` (this module) — `bayes.model` + `bayes.likelihood` | **Hypothesis comparison** via likelihood ratios |
-| Estimate a single uncertain quantity and ask threshold / simple equation questions about it (`T_c > 100 K`, `y == baseline + slope * x`) | `Distribution` + `claim(content, predicate)` + `observe(dist, value, error)` | **Quantity with predicates** via generated prior records and equation metadata |
+| You want to … | Use this surface | Status | Mental model |
+|---|---|---|---|
+| Compare competing parameter-value hypotheses (Mendel 3:1 vs 1:1, Galileo Model A vs Model B) | `gaia.engine.bayes` (this module) — `bayes.model` + `bayes.likelihood` | **v0.5 canonical** | **Hypothesis comparison** via likelihood ratios |
+| Estimate a single uncertain quantity and ask threshold / simple equation questions about it (`T_c > 100 K`, `y == baseline + slope * x`) | `Distribution` + `claim(content, predicate)` + `observe(dist, value, error)` | **v0.6+ target design** | **Quantity with predicates** via generated prior records and equation metadata |
 
 Both surfaces ride on the same scipy-backed distribution machinery
 (``gaia.engine.bayes.distributions``); the difference is the authoring shape
@@ -86,31 +102,14 @@ alternative, where every exact count has marginal likelihood `1 / (n + 1)`.
 
 ## Verbs at a Glance
 
-```python
-bayes.model(
-    hypothesis: Claim,
-    *,
-    observable: Variable,
-    distribution: Distribution,
-    background: list[Knowledge] | None = None,
-    rationale: str = "",
-    label: str | None = None,
-    metadata: dict[str, Any] | None = None,
-) -> Claim                               # returns the model helper claim
-
-bayes.likelihood(
-    data: Claim | list[Claim] | tuple[Claim, ...],
-    *,
-    model: Claim,
-    against: Claim | list[Claim] | tuple[Claim, ...] = (),
-    background: list[Knowledge] | None = None,
-    rationale: str = "",
-    label: str | None = None,
-    exclusivity: str = "pairwise_contradiction",
-    precomputed: dict[Claim, float] | None = None,
-    metadata: dict[str, Any] | None = None,
-) -> Claim                               # returns the comparison helper claim
-```
+`bayes.model` declares a predictive-model helper Claim that ties a hypothesis
+Claim to a predictive distribution over an observable; `bayes.likelihood`
+declares a model-preference helper Claim that compares one model against a
+list of alternatives and emits the chosen exclusivity contract. The full
+parameter list, return types, and current defaults are auto-generated from
+docstrings on [`docs/reference/engine/bayes.md`](../../reference/engine/bayes.md);
+the conceptual contract that this foundation doc owns is the **`exclusivity`
+contract** below.
 
 `exclusivity` accepts:
 
@@ -277,11 +276,17 @@ Claim prior and no `priors.py` entry contribute `0.5` to the sum.
 
 ## Quantity-With-Predicate Surface (v0.6+)
 
+> **Roadmap (v0.6+) — not current contract.** Everything from this section
+> down to the next top-level `##` heading describes target design that has not
+> shipped in v0.5. The behavior, syntax, and diagnostics are subject to change
+> before release; do not author new v0.5 packages against these names. The
+> hypothesis-comparison surface above is the v0.5 source of truth.
+
 The hypothesis-comparison surface above is verbose for a common scientific
 pattern: *"I have one continuous parameter with prior uncertainty, and I want
 to ask threshold or equation questions about it"*. The
-**quantity-with-predicate** surface added in v0.6 collapses that pattern into
-three concepts:
+**quantity-with-predicate** surface planned for v0.6+ collapses that pattern
+into three concepts:
 
 1. **Distribution** — a named continuous (or discrete) quantity with a prior
    distribution attached.

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -228,6 +228,8 @@ Most action helpers carry `metadata["review"] = true` and `metadata["helper_kind
 
 Structural-expression helpers from the deprecated `~A`, `A & B`, `A | B` shortcuts use `metadata["review"] = false` and the kinds `negation_result / conjunction_result / disjunction_result`; they are non-reviewable scaffolding for propositional algebra and are detected by `gaia.engine.ir.knowledge.is_structural_expression_helper`.
 
+The IR-side public/private boundary for these helpers — including which helper Claims may be referenced from outside their FormalStrategy and which must stay encapsulated — is defined in [gaia-ir/04-helper-claims.md](../gaia-ir/04-helper-claims.md). Action lowering follows that boundary: the warrant helper for a `Derive` / `Observe` / `Compute` / `Infer` / `Associate` is a public Claim (reviewable, addressable via `[@label]`); the intermediate `conjunction_result` of a multi-premise `Derive` lives inside the FormalStrategy's `formal_expr` as a private node and is not addressable.
+
 ### 4.3 Action Label References
 
 Author-side `[@label]` and `@label` references in claim content, action `rationale`, and notes resolve through a single `label_to_id` table built from:
@@ -238,6 +240,27 @@ Author-side `[@label]` and `@label` references in claim content, action `rationa
 A label collision between a Claim and an Action in the same package is a compile error (`ambiguous reference key`). `DependsOn` labels are intentionally not addressable. Cross-package action references follow the same rules as cross-package Claim references once the registry supports them.
 
 Reference: `docs/specs/2026-05-10-action-label-references-design.md`, issue #539.
+
+### 4.4 Compiler extension registry
+
+Action lowering is dispatched through a typed registry in
+`gaia/engine/lang/compiler/extensions.py`. Each built-in action subclass is
+registered with `register_action_lowerer(action_type, lowerer, *, replace=False)`
+so the compiler can map a runtime `Action` to the IR target documented in §4.1.
+Authors normally do not call this directly — every built-in verb is registered
+at import time — but **plugins or experimental DSL extensions** can supply a
+new action subclass plus its IR lowerer through the same hook. `replace=True`
+is required to overwrite an already-registered lowerer; otherwise a duplicate
+registration is a compile-time error so packages cannot silently shadow each
+other.
+
+Public surface (auto-rendered from docstrings on
+[`docs/reference/engine/lang/compiler.md`](../../reference/engine/lang/compiler.md)):
+
+- `register_action_lowerer(action_type, lowerer, *, replace=False)` — register
+  a lowerer for a custom `Action` subclass.
+- `registered_action_lowerers()` — snapshot of currently-registered lowerers
+  (used by `gaia build check` to surface plugin-provided actions).
 
 ---
 

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -243,24 +243,18 @@ Reference: `docs/specs/2026-05-10-action-label-references-design.md`, issue #539
 
 ### 4.4 Compiler extension registry
 
-Action lowering is dispatched through a typed registry in
-`gaia/engine/lang/compiler/extensions.py`. Each built-in action subclass is
-registered with `register_action_lowerer(action_type, lowerer, *, replace=False)`
-so the compiler can map a runtime `Action` to the IR target documented in §4.1.
-Authors normally do not call this directly — every built-in verb is registered
-at import time — but **plugins or experimental DSL extensions** can supply a
-new action subclass plus its IR lowerer through the same hook. `replace=True`
-is required to overwrite an already-registered lowerer; otherwise a duplicate
-registration is a compile-time error so packages cannot silently shadow each
-other.
+Action lowering is dispatched through a small registry in
+`gaia/engine/lang/compiler/extensions.py`. Peer engine modules, such as
+`gaia.engine.bayes`, register lowerers by stable name:
 
-Public surface (auto-rendered from docstrings on
-[`docs/reference/engine/lang/compiler.md`](../../reference/engine/lang/compiler.md)):
+- `register_action_lowerer(name, *, handles, lower)` — add or replace a lowerer
+  selected by a predicate over runtime `Action` objects.
+- `registered_action_lowerers()` — return the current registry snapshot.
 
-- `register_action_lowerer(action_type, lowerer, *, replace=False)` — register
-  a lowerer for a custom `Action` subclass.
-- `registered_action_lowerers()` — snapshot of currently-registered lowerers
-  (used by `gaia build check` to surface plugin-provided actions).
+This is an engine-extension hook, not a package-author DSL surface. The
+generated compiler reference currently renders `gaia.engine.lang.compiler`, not
+the private `extensions` submodule, so the source docstrings remain the
+authority for this hook.
 
 ---
 

--- a/docs/foundations/gaia-lang/package.md
+++ b/docs/foundations/gaia-lang/package.md
@@ -64,7 +64,7 @@ uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 | `name` | Required. Must end with `-gaia`. | Used as the PyPI distribution name. The import name is derived by stripping the `-gaia` suffix and converting hyphens to underscores. |
 | `version` | Required. Semantic versioning. | See [Version Semantics](#version-semantics) below. |
 | `description` | Optional. | Included in registry metadata if present. |
-| `dependencies` | List. | Declare `*-gaia` packages here for cross-package knowledge references. Non-Gaia dependencies are allowed but ignored by the compiler. |
+| `dependencies` | List. | Declare `*-gaia` packages here for cross-package knowledge references. Non-Gaia dependencies are allowed but ignored by the compiler. `gaia-lang` itself is the runtime distribution; in v0.5 it brings the full DSL surface (`gaia.engine.lang`) plus the Bayes peer module (`gaia.engine.bayes`) — see [bayes.md](bayes.md) for the import contract. |
 
 ### `[tool.gaia]` section
 
@@ -104,7 +104,7 @@ galileo-falling-bodies-gaia/
 │   └── galileo_falling_bodies/
 │       ├── __init__.py          # Package entry: exports + DSL declarations
 │       ├── premises.py          # Background knowledge and observations
-│       ├── reasoning.py         # Reasoning strategies
+│       ├── reasoning.py         # Reasoning actions (derive / observe / infer / relations / ...)
 │       └── priors.py            # Prior records via register_prior(...)
 └── .gaia/                       # Compiled artifacts (git-tracked)
     ├── ir.json                  # LocalCanonicalGraph JSON

--- a/docs/foundations/gaia-lang/package.md
+++ b/docs/foundations/gaia-lang/package.md
@@ -48,7 +48,7 @@ description = "Galileo's falling bodies argument"
 authors = [{name = "Galileo Galilei"}]
 requires-python = ">=3.12"
 dependencies = [
-    "gaia-lang >= 2.0.0",
+    "gaia-lang >= 0.5.0",
     "aristotle-mechanics-gaia >= 1.0.0",
 ]
 

--- a/docs/foundations/gaia-lang/predicate-logic.md
+++ b/docs/foundations/gaia-lang/predicate-logic.md
@@ -599,14 +599,14 @@ then `claim(formula=forall(n, ...))` currently raises during lowering, because
 
 ### 6.5 Existential Quantification
 
-`Exists(variable, body)` also requires a finite `Domain`.
+`exists(variable, body)` also requires a finite `Domain` (the underlying AST node `Exists` is what `gaia.engine.lang.formula` exposes; `exists` is the recommended top-level helper).
 
 ```python
-from gaia.engine.lang import ClaimKind, Exists, claim
+from gaia.engine.lang import ClaimKind, claim, exists
 
 some_stable = claim(
     "Some particle is stable.",
-    formula=Exists(variable=x, body=UserPredicate(Stable, (x,))),
+    formula=exists(x, UserPredicate(Stable, (x,))),
     kind=ClaimKind.QUANTIFIED,
     prior=0.6,
 )


### PR DESCRIPTION
## Summary

**Phase 3b (PR #5 of 6) of the v0.5 doc-vs-code alignment series.** Apply the slim-and-link strategy to \`gaia-lang\` foundations; correct a \`bp/inference\` routing pitfall; tighten contract status banners. Non-protected foundation layer. **Two commits**: original refactor + a codex review pass that caught a wrong API signature, a wrong \`v0.5/v0.6\` framing, and a wrong dependency version.

Stacked on top of \`kun/docs-v05-p3a-ir-contract\` (#637). Merge #634 → #635 → #636 → #637 first.

### Original commit

#### \`gaia-lang/knowledge-and-reasoning.md\`
- §4.2 helper claim visibility now points at \`gaia-ir/04-helper-claims\` for the public/private boundary.
- New §4.4 documents the **compiler extension registry** from \`gaia/engine/lang/compiler/extensions.py\`.

#### \`gaia-lang/predicate-logic.md\`
- Normalise quantifier examples to \`exists(x, ...)\` / \`forall(x, ...)\` helpers; add a note that \`Exists\` / \`Forall\` are the underlying AST nodes.

#### \`gaia-lang/bayes.md\`
- Add a status callout at the top distinguishing the two surfaces.
- Slim the "Verbs at a Glance" pseudo-signature block to a one-line conceptual summary plus a deep link to the auto-generated \`docs/reference/engine/bayes.md\`.

#### \`gaia-lang/package.md\`
- Replace the historical "reasoning strategies (reasoning.py)" naming with v0.5 action-verb framing.
- Cross-link \`bayes.md\` from the dependencies table.

#### \`bp/inference.md\` (high-impact fix)
- Add an explicit **"two paths" warning callout**: \`gaia.engine.bp.infer()\` is the legacy convenience wrapper that routes large graphs to **loopy BP**, while CLI \`gaia run infer\` uses \`InferenceEngine\` and routes the same regime to **Mean Field VI**.

#### \`bp/potentials.md\`
- Document the \`formula_lowering="connective"\` exception on \`IMPLICATION\` lowering.

#### \`contracts/rebuttal-report.md\`
- Promote the status banner: no v0.5 code emits or consumes \`RebuttalReport\` / \`.gaia/review/rebuttal.json\`.

### Codex review pass — 4 corrections (3 substantive errors)

- **\`knowledge-and-reasoning.md\` §4.4 \`register_action_lowerer\` signature (wrong API)** — original wrote signature as \`register_action_lowerer(action_type, lowerer, *, replace=False)\`. Actual signature in \`gaia/engine/lang/compiler/extensions.py:57-66\` is **\`register_action_lowerer(name, *, handles, lower)\`**. There is no \`replace\` parameter (duplicate names just overwrite). Codex corrected the signature and clarified this is an engine-extension hook used by peer modules like \`gaia.engine.bayes\`, **not** a package-author DSL surface.

- **\`bayes.md\` Quantity-With-Predicate v0.5 vs v0.6+ status (wrong framing)** — original framed Quantity-With-Predicate as "v0.6+ target design" / "Roadmap (v0.6+) — not current contract". The actual code in \`gaia/engine/lang/compiler/predicate_lowering.py\` and \`gaia/engine/lang/runtime/distribution.py\` ships in v0.5: predicate priors are computed from prior CDFs at compile time, measurement events are recorded in IR. What is **partial** (not yet implemented) is observation-aware posterior CDF updates, distribution-vs-distribution predicates, and richer equation propagation. Codex relabelled to "v0.5 current, partial" throughout — including section heading, status table row, "Roadmap" callout, "Current PR1 lowering" / "PR1 v0.6 stores" / "Migration (v0.6 breaking change for Poisson)" mentions.

- **\`bp/potentials.md\` \`formula_lowering\` mechanism (wrong description)** — original implied \`formula_lowering="connective"\` is a runtime parameter passed to lowering. Actual mechanism in \`gaia/engine/bp/lowering.py:152-159\`: it is **metadata** on the Operator (\`op.metadata.get("formula_lowering")\`), set by the compiler. Source pointer was also wrong (\`_lower_one_operator\` does not exist); corrected to \`_operator_asserts_relation\` + \`_lower_operators\`.

- **\`package.md\` dependency example (wrong version)** — example had \`gaia-lang >= 2.0.0\`. \`pyproject.toml\` actual version is \`0.5.0\`; codex bumped to \`gaia-lang >= 0.5.0\`.

## Stacked-PR series

PR **#5 of 6**. Series root: #634.

## Test plan

- [x] \`mkdocs build --strict\` clean
- [x] \`git diff --check\` clean
- [ ] CI