### PR TITLE
Add formula logic diagnostics API

### DIFF
--- a/docs/specs/2026-05-17-formula-logic-diagnostics-design.md
+++ b/docs/specs/2026-05-17-formula-logic-diagnostics-design.md
@@ -190,6 +190,7 @@ Severity and logical strength are independent fields.
 | One claim formula is unsatisfiable | `claim` | `hard` | `fatal` | The claim is internally malformed as a logical object. |
 | One claim formula is tautological | `claim` | `hard` | `warning` | The claim may be uninformative but not invalid. |
 | Repeated redundant operands in one formula | `claim` | `hard` | `info` | Useful cleanup signal. |
+| Malformed formula projection after validation was bypassed | `claim` | `unknown` | `warning` | Reviewer-facing diagnostics should isolate the malformed graph and continue inspecting the package. |
 | Two hard formula claims cannot both hold | `claim_pair` | `hard` | `warning` | Claims have priors and beliefs; this is review evidence, not compile failure. |
 | A soft relation is crossed | `claim_pair` | `soft` | `warning` | Soft constraints are allowed to be violated. |
 | One claim entails another | `claim_pair` | `hard` | `info` | The relation becomes important if BP assigns high probability to `A and not B`. |

--- a/docs/specs/2026-05-17-formula-logic-diagnostics-design.md
+++ b/docs/specs/2026-05-17-formula-logic-diagnostics-design.md
@@ -1,0 +1,399 @@
+# Formula Logic Diagnostics API
+
+**Status:** Draft for review
+**Date:** 2026-05-17
+**Branch:** `codex/formula-logic-diagnostics-design`
+**Related PRs:** #632, #633
+**Scope:** Gaia v0.5, reviewer-facing formula logic diagnostics
+**Non-goals:** No theorem prover, no CLI gate in phase 1, no BP probability
+estimation inside diagnostics, and no fatal errors for cross-claim disagreement.
+
+## 1. Goal
+
+Expose the smallest useful interface that lets reviewer-like callers inspect
+formula-level logic issues in a compiled Gaia package.
+
+The first implementation phase should cover:
+
+1. Claim-local logic defects, where an internally contradictory formula is a
+   fatal issue for that claim.
+2. Conservative cross-claim logic warnings, where even hard logical
+   incompatibility is not fatal because each claim can carry its own prior and
+   posterior belief.
+3. Machine-readable diagnostic conditions that a downstream BP or review layer
+   can turn into a probability of the warning being active.
+
+This is best treated as **A-prime + C0**:
+
+- A-prime: connect the FormulaGraph IR added in #632 to a real diagnostics API.
+- C0: include the minimal pairwise cross-claim analysis needed for useful
+  warnings.
+- B: defer CLI and presentation until the API contract is stable.
+- C-rich: defer broader package-level theorem proving and probability queries.
+
+## 2. First Principles
+
+Formula logic diagnostics must separate four concepts that are easy to conflate:
+
+| Concept | Meaning | Example |
+|---|---|---|
+| Logical structure | What follows from formulas if their formulas are treated as hard Boolean structure. | `A` and `not A` cannot both hold. |
+| Claim belief | How credible each claim currently is under prior/reviewer/BP evidence. | `belief(A) = 0.7`. |
+| Diagnostic severity | How Gaia should treat the issue operationally. | claim-local contradiction is `fatal`; cross-claim contradiction is `warning`. |
+| Diagnostic probability | A downstream probability that the warning condition is active. | `Pr(A and B)`. |
+
+The diagnostics layer should report structure, not decide scientific truth.
+Cross-claim disagreement is usually a review signal, not a compilation failure.
+
+The only fatal class in the first implementation should be a defect inside the
+same formula-bearing claim, such as a single claim whose own formula is
+unsatisfiable. That makes the claim malformed as a logical object.
+
+## 3. Current Code Facts
+
+The v0.5 branch already has the foundation needed for this API:
+
+- `gaia.engine.ir.formula` defines `FormulaGraph`, `FormulaNode`,
+  `FormulaEdge`, and `formula_node_id`.
+- `LocalCanonicalGraph` includes `formula_graphs`, and the graph hash includes
+  formula graph content.
+- The compiler emits formula graphs from `claim(formula=...)`.
+- IR validation checks formula graph source claims, node ids, root ids,
+  descriptors, and edge references.
+- `gaia.engine.ir.logic.propositional` currently projects existing
+  `Operator`/`FormalStrategy` graphs into SymPy propositions.
+- `gaia.engine.ir.review` provides `ReviewManifest`, but it is a qualitative
+  review record model and should not be mutated by the first diagnostics API.
+
+The missing piece is a formula-graph diagnostics module that consumes
+`LocalCanonicalGraph.formula_graphs` directly.
+
+## 4. Public API
+
+Add a small module:
+
+```python
+gaia.engine.ir.logic.diagnostics
+```
+
+The primary entry point should be:
+
+```python
+def inspect_formula_graphs(
+    graph: LocalCanonicalGraph,
+    *,
+    include_pairwise: bool = True,
+) -> FormulaDiagnosticReport:
+    ...
+```
+
+The API returns a report instead of raising for logical warnings. Structural IR
+errors remain the responsibility of `validate_local_graph` and Pydantic model
+validation.
+
+### 4.1 Models
+
+Use Pydantic models, consistent with the IR and review layers:
+
+```python
+FormulaDiagnosticSeverity = Literal["info", "warning", "fatal"]
+FormulaDiagnosticScope = Literal["claim", "claim_pair", "package"]
+FormulaLogicStrength = Literal["hard", "soft", "mixed", "unknown"]
+
+DiagnosticConditionKind = Literal[
+    "formula_unsat",
+    "formula_tautology",
+    "joint_incompatibility",
+    "entailment_violation",
+    "redundant_formula",
+]
+
+ConditionConfidenceBasis = Literal[
+    "hard_logic",
+    "soft_relation",
+    "projection",
+]
+```
+
+```python
+class DiagnosticCondition(BaseModel):
+    kind: DiagnosticConditionKind
+    variables: list[str] = Field(default_factory=list)
+    expression: dict[str, Any]
+    confidence_basis: ConditionConfidenceBasis
+
+
+class FormulaDiagnostic(BaseModel):
+    code: str
+    severity: FormulaDiagnosticSeverity
+    scope: FormulaDiagnosticScope
+    logic_strength: FormulaLogicStrength
+    source_claim: str | None = None
+    related_claims: list[str] = Field(default_factory=list)
+    formula_nodes: list[str] = Field(default_factory=list)
+    condition: DiagnosticCondition | None = None
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class FormulaDiagnosticReport(BaseModel):
+    diagnostics: list[FormulaDiagnostic] = Field(default_factory=list)
+
+    @property
+    def has_fatal(self) -> bool:
+        return any(d.severity == "fatal" for d in self.diagnostics)
+```
+
+The concrete implementation may use tuples internally, but the serialized
+contract should be JSON-friendly and deterministic.
+
+### 4.2 Condition Expression AST
+
+`DiagnosticCondition.expression` should be a small JSON Boolean AST, not a
+SymPy object and not Python source code.
+
+Supported shapes in phase 1:
+
+```json
+{"var": "claim_a"}
+{"op": "not", "arg": {"var": "claim_a"}}
+{"op": "and", "args": [{"var": "claim_a"}, {"var": "claim_b"}]}
+{"op": "or", "args": [{"var": "claim_a"}, {"var": "claim_b"}]}
+```
+
+Variables should use stable claim ids when the warning is about claim truth
+values. The examples use short aliases; real diagnostics should use the exact
+ids already present in Gaia IR. Formula node ids can be used for local formula
+atoms only when no claim qid exists.
+
+This condition is the bridge to BP. The diagnostics module does not estimate
+`Pr(condition)`. It exposes a queryable event such as:
+
+| Diagnostic | Condition event for downstream probability |
+|---|---|
+| Cross-claim incompatibility between `A` and `B` | `A and B` |
+| Entailment from `A` to `B` | `A and not B` |
+| Formula equivalence between `A` and `B` | `(A and not B) or (B and not A)` |
+| Local unsatisfiable formula in `A` | `A`; usually no BP probability is needed because this is fatal. |
+
+Downstream BP can estimate the probability with exact event queries,
+approximate factor-graph queries, sampled beliefs, or a later dedicated joint
+query API. The diagnostics contract should not depend on which estimator is
+available.
+
+## 5. Severity Semantics
+
+Severity and logical strength are independent fields.
+
+| Situation | Scope | Logic strength | Severity | Rationale |
+|---|---|---|---|---|
+| One claim formula is unsatisfiable | `claim` | `hard` | `fatal` | The claim is internally malformed as a logical object. |
+| One claim formula is tautological | `claim` | `hard` | `warning` | The claim may be uninformative but not invalid. |
+| Repeated redundant operands in one formula | `claim` | `hard` | `info` | Useful cleanup signal. |
+| Two hard formula claims cannot both hold | `claim_pair` | `hard` | `warning` | Claims have priors and beliefs; this is review evidence, not compile failure. |
+| A soft relation is crossed | `claim_pair` | `soft` | `warning` | Soft constraints are allowed to be violated. |
+| One claim entails another | `claim_pair` | `hard` | `info` | The relation becomes important if BP assigns high probability to `A and not B`. |
+
+The first implementation should not emit `fatal` for any cross-claim condition.
+If future package policies want a stricter gate, that policy should live above
+this diagnostics API.
+
+## 6. Phase 1 Algorithm
+
+### 6.1 FormulaGraph Projection
+
+Add an internal projector from `FormulaGraph` roots to a backend Boolean
+expression:
+
+```python
+formula_graph_to_sympy(formula_graph: FormulaGraph) -> Any
+```
+
+It should support only propositional shapes in phase 1:
+
+- atom
+- `and`
+- `or`
+- `not`
+- `implies`
+- `iff`
+
+Unsupported first-order, quantifier, term, or predicate shapes should be
+handled conservatively:
+
+- If the whole formula cannot be projected, skip logic solving for that graph
+  and optionally emit an `info` diagnostic with code
+  `formula_projection_unsupported`.
+- Do not fail the API because a formula is outside the current propositional
+  subset.
+
+Atom symbols should be stable and derived from formula node ids or claim-atom
+qids. Do not use object identity or source order.
+
+### 6.2 Claim-Local Diagnostics
+
+For each projectable formula graph:
+
+- `satisfiable(expr) is False` emits:
+  - `code="formula_unsat"`
+  - `severity="fatal"`
+  - `scope="claim"`
+  - `source_claim=<claim id>`
+  - `condition.kind="formula_unsat"`
+- `satisfiable(Not(expr)) is False` emits:
+  - `code="formula_tautology"`
+  - `severity="warning"`
+  - `scope="claim"`
+- repeated operands in a single commutative connective emit:
+  - `code="formula_redundant_operand"`
+  - `severity="info"`
+  - `scope="claim"`
+
+The local pass should not inspect reviewer beliefs.
+
+### 6.3 Pairwise Cross-Claim Diagnostics
+
+When `include_pairwise=True`, compare pairs of projectable formula graphs.
+
+Candidate selection should be conservative:
+
+- Compare only pairs that share at least one stable atom id or claim-atom qid.
+- Avoid an unconditional `O(n^2)` scan across unrelated formulas.
+- Do not compare a graph with itself.
+
+For candidate pair `(A, B)`:
+
+- If `A and B` is unsatisfiable, emit:
+  - `code="cross_claim_incompatibility"`
+  - `severity="warning"`
+  - `scope="claim_pair"`
+  - `logic_strength="hard"` unless metadata marks one side soft.
+  - `condition.kind="joint_incompatibility"`
+  - `condition.expression = A_claim and B_claim`
+- If `A -> B` is tautological and not equivalent, emit:
+  - `code="cross_claim_entailment"`
+  - `severity="info"`
+  - `condition.kind="entailment_violation"`
+  - `condition.expression = A_claim and not B_claim`
+- If `A` and `B` are equivalent, emit:
+  - `code="cross_claim_equivalence"`
+  - `severity="info"`
+  - `condition.kind="redundant_formula"`
+
+Cross-claim diagnostics are never fatal in phase 1.
+
+## 7. Reviewer Integration
+
+The first implementation should keep this independent from `ReviewManifest`.
+
+Reviewer-like callers can do:
+
+```python
+compiled = compile_package(...)
+report = inspect_formula_graphs(compiled.graph)
+```
+
+This avoids changing the existing `ReviewManifest` schema before the diagnostics
+shape is proven useful.
+
+A later adapter can map diagnostics into review records, for example:
+
+```python
+formula_diagnostics_to_reviews(report: FormulaDiagnosticReport) -> ReviewManifest
+```
+
+That adapter belongs in phase B or later because it is presentation and
+workflow-specific. The core API should remain usable by CLI, reviewer, tests,
+and BP code without depending on a review manifest.
+
+## 8. BP Integration Contract
+
+The diagnostics API must be BP-compatible without requiring BP to run.
+
+The contract is:
+
+1. Every probabilistic warning has a `DiagnosticCondition`.
+2. The condition uses stable ids and a JSON Boolean AST.
+3. The condition represents the bad event or violation event whose probability
+   a downstream layer may estimate.
+4. Diagnostics report `severity`, not posterior probability.
+
+Example:
+
+```json
+{
+  "code": "cross_claim_incompatibility",
+  "severity": "warning",
+  "scope": "claim_pair",
+  "logic_strength": "hard",
+  "source_claim": "claim_a",
+  "related_claims": ["claim_b"],
+  "condition": {
+    "kind": "joint_incompatibility",
+    "variables": ["claim_a", "claim_b"],
+    "expression": {
+      "op": "and",
+      "args": [{"var": "claim_a"}, {"var": "claim_b"}]
+    },
+    "confidence_basis": "hard_logic"
+  }
+}
+```
+
+A BP layer can then compute or approximate `Pr(claim_a and claim_b)`. If that
+probability is low, the warning may be low priority. If it is high, a reviewer
+can prioritize it.
+
+This design also allows future soft constraints:
+
+```json
+{
+  "logic_strength": "soft",
+  "condition": {
+    "kind": "joint_incompatibility",
+    "confidence_basis": "soft_relation",
+    "expression": {"op": "and", "args": [{"var": "A"}, {"var": "B"}]}
+  }
+}
+```
+
+The contradiction remains legal; the probability and relation strength decide
+review priority.
+
+## 9. Tests
+
+Phase 1 should add focused tests for:
+
+- JSON round-trip of `FormulaDiagnostic` and `DiagnosticCondition`.
+- Claim-local unsatisfiable formula produces `fatal`.
+- Claim-local tautology produces `warning`.
+- Redundant operands produce `info`.
+- Cross-claim hard incompatibility produces `warning`, not `fatal`.
+- Cross-claim incompatibility condition is `A and B`.
+- Cross-claim entailment condition is `A and not B`.
+- Disjoint formulas do not produce pairwise diagnostics.
+- Unsupported quantifier or term formulas do not crash the API.
+- Diagnostics can be consumed without constructing a `ReviewManifest`.
+
+These tests should use compiled Gaia Lang fixtures where possible and direct IR
+fixtures only for edge cases.
+
+## 10. Later Phases
+
+Phase B should add presentation only after the API stabilizes:
+
+- `gaia inspect formula-graph`
+- optional `gaia check --logic`
+- JSON and human output for diagnostics
+
+Phase C-rich can add deeper package reasoning:
+
+- richer entailment indexing
+- exact or approximate event probability queries
+- support for finite grounded quantifiers where safe
+- policy adapters that convert warnings into review tasks
+- optional package-specific gates above the diagnostics API
+
+None of these later features should change the first principle that claim-local
+malformed logic can be fatal, while cross-claim logical tension remains a
+reviewable warning unless a higher-level policy explicitly says otherwise.

