### PR TITLE
chore(agents): reshape AGENTS.md + switch PR-CI gate to pr_gate marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: uv run python scripts/check_suppression_budget.py
 
       - name: Run tests
-        run: uv run pytest -n auto tests/baseline tests/cli -v -m "not slow"
+        run: uv run pytest -n auto -v -m "pr_gate and not slow"
 
       - name: Wheel smoke
         uses: ./.github/actions/wheel-smoke

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,8 +71,8 @@ repos:
         stages: [pre-push]
 
       - id: pytest
-        name: pytest baseline + cli (CI byte-aligned)
-        entry: env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE -u GIT_PREFIX -u GIT_REFLOG_ACTION uv run pytest -n auto tests/baseline tests/cli -v -m "not slow"
+        name: pytest pr_gate slice (CI byte-aligned)
+        entry: env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE -u GIT_PREFIX -u GIT_REFLOG_ACTION uv run pytest -n auto -v -m "pr_gate and not slow"
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,10 @@
 # Contributor and Agent Guide
 
-This file is the canonical operating guide for both human contributors and in-repo agents
-(Claude Code, Cursor, Codex, and any other agent driving the repo). `CLAUDE.md` is a symlink
-to this file so Claude Code auto-loads it; `CONTRIBUTING.md` is a short stub that points
-back here. Edit this file directly — never the symlink, and never duplicate guidance into
-`CONTRIBUTING.md`.
-
-For product overview, architecture, CLI behavior, and DSL reference, start with `README.md`
-and then read the relevant canonical documents under `docs/foundations/`. This guide is only
-for contributor workflow and guardrails.
-
-## Project Map
-
-Gaia is a Python 3.12 project for compiling a Python authoring DSL into Gaia IR and running
-probabilistic inference over the resulting graph.
-
-Key entry points:
-
-- `gaia/lang/` owns the authoring DSL.
-- `gaia/ir/` implements the Gaia IR contract shared by CLI and downstream systems.
-- `gaia/bp/` implements factor-graph lowering and inference.
-- `gaia/cli/` exposes the installed `gaia` Typer command.
-- `tests/` contains the behavior and compatibility suite.
-- `docs/foundations/` is the canonical design surface; `docs/specs/` holds current and
-  historical design specs.
+Canonical operating guide for both human contributors and in-repo agents (Claude Code,
+Cursor, Codex, etc.). `CLAUDE.md` is a symlink to this file so Claude Code auto-loads it;
+`CONTRIBUTING.md` is a stub pointer. Edit this file directly — never the symlink, never
+duplicate guidance into `CONTRIBUTING.md`. For product overview, architecture, CLI, and
+DSL reference, start with `README.md` and then `docs/foundations/`.
 
 ## Local Setup
 
