### PR TITLE
docs(for-users): correct visitor framing and quick-start scaffolding

### DIFF
--- a/docs/for-users/hole-bridge-tutorial.md
+++ b/docs/for-users/hole-bridge-tutorial.md
@@ -38,7 +38,7 @@ Those results are written into:
 name = "paper-a-gaia"
 version = "1.0.0"
 dependencies = [
-  "gaia-lang>=0.1.0",
+  "gaia-lang>=0.5",
 ]
 
 [tool.gaia]
@@ -63,6 +63,13 @@ deduction(
 
 __all__ = ["main_theorem"]
 ```
+
+> **Why `compat.deduction`?** `deduction` is the v5 named-strategy verb; in v0.5
+> the canonical replacement is `derive(main_theorem, given=[missing_lemma])`,
+> which is functionally equivalent. We use `compat.deduction` here only because
+> the tutorial deliberately walks you through the *legacy authoring shape* that
+> exposes a missing premise as a `local_hole`. New v0.5 packages should prefer
+> `derive(...)`; see [Migration to alpha 0 §Layer 3](../migration.md#layer-3-legacy-dsl-verb-migration).
 
 Compile and inspect:
 
@@ -99,7 +106,7 @@ path; it installs the pinned package version and caches any release beliefs.
 name = "paper-b-gaia"
 version = "1.0.0"
 dependencies = [
-  "gaia-lang>=0.1.0",
+  "gaia-lang>=0.5",
   "paper-a-gaia>=1.0.0,<2.0.0",
 ]
 

--- a/docs/for-users/quick-start.md
+++ b/docs/for-users/quick-start.md
@@ -55,14 +55,14 @@ The name **must** end with `-gaia`. The command:
 3. Renames `src/my_first_gaia/` → `src/my_first/` (the import name strips the `-gaia` suffix and replaces hyphens with underscores).
 4. Writes a minimal DSL template into `src/my_first/__init__.py`.
 5. Adds `.gaia/beliefs.json` and `.gaia/dep_beliefs/` to `.gitignore` (`.gaia/ir.json` and `.gaia/ir_hash` stay tracked so the registry can verify them).
-6. Runs `uv add gaia-lang` to record the dependency in `pyproject.toml` / `uv.lock`.
+6. Attempts `uv add gaia-lang` to record the dependency in `pyproject.toml` / `uv.lock`. If that step warns, run `uv add gaia-lang` manually inside the package.
 
 The resulting layout:
 
 ```
 my-first-gaia/
   pyproject.toml              # [project], [tool.hatch.build.targets.wheel], [tool.gaia]
-  uv.lock                     # pinned dependency tree
+  uv.lock                     # pinned dependency tree, present after uv dependency resolution succeeds
   src/my_first/
     __init__.py               # DSL declarations (template)
   .gitignore                  # ignores .gaia/beliefs.json, .gaia/dep_beliefs/

--- a/docs/for-users/quick-start.md
+++ b/docs/for-users/quick-start.md
@@ -11,7 +11,8 @@ Create, build, and publish your first Gaia knowledge package in 10 minutes.
 | Python | 3.12+ | [python.org](https://www.python.org/downloads/) |
 | uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 
-Verify both are available:
+`uv` is required: `gaia build init` calls `uv init --lib` and `uv add gaia-lang` under
+the hood, so the CLI errors out with an actionable message if `uv` is missing. Verify:
 
 ```bash
 python3 --version   # 3.12+
@@ -20,13 +21,24 @@ uv --version
 
 ## Install Gaia
 
+Pick whichever installer you already use; both are supported.
+
 ```bash
+# Option A: pip (works on any Python environment)
 pip install gaia-lang
+
+# Option B: uv (recommended if you already work in uv-managed projects)
+uv tool install gaia-lang
 ```
 
-Verify:
+Verify the version, release channel, commit, and IR schema metadata:
 
 ```bash
+gaia --version
+# gaia-lang 0.5.0
+# channel: stable
+# commit: ...
+# ir_schema: ...
 gaia --help
 ```
 
@@ -36,14 +48,24 @@ gaia --help
 gaia build init my-first-gaia
 ```
 
-The name **must** end with `-gaia`. This creates:
+The name **must** end with `-gaia`. The command:
+
+1. Runs `uv init --lib my-first-gaia` to create the package skeleton.
+2. Patches `pyproject.toml` with `[tool.hatch.build.targets.wheel]` (so the package builds as a wheel) and `[tool.gaia]` (`type = "knowledge-package"`, freshly generated `uuid`).
+3. Renames `src/my_first_gaia/` → `src/my_first/` (the import name strips the `-gaia` suffix and replaces hyphens with underscores).
+4. Writes a minimal DSL template into `src/my_first/__init__.py`.
+5. Adds `.gaia/beliefs.json` and `.gaia/dep_beliefs/` to `.gitignore` (`.gaia/ir.json` and `.gaia/ir_hash` stay tracked so the registry can verify them).
+6. Runs `uv add gaia-lang` to record the dependency in `pyproject.toml` / `uv.lock`.
+
+The resulting layout:
 
 ```
 my-first-gaia/
-  pyproject.toml              # [tool.gaia] metadata
+  pyproject.toml              # [project], [tool.hatch.build.targets.wheel], [tool.gaia]
+  uv.lock                     # pinned dependency tree
   src/my_first/
-    __init__.py               # DSL declarations
-  .gitignore
+    __init__.py               # DSL declarations (template)
+  .gitignore                  # ignores .gaia/beliefs.json, .gaia/dep_beliefs/
 ```
 
 ## Edit Your Package
@@ -215,8 +237,21 @@ gaia run render . --target docs
 
 This produces `docs/detailed-reasoning.md` with per-module Mermaid reasoning graphs.
 
+## Inspect (optional)
+
+Visualize the compiled package as an interactive graph:
+
+```bash
+gaia inspect starmap .
+# writes .gaia/starmap.html (open in a browser)
+gaia inspect starmap . --format dot --out starmap.dot
+```
+
+This is read-only — it never mutates IR, priors, or beliefs.
+
 ## Next Steps
 
 - [Language Reference](language-reference.md) — full cheat sheet for all knowledge types, operators, and strategies
-- [CLI Commands](cli-commands.md) — complete reference for all `gaia` commands
+- [CLI Commands](cli-commands.md) — complete reference for all `gaia` commands (verb groups, options, exit codes)
 - [Hole And Bridge Tutorial](hole-bridge-tutorial.md) — cross-package dependency resolution with `fills()`
+- [Migration to alpha 0](../migration.md) — if you have a pre-alpha-0 package, the import-path and CLI-verb migration table

--- a/docs/for-visitors/what-is-gaia.md
+++ b/docs/for-visitors/what-is-gaia.md
@@ -12,7 +12,7 @@ Today, no system tracks this. Scientists do it in their heads, in literature rev
 
 Gaia represents scientific knowledge as a structured graph and computes how trust flows through it. Each claim, each experimental setup, each reasoning step is a node or a link. Every claim carries a posterior between 0 and 1 representing how much we should trust it given the evidence currently in the system.
 
-When new evidence arrives — a new package, a new experiment, a contradiction — beliefs are recomputed across the entire connected graph. Claims that lose support drop in credibility; claims that gain new evidence rise. The graph stays internally consistent without anyone having to manually trace every dependency.
+When authors run inference after adding new evidence — a package update, a new experiment, a contradiction — Gaia recomputes beliefs for the local package and, when requested, installed dependency graphs. Claims that lose support drop in credibility; claims that gain new evidence rise. Global corpus-wide recomputation belongs to the registry / LKM layer, not to a hidden automatic step in the local CLI.
 
 ## How It Works
 
@@ -22,7 +22,7 @@ Authors (or AI agents) write **knowledge packages** — small structured descrip
 2. The author writes `claim(...)`, `note(...)`, `derive(...)`, `infer(...)`, relation verbs (`contradict`, `equal`, `exclusive`), and propositional formulas in Python.
 3. `gaia build compile` lowers the DSL into Gaia IR (`Knowledge / Operator / Strategy / Compose` records).
 4. `gaia run infer` lowers the IR into a factor graph and runs belief propagation locally.
-5. `gaia pkg register` publishes the package into a git-backed registry, where downstream packages can depend on its exported claims.
+5. `gaia pkg register` checks the release artifacts and prepares or writes git-backed registry metadata, where downstream packages can depend on exported claims.
 
 Knowledge extraction itself is **author-side or agent-side work**, not an automated pipeline inside Gaia. Gaia's contribution is the **executable contract** (compile, validate, infer, gate, register) that turns those declarations into a graph whose beliefs are reproducible and machine-checkable.
 

--- a/docs/for-visitors/what-is-gaia.md
+++ b/docs/for-visitors/what-is-gaia.md
@@ -10,13 +10,21 @@ Today, no system tracks this. Scientists do it in their heads, in literature rev
 
 ## What Gaia Does
 
-Gaia reads scientific papers and extracts their knowledge as a structured graph. Each claim, each experimental setup, each reasoning step becomes a node or link in the graph. Every claim carries a number between 0 and 1 representing how much we should trust it, given all the evidence in the system.
+Gaia represents scientific knowledge as a structured graph and computes how trust flows through it. Each claim, each experimental setup, each reasoning step is a node or a link. Every claim carries a posterior between 0 and 1 representing how much we should trust it given the evidence currently in the system.
 
-When new evidence arrives -- a new paper, a new experiment, a contradiction -- Gaia automatically recalculates trust across the entire graph. Claims that were well-supported might drop in credibility. Claims that gain new evidence rise. The whole graph stays internally consistent without anyone having to manually trace every dependency.
+When new evidence arrives — a new package, a new experiment, a contradiction — beliefs are recomputed across the entire connected graph. Claims that lose support drop in credibility; claims that gain new evidence rise. The graph stays internally consistent without anyone having to manually trace every dependency.
 
 ## How It Works
 
-Authors (or AI agents) write knowledge packages -- structured descriptions of a paper's claims, experimental settings, and reasoning chains. Gaia compiles each package into a factor graph, a mathematical structure that encodes how claims support or contradict each other. It then runs belief propagation, an algorithm that passes messages between nodes until the graph reaches a stable set of beliefs. When a new package enters the system, beliefs update automatically across every connected claim.
+Authors (or AI agents) write **knowledge packages** — small structured descriptions of a paper's claims, settings, and reasoning chains. They use a Python authoring DSL (`gaia.engine.lang`) and the `gaia` command-line toolchain:
+
+1. `gaia build init <name>-gaia` scaffolds a package.
+2. The author writes `claim(...)`, `note(...)`, `derive(...)`, `infer(...)`, relation verbs (`contradict`, `equal`, `exclusive`), and propositional formulas in Python.
+3. `gaia build compile` lowers the DSL into Gaia IR (`Knowledge / Operator / Strategy / Compose` records).
+4. `gaia run infer` lowers the IR into a factor graph and runs belief propagation locally.
+5. `gaia pkg register` publishes the package into a git-backed registry, where downstream packages can depend on its exported claims.
+
+Knowledge extraction itself is **author-side or agent-side work**, not an automated pipeline inside Gaia. Gaia's contribution is the **executable contract** (compile, validate, infer, gate, register) that turns those declarations into a graph whose beliefs are reproducible and machine-checkable.
 
 ## What Gaia Is NOT
 
@@ -24,7 +32,7 @@ Authors (or AI agents) write knowledge packages -- structured descriptions of a 
 - **Not a chatbot.** It does not generate text or answer questions in natural language.
 - **Not a citation manager.** It does not track who cited whom -- it tracks which claims depend on which evidence and how much each claim should be trusted.
 
-Gaia is a **reasoning engine for scientific knowledge**.
+Gaia is a **reasoning engine for scientific knowledge**, with a Python authoring DSL on the input side and belief propagation on the output side.
 
 ## Key Concepts
 


### PR DESCRIPTION
**Replaces #635** (which GitHub auto-closed when its base branch \`kun/docs-v05-p0-fixes\` was deleted on #634 merge — same content, fresh PR number).

## Summary

**Phase 2 part 1 of the v0.5 doc-vs-code alignment series.** User-facing framing fixes; no behavior changes. **Two commits**: original framing fix + a codex review pass that tightens overclaims.

### Original commit — visitor + quick-start + hole-bridge

- **\`for-visitors/what-is-gaia.md\`** — rewrite "What Gaia Does" / "How It Works" so the v0.5 reality is visible. Gaia v0.5 does **not** auto-extract knowledge from papers; authors or AI agents write Python DSL packages and Gaia compiles + lowers + runs BP.
- **\`for-users/quick-start.md\`** — note that \`gaia build init\` requires \`uv\`; document both \`pip install gaia-lang\` and \`uv tool install gaia-lang\`; add \`gaia --version\`; match the directory layout to what \`init.py\` actually emits; add \`gaia inspect starmap\` next-step.
- **\`for-users/hole-bridge-tutorial.md\`** — add a callout at \`compat.deduction\` noting it is the legacy v5 surface (canonical v0.5 replacement is \`derive(C, given=[P])\`); bump dependency \`gaia-lang>=0.1.0\` → \`gaia-lang>=0.5\`.

### Codex review pass — 4 overclaim corrections

- **\`for-users/quick-start.md\`** — \`gaia build init\` step 6 was overclaiming "Runs \`uv add gaia-lang\`" but \`gaia/cli/commands/init.py:131-137\` wraps the call in try/except. Codex changed to "**Attempts** \`uv add gaia-lang\` ... If that step warns, run \`uv add gaia-lang\` manually".
- **\`for-visitors/what-is-gaia.md\` (significant)** — original "When new evidence arrives ... beliefs are recomputed across the entire connected graph" implied automatic global recomputation. Codex made it explicit that recomputation only happens when authors run \`gaia run infer\`, and that **global corpus-wide recomputation belongs to the registry / LKM layer, not to a hidden automatic step in the local CLI**.
- **\`for-visitors/what-is-gaia.md\`** — \`gaia pkg register\` description was over-strong. Codex narrowed to "checks the release artifacts and prepares or writes git-backed registry metadata" — the default mode of \`gaia pkg register\` is dry-run.
- **\`for-users/quick-start.md\`** — marked \`uv.lock\` as "present after uv dependency resolution succeeds" instead of unconditional.

## Stacked-PR series

Part of the v0.5 doc-vs-code alignment series. Companion PRs: **#634** (P0 fixes, merged), **#636** (cli-commands + lang-ref slim), **#637** (gaia-ir contract), **#638** (gaia-lang slim + bp/contracts), **#639** (theory + ecosystem). All 5 follow-ups now base on \`v0.5\` directly after the #635 → #634 merge cascade.

## Test plan

- [x] \`mkdocs build --strict\` clean
- [x] \`git diff --check\` clean
- [ ] CI

Made with [Cursor](https://cursor.com)