--- a/docs/superpowers/plans/2026-05-17-formula-logic-diagnostics-api.md
+++ b/docs/superpowers/plans/2026-05-17-formula-logic-diagnostics-api.md
@@ -1,0 +1,967 @@
+# Formula Logic Diagnostics API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first reviewer-facing formula logic diagnostics API for Gaia v0.5.
+
+**Architecture:** Add `gaia.engine.ir.logic.diagnostics` as a small, solver-backed API over `LocalCanonicalGraph.formula_graphs`. The API projects propositional `FormulaGraph` shapes to SymPy, emits fatal claim-local diagnostics, emits non-fatal cross-claim warnings/infos, and attaches JSON Boolean conditions for downstream BP probability estimation.
+
+**Tech Stack:** Python, Pydantic, SymPy Boolean logic, pytest, ruff.
+
+---
+
+## File Structure
+
+- Create: `gaia/engine/ir/logic/diagnostics.py`
+  - Owns diagnostic Pydantic models.
+  - Owns formula graph projection to SymPy.
+  - Owns `inspect_formula_graphs`.
+  - Does not import BP or review manifest code.
+- Modify: `gaia/engine/ir/logic/__init__.py`
+  - Re-export the public diagnostics models and entry point.
+- Create: `tests/gaia/logic/test_formula_diagnostics.py`
+  - Covers model serialization, projection, local diagnostics, pairwise diagnostics, unsupported formulas, and package/review independence.
+- Already added spec: `docs/specs/2026-05-17-formula-logic-diagnostics-design.md`
+  - Treat as the source of truth for semantics.
+
+## Task 1: Diagnostic Models And Public Export
+
+**Files:**
+- Create: `gaia/engine/ir/logic/diagnostics.py`
+- Modify: `gaia/engine/ir/logic/__init__.py`
+- Test: `tests/gaia/logic/test_formula_diagnostics.py`
+
+- [ ] **Step 1: Write the failing model round-trip test**
+
+Add this new test file:
+
+```python
+from gaia.engine.ir.logic.diagnostics import (
+    DiagnosticCondition,
+    FormulaDiagnostic,
+    FormulaDiagnosticReport,
+    inspect_formula_graphs,
+)
+
+
+def test_formula_diagnostic_models_round_trip_json():
+    condition = DiagnosticCondition(
+        kind="joint_incompatibility",
+        variables=["t:pkg::left", "t:pkg::right"],
+        expression={
+            "op": "and",
+            "args": [{"var": "t:pkg::left"}, {"var": "t:pkg::right"}],
+        },
+        confidence_basis="hard_logic",
+    )
+    diagnostic = FormulaDiagnostic(
+        code="cross_claim_incompatibility",
+        severity="warning",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim="t:pkg::left",
+        related_claims=["t:pkg::right"],
+        formula_nodes=["fg:left", "fg:right"],
+        condition=condition,
+        message="Claims cannot both hold.",
+    )
+    report = FormulaDiagnosticReport(diagnostics=[diagnostic])
+
+    round_tripped = FormulaDiagnosticReport.model_validate_json(report.model_dump_json())
+
+    assert round_tripped == report
+    assert round_tripped.has_fatal is False
+    assert inspect_formula_graphs is not None
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_formula_diagnostic_models_round_trip_json -q --no-cov
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'gaia.engine.ir.logic.diagnostics'`.
+
+- [ ] **Step 3: Add the diagnostics models and a no-op API**
+
+Create `gaia/engine/ir/logic/diagnostics.py`:
+
+```python
+"""Formula-graph logic diagnostics for Gaia IR."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from gaia.engine.ir.graphs import LocalCanonicalGraph
+
+FormulaDiagnosticSeverity = Literal["info", "warning", "fatal"]
+FormulaDiagnosticScope = Literal["claim", "claim_pair", "package"]
+FormulaLogicStrength = Literal["hard", "soft", "mixed", "unknown"]
+
+DiagnosticConditionKind = Literal[
+    "formula_unsat",
+    "formula_tautology",
+    "joint_incompatibility",
+    "entailment_violation",
+    "redundant_formula",
+]
+ConditionConfidenceBasis = Literal["hard_logic", "soft_relation", "projection"]
+
+
+class DiagnosticCondition(BaseModel):
+    """Machine-readable Boolean event associated with a diagnostic."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: DiagnosticConditionKind
+    variables: list[str] = Field(default_factory=list)
+    expression: dict[str, Any]
+    confidence_basis: ConditionConfidenceBasis
+
+
+class FormulaDiagnostic(BaseModel):
+    """One formula-level diagnostic emitted for a compiled graph."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    severity: FormulaDiagnosticSeverity
+    scope: FormulaDiagnosticScope
+    logic_strength: FormulaLogicStrength
+    source_claim: str | None = None
+    related_claims: list[str] = Field(default_factory=list)
+    formula_nodes: list[str] = Field(default_factory=list)
+    condition: DiagnosticCondition | None = None
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class FormulaDiagnosticReport(BaseModel):
+    """Collection of formula diagnostics."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    diagnostics: list[FormulaDiagnostic] = Field(default_factory=list)
+
+    @property
+    def has_fatal(self) -> bool:
+        """Return whether any diagnostic should block the local claim."""
+        return any(diagnostic.severity == "fatal" for diagnostic in self.diagnostics)
+
+
+def inspect_formula_graphs(
+    graph: LocalCanonicalGraph,
+    *,
+    include_pairwise: bool = True,
+) -> FormulaDiagnosticReport:
+    """Inspect formula graphs and return reviewer-facing logic diagnostics."""
+    del graph, include_pairwise
+    return FormulaDiagnosticReport()
+```
+
+- [ ] **Step 4: Export the new public API**
+
+Modify `gaia/engine/ir/logic/__init__.py`:
+
+```python
+from gaia.engine.ir.logic.diagnostics import (
+    DiagnosticCondition,
+    FormulaDiagnostic,
+    FormulaDiagnosticReport,
+    inspect_formula_graphs,
+)
+```
+
+Add the same names to `__all__`.
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_formula_diagnostic_models_round_trip_json -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/engine/ir/logic/diagnostics.py gaia/engine/ir/logic/__init__.py tests/gaia/logic/test_formula_diagnostics.py
+git commit -m "feat: add formula diagnostic models"
+```
+
+## Task 2: FormulaGraph To SymPy Projection
+
+**Files:**
+- Modify: `gaia/engine/ir/logic/diagnostics.py`
+- Modify: `tests/gaia/logic/test_formula_diagnostics.py`
+
+- [ ] **Step 1: Add projection tests**
+
+Append these tests:
+
+```python
+from sympy import And, Implies, Not, Symbol
+
+from gaia.engine.lang import ClaimAtom, claim, forall, land, lnot, implies
+from gaia.engine.lang.compiler import compile_package_artifact
+from gaia.engine.lang.runtime.package import CollectedPackage
+from gaia.engine.lang import Domain, PredicateSymbol, UserPredicate, Variable
+from gaia.engine.ir.logic.diagnostics import formula_graph_to_sympy
+
+
+def _qid(package: str, label: str) -> str:
+    return f"t:{package}::{label}"
+
+
+def _formula_graph_for(artifact, source_claim_id: str):
+    return next(
+        formula_graph
+        for formula_graph in artifact.graph.formula_graphs
+        if formula_graph.source_claim == source_claim_id
+    )
+
+
+def test_formula_graph_to_sympy_projects_claim_atom_connectives():
+    package = "formula_diag_projection"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        rule = claim(
+            "A and not B implies A.",
+            formula=implies(land(ClaimAtom(a), lnot(ClaimAtom(b))), ClaimAtom(a)),
+        )
+        rule.label = "rule"
+
+    artifact = compile_package_artifact(pkg)
+    formula_graph = _formula_graph_for(artifact, _qid(package, "rule"))
+
+    expression = formula_graph_to_sympy(formula_graph)
+
+    assert expression == Implies(
+        And(Symbol(_qid(package, "a")), Not(Symbol(_qid(package, "b")))),
+        Symbol(_qid(package, "a")),
+    )
+
+
+def test_formula_graph_to_sympy_returns_none_for_quantifier_root():
+    package = "formula_diag_quantifier"
+    with CollectedPackage(package, namespace="t") as pkg:
+        domain = Domain(content="Particles", members=["p1"])
+        x = Variable(symbol="x", domain=domain)
+        stable = PredicateSymbol(name="Stable", arg_domains=(domain,))
+        universal = claim("All particles are stable.", formula=forall(x, UserPredicate(stable, (x,))))
+        universal.label = "universal"
+
+    artifact = compile_package_artifact(pkg)
+    formula_graph = _formula_graph_for(artifact, _qid(package, "universal"))
+
+    assert formula_graph_to_sympy(formula_graph) is None
+```
+
+- [ ] **Step 2: Run projection tests and verify they fail**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_formula_graph_to_sympy_projects_claim_atom_connectives tests/gaia/logic/test_formula_diagnostics.py::test_formula_graph_to_sympy_returns_none_for_quantifier_root -q --no-cov
+```
+
+Expected: FAIL because `formula_graph_to_sympy` is not defined.
+
+- [ ] **Step 3: Implement projection helpers**
+
+Add these imports to `diagnostics.py`:
+
+```python
+from dataclasses import dataclass
+
+from sympy import Symbol
+from sympy.logic.boolalg import And, Equivalent, Implies, Not, Or
+
+from gaia.engine.ir.formula import FormulaGraph, FormulaNode
+```
+
+Add this projection implementation above `inspect_formula_graphs`:
+
+```python
+@dataclass(frozen=True)
+class _ProjectedFormula:
+    source_claim: str
+    root: str
+    expression: Any
+    atom_ids: frozenset[str]
+
+
+def formula_graph_to_sympy(formula_graph: FormulaGraph) -> Any | None:
+    """Project a propositional FormulaGraph into a SymPy Boolean expression."""
+    projected = _project_formula_graph(formula_graph)
+    if projected is None:
+        return None
+    return projected.expression
+
+
+def _project_formula_graph(formula_graph: FormulaGraph) -> _ProjectedFormula | None:
+    nodes = {node.id: node for node in formula_graph.nodes}
+    atom_ids: set[str] = set()
+    expression = _project_node(formula_graph.root, nodes, atom_ids)
+    if expression is None:
+        return None
+    return _ProjectedFormula(
+        source_claim=formula_graph.source_claim,
+        root=formula_graph.root,
+        expression=expression,
+        atom_ids=frozenset(atom_ids),
+    )
+
+
+def _project_node(
+    node_id: str,
+    nodes: dict[str, FormulaNode],
+    atom_ids: set[str],
+) -> Any | None:
+    node = nodes[node_id]
+    if node.kind == "atom":
+        symbol_name = _atom_symbol_name(node)
+        atom_ids.add(symbol_name)
+        return Symbol(symbol_name)
+    if node.kind != "op":
+        return None
+
+    operator = node.descriptor.get("operator")
+    children = node.descriptor.get("children", [])
+    if not isinstance(operator, str) or not isinstance(children, list):
+        return None
+
+    projected_children = [_project_node(child, nodes, atom_ids) for child in children]
+    if any(child is None for child in projected_children):
+        return None
+
+    if operator == "conjunction":
+        return And(*projected_children)
+    if operator == "disjunction":
+        return Or(*projected_children)
+    if operator == "negation" and len(projected_children) == 1:
+        return Not(projected_children[0])
+    if operator == "implication" and len(projected_children) == 2:
+        return Implies(projected_children[0], projected_children[1])
+    if operator == "equivalence" and len(projected_children) == 2:
+        return Equivalent(projected_children[0], projected_children[1])
+    return None
+
+
+def _atom_symbol_name(node: FormulaNode) -> str:
+    descriptor = node.descriptor
+    if descriptor.get("kind") == "claim" and isinstance(descriptor.get("qid"), str):
+        return descriptor["qid"]
+    return node.id
+```
+
+- [ ] **Step 4: Run projection tests and verify they pass**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_formula_graph_to_sympy_projects_claim_atom_connectives tests/gaia/logic/test_formula_diagnostics.py::test_formula_graph_to_sympy_returns_none_for_quantifier_root -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/engine/ir/logic/diagnostics.py tests/gaia/logic/test_formula_diagnostics.py
+git commit -m "feat: project formula graphs to sympy"
+```
+
+## Task 3: Claim-Local Diagnostics
+
+**Files:**
+- Modify: `gaia/engine/ir/logic/diagnostics.py`
+- Modify: `tests/gaia/logic/test_formula_diagnostics.py`
+
+- [ ] **Step 1: Add claim-local diagnostic tests**
+
+Append these tests:
+
+```python
+from gaia.engine.lang import lor
+
+
+def test_inspect_formula_graphs_reports_claim_local_unsat_as_fatal():
+    package = "formula_diag_local_unsat"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        impossible = claim("A and not A.", formula=land(ClaimAtom(a), lnot(ClaimAtom(a))))
+        impossible.label = "impossible"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph, include_pairwise=False)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_unsat")
+    assert diagnostic.severity == "fatal"
+    assert diagnostic.scope == "claim"
+    assert diagnostic.logic_strength == "hard"
+    assert diagnostic.source_claim == _qid(package, "impossible")
+    assert diagnostic.condition.kind == "formula_unsat"
+    assert diagnostic.condition.expression == {"var": _qid(package, "impossible")}
+    assert report.has_fatal is True
+
+
+def test_inspect_formula_graphs_reports_claim_local_tautology_as_warning():
+    package = "formula_diag_local_tautology"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        tautology = claim("A or not A.", formula=lor(ClaimAtom(a), lnot(ClaimAtom(a))))
+        tautology.label = "tautology"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph, include_pairwise=False)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_tautology")
+    assert diagnostic.severity == "warning"
+    assert diagnostic.scope == "claim"
+    assert diagnostic.source_claim == _qid(package, "tautology")
+    assert report.has_fatal is False
+
+
+def test_inspect_formula_graphs_reports_redundant_operands_as_info():
+    package = "formula_diag_redundant_operand"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        repeated = claim("A and A.", formula=land(ClaimAtom(a), ClaimAtom(a)))
+        repeated.label = "repeated"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph, include_pairwise=False)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_redundant_operand")
+    assert diagnostic.severity == "info"
+    assert diagnostic.scope == "claim"
+    assert diagnostic.source_claim == _qid(package, "repeated")
+    assert diagnostic.details["repeated_children"] == [_qid(package, "a")]
+```
+
+- [ ] **Step 2: Run local diagnostic tests and verify they fail**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_inspect_formula_graphs_reports_claim_local_unsat_as_fatal tests/gaia/logic/test_formula_diagnostics.py::test_inspect_formula_graphs_reports_claim_local_tautology_as_warning tests/gaia/logic/test_formula_diagnostics.py::test_inspect_formula_graphs_reports_redundant_operands_as_info -q --no-cov
+```
+
+Expected: FAIL because `inspect_formula_graphs` still returns an empty report.
+
+- [ ] **Step 3: Implement local diagnostics**
+
+Add imports:
+
+```python
+from sympy.logic.inference import satisfiable
+```
+
+Replace `inspect_formula_graphs` with:
+
+```python
+def inspect_formula_graphs(
+    graph: LocalCanonicalGraph,
+    *,
+    include_pairwise: bool = True,
+) -> FormulaDiagnosticReport:
+    """Inspect formula graphs and return reviewer-facing logic diagnostics."""
+    diagnostics: list[FormulaDiagnostic] = []
+    projected: list[_ProjectedFormula] = []
+
+    for formula_graph in graph.formula_graphs:
+        projection = _project_formula_graph(formula_graph)
+        diagnostics.extend(_redundant_operand_diagnostics(formula_graph))
+        if projection is None:
+            diagnostics.append(_projection_unsupported_diagnostic(formula_graph))
+            continue
+        projected.append(projection)
+        diagnostics.extend(_claim_local_diagnostics(projection))
+
+    if include_pairwise:
+        diagnostics.extend(_pairwise_diagnostics(projected))
+
+    return FormulaDiagnosticReport(diagnostics=diagnostics)
+```
+
+Add these helpers:
+
+```python
+def _claim_local_diagnostics(projection: _ProjectedFormula) -> list[FormulaDiagnostic]:
+    diagnostics: list[FormulaDiagnostic] = []
+    if satisfiable(projection.expression) is False:
+        diagnostics.append(
+            FormulaDiagnostic(
+                code="formula_unsat",
+                severity="fatal",
+                scope="claim",
+                logic_strength="hard",
+                source_claim=projection.source_claim,
+                formula_nodes=[projection.root],
+                condition=_condition(
+                    "formula_unsat",
+                    [projection.source_claim],
+                    {"var": projection.source_claim},
+                    "hard_logic",
+                ),
+                message=f"Formula for claim {projection.source_claim!r} is unsatisfiable.",
+            )
+        )
+    elif satisfiable(Not(projection.expression)) is False:
+        diagnostics.append(
+            FormulaDiagnostic(
+                code="formula_tautology",
+                severity="warning",
+                scope="claim",
+                logic_strength="hard",
+                source_claim=projection.source_claim,
+                formula_nodes=[projection.root],
+                condition=_condition(
+                    "formula_tautology",
+                    [projection.source_claim],
+                    {"var": projection.source_claim},
+                    "hard_logic",
+                ),
+                message=f"Formula for claim {projection.source_claim!r} is tautological.",
+            )
+        )
+    return diagnostics
+
+
+def _redundant_operand_diagnostics(formula_graph: FormulaGraph) -> list[FormulaDiagnostic]:
+    diagnostics: list[FormulaDiagnostic] = []
+    nodes = {node.id: node for node in formula_graph.nodes}
+    for node in formula_graph.nodes:
+        operator = node.descriptor.get("operator")
+        if node.kind != "op" or operator not in {"conjunction", "disjunction"}:
+            continue
+        children = node.descriptor.get("children", [])
+        if not isinstance(children, list):
+            continue
+        repeated = sorted({child for child in children if children.count(child) > 1})
+        if not repeated:
+            continue
+        diagnostics.append(
+            FormulaDiagnostic(
+                code="formula_redundant_operand",
+                severity="info",
+                scope="claim",
+                logic_strength="hard",
+                source_claim=formula_graph.source_claim,
+                formula_nodes=[node.id, *repeated],
+                condition=_condition(
+                    "redundant_formula",
+                    [formula_graph.source_claim],
+                    {"var": formula_graph.source_claim},
+                    "hard_logic",
+                ),
+                message=f"Formula for claim {formula_graph.source_claim!r} repeats an operand.",
+                details={
+                    "operator": operator,
+                    "repeated_children": [_condition_var_for_node(nodes[child]) for child in repeated],
+                },
+            )
+        )
+    return diagnostics
+
+
+def _projection_unsupported_diagnostic(formula_graph: FormulaGraph) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="formula_projection_unsupported",
+        severity="info",
+        scope="claim",
+        logic_strength="unknown",
+        source_claim=formula_graph.source_claim,
+        formula_nodes=[formula_graph.root],
+        message=(
+            f"Formula for claim {formula_graph.source_claim!r} is outside the current "
+            "propositional diagnostics subset."
+        ),
+    )
+
+
+def _condition(
+    kind: DiagnosticConditionKind,
+    variables: list[str],
+    expression: dict[str, Any],
+    confidence_basis: ConditionConfidenceBasis,
+) -> DiagnosticCondition:
+    return DiagnosticCondition(
+        kind=kind,
+        variables=variables,
+        expression=expression,
+        confidence_basis=confidence_basis,
+    )
+
+
+def _condition_var_for_node(node: FormulaNode) -> str:
+    if node.kind == "atom":
+        return _atom_symbol_name(node)
+    return node.id
+```
+
+Add a temporary pairwise stub below the helpers so Task 3 is complete:
+
+```python
+def _pairwise_diagnostics(projected: list[_ProjectedFormula]) -> list[FormulaDiagnostic]:
+    del projected
+    return []
+```
+
+- [ ] **Step 4: Run local diagnostic tests and verify they pass**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_inspect_formula_graphs_reports_claim_local_unsat_as_fatal tests/gaia/logic/test_formula_diagnostics.py::test_inspect_formula_graphs_reports_claim_local_tautology_as_warning tests/gaia/logic/test_formula_diagnostics.py::test_inspect_formula_graphs_reports_redundant_operands_as_info -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/engine/ir/logic/diagnostics.py tests/gaia/logic/test_formula_diagnostics.py
+git commit -m "feat: add claim-local formula diagnostics"
+```
+
+## Task 4: Pairwise Cross-Claim Diagnostics
+
+**Files:**
+- Modify: `gaia/engine/ir/logic/diagnostics.py`
+- Modify: `tests/gaia/logic/test_formula_diagnostics.py`
+
+- [ ] **Step 1: Add pairwise diagnostic tests**
+
+Append these tests:
+
+```python
+def test_pairwise_incompatibility_is_warning_with_bp_condition():
+    package = "formula_diag_pair_incompat"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        left = claim("A holds.", formula=ClaimAtom(a))
+        left.label = "left"
+        right = claim("A does not hold.", formula=lnot(ClaimAtom(a)))
+        right.label = "right"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "cross_claim_incompatibility")
+    assert diagnostic.severity == "warning"
+    assert diagnostic.scope == "claim_pair"
+    assert diagnostic.logic_strength == "hard"
+    assert diagnostic.source_claim == _qid(package, "left")
+    assert diagnostic.related_claims == [_qid(package, "right")]
+    assert diagnostic.condition.kind == "joint_incompatibility"
+    assert diagnostic.condition.expression == {
+        "op": "and",
+        "args": [{"var": _qid(package, "left")}, {"var": _qid(package, "right")}],
+    }
+    assert report.has_fatal is False
+
+
+def test_pairwise_entailment_is_info_with_violation_condition():
+    package = "formula_diag_pair_entailment"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        strong = claim("A and B.", formula=land(ClaimAtom(a), ClaimAtom(b)))
+        strong.label = "strong"
+        weak = claim("A.", formula=ClaimAtom(a))
+        weak.label = "weak"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "cross_claim_entailment")
+    assert diagnostic.severity == "info"
+    assert diagnostic.source_claim == _qid(package, "strong")
+    assert diagnostic.related_claims == [_qid(package, "weak")]
+    assert diagnostic.condition.kind == "entailment_violation"
+    assert diagnostic.condition.expression == {
+        "op": "and",
+        "args": [
+            {"var": _qid(package, "strong")},
+            {"op": "not", "arg": {"var": _qid(package, "weak")}},
+        ],
+    }
+
+
+def test_pairwise_diagnostics_skip_disjoint_formulas():
+    package = "formula_diag_pair_disjoint"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        left = claim("A holds.", formula=ClaimAtom(a))
+        left.label = "left"
+        right = claim("B holds.", formula=ClaimAtom(b))
+        right.label = "right"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    assert [d for d in report.diagnostics if d.scope == "claim_pair"] == []
+```
+
+- [ ] **Step 2: Run pairwise tests and verify they fail**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_pairwise_incompatibility_is_warning_with_bp_condition tests/gaia/logic/test_formula_diagnostics.py::test_pairwise_entailment_is_info_with_violation_condition tests/gaia/logic/test_formula_diagnostics.py::test_pairwise_diagnostics_skip_disjoint_formulas -q --no-cov
+```
+
+Expected: FAIL because `_pairwise_diagnostics` is still a stub.
+
+- [ ] **Step 3: Implement pairwise diagnostics**
+
+Add import:
+
+```python
+from itertools import combinations
+```
+
+Replace the pairwise stub:
+
+```python
+def _pairwise_diagnostics(projected: list[_ProjectedFormula]) -> list[FormulaDiagnostic]:
+    diagnostics: list[FormulaDiagnostic] = []
+    for left, right in combinations(projected, 2):
+        if left.atom_ids.isdisjoint(right.atom_ids):
+            continue
+
+        if satisfiable(And(left.expression, right.expression)) is False:
+            diagnostics.append(_cross_claim_incompatibility(left, right))
+            continue
+
+        left_entails_right = satisfiable(And(left.expression, Not(right.expression))) is False
+        right_entails_left = satisfiable(And(right.expression, Not(left.expression))) is False
+        if left_entails_right and right_entails_left:
+            diagnostics.append(_cross_claim_equivalence(left, right))
+        elif left_entails_right:
+            diagnostics.append(_cross_claim_entailment(left, right))
+        elif right_entails_left:
+            diagnostics.append(_cross_claim_entailment(right, left))
+    return diagnostics
+
+
+def _cross_claim_incompatibility(
+    left: _ProjectedFormula,
+    right: _ProjectedFormula,
+) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="cross_claim_incompatibility",
+        severity="warning",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim=left.source_claim,
+        related_claims=[right.source_claim],
+        formula_nodes=[left.root, right.root],
+        condition=_condition(
+            "joint_incompatibility",
+            [left.source_claim, right.source_claim],
+            _and_event(left.source_claim, right.source_claim),
+            "hard_logic",
+        ),
+        message=(
+            f"Formula claims {left.source_claim!r} and {right.source_claim!r} "
+            "cannot both hold."
+        ),
+    )
+
+
+def _cross_claim_entailment(
+    antecedent: _ProjectedFormula,
+    consequent: _ProjectedFormula,
+) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="cross_claim_entailment",
+        severity="info",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim=antecedent.source_claim,
+        related_claims=[consequent.source_claim],
+        formula_nodes=[antecedent.root, consequent.root],
+        condition=_condition(
+            "entailment_violation",
+            [antecedent.source_claim, consequent.source_claim],
+            {
+                "op": "and",
+                "args": [
+                    {"var": antecedent.source_claim},
+                    {"op": "not", "arg": {"var": consequent.source_claim}},
+                ],
+            },
+            "hard_logic",
+        ),
+        message=(
+            f"Formula claim {antecedent.source_claim!r} entails "
+            f"{consequent.source_claim!r}."
+        ),
+    )
+
+
+def _cross_claim_equivalence(
+    left: _ProjectedFormula,
+    right: _ProjectedFormula,
+) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="cross_claim_equivalence",
+        severity="info",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim=left.source_claim,
+        related_claims=[right.source_claim],
+        formula_nodes=[left.root, right.root],
+        condition=_condition(
+            "redundant_formula",
+            [left.source_claim, right.source_claim],
+            {
+                "op": "or",
+                "args": [
+                    {
+                        "op": "and",
+                        "args": [
+                            {"var": left.source_claim},
+                            {"op": "not", "arg": {"var": right.source_claim}},
+                        ],
+                    },
+                    {
+                        "op": "and",
+                        "args": [
+                            {"var": right.source_claim},
+                            {"op": "not", "arg": {"var": left.source_claim}},
+                        ],
+                    },
+                ],
+            },
+            "hard_logic",
+        ),
+        message=(
+            f"Formula claims {left.source_claim!r} and {right.source_claim!r} "
+            "are logically equivalent."
+        ),
+    )
+
+
+def _and_event(left: str, right: str) -> dict[str, Any]:
+    return {"op": "and", "args": [{"var": left}, {"var": right}]}
+```
+
+- [ ] **Step 4: Run pairwise tests and verify they pass**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_pairwise_incompatibility_is_warning_with_bp_condition tests/gaia/logic/test_formula_diagnostics.py::test_pairwise_entailment_is_info_with_violation_condition tests/gaia/logic/test_formula_diagnostics.py::test_pairwise_diagnostics_skip_disjoint_formulas -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/engine/ir/logic/diagnostics.py tests/gaia/logic/test_formula_diagnostics.py
+git commit -m "feat: add pairwise formula diagnostics"
+```
+
+## Task 5: Unsupported Formula Coverage And Final Verification
+
+**Files:**
+- Modify: `gaia/engine/ir/logic/diagnostics.py`
+- Modify: `tests/gaia/logic/test_formula_diagnostics.py`
+
+- [ ] **Step 1: Add unsupported formula and export tests**
+
+Append these tests:
+
+```python
+from gaia.engine.ir.logic import FormulaDiagnosticReport as ExportedFormulaDiagnosticReport
+from gaia.engine.ir.logic import inspect_formula_graphs as exported_inspect_formula_graphs
+
+
+def test_unsupported_quantifier_emits_info_without_crashing():
+    package = "formula_diag_unsupported_quantifier"
+    with CollectedPackage(package, namespace="t") as pkg:
+        domain = Domain(content="Particles", members=["p1"])
+        x = Variable(symbol="x", domain=domain)
+        stable = PredicateSymbol(name="Stable", arg_domains=(domain,))
+        universal = claim("All particles are stable.", formula=forall(x, UserPredicate(stable, (x,))))
+        universal.label = "universal"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_projection_unsupported")
+    assert diagnostic.severity == "info"
+    assert diagnostic.logic_strength == "unknown"
+    assert diagnostic.source_claim == _qid(package, "universal")
+
+
+def test_logic_package_exports_formula_diagnostics_api():
+    assert ExportedFormulaDiagnosticReport is FormulaDiagnosticReport
+    assert exported_inspect_formula_graphs is inspect_formula_graphs
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py::test_unsupported_quantifier_emits_info_without_crashing tests/gaia/logic/test_formula_diagnostics.py::test_logic_package_exports_formula_diagnostics_api -q --no-cov
+```
+
+Expected: PASS. If export assertions fail, update `gaia/engine/ir/logic/__init__.py`.
+
+- [ ] **Step 3: Run focused regression suite**
+
+Run:
+
+```bash
+python -m pytest tests/gaia/logic/test_formula_diagnostics.py tests/ir/test_formula_graph.py tests/gaia/logic/test_propositional.py tests/gaia/lang/test_formula_lowering.py -q --no-cov
+```
+
+Expected: PASS. Existing deprecation warnings from old formula sugar are acceptable.
+
+- [ ] **Step 4: Run formatting and lint checks**
+
+Run:
+
+```bash
+ruff format --check gaia/engine/ir/logic/diagnostics.py tests/gaia/logic/test_formula_diagnostics.py
+ruff check gaia/engine/ir/logic/diagnostics.py tests/gaia/logic/test_formula_diagnostics.py gaia/engine/ir/logic/__init__.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit final polish**
+
+```bash
+git add gaia/engine/ir/logic/diagnostics.py gaia/engine/ir/logic/__init__.py tests/gaia/logic/test_formula_diagnostics.py
+git commit -m "test: cover formula diagnostics api"
+```
+
+## Completion Criteria
+
+- `inspect_formula_graphs(graph)` exists and returns `FormulaDiagnosticReport`.
+- Same-claim unsatisfiable formulas produce `fatal`.
+- Cross-claim incompatibilities produce `warning`, never `fatal`.
+- Soft/hard separation is represented by `logic_strength`, even if phase 1 only emits hard/unknown.
+- Every probabilistic warning has a JSON Boolean `DiagnosticCondition`.
+- BP is not imported or run by diagnostics.
+- `ReviewManifest` is not changed.
+- Focused tests and ruff pass.