@@ -34,36 +15,32 @@ make bootstrap
 ```
 
 `make bootstrap` runs `uv sync --extra dev`, enables `extensions.worktreeConfig`, installs
-all three hook stages — `pre-commit`, `pre-push`, and `commit-msg` — into the worktree-local
-`.githooks/` directory, and sets `core.hooksPath` per worktree so git picks them up. The
-pre-push hook runs the CI-byte-aligned gate locally so red CI is caught before the push
-leaves your machine; the commit-msg hook enforces Conventional Commits on every commit.
+all three hook stages (`pre-commit`, `pre-push`, `commit-msg`) into the worktree-local
+`.githooks/` directory, and sets `core.hooksPath` per worktree.
 
-Hooks live in `<worktree>/.githooks/` rather than the shared `.git/hooks/` directory, and
-the convention applies whether or not you use additional worktrees — single clones get their
-own `.githooks/` just the same. The rationale is that in a bare-hub-with-worktrees setup
-`.git/hooks/` is shared across every worktree, while `pre-commit install` stubs hardcode the
-installing worktree's `.venv/bin/python`. Per-worktree `.githooks/` makes each worktree's
-hooks point at its own venv, so removing one worktree never leaves stale stubs that break
-commits in another. Existing contributors migrate by re-running `make bootstrap` once; the
-target is idempotent.
+Hooks live in `<worktree>/.githooks/` rather than the shared `.git/hooks/`, and the
+convention applies whether or not you use additional worktrees. In a
+bare-hub-with-worktrees setup `.git/hooks/` is shared across every worktree while
+`pre-commit install` stubs hardcode the installing worktree's `.venv/bin/python` —
+per-worktree `.githooks/` makes each worktree's hooks point at its own venv. Existing
+contributors migrate by re-running `make bootstrap`; the target is idempotent.
 
 ## Quality Gates
 
 Local hooks split work across three stages:
 
-- **pre-commit** (fast, per commit): hygiene hooks (trailing whitespace / EOF newline /
-  merge-conflict / detect-private-key), `ruff check` narrow select + `--fix`, `ruff format`,
-  `mypy --strict`, and the `CLAUDE.md` symlink check.
-- **commit-msg** (per commit): `commitizen` validates the commit message against the
-  Conventional Commits format. Merge and revert commits are exempt by commitizen defaults.
-- **pre-push** (CI-byte-aligned, per push): `ruff check .` full 15-cat select,
+- **pre-commit** (per commit, fast): hygiene hooks (trailing whitespace / EOF newline /
+  merge-conflict / detect-private-key), `ruff check` narrow select + `--fix`,
+  `ruff format`, `mypy --strict`, and the `CLAUDE.md` symlink check.
+- **commit-msg** (per commit): `commitizen` validates the message against Conventional
+  Commits. Merge and revert commits are exempt by commitizen defaults.
+- **pre-push** (per push, CI-byte-aligned): `ruff check .` full 15-cat select,
   `ruff format --check .`, the `ir-schema` bump check, and
-  `pytest -n auto tests/baseline tests/cli -v -m "not slow"`, plus the symlink and
-  suppression-budget checks again. `mypy --strict` is not re-run here — it runs at pre-commit
-  and CI's test job carries it as the push-time backstop.
+  `pytest -n auto -v -m "pr_gate and not slow"`, plus the symlink and suppression-budget
+  checks again. `mypy --strict` runs at pre-commit and CI carries it as the push-time
+  backstop.
 
-For ad-hoc runs:
+Ad-hoc:
 
 ```bash
 make check       # pre-commit (all files) + full pytest suite, parallel via pytest-xdist
@@ -72,83 +49,70 @@ make test        # fast pytest slice (-m "not slow"), parallel, no coverage
 make typecheck   # strict mypy over gaia and tests
 ```
 
-Pytest is configured with strict markers only. The PR-CI test gate runs the
-`tests/baseline` (regression gold standard) and `tests/cli` (CLI E2E user entry points)
-slices via `pytest -n auto tests/baseline tests/cli -v -m "not slow"` at the two call
-sites that matter — the CI workflow's `Run tests` step (`.github/workflows/ci.yml`) and
-the pre-push `pytest` hook. The broader test suite (`tests/eval`, `tests/ir`,
-`tests/lowering`, `tests/scripts`, `tests/unit`, top-level `tests/test_*.py`) runs in
-nightly via `make test-all`, so regressions outside the narrowed slice still surface
-within ~24h. Coverage is no longer a gate anywhere; developers can opt-in ad-hoc via
-`pytest --cov=gaia`.
+The PR-CI test gate runs the `pr_gate` slice at the two call sites that matter — the CI
+workflow's `Run tests` step (`.github/workflows/ci.yml`) and the pre-push `pytest` hook.
+The broader test suite runs in nightly via `make test-all`, so regressions outside the
+narrowed slice still surface within ~24h. Coverage is no longer a gate anywhere; opt-in
+ad-hoc via `pytest --cov=gaia`.
 
-Ruff's mccabe complexity limit is set to 12. An earlier limit of 9 proved too tight for
-Gaia's mix of CLI workflows with BP message passing, IR coarsening, DSL compile/lower/link
-passes, and inquiry orchestration. A limit of 12 is a mainstream Python threshold for mixed
-CLI + library + algorithmic codebases while still requiring true decomposition of
-high-complexity functions.
+### Test placement and PR-CI marker
 
-## Push Pre-flight
+PR-CI gate uses the `pr_gate` pytest marker:
 
-The pre-push hook runs the CI-byte-aligned gate (full ruff + format check + ir-schema bump +
-parallel `pytest -n auto tests/baseline tests/cli -v -m "not slow"`) on every `git push`.
-If the hook is green, local state has passed the same commands that CI's test job runs; mypy
-was already enforced at pre-commit and is re-run by CI as the push-time backstop. The full
-test suite runs in nightly via `make test-all`. GitHub may still catch environment,
-branch-protection, or service-side issues.
+```bash
+pytest -n auto -m "pr_gate and not slow"
+```
 
-**Do not bypass the pre-push hook** with `--no-verify` or any other hook-skip flag. If the hook
-fails, fix the underlying issue and create a new commit — do not skip the hook to "ship now,
-fix later". Bypassing produces silent drift between local and CI state and defeats the entire
-point of byte-aligning the gates.
+Where new tests go:
 
-This applies equally to in-repo agents (Claude Code, Cursor, Codex, etc.). Agents must not
-push without a green pre-push gate. Only the human contributor can override the hook in
-genuinely exceptional circumstances, and the override should be called out explicitly in the
-PR description.
+- **Place by module structure**: tests for `gaia/foo/` go to `tests/foo/` (preferred) or
+  `tests/unit/` (for tightly-scoped unit tests of `gaia/foo/`).
+- **`tests/baseline/`** is the regression gold standard — a frozen surface; new tests
+  there require maintainer review.
+- **`tests/cli/`** is for CLI E2E user-facing entry-point tests.
+
+Whether to add `@pytest.mark.pr_gate`:
+
+- **Yes**: test catches user-facing regression (CLI behavior change, baseline contract
+  drift, public API break).
+- **No**: test is internal contract / unit / fixture — nightly's `make test-all` catches
+  drift within 24h.
+
+The marker can apply per-test or per-file (module-level
+`pytestmark = pytest.mark.pr_gate`). Judgment call belongs to the PR author and reviewer.
+
+### Push pre-flight
+
+**Do not bypass the pre-push hook** with `--no-verify` or any other hook-skip flag. If the
+hook fails, fix the underlying issue and create a new commit. Bypassing produces silent
+drift between local and CI state and defeats the entire point of byte-aligning the gates.
+Applies equally to in-repo agents; only the human contributor can override in genuinely
+exceptional circumstances, and the override should be called out in the PR description.
 
 ### CLAUDE.md ↔ AGENTS.md sync
 
-`CLAUDE.md` is a symlink to `AGENTS.md`. The pre-commit + pre-push hooks both verify this
-relationship. Editing `AGENTS.md` is the canonical action; `CLAUDE.md` is never edited as a
-separate file. `CONTRIBUTING.md` is a short stub that points back here — it intentionally
-does not duplicate any guidance, so all contributor and agent rules stay in one place. If
-you ever find `CLAUDE.md` diverging (the symlink replaced by a real file copy), restore with:
+`CLAUDE.md` is a symlink to `AGENTS.md`; pre-commit + pre-push both verify the relationship.
+Editing `AGENTS.md` is the canonical action. If `CLAUDE.md` ever diverges (symlink replaced
+by a real file), restore with `rm CLAUDE.md && ln -sf AGENTS.md CLAUDE.md`.
 
-```bash
-rm CLAUDE.md && ln -sf AGENTS.md CLAUDE.md
-```
+### Ruff mccabe complexity
+
+Ruff's mccabe complexity limit is set to 12. An earlier limit of 9 proved too tight for
+Gaia's mix of CLI workflows with BP message passing, IR coarsening, DSL compile/lower/link
+passes, and inquiry orchestration. 12 is mainstream for mixed CLI + library + algorithmic
+codebases while still requiring true decomposition of high-complexity functions.
 
 ## Commits
 
-This repo uses **Conventional Commits**. Every commit subject must follow:
+This repo uses **Conventional Commits**: `<type>(<scope>): <imperative summary>`. Allowed
+`<type>` values: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `style`, `perf`,
+`build`, `ci`. `<scope>` is free-form lower-kebab (e.g. `bp`, `cli`, `gaia-ir`). Subject
+≤ 72 characters, no trailing period. Use the body for context, motivation, and
+breaking-change notes (`BREAKING CHANGE: …`).
 
-```
-<type>(<scope>): <imperative summary>
-```
-
-Allowed `<type>` values: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `style`,
-`perf`, `build`, `ci`. `<scope>` is free-form, lower-kebab (for example `bp`, `cli`,
-`gaia-ir`, `docs-foundations`). The subject must be ≤ 72 characters and must not end with a
-period. Use the body (separated by a blank line) for context, motivation, and breaking-change
-notes (`BREAKING CHANGE: …`).
-
-Enforcement is two-sided: a local `commit-msg` hook runs `commitizen` on every commit, and a
-CI job runs `cz check` over every commit in a pull request. Merge commits and revert commits
-are exempt by commitizen defaults, so normal `git merge` and `git revert` workflows are not
-blocked.
-
-## Engineering Rules
-
-- Follow the design docs exactly. If a requested implementation would downgrade or diverge from
-  a documented design, stop and ask before coding.
-- Keep plans aligned with specs step by step; omitting a spec requirement is not an acceptable
-  simplification.
-- Prefer existing repo patterns and helper APIs over new abstractions.
-- Keep edits scoped to the work unit. Do not clean up unrelated files, protected docs, generated
-  fixtures, or user changes in the same pass.
-- If the environment exposes repo skills or agent workflows, use the matching one before going
-  manual.
+Enforcement is two-sided: the local `commit-msg` hook runs `commitizen` on every commit,
+and a CI job runs `cz check` over every commit in a PR. Merge and revert commits are
+exempt by commitizen defaults.
 
 ## Code Style
 
@@ -159,129 +123,38 @@ blocked.
 - Use Pydantic v2 APIs: `.model_dump()`, `.model_validate()`, `.model_validate_json()`.
 - Keep Typer command docstrings concise because they can affect `--help` output.
 
-## Doc Fidelity
+## Design Discipline
 
-Documentation fidelity is load-bearing in this repo. Code, annotations, docstrings, tests, and
-tooling must match the semantics described in `docs/foundations/**` and current-canonical
-`docs/specs/**`.
-
-If you find a semantic contradiction between docs and code:
-
-1. Do not decide which side is right.
-2. Do not fix it in passing.
-3. Stop work on the affected unit and record the doc reference, code location, contradiction,
-   and impact area.
-4. Tell the user so the issue can be escalated and resolved before the code change lands.
-
-Missing annotations, missing docstrings, and normal test gaps are not contradictions; actual
-behavioral or semantic disagreement is.
-
-## Foundations Layers
-
-`docs/foundations/` mirrors the architecture. Information flows downward; lower layers reference
-upper layers instead of redefining them.
-
-| Layer | Responsibility |
-| --- | --- |
-| `theory/` | External theory: Jaynes, propositional operators, BP foundations |
-| `ecosystem/` | Product scope, decentralized package flow, registry operations |
-| `gaia-ir/` | Gaia IR structure contract and validation rules |
-| `gaia-lang/` | Authoring DSL, package model, predicate logic, Bayes surface |
-| `bp/` | BP computation over Gaia IR |
-| `review/` | Review, inquiry, and gating pipeline |
-| `cli/` | Local authoring, compile, inference, storage, registration |
-| `contracts/` | Shared report/data contracts |
-
-Hard layering rules:
-
-1. `docs/foundations/gaia-ir/` is the single source for IR structure definitions.
-2. `docs/foundations/bp/` defines BP computation semantics.
-3. `gaia/cli/` owns Gaia Lang workflows; LKM-side systems operate on Gaia IR, not Gaia Lang.
-4. Cross-layer definitions should link instead of copying content.
-5. Schema changes start in the IR layer and require downstream validation.
-
-## Protected Layers
-
-Do not edit these documentation layers directly:
-
-- `docs/foundations/gaia-ir/`
-- `docs/foundations/theory/`
-
-If implementation work appears to require changing Gaia IR or theory definitions, stop and ask
-the user with:
-
-1. the current definition,
-2. why it needs to change,
-3. the proposed change.
-
-Approved protected-layer changes must be isolated from feature or quality-refactor work.
-
-## Documentation Policy
-
-Before editing architecture or foundation docs, read `docs/documentation-policy.md`.
-
-Foundation documents must clearly distinguish:
-
-- current canonical behavior,
-- target designs,
-- transitional notes,
-- historical background,
-- runtime implementation quirks.
-
-Prefer replacing or archiving obsolete conceptual models over repeatedly patching them in place.
-
-## Scripts and Pipelines
-
-CLI scripts and pipeline entry points must log enough detail to be diagnosable when run in the
-background. This applies to `scripts/*.py` and any package pipeline entry point with `__main__`.
-
-Required logging pattern:
-
-1. log to both console and `logs/{name}-{timestamp}.log`,
-2. use `logging.basicConfig(..., force=True)`,
-3. log each phase start and finish,
-4. print or log the log-file path first,
-5. use `print(..., flush=True)` for ordinary prints.
-
-Template:
-
-```python
-import logging
-import os
-import time
-
-_LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "logs")
-os.makedirs(_LOG_DIR, exist_ok=True)
-_LOG_FILE = os.path.join(_LOG_DIR, f"{script_name}-{time.strftime('%Y%m%d-%H%M%S')}.log")
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(message)s",
-    handlers=[logging.StreamHandler(), logging.FileHandler(_LOG_FILE)],
-    force=True,
-)
-logger = logging.getLogger(__name__)
-logger.info("Log file: %s", _LOG_FILE)
-```
-
-If you run a background script, inspect its log before reporting results.
+- Design-level changes (IR contract, channel/release contract, public API surface) start
+  in `docs/specs/` and land via PR review, not silent in-code edits.
+- If you find code drifting from a current spec, flag it in the PR description; don't
+  silently "fix in passing" — the drift may be intentional and undocumented, or the spec
+  may be the stale side.
+- Scope edits to the work unit. Don't clean up unrelated files, generated fixtures, or
+  user changes in the same pass.
+- Prefer existing repo patterns and helper APIs over new abstractions.
 
 ## Git and Worktrees
 
-Work in a branch or an isolated worktree unless the user explicitly asks otherwise. Worktrees
-live under `.worktrees/<slug>`, which is gitignored:
+Work in a branch or isolated worktree unless the user explicitly asks otherwise.
+Worktrees live under `.worktrees/<slug>`, which is gitignored:
 
 ```bash
 git worktree add .worktrees/<slug> -b feature/<slug>
 ```
 
-Never use destructive git commands, force-push shared branches, or revert user changes unless
-the user explicitly requests it.
+After `git worktree add`, run `git config --worktree core.bare false` before `git status`
+works — `git worktree add` does not set this automatically when the parent is a bare hub,
+and `git status` will fail with "fatal: this operation must be run in a work tree" until
+the override is applied.
+
+Never use destructive git commands, force-push shared branches, or revert user changes
+unless the user explicitly requests it.
 
 ## Community
 
 - License: MIT, see [`LICENSE`](LICENSE).
 - Security: report vulnerabilities via GitHub private vulnerability reporting — see
   [`SECURITY.md`](SECURITY.md).
-- Contributing: this file is the canonical guide; [`CONTRIBUTING.md`](CONTRIBUTING.md) is a
-  short stub pointer.
+- Contributing: this file is the canonical guide; [`CONTRIBUTING.md`](CONTRIBUTING.md) is
+  a short stub pointer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ testpaths = ["tests"]
 markers = [
     "legacy_dsl: tests that intentionally exercise deprecated v5 DSL compatibility",
     "slow: slower regression tests kept out of the default fast feedback slice",
+    "pr_gate: tests gated at PR CI time (fast feedback; full suite runs in nightly via make test-all)",
 ]
 
 [project.scripts]

--- a/tests/baseline/test_artifact_snapshot.py
+++ b/tests/baseline/test_artifact_snapshot.py
@@ -46,6 +46,8 @@ from tests.baseline.conftest import (
     serialize_artifact_tree,
 )
 
+pytestmark = pytest.mark.pr_gate
+
 try:
     import tomllib
 except ImportError:  # pragma: no cover

--- a/tests/baseline/test_error_path_snapshots.py
+++ b/tests/baseline/test_error_path_snapshots.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tests.baseline.conftest import cli_snapshot
+
+pytestmark = pytest.mark.pr_gate
 
 # --------------------------------------------------------------------------- #
 # Top-level leaves                                                            #

--- a/tests/baseline/test_flat_verb_death.py
+++ b/tests/baseline/test_flat_verb_death.py
@@ -20,6 +20,8 @@ import pytest
 from gaia.cli.commands._flat_tombstones import _FLAT_VERB_REDIRECTS
 from tests.baseline.conftest import cli_snapshot
 
+pytestmark = pytest.mark.pr_gate
+
 
 @pytest.mark.parametrize(
     ("flat_verb", "new_form"),

--- a/tests/baseline/test_help_snapshots.py
+++ b/tests/baseline/test_help_snapshots.py
@@ -15,6 +15,8 @@ import pytest
 
 from tests.baseline.conftest import cli_snapshot
 
+pytestmark = pytest.mark.pr_gate
+
 # Every reachable help path. Order matters only for readability.
 #
 # Alpha 0 reorganizes 9 flat verbs into 6 groups + trace independent

--- a/tests/baseline/test_inquiry_read_snapshots.py
+++ b/tests/baseline/test_inquiry_read_snapshots.py
@@ -16,7 +16,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tests.baseline.conftest import cli_snapshot
+
+pytestmark = pytest.mark.pr_gate
 
 
 def test_inquiry_focus_default_snapshot(tmp_path: Path, run_gaia, snapshot) -> None:

--- a/tests/baseline/test_l2_facade.py
+++ b/tests/baseline/test_l2_facade.py
@@ -20,6 +20,8 @@ import importlib
 
 import pytest
 
+pytestmark = pytest.mark.pr_gate
+
 EXPECTED = {
     "gaia.engine.bayes": 19,
     "gaia.engine.bp": 17,

--- a/tests/baseline/test_l2_tombstones.py
+++ b/tests/baseline/test_l2_tombstones.py
@@ -13,6 +13,8 @@ import pytest
 
 from gaia._legacy_imports import TOMBSTONED_NAMESPACES, TOMBSTONED_SYMBOLS
 
+pytestmark = pytest.mark.pr_gate
+
 
 @pytest.mark.parametrize("old_ns,new_ns", sorted(TOMBSTONED_NAMESPACES.items()))
 def test_namespace_tombstone(old_ns: str, new_ns: str) -> None:

--- a/tests/baseline/test_pipeline_snapshots.py
+++ b/tests/baseline/test_pipeline_snapshots.py
@@ -25,6 +25,8 @@ import pytest
 
 from tests.baseline.conftest import EXAMPLES_DIR, cli_snapshot
 
+pytestmark = pytest.mark.pr_gate
+
 MENDEL_REPLAY_FIXTURE = (
     Path(__file__).resolve().parents[1] / "fixtures" / "starmap_replay" / "mendelian_inheritance"
 )

--- a/tests/baseline/test_trace_snapshots.py
+++ b/tests/baseline/test_trace_snapshots.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tests.baseline.conftest import cli_snapshot
+
+pytestmark = pytest.mark.pr_gate
 
 
 def test_trace_verify_clean_snapshot(clean_trace_path: Path, run_gaia, snapshot) -> None:

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -10,6 +10,8 @@ from gaia.cli._registry import RegistryVersion, _fetch_file, fetch_file_optional
 from gaia.cli.main import app
 from gaia.engine.packaging import GaiaPackagingError
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 
 MOCK_VERSION = RegistryVersion(

--- a/tests/cli/test_brief.py
+++ b/tests/cli/test_brief.py
@@ -7,6 +7,8 @@ from typer.testing import CliRunner
 
 from gaia.cli.main import app
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 LEGACY_SUPPORT_WARNING = pytest.mark.filterwarnings(
     "ignore:support\\(\\) is deprecated:DeprecationWarning"

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -7,6 +7,8 @@ from typer.testing import CliRunner
 
 from gaia.cli.main import app
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 
 

--- a/tests/cli/test_check_warrants.py
+++ b/tests/cli/test_check_warrants.py
@@ -1,6 +1,9 @@
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -9,6 +9,8 @@ from gaia.cli.main import app
 from gaia.engine.ir import LocalCanonicalGraph
 from gaia.engine.ir.validator import validate_local_graph
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 
 LEGACY_NOISY_AND_WARNING = pytest.mark.filterwarnings(

--- a/tests/cli/test_compile_v6.py
+++ b/tests/cli/test_compile_v6.py
@@ -2,9 +2,12 @@
 
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_compile_v6_actions.py
+++ b/tests/cli/test_compile_v6_actions.py
@@ -1,8 +1,11 @@
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_detailed_reasoning.py
+++ b/tests/cli/test_detailed_reasoning.py
@@ -1,5 +1,6 @@
 """Tests for docs/detailed-reasoning.md generator (legacy gaia compile --readme/--module-graphs)."""
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.commands._detailed_reasoning import (
@@ -10,6 +11,8 @@ from gaia.cli.commands._detailed_reasoning import (
     topo_layers,
 )
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_github_bundle.py
+++ b/tests/cli/test_github_bundle.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from gaia.cli.commands._github import generate_github_output
+
+pytestmark = pytest.mark.pr_gate
 
 
 def test_github_data_bundle_written_without_react_template(tmp_path: Path):

--- a/tests/cli/test_github_integration.py
+++ b/tests/cli/test_github_integration.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.commands._github import generate_github_output
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_graph_json.py
+++ b/tests/cli/test_graph_json.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from gaia.cli.commands._graph_json import generate_graph_json
+
+pytestmark = pytest.mark.pr_gate
 
 
 def _make_ir(

--- a/tests/cli/test_infer.py
+++ b/tests/cli/test_infer.py
@@ -9,6 +9,8 @@ from typer.testing import CliRunner
 
 from gaia.cli.main import app
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -6,9 +6,12 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 try:
     import tomllib

--- a/tests/cli/test_inquiry.py
+++ b/tests/cli/test_inquiry.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
@@ -8,6 +9,8 @@ from gaia.engine.lang import Claim, candidate_relation, depends_on, derive, obse
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.review.manifest import generate_review_manifest
 from gaia.engine.lang.runtime.package import CollectedPackage
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_manifest.py
+++ b/tests/cli/test_manifest.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from gaia.cli.commands._manifest import generate_manifest
+
+pytestmark = pytest.mark.pr_gate
 
 
 def test_manifest_has_required_fields():

--- a/tests/cli/test_module_compile.py
+++ b/tests/cli/test_module_compile.py
@@ -7,6 +7,8 @@ from typer.testing import CliRunner
 
 from gaia.cli.main import app
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 
 

--- a/tests/cli/test_obsidian.py
+++ b/tests/cli/test_obsidian.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from gaia.cli.commands._obsidian import generate_obsidian_vault
+
+pytestmark = pytest.mark.pr_gate
 
 
 def _make_ir(knowledges=None, strategies=None, operators=None):

--- a/tests/cli/test_quality_gate.py
+++ b/tests/cli/test_quality_gate.py
@@ -1,8 +1,11 @@
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_register.py
+++ b/tests/cli/test_register.py
@@ -11,6 +11,8 @@ from typer.testing import CliRunner
 from gaia.cli.commands import register as register_module
 from gaia.cli.main import app
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 
 

--- a/tests/cli/test_render.py
+++ b/tests/cli/test_render.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_review_manifest_io.py
+++ b/tests/cli/test_review_manifest_io.py
@@ -1,10 +1,14 @@
 import json
 
+import pytest
+
 from gaia.engine.inquiry.review_manifest import load_or_generate_review_manifest
 from gaia.engine.ir import ReviewManifest, ReviewStatus
 from gaia.engine.lang import Claim, derive, observe
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
+
+pytestmark = pytest.mark.pr_gate
 
 
 def _compiled_with_reviewable_action():

--- a/tests/cli/test_simplified_mermaid.py
+++ b/tests/cli/test_simplified_mermaid.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from gaia.cli.commands._simplified_mermaid import (
     render_simplified_mermaid,
     select_simplified_nodes,
 )
+
+pytestmark = pytest.mark.pr_gate
 
 # ── Task 6: select_simplified_nodes ──
 

--- a/tests/cli/test_starmap.py
+++ b/tests/cli/test_starmap.py
@@ -17,6 +17,8 @@ from gaia.cli.commands._stellaris_svg import (
 )
 from gaia.cli.main import app
 
+pytestmark = pytest.mark.pr_gate
+
 runner = CliRunner()
 
 

--- a/tests/cli/test_starmap_replay.py
+++ b/tests/cli/test_starmap_replay.py
@@ -7,6 +7,7 @@ import os
 import re
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.commands._replay_build import (
@@ -24,6 +25,8 @@ from gaia.cli.commands.starmap_replay import (
     merge_events,
 )
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import re
 
+import pytest
 from typer.testing import CliRunner
 
 from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
 
 runner = CliRunner()
 

--- a/tests/cli/test_wiki.py
+++ b/tests/cli/test_wiki.py
@@ -1,11 +1,15 @@
 """Tests for gaia wiki page generation."""
 
+import pytest
+
 from gaia.cli.commands._wiki import (
     generate_all_wiki,
     generate_wiki_home,
     generate_wiki_inference,
     generate_wiki_module,
 )
+
+pytestmark = pytest.mark.pr_gate
 
 
 def test_wiki_home_has_title_and_index():


### PR DESCRIPTION
Two related changes addressing collaboration-norm gaps surfaced in [chenkun's PR #620 post-merge review](https://github.com/SiliconEinstein/Gaia/pull/620#issuecomment-4467251197):

1. **AGENTS.md reshape**: 287 → 160 lines, removing overlap with README and consolidating policy framings.
2. **PR-CI gate switches to `pr_gate` marker**: contributors can opt new tests into PR-CI gate by adding `@pytest.mark.pr_gate` without modifying `ci.yml`.

## AGENTS.md reshape (\`e9d3d158\`)

**Removed sections**:
- Project Map (overlapped with README.md)
- Doc Fidelity (consolidated into new \"Design Discipline\")
- Protected Layers (consolidated into new \"Design Discipline\")
- Foundations Layers (off-loaded to \`docs/foundations/README.md\`)
- Scripts and Pipelines (logging template) — current scripts are simple enough not to need it inline in canon

**Added sections**:
- **Design Discipline**: 4 bullets covering specs-first design, flag-don't-silent-fix on doc/code drift, scope discipline, prefer existing patterns. Replaces the protective intent of Doc Fidelity + Protected Layers with weaker but still-actionable PR-review-based discipline.
- **Quality Gates → Test placement and PR-CI marker**: the gap chenkun surfaced — tells contributors which test directory new tests go to, and when to add the \`pr_gate\` marker.

**Adjusted**:
- **Git and Worktrees**: one new sentence on \`git config --worktree core.bare false\` (the codified workaround for \`git status\` after \`git worktree add\` on a bare hub).

**Preserved**: Local Setup / Push Pre-flight / CLAUDE.md sync / Commits / Code Style / Community.

## PR-CI gate switches to \`pr_gate\` marker (\`5121cfd6\`)

**Before**: \`pytest -n auto tests/baseline tests/cli -v -m \"not slow\"\` (directory-based)
**After**: \`pytest -n auto -v -m \"pr_gate and not slow\"\` (marker-based)

Migration:
- Registered \`pr_gate\` marker in \`pyproject.toml\`
- Updated \`ci.yml\` Run tests step + pre-push pytest hook
- Mass-tagged 35 test files under \`tests/baseline\` + \`tests/cli\` with module-level \`pytestmark = pytest.mark.pr_gate\` via a temporary script (deleted after use)

**Result**: 423 tests selected (exact match to previous directory-based baseline). 420 pass + 3 skip in ~10s wall-clock. Zero scope drift.

**Future contributors**: add new tests in the natural module directory (\`tests/<module>/\` or \`tests/unit/\`); if the test should gate PR-CI, add \`@pytest.mark.pr_gate\`. Otherwise it runs in nightly via \`make test-all\`.

## Test plan

- [x] Local pre-push gate green (all 11 hooks including new marker-based pytest)
- [x] \`pytest --collect-only -m \"pr_gate and not slow\"\` yields 423 (matches baseline)
- [x] \`AGENTS.md\` ↔ \`CLAUDE.md\` symlink intact
- [ ] PR CI on push should be green using new marker-based selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)