--- a/gaia/engine/ir/logic/__init__.py
+++ b/gaia/engine/ir/logic/__init__.py
@@ -9,6 +9,8 @@ Current scope:
         (NEGATION/CONJUNCTION/DISJUNCTION/IMPLICATION/EQUIVALENCE/
         CONTRADICTION/COMPLEMENT). Treats Knowledge nodes as atoms; does
         not look inside Claim.formula metadata.
+    diagnostics — FormulaGraph-level inspection for reviewer-facing local
+        formula issues and conservative cross-claim warnings.
 
 Future (out of scope for this PR; tracked separately):
     predicate — first-order / SMT backends consuming `formula_atom` metadata

--- a/gaia/engine/ir/logic/__init__.py
+++ b/gaia/engine/ir/logic/__init__.py
@@ -20,6 +20,12 @@ See docs/specs/2026-05-16-engine-module-reorg-design.md §5 for the three-scope
 taxonomy.
 """
 
+from gaia.engine.ir.logic.diagnostics import (
+    DiagnosticCondition,
+    FormulaDiagnostic,
+    FormulaDiagnosticReport,
+    inspect_formula_graphs,
+)
 from gaia.engine.ir.logic.propositional import (
     are_equivalent,
     is_satisfiable,
@@ -31,7 +37,11 @@ from gaia.engine.ir.logic.propositional import (
 )
 
 __all__ = [
+    "DiagnosticCondition",
+    "FormulaDiagnostic",
+    "FormulaDiagnosticReport",
     "are_equivalent",
+    "inspect_formula_graphs",
     "is_satisfiable",
     "simplify_proposition",
     "to_cnf_proposition",

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import combinations
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -320,5 +321,120 @@ def _condition_var_for_node(node: FormulaNode) -> str:
 
 
 def _pairwise_diagnostics(projected: list[_ProjectedFormula]) -> list[FormulaDiagnostic]:
-    del projected
-    return []
+    diagnostics: list[FormulaDiagnostic] = []
+    for left, right in combinations(projected, 2):
+        if left.atom_ids.isdisjoint(right.atom_ids):
+            continue
+
+        if satisfiable(And(left.expression, right.expression)) is False:
+            diagnostics.append(_cross_claim_incompatibility(left, right))
+            continue
+
+        left_entails_right = satisfiable(And(left.expression, Not(right.expression))) is False
+        right_entails_left = satisfiable(And(right.expression, Not(left.expression))) is False
+        if left_entails_right and right_entails_left:
+            diagnostics.append(_cross_claim_equivalence(left, right))
+        elif left_entails_right:
+            diagnostics.append(_cross_claim_entailment(left, right))
+        elif right_entails_left:
+            diagnostics.append(_cross_claim_entailment(right, left))
+    return diagnostics
+
+
+def _cross_claim_incompatibility(
+    left: _ProjectedFormula,
+    right: _ProjectedFormula,
+) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="cross_claim_incompatibility",
+        severity="warning",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim=left.source_claim,
+        related_claims=[right.source_claim],
+        formula_nodes=[left.root, right.root],
+        condition=_condition(
+            "joint_incompatibility",
+            [left.source_claim, right.source_claim],
+            _and_event(left.source_claim, right.source_claim),
+            "hard_logic",
+        ),
+        message=(
+            f"Formula claims {left.source_claim!r} and {right.source_claim!r} cannot both hold."
+        ),
+    )
+
+
+def _cross_claim_entailment(
+    antecedent: _ProjectedFormula,
+    consequent: _ProjectedFormula,
+) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="cross_claim_entailment",
+        severity="info",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim=antecedent.source_claim,
+        related_claims=[consequent.source_claim],
+        formula_nodes=[antecedent.root, consequent.root],
+        condition=_condition(
+            "entailment_violation",
+            [antecedent.source_claim, consequent.source_claim],
+            {
+                "op": "and",
+                "args": [
+                    {"var": antecedent.source_claim},
+                    {"op": "not", "arg": {"var": consequent.source_claim}},
+                ],
+            },
+            "hard_logic",
+        ),
+        message=(f"Formula claim {antecedent.source_claim!r} entails {consequent.source_claim!r}."),
+    )
+
+
+def _cross_claim_equivalence(
+    left: _ProjectedFormula,
+    right: _ProjectedFormula,
+) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="cross_claim_equivalence",
+        severity="info",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim=left.source_claim,
+        related_claims=[right.source_claim],
+        formula_nodes=[left.root, right.root],
+        condition=_condition(
+            "redundant_formula",
+            [left.source_claim, right.source_claim],
+            {
+                "op": "or",
+                "args": [
+                    {
+                        "op": "and",
+                        "args": [
+                            {"var": left.source_claim},
+                            {"op": "not", "arg": {"var": right.source_claim}},
+                        ],
+                    },
+                    {
+                        "op": "and",
+                        "args": [
+                            {"var": right.source_claim},
+                            {"op": "not", "arg": {"var": left.source_claim}},
+                        ],
+                    },
+                ],
+            },
+            "hard_logic",
+        ),
+        message=(
+            f"Formula claims {left.source_claim!r} and {right.source_claim!r} "
+            "are logically equivalent."
+        ),
+    )
+
+
+def _and_event(left: str, right: str) -> dict[str, Any]:
+    return {"op": "and", "args": [{"var": left}, {"var": right}]}

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -188,16 +188,17 @@ def inspect_formula_graphs(
 
     for formula_graph in graph.formula_graphs:
         diagnostics.extend(_redundant_operand_diagnostics(formula_graph))
-        projection = _project_formula_graph(formula_graph)
+        try:
+            projection = _project_formula_graph(formula_graph)
+        except ValueError as error:
+            diagnostics.append(_projection_malformed_diagnostic(formula_graph, error))
+            continue
         if projection is None:
             diagnostics.append(_projection_unsupported_diagnostic(formula_graph))
             continue
         local_diagnostics = _claim_local_diagnostics(projection)
         diagnostics.extend(local_diagnostics)
-        if not any(
-            diagnostic.code == "formula_unsat" and diagnostic.severity == "fatal"
-            for diagnostic in local_diagnostics
-        ):
+        if _is_pairwise_candidate(local_diagnostics):
             projected.append(projection)
 
     if include_pairwise:
@@ -303,6 +304,27 @@ def _projection_unsupported_diagnostic(formula_graph: FormulaGraph) -> FormulaDi
             "propositional diagnostics subset."
         ),
     )
+
+
+def _projection_malformed_diagnostic(
+    formula_graph: FormulaGraph,
+    error: ValueError,
+) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="formula_projection_malformed",
+        severity="warning",
+        scope="claim",
+        logic_strength="unknown",
+        source_claim=formula_graph.source_claim,
+        formula_nodes=[formula_graph.root],
+        message=f"Formula for claim {formula_graph.source_claim!r} is malformed.",
+        details={"error": str(error)},
+    )
+
+
+def _is_pairwise_candidate(local_diagnostics: list[FormulaDiagnostic]) -> bool:
+    excluded_codes = {"formula_unsat", "formula_tautology"}
+    return not any(diagnostic.code in excluded_codes for diagnostic in local_diagnostics)
 
 
 def _condition(

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -324,6 +324,13 @@ def _projection_malformed_diagnostic(
 
 
 def _is_pairwise_candidate(local_diagnostics: list[FormulaDiagnostic]) -> bool:
+    """Exclude locally degenerate formulas from pairwise scans.
+
+    Unsatisfiable formulas would look incompatible with every overlapping
+    formula, and tautologies would be entailed by every overlap. Those cases are
+    already reported as claim-local diagnostics, so pairwise would only add
+    noise.
+    """
     excluded_codes = {"formula_unsat", "formula_tautology"}
     return not any(diagnostic.code in excluded_codes for diagnostic in local_diagnostics)
 

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -135,6 +135,9 @@ def _project_op_node(
         return None
     if not all(isinstance(child_id, str) for child_id in children):
         return None
+    for child_id in children:
+        if child_id not in nodes_by_id:
+            raise ValueError(f"FormulaGraph '{node.id}' references missing child node '{child_id}'")
 
     child_expressions = [_project_node(child_id, nodes_by_id, atom_ids) for child_id in children]
     if any(child_expression is None for child_expression in child_expressions):

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -192,8 +192,13 @@ def inspect_formula_graphs(
         if projection is None:
             diagnostics.append(_projection_unsupported_diagnostic(formula_graph))
             continue
-        projected.append(projection)
-        diagnostics.extend(_claim_local_diagnostics(projection))
+        local_diagnostics = _claim_local_diagnostics(projection)
+        diagnostics.extend(local_diagnostics)
+        if not any(
+            diagnostic.code == "formula_unsat" and diagnostic.severity == "fatal"
+            for diagnostic in local_diagnostics
+        ):
+            projected.append(projection)
 
     if include_pairwise:
         diagnostics.extend(_pairwise_diagnostics(projected))

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -1,0 +1,73 @@
+"""Formula-graph logic diagnostics for Gaia IR."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from gaia.engine.ir.graphs import LocalCanonicalGraph
+
+FormulaDiagnosticSeverity = Literal["info", "warning", "fatal"]
+FormulaDiagnosticScope = Literal["claim", "claim_pair", "package"]
+FormulaLogicStrength = Literal["hard", "soft", "mixed", "unknown"]
+
+DiagnosticConditionKind = Literal[
+    "formula_unsat",
+    "formula_tautology",
+    "joint_incompatibility",
+    "entailment_violation",
+    "redundant_formula",
+]
+ConditionConfidenceBasis = Literal["hard_logic", "soft_relation", "projection"]
+
+
+class DiagnosticCondition(BaseModel):
+    """Machine-readable Boolean event associated with a diagnostic."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: DiagnosticConditionKind
+    variables: list[str] = Field(default_factory=list)
+    expression: dict[str, Any]
+    confidence_basis: ConditionConfidenceBasis
+
+
+class FormulaDiagnostic(BaseModel):
+    """One formula-level diagnostic emitted for a compiled graph."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    severity: FormulaDiagnosticSeverity
+    scope: FormulaDiagnosticScope
+    logic_strength: FormulaLogicStrength
+    source_claim: str | None = None
+    related_claims: list[str] = Field(default_factory=list)
+    formula_nodes: list[str] = Field(default_factory=list)
+    condition: DiagnosticCondition | None = None
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class FormulaDiagnosticReport(BaseModel):
+    """Collection of formula diagnostics."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    diagnostics: list[FormulaDiagnostic] = Field(default_factory=list)
+
+    @property
+    def has_fatal(self) -> bool:
+        """Return whether any diagnostic should block the local claim."""
+        return any(diagnostic.severity == "fatal" for diagnostic in self.diagnostics)
+
+
+def inspect_formula_graphs(
+    graph: LocalCanonicalGraph,
+    *,
+    include_pairwise: bool = True,
+) -> FormulaDiagnosticReport:
+    """Inspect formula graphs and return reviewer-facing logic diagnostics."""
+    del graph, include_pairwise
+    return FormulaDiagnosticReport()

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+from sympy import And, Equivalent, Implies, Not, Or, Symbol
 
+from gaia.engine.ir.formula import FormulaGraph, FormulaNode
 from gaia.engine.ir.graphs import LocalCanonicalGraph
 
 FormulaDiagnosticSeverity = Literal["info", "warning", "fatal"]
@@ -20,6 +23,14 @@ DiagnosticConditionKind = Literal[
     "redundant_formula",
 ]
 ConditionConfidenceBasis = Literal["hard_logic", "soft_relation", "projection"]
+
+
+@dataclass(frozen=True)
+class _ProjectedFormula:
+    source_claim: str
+    root: str
+    expression: Any
+    atom_ids: frozenset[str]
 
 
 class DiagnosticCondition(BaseModel):
@@ -61,6 +72,100 @@ class FormulaDiagnosticReport(BaseModel):
     def has_fatal(self) -> bool:
         """Return whether any diagnostic should block the local claim."""
         return any(diagnostic.severity == "fatal" for diagnostic in self.diagnostics)
+
+
+def formula_graph_to_sympy(formula_graph: FormulaGraph) -> Any | None:
+    """Project a propositional FormulaGraph root to a SymPy Boolean expression."""
+    projected = _project_formula_graph(formula_graph)
+    if projected is None:
+        return None
+    return projected.expression
+
+
+def _project_formula_graph(formula_graph: FormulaGraph) -> _ProjectedFormula | None:
+    nodes_by_id = {node.id: node for node in formula_graph.nodes}
+    atom_ids: set[str] = set()
+    expression = _project_node(formula_graph.root, nodes_by_id, atom_ids)
+    if expression is None:
+        return None
+    return _ProjectedFormula(
+        source_claim=formula_graph.source_claim,
+        root=formula_graph.root,
+        expression=expression,
+        atom_ids=frozenset(atom_ids),
+    )
+
+
+def _project_node(
+    node_id: str,
+    nodes_by_id: dict[str, FormulaNode],
+    atom_ids: set[str],
+) -> Any | None:
+    node = nodes_by_id.get(node_id)
+    if node is None:
+        return None
+
+    if node.kind == "atom":
+        return _project_atom_node(node, atom_ids)
+
+    if node.kind == "op":
+        return _project_op_node(node, nodes_by_id, atom_ids)
+
+    return None
+
+
+def _project_atom_node(node: FormulaNode, atom_ids: set[str]) -> Any:
+    descriptor = node.descriptor
+    symbol_name = node.id
+    if descriptor.get("kind") == "claim" and isinstance(descriptor.get("qid"), str):
+        symbol_name = descriptor["qid"]
+    atom_ids.add(symbol_name)
+    return Symbol(symbol_name)
+
+
+def _project_op_node(
+    node: FormulaNode,
+    nodes_by_id: dict[str, FormulaNode],
+    atom_ids: set[str],
+) -> Any | None:
+    descriptor = node.descriptor
+    operator = descriptor.get("operator")
+    children = descriptor.get("children")
+    if not isinstance(operator, str) or not isinstance(children, list):
+        return None
+    if not all(isinstance(child_id, str) for child_id in children):
+        return None
+
+    child_expressions = [_project_node(child_id, nodes_by_id, atom_ids) for child_id in children]
+    if any(child_expression is None for child_expression in child_expressions):
+        return None
+
+    return _build_sympy_operation(operator, child_expressions)
+
+
+def _build_sympy_operation(operator: str, child_expressions: list[Any]) -> Any | None:
+    if operator == "conjunction":
+        if len(child_expressions) < 2:
+            return None
+        return And(*child_expressions)
+    if operator == "disjunction":
+        if len(child_expressions) < 2:
+            return None
+        return Or(*child_expressions)
+    if operator == "negation":
+        if len(child_expressions) != 1:
+            return None
+        return Not(child_expressions[0])
+    if operator == "implication":
+        if len(child_expressions) != 2:
+            return None
+        return Implies(child_expressions[0], child_expressions[1])
+    if operator == "equivalence":
+        if len(child_expressions) != 2:
+            return None
+        return Equivalent(child_expressions[0], child_expressions[1])
+
+    return None
 
 
 def inspect_formula_graphs(

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from sympy import And, Equivalent, Implies, Not, Or, Symbol
+from sympy.logic.inference import satisfiable
 
 from gaia.engine.ir.formula import FormulaGraph, FormulaNode
 from gaia.engine.ir.graphs import LocalCanonicalGraph
@@ -115,12 +116,16 @@ def _project_node(
 
 
 def _project_atom_node(node: FormulaNode, atom_ids: set[str]) -> Any:
-    descriptor = node.descriptor
-    symbol_name = node.id
-    if descriptor.get("kind") == "claim" and isinstance(descriptor.get("qid"), str):
-        symbol_name = descriptor["qid"]
+    symbol_name = _atom_symbol_name(node)
     atom_ids.add(symbol_name)
     return Symbol(symbol_name)
+
+
+def _atom_symbol_name(node: FormulaNode) -> str:
+    descriptor = node.descriptor
+    if descriptor.get("kind") == "claim" and isinstance(descriptor.get("qid"), str):
+        return descriptor["qid"]
+    return node.id
 
 
 def _project_op_node(
@@ -177,5 +182,143 @@ def inspect_formula_graphs(
     include_pairwise: bool = True,
 ) -> FormulaDiagnosticReport:
     """Inspect formula graphs and return reviewer-facing logic diagnostics."""
-    del graph, include_pairwise
-    return FormulaDiagnosticReport()
+    diagnostics: list[FormulaDiagnostic] = []
+    projected: list[_ProjectedFormula] = []
+
+    for formula_graph in graph.formula_graphs:
+        diagnostics.extend(_redundant_operand_diagnostics(formula_graph))
+        projection = _project_formula_graph(formula_graph)
+        if projection is None:
+            diagnostics.append(_projection_unsupported_diagnostic(formula_graph))
+            continue
+        projected.append(projection)
+        diagnostics.extend(_claim_local_diagnostics(projection))
+
+    if include_pairwise:
+        diagnostics.extend(_pairwise_diagnostics(projected))
+
+    return FormulaDiagnosticReport(diagnostics=diagnostics)
+
+
+def _claim_local_diagnostics(projection: _ProjectedFormula) -> list[FormulaDiagnostic]:
+    diagnostics: list[FormulaDiagnostic] = []
+    if satisfiable(projection.expression) is False:
+        diagnostics.append(
+            FormulaDiagnostic(
+                code="formula_unsat",
+                severity="fatal",
+                scope="claim",
+                logic_strength="hard",
+                source_claim=projection.source_claim,
+                formula_nodes=[projection.root],
+                condition=_condition(
+                    "formula_unsat",
+                    [projection.source_claim],
+                    {"var": projection.source_claim},
+                    "hard_logic",
+                ),
+                message=f"Formula for claim {projection.source_claim!r} is unsatisfiable.",
+            )
+        )
+    elif satisfiable(Not(projection.expression)) is False:
+        diagnostics.append(
+            FormulaDiagnostic(
+                code="formula_tautology",
+                severity="warning",
+                scope="claim",
+                logic_strength="hard",
+                source_claim=projection.source_claim,
+                formula_nodes=[projection.root],
+                condition=_condition(
+                    "formula_tautology",
+                    [projection.source_claim],
+                    {"var": projection.source_claim},
+                    "hard_logic",
+                ),
+                message=f"Formula for claim {projection.source_claim!r} is tautological.",
+            )
+        )
+    return diagnostics
+
+
+def _redundant_operand_diagnostics(formula_graph: FormulaGraph) -> list[FormulaDiagnostic]:
+    diagnostics: list[FormulaDiagnostic] = []
+    nodes_by_id = {node.id: node for node in formula_graph.nodes}
+    for node in formula_graph.nodes:
+        operator = node.descriptor.get("operator")
+        if node.kind != "op" or operator not in {"conjunction", "disjunction"}:
+            continue
+        children = node.descriptor.get("children", [])
+        if not isinstance(children, list):
+            continue
+        repeated = sorted(
+            {child for child in children if isinstance(child, str) and children.count(child) > 1}
+        )
+        if not repeated:
+            continue
+        diagnostics.append(
+            FormulaDiagnostic(
+                code="formula_redundant_operand",
+                severity="info",
+                scope="claim",
+                logic_strength="hard",
+                source_claim=formula_graph.source_claim,
+                formula_nodes=[node.id, *repeated],
+                condition=_condition(
+                    "redundant_formula",
+                    [formula_graph.source_claim],
+                    {"var": formula_graph.source_claim},
+                    "hard_logic",
+                ),
+                message=f"Formula for claim {formula_graph.source_claim!r} repeats an operand.",
+                details={
+                    "operator": operator,
+                    "repeated_children": [
+                        _condition_var_for_node(nodes_by_id[child])
+                        for child in repeated
+                        if child in nodes_by_id
+                    ],
+                },
+            )
+        )
+    return diagnostics
+
+
+def _projection_unsupported_diagnostic(formula_graph: FormulaGraph) -> FormulaDiagnostic:
+    return FormulaDiagnostic(
+        code="formula_projection_unsupported",
+        severity="info",
+        scope="claim",
+        logic_strength="unknown",
+        source_claim=formula_graph.source_claim,
+        formula_nodes=[formula_graph.root],
+        message=(
+            f"Formula for claim {formula_graph.source_claim!r} is outside the current "
+            "propositional diagnostics subset."
+        ),
+    )
+
+
+def _condition(
+    kind: DiagnosticConditionKind,
+    variables: list[str],
+    expression: dict[str, Any],
+    confidence_basis: ConditionConfidenceBasis,
+) -> DiagnosticCondition:
+    return DiagnosticCondition(
+        kind=kind,
+        variables=variables,
+        expression=expression,
+        confidence_basis=confidence_basis,
+    )
+
+
+def _condition_var_for_node(node: FormulaNode) -> str:
+    if node.kind == "atom":
+        return _atom_symbol_name(node)
+    return node.id
+
+
+def _pairwise_diagnostics(projected: list[_ProjectedFormula]) -> list[FormulaDiagnostic]:
+    del projected
+    return []

--- a/gaia/engine/ir/logic/diagnostics.py
+++ b/gaia/engine/ir/logic/diagnostics.py
@@ -124,8 +124,9 @@ def _project_atom_node(node: FormulaNode, atom_ids: set[str]) -> Any:
 
 def _atom_symbol_name(node: FormulaNode) -> str:
     descriptor = node.descriptor
-    if descriptor.get("kind") == "claim" and isinstance(descriptor.get("qid"), str):
-        return descriptor["qid"]
+    qid = descriptor.get("qid")
+    if descriptor.get("kind") == "claim" and isinstance(qid, str):
+        return qid
     return node.id
 
 

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -179,3 +179,74 @@ def test_inspect_formula_graphs_reports_redundant_operands_as_info():
     assert diagnostic.scope == "claim"
     assert diagnostic.source_claim == _qid(package, "repeated")
     assert diagnostic.details["repeated_children"] == [_qid(package, "a")]
+
+
+def test_pairwise_incompatibility_is_warning_with_bp_condition():
+    package = "formula_diag_pair_incompat"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        left = claim("A holds.", formula=ClaimAtom(a))
+        left.label = "left"
+        right = claim("A does not hold.", formula=lnot(ClaimAtom(a)))
+        right.label = "right"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "cross_claim_incompatibility")
+    assert diagnostic.severity == "warning"
+    assert diagnostic.scope == "claim_pair"
+    assert diagnostic.logic_strength == "hard"
+    assert diagnostic.source_claim == _qid(package, "left")
+    assert diagnostic.related_claims == [_qid(package, "right")]
+    assert diagnostic.condition.kind == "joint_incompatibility"
+    assert diagnostic.condition.expression == {
+        "op": "and",
+        "args": [{"var": _qid(package, "left")}, {"var": _qid(package, "right")}],
+    }
+    assert report.has_fatal is False
+
+
+def test_pairwise_entailment_is_info_with_violation_condition():
+    package = "formula_diag_pair_entailment"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        strong = claim("A and B.", formula=land(ClaimAtom(a), ClaimAtom(b)))
+        strong.label = "strong"
+        weak = claim("A.", formula=ClaimAtom(a))
+        weak.label = "weak"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "cross_claim_entailment")
+    assert diagnostic.severity == "info"
+    assert diagnostic.source_claim == _qid(package, "strong")
+    assert diagnostic.related_claims == [_qid(package, "weak")]
+    assert diagnostic.condition.kind == "entailment_violation"
+    assert diagnostic.condition.expression == {
+        "op": "and",
+        "args": [
+            {"var": _qid(package, "strong")},
+            {"op": "not", "arg": {"var": _qid(package, "weak")}},
+        ],
+    }
+
+
+def test_pairwise_diagnostics_skip_disjoint_formulas():
+    package = "formula_diag_pair_disjoint"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        left = claim("A holds.", formula=ClaimAtom(a))
+        left.label = "left"
+        right = claim("B holds.", formula=ClaimAtom(b))
+        right.label = "right"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    assert [d for d in report.diagnostics if d.scope == "claim_pair"] == []

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -2,6 +2,8 @@ import pytest
 from sympy import And, Implies, Not, Symbol
 
 from gaia.engine.ir import FormulaGraph, FormulaNode, formula_node_id
+from gaia.engine.ir.logic import FormulaDiagnosticReport as ExportedFormulaDiagnosticReport
+from gaia.engine.ir.logic import inspect_formula_graphs as exported_inspect_formula_graphs
 from gaia.engine.ir.logic.diagnostics import (
     DiagnosticCondition,
     FormulaDiagnostic,
@@ -108,6 +110,31 @@ def test_formula_graph_to_sympy_returns_none_for_quantifier_root():
     formula_graph = _formula_graph_for(artifact, _qid(package, "universal"))
 
     assert formula_graph_to_sympy(formula_graph) is None
+
+
+def test_unsupported_quantifier_emits_info_without_crashing():
+    package = "formula_diag_unsupported_quantifier"
+    with CollectedPackage(package, namespace="t") as pkg:
+        domain = Domain(content="Particles", members=["p1"])
+        x = Variable(symbol="x", domain=domain)
+        stable = PredicateSymbol(name="Stable", arg_domains=(domain,))
+        universal = claim(
+            "All particles are stable.",
+            formula=forall(x, UserPredicate(stable, (x,))),
+        )
+        universal.label = "universal"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_projection_unsupported")
+    assert diagnostic.severity == "info"
+    assert diagnostic.logic_strength == "unknown"
+    assert diagnostic.source_claim == _qid(package, "universal")
+
+
+def test_logic_package_exports_formula_diagnostics_api():
+    assert ExportedFormulaDiagnosticReport is FormulaDiagnosticReport
+    assert exported_inspect_formula_graphs is inspect_formula_graphs
 
 
 def test_formula_graph_to_sympy_rejects_missing_op_child_id():

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -1,0 +1,36 @@
+from gaia.engine.ir.logic.diagnostics import (
+    DiagnosticCondition,
+    FormulaDiagnostic,
+    FormulaDiagnosticReport,
+    inspect_formula_graphs,
+)
+
+
+def test_formula_diagnostic_models_round_trip_json():
+    condition = DiagnosticCondition(
+        kind="joint_incompatibility",
+        variables=["t:pkg::left", "t:pkg::right"],
+        expression={
+            "op": "and",
+            "args": [{"var": "t:pkg::left"}, {"var": "t:pkg::right"}],
+        },
+        confidence_basis="hard_logic",
+    )
+    diagnostic = FormulaDiagnostic(
+        code="cross_claim_incompatibility",
+        severity="warning",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim="t:pkg::left",
+        related_claims=["t:pkg::right"],
+        formula_nodes=["fg:left", "fg:right"],
+        condition=condition,
+        message="Claims cannot both hold.",
+    )
+    report = FormulaDiagnosticReport(diagnostics=[diagnostic])
+
+    round_tripped = FormulaDiagnosticReport.model_validate_json(report.model_dump_json())
+
+    assert round_tripped == report
+    assert round_tripped.has_fatal is False
+    assert inspect_formula_graphs is not None

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -20,6 +20,7 @@ from gaia.engine.lang import (
     implies,
     land,
     lnot,
+    lor,
 )
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
@@ -124,3 +125,57 @@ def test_formula_graph_to_sympy_rejects_missing_op_child_id():
 
     with pytest.raises(ValueError, match="fg:missing"):
         formula_graph_to_sympy(graph)
+
+
+def test_inspect_formula_graphs_reports_claim_local_unsat_as_fatal():
+    package = "formula_diag_local_unsat"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        impossible = claim("A and not A.", formula=land(ClaimAtom(a), lnot(ClaimAtom(a))))
+        impossible.label = "impossible"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph, include_pairwise=False)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_unsat")
+    assert diagnostic.severity == "fatal"
+    assert diagnostic.scope == "claim"
+    assert diagnostic.logic_strength == "hard"
+    assert diagnostic.source_claim == _qid(package, "impossible")
+    assert diagnostic.condition.kind == "formula_unsat"
+    assert diagnostic.condition.expression == {"var": _qid(package, "impossible")}
+    assert report.has_fatal is True
+
+
+def test_inspect_formula_graphs_reports_claim_local_tautology_as_warning():
+    package = "formula_diag_local_tautology"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        tautology = claim("A or not A.", formula=lor(ClaimAtom(a), lnot(ClaimAtom(a))))
+        tautology.label = "tautology"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph, include_pairwise=False)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_tautology")
+    assert diagnostic.severity == "warning"
+    assert diagnostic.scope == "claim"
+    assert diagnostic.source_claim == _qid(package, "tautology")
+    assert report.has_fatal is False
+
+
+def test_inspect_formula_graphs_reports_redundant_operands_as_info():
+    package = "formula_diag_redundant_operand"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        repeated = claim("A and A.", formula=land(ClaimAtom(a), ClaimAtom(a)))
+        repeated.label = "repeated"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph, include_pairwise=False)
+
+    diagnostic = next(d for d in report.diagnostics if d.code == "formula_redundant_operand")
+    assert diagnostic.severity == "info"
+    assert diagnostic.scope == "claim"
+    assert diagnostic.source_claim == _qid(package, "repeated")
+    assert diagnostic.details["repeated_children"] == [_qid(package, "a")]

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -1,7 +1,14 @@
 import pytest
 from sympy import And, Implies, Not, Symbol
 
-from gaia.engine.ir import FormulaGraph, FormulaNode, formula_node_id
+from gaia.engine.ir import (
+    FormulaGraph,
+    FormulaNode,
+    Knowledge,
+    KnowledgeType,
+    LocalCanonicalGraph,
+    formula_node_id,
+)
 from gaia.engine.ir.logic import FormulaDiagnosticReport as ExportedFormulaDiagnosticReport
 from gaia.engine.ir.logic import inspect_formula_graphs as exported_inspect_formula_graphs
 from gaia.engine.ir.logic.diagnostics import (
@@ -154,6 +161,57 @@ def test_formula_graph_to_sympy_rejects_missing_op_child_id():
         formula_graph_to_sympy(graph)
 
 
+def test_inspect_formula_graphs_reports_malformed_projection_and_continues():
+    bad_descriptor = {
+        "kind": "op",
+        "operator": "conjunction",
+        "children": ["fg:missing"],
+    }
+    bad_root = FormulaNode(
+        id=formula_node_id(bad_descriptor),
+        kind="op",
+        descriptor=bad_descriptor,
+    )
+    bad_graph = FormulaGraph(
+        source_claim="t:malformed_pkg::bad",
+        root=bad_root.id,
+        nodes=[bad_root],
+    )
+
+    good_descriptor = {"kind": "claim", "qid": "t:malformed_pkg::a"}
+    good_root = FormulaNode(
+        id=formula_node_id(good_descriptor),
+        kind="atom",
+        descriptor=good_descriptor,
+    )
+    good_graph = FormulaGraph(
+        source_claim="t:malformed_pkg::good",
+        root=good_root.id,
+        nodes=[good_root],
+    )
+    graph = LocalCanonicalGraph(
+        namespace="t",
+        package_name="malformed_pkg",
+        knowledges=[
+            Knowledge(id="t:malformed_pkg::bad", type=KnowledgeType.CLAIM, content="bad"),
+            Knowledge(id="t:malformed_pkg::good", type=KnowledgeType.CLAIM, content="good"),
+            Knowledge(id="t:malformed_pkg::a", type=KnowledgeType.CLAIM, content="A"),
+        ],
+        formula_graphs=[bad_graph, good_graph],
+    )
+
+    report = inspect_formula_graphs(graph)
+
+    malformed = next(d for d in report.diagnostics if d.code == "formula_projection_malformed")
+    assert malformed.severity == "warning"
+    assert malformed.scope == "claim"
+    assert malformed.logic_strength == "unknown"
+    assert malformed.source_claim == "t:malformed_pkg::bad"
+    assert malformed.formula_nodes == [bad_root.id]
+    assert "fg:missing" in malformed.details["error"]
+    assert not report.has_fatal
+
+
 def test_inspect_formula_graphs_reports_claim_local_unsat_as_fatal():
     package = "formula_diag_local_unsat"
     with CollectedPackage(package, namespace="t") as pkg:
@@ -292,4 +350,22 @@ def test_pairwise_diagnostics_skip_locally_unsat_formulas():
     report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
 
     assert any(d.code == "formula_unsat" and d.severity == "fatal" for d in report.diagnostics)
+    assert [d for d in report.diagnostics if d.scope == "claim_pair"] == []
+
+
+def test_pairwise_diagnostics_skip_locally_tautological_formulas():
+    package = "formula_diag_pair_skip_tautology"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        tautology = claim("A or not A.", formula=lor(ClaimAtom(a), lnot(ClaimAtom(a))))
+        tautology.label = "tautology"
+        ordinary = claim("A holds.", formula=ClaimAtom(a))
+        ordinary.label = "ordinary"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    assert any(
+        d.code == "formula_tautology" and d.severity == "warning" for d in report.diagnostics
+    )
     assert [d for d in report.diagnostics if d.scope == "claim_pair"] == []

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -250,3 +250,19 @@ def test_pairwise_diagnostics_skip_disjoint_formulas():
     report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
 
     assert [d for d in report.diagnostics if d.scope == "claim_pair"] == []
+
+
+def test_pairwise_diagnostics_skip_locally_unsat_formulas():
+    package = "formula_diag_pair_skip_unsat"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        impossible = claim("A and not A.", formula=land(ClaimAtom(a), lnot(ClaimAtom(a))))
+        impossible.label = "impossible"
+        ordinary = claim("A holds.", formula=ClaimAtom(a))
+        ordinary.label = "ordinary"
+
+    report = inspect_formula_graphs(compile_package_artifact(pkg).graph)
+
+    assert any(d.code == "formula_unsat" and d.severity == "fatal" for d in report.diagnostics)
+    assert [d for d in report.diagnostics if d.scope == "claim_pair"] == []

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -1,5 +1,7 @@
+import pytest
 from sympy import And, Implies, Not, Symbol
 
+from gaia.engine.ir import FormulaGraph, FormulaNode, formula_node_id
 from gaia.engine.ir.logic.diagnostics import (
     DiagnosticCondition,
     FormulaDiagnostic,
@@ -105,3 +107,20 @@ def test_formula_graph_to_sympy_returns_none_for_quantifier_root():
     formula_graph = _formula_graph_for(artifact, _qid(package, "universal"))
 
     assert formula_graph_to_sympy(formula_graph) is None
+
+
+def test_formula_graph_to_sympy_rejects_missing_op_child_id():
+    descriptor = {
+        "kind": "op",
+        "operator": "conjunction",
+        "children": ["fg:missing"],
+    }
+    root = FormulaNode(
+        id=formula_node_id(descriptor),
+        kind="op",
+        descriptor=descriptor,
+    )
+    graph = FormulaGraph(source_claim="t:pkg::bad", root=root.id, nodes=[root])
+
+    with pytest.raises(ValueError, match="fg:missing"):
+        formula_graph_to_sympy(graph)

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -34,6 +34,8 @@ from gaia.engine.lang import (
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
 
+pytestmark = pytest.mark.pr_gate
+
 
 def _qid(package: str, label: str) -> str:
     return f"t:{package}::{label}"

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -1,9 +1,38 @@
+from sympy import And, Implies, Not, Symbol
+
 from gaia.engine.ir.logic.diagnostics import (
     DiagnosticCondition,
     FormulaDiagnostic,
     FormulaDiagnosticReport,
+    formula_graph_to_sympy,
     inspect_formula_graphs,
 )
+from gaia.engine.lang import (
+    ClaimAtom,
+    Domain,
+    PredicateSymbol,
+    UserPredicate,
+    Variable,
+    claim,
+    forall,
+    implies,
+    land,
+    lnot,
+)
+from gaia.engine.lang.compiler import compile_package_artifact
+from gaia.engine.lang.runtime.package import CollectedPackage
+
+
+def _qid(package: str, label: str) -> str:
+    return f"t:{package}::{label}"
+
+
+def _formula_graph_for(artifact, source_claim_id: str):
+    return next(
+        formula_graph
+        for formula_graph in artifact.graph.formula_graphs
+        if formula_graph.source_claim == source_claim_id
+    )
 
 
 def test_formula_diagnostic_models_round_trip_json():
@@ -34,3 +63,45 @@ def test_formula_diagnostic_models_round_trip_json():
     assert round_tripped == report
     assert round_tripped.has_fatal is False
     assert inspect_formula_graphs is not None
+
+
+def test_formula_graph_to_sympy_projects_claim_atom_connectives():
+    package = "formula_diag_projection"
+    with CollectedPackage(package, namespace="t") as pkg:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        rule = claim(
+            "A and not B implies A.",
+            formula=implies(land(ClaimAtom(a), lnot(ClaimAtom(b))), ClaimAtom(a)),
+        )
+        rule.label = "rule"
+
+    artifact = compile_package_artifact(pkg)
+    formula_graph = _formula_graph_for(artifact, _qid(package, "rule"))
+
+    expression = formula_graph_to_sympy(formula_graph)
+
+    assert expression == Implies(
+        And(Symbol(_qid(package, "a")), Not(Symbol(_qid(package, "b")))),
+        Symbol(_qid(package, "a")),
+    )
+
+
+def test_formula_graph_to_sympy_returns_none_for_quantifier_root():
+    package = "formula_diag_quantifier"
+    with CollectedPackage(package, namespace="t") as pkg:
+        domain = Domain(content="Particles", members=["p1"])
+        x = Variable(symbol="x", domain=domain)
+        stable = PredicateSymbol(name="Stable", arg_domains=(domain,))
+        universal = claim(
+            "All particles are stable.",
+            formula=forall(x, UserPredicate(stable, (x,))),
+        )
+        universal.label = "universal"
+
+    artifact = compile_package_artifact(pkg)
+    formula_graph = _formula_graph_for(artifact, _qid(package, "universal"))
+
+    assert formula_graph_to_sympy(formula_graph) is None

--- a/tests/gaia/logic/test_formula_diagnostics.py
+++ b/tests/gaia/logic/test_formula_diagnostics.py
@@ -178,16 +178,26 @@ def test_inspect_formula_graphs_reports_malformed_projection_and_continues():
         nodes=[bad_root],
     )
 
-    good_descriptor = {"kind": "claim", "qid": "t:malformed_pkg::a"}
+    good_atom_descriptor = {"kind": "claim", "qid": "t:malformed_pkg::a"}
+    good_atom = FormulaNode(
+        id=formula_node_id(good_atom_descriptor),
+        kind="atom",
+        descriptor=good_atom_descriptor,
+    )
+    good_descriptor = {
+        "kind": "op",
+        "operator": "conjunction",
+        "children": [good_atom.id, good_atom.id],
+    }
     good_root = FormulaNode(
         id=formula_node_id(good_descriptor),
-        kind="atom",
+        kind="op",
         descriptor=good_descriptor,
     )
     good_graph = FormulaGraph(
         source_claim="t:malformed_pkg::good",
         root=good_root.id,
-        nodes=[good_root],
+        nodes=[good_root, good_atom],
     )
     graph = LocalCanonicalGraph(
         namespace="t",
@@ -209,6 +219,9 @@ def test_inspect_formula_graphs_reports_malformed_projection_and_continues():
     assert malformed.source_claim == "t:malformed_pkg::bad"
     assert malformed.formula_nodes == [bad_root.id]
     assert "fg:missing" in malformed.details["error"]
+    continued = next(d for d in report.diagnostics if d.code == "formula_redundant_operand")
+    assert continued.source_claim == "t:malformed_pkg::good"
+    assert continued.details["repeated_children"] == ["t:malformed_pkg::a"]
     assert not report.has_fatal
 
 


### PR DESCRIPTION
## Summary
- Add FormulaDiagnostic/FormulaDiagnosticReport and inspect_formula_graphs() for reviewer-facing formula logic diagnostics.
- Project propositional FormulaGraph IR to SymPy and emit claim-local fatal/warning/info diagnostics.
- Add cross-claim warning/info diagnostics with BP-compatible JSON condition events, without importing BP or changing ReviewManifest.

## Test Plan
- python -m pytest tests/gaia/logic/test_formula_diagnostics.py tests/ir/test_formula_graph.py tests/gaia/logic/test_propositional.py tests/gaia/lang/test_formula_lowering.py -q --no-cov
- python -m ruff check gaia/engine/ir/logic/diagnostics.py tests/gaia/logic/test_formula_diagnostics.py gaia/engine/ir/logic/__init__.py
- python -m ruff format --check gaia/engine/ir/logic/diagnostics.py tests/gaia/logic/test_formula_diagnostics.py gaia/engine/ir/logic/__init__.py