### PR TITLE
docs: restructure nav into 5 Diátaxis-style regions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,43 +1,62 @@
 # Gaia Documentation
 
-## Start Here
+Gaia 的文档按读者**正在问的问题**分为 5 个顶层区，每个区只解决一类问题：
 
-Choose your path:
+| 区 | 你在问 | 入口示例 |
+|---|---|---|
+| **Tutorials** | "我第一次接触 Gaia，能不能带我走一遍？" | [What Is Gaia?](for-visitors/what-is-gaia.md) · [Quick Start](for-users/quick-start.md) |
+| **How-To Guides** | "我有一个具体任务要解决，给我配方" | [Hole And Bridge](for-users/hole-bridge-tutorial.md) · [Choosing A BP Algorithm](foundations/bp/choosing-algorithm.md) |
+| **Reference** | "我知道要查什么，给我精确规格 / API / 命令" | [Language Reference](for-users/language-reference.md) · [CLI Commands](for-users/cli-commands.md) · [Engine API](reference/engine/index.md) · [CLI Internals](reference/cli/index.md) · [Contracts](foundations/contracts/review-report.md) |
+| **Foundations** | "为什么 Gaia 是这样的？把推导链给我" | [Foundations Overview](foundations/README.md) · [Theory](foundations/theory/01-plausible-reasoning.md) · [Belief Propagation](foundations/bp/inference.md) |
+| **Policy & Migration** | "文档自身的规则、版本迁移说明" | [Documentation Policy](documentation-policy.md) · [Migration to alpha 0](migration.md) |
 
-### I want to understand what Gaia is
-> You're a visitor, researcher, or evaluator.
+侧边栏与本表完全对应。这是 [Diátaxis](https://diataxis.fr) 的一个变体——把"explanation"展开为带顺序的 **Foundations** 区，因为 Gaia 的 theory 文档（`theory/01–08`）是真正的 derivation chain，不能折成无序解释。
 
-Start with [What is Gaia?](for-visitors/what-is-gaia.md).
+> **关于命名变更**：之前的 "Start Here" / "User Reference" / "Foundational Docs" / "Deep Reference" 标签已合并为这 5 个区。如果你来自旧链接，URL 路径不变（`for-visitors/`、`for-users/`、`foundations/`、`reference/` 仍然有效），只是 nav label 变了。背景见 [RFC #647](https://github.com/SiliconEinstein/Gaia/issues/647)。
 
-### I want to use Gaia to author knowledge packages
-> You're a researcher or research agent using the Gaia CLI.
+## Choose your path
 
-Start with the [Quick Start](for-users/quick-start.md), then read the [Hole And Bridge Tutorial](for-users/hole-bridge-tutorial.md), [Language Reference](for-users/language-reference.md), and [CLI Commands](for-users/cli-commands.md).
+### 我想了解 Gaia 是什么
+你是访问者、研究者、评估者。
 
-### I want to develop Gaia
-> You're a developer working on the codebase.
+→ 从 [What is Gaia?](for-visitors/what-is-gaia.md) 开始。
 
-Start with the [Python API Reference](reference/engine/index.md), then explore:
-- [CLI surface](foundations/cli/workflow.md) — local authoring, compilation, inference
-- [LKM surface](https://github.com/SiliconEinstein/gaia-lkm) — server-side review, curation, global inference (maintained in gaia-lkm repo)
-- [Gaia Lang design](foundations/gaia-lang/knowledge-and-reasoning.md) — authoring model, actions, formulas, helper claims
-- [Gaia IR design](foundations/gaia-ir/01-overview.md) — persistent structure, identity, lowering, validation
-- [Gaia Lang API](reference/engine/lang.md) — generated from current Python docstrings and type hints
-- [Gaia IR API](reference/engine/ir.md) — generated from current Python docstrings and type hints
+### 我想用 Gaia 写知识包
+你是研究者或正在使用 Gaia CLI 的研究 agent。
 
-## Deep Reference
+→ 跟着 [Quick Start](for-users/quick-start.md) 走完一次完整流程，然后按需查阅：
 
-The [Foundations](foundations/README.md) directory contains Gaia's conceptual reference docs. Python module interfaces live in the generated [Python API Reference](reference/engine/index.md).
+- [Hole And Bridge](for-users/hole-bridge-tutorial.md) — 跨包补洞 / bridge 机制（How-To）
+- [Choosing A BP Algorithm](foundations/bp/choosing-algorithm.md) — 给你的图选合适的 BP 算法（How-To）
+- [Language Reference](for-users/language-reference.md) — DSL 语法查询（Reference）
+- [CLI Commands](for-users/cli-commands.md) — 用户面 CLI 命令查询（Reference）
 
-| Layer | What it answers | Changes |
-|-------|----------------|---------|
-| [Theory](foundations/theory/01-plausible-reasoning.md) | Why does Gaia reason this way? | Never |
-| [Ecosystem](foundations/ecosystem/01-product-scope.md) | What are Gaia's design choices? | Rarely |
+### 我想开发 Gaia
+你是给 Gaia 代码库写代码的开发者。
+
+→ 入口是 [Engine API Overview](reference/engine/index.md)，然后按需深入：
+
+- [CLI Internals](reference/cli/index.md) — engine-internal CLI invocation 规格（Reference）
+- [CLI Workflow](foundations/cli/workflow.md) — 本地 authoring / compilation / inference 的设计原则（Foundations）
+- [Gaia Lang Design](foundations/gaia-lang/knowledge-and-reasoning.md) — authoring 模型、actions、formulas、helper claims
+- [Gaia IR Design](foundations/gaia-ir/01-overview.md) — persistent structure、identity、lowering、validation
+- [Gaia Lang API](reference/engine/lang.md) / [Gaia IR API](reference/engine/ir.md) — 当前 Python 模块自动生成的接口
+- LKM server 在 [gaia-lkm repo](https://github.com/SiliconEinstein/gaia-lkm) 维护
+
+## Foundations: derivation chain by rate of change
+
+Foundations 区的子目录按 "内容多久变一次" 组织。读者依据想了解的层次进入：
+
+| 子目录 | 它回答 | 变更频率 |
+|---|---|---|
+| [Theory](foundations/theory/01-plausible-reasoning.md) | Why does Gaia reason this way? Cox / MaxEnt / propositional operators / causality | Never |
+| [Belief Propagation](foundations/bp/inference.md) | How does inference run on Gaia IR? Cromwell, factor types, algorithm parameters | Sometimes |
 | [Gaia Lang Design](foundations/gaia-lang/knowledge-and-reasoning.md) | What is the authoring language model? | Sometimes |
 | [Gaia IR Design](foundations/gaia-ir/01-overview.md) | What is the persistent reasoning contract? | Sometimes |
-| [BP](foundations/bp/inference.md) | How does inference work? | Sometimes |
-| [CLI](foundations/cli/workflow.md) | How does local authoring work? | Often |
-| [Python API](reference/engine/index.md) | What do current Gaia Lang, Gaia IR, BP, CLI, and logic modules expose? | Often |
+| [Ecosystem](foundations/ecosystem/01-product-scope.md) | What are Gaia's product / system design choices? | Rarely |
+| [Review Pipeline](foundations/review/review-pipeline.md) | How does package review and curation flow? (process narrative; the report contracts live in Reference / Contracts) | Sometimes |
+| [CLI Workflow](foundations/cli/workflow.md) | How does local authoring map to CLI commands? (design layer; the user-facing command list lives in Reference / CLI Commands) | Often |
+| [Python API](reference/engine/index.md) | What do current modules expose? (Reference 区，从 docstring 自动生成) | Often |
 | LKM | How does the server work? | [gaia-lkm repo](https://github.com/SiliconEinstein/gaia-lkm) |
 
 ## Other Resources

--- a/docs/for-users/cli-commands.md
+++ b/docs/for-users/cli-commands.md
@@ -1,6 +1,8 @@
 # CLI Commands
 
 > **Status:** Current canonical (alpha 0)
+>
+> **本页定位：** **Reference** 区的用户面 CLI 命令查询；CLI 的 workflow 设计（authoring 流水线、子命令分组的设计意图）见 Foundations / [CLI Workflow](../foundations/cli/workflow.md)，engine-internal invocation 规格见 Reference / [CLI Internals](../reference/cli/index.md)。
 
 Reference for the Gaia Lang v0.5 CLI. The installed entrypoint is `gaia`.
 

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -1,6 +1,8 @@
 # Language Reference
 
 > **Status:** Current v0.5 canonical
+>
+> **本页定位：** **Reference** 区的用户面 DSL 速查；语言模型本身的设计动机、Knowledge 类型本体、Reasoning 到 IR 的 lowering 规则见 Foundations / [Knowledge And Reasoning](../foundations/gaia-lang/knowledge-and-reasoning.md)。
 
 Practical cheat sheet for the Gaia Language v0.5 Python DSL. For the generated API reference, see [Gaia Lang DSL API](../reference/engine/lang/dsl.md).
 

--- a/docs/foundations/cli/workflow.md
+++ b/docs/foundations/cli/workflow.md
@@ -6,6 +6,8 @@ since: v0.5
 
 # CLI Workflow
 
+> **本页定位：** **Foundations** 区的 CLI 设计文档（authoring 流水线分层、子命令的设计意图）；面向作者的命令查询见 Reference / [CLI Commands](../../for-users/cli-commands.md)，engine-internal invocation 规格见 Reference / [CLI Internals](../../reference/cli/index.md)。
+
 ## Overview
 
 The Gaia CLI is a knowledge package authoring toolkit. The main authoring pipeline takes a Python DSL package from scaffolding to registry registration:

--- a/docs/foundations/contracts/rebuttal-report.md
+++ b/docs/foundations/contracts/rebuttal-report.md
@@ -3,6 +3,8 @@
 > **Status:** Target design — **not implemented in v0.5 CLI**.
 >
 > v0.5 没有任何代码生成 `RebuttalReport` / `RebuttalEntry` 或读写 `.gaia/review/rebuttal.json`；这是为未来 ReviewService（多 agent 同行评审 + 反驳周期）准备的合约草案。本文档保留作为下游设计输入，但不应被解读为 `gaia inquiry review` / `gaia run infer` 当前会执行的流程。当前本地 review 路径见 [../review/review-pipeline.md](../review/review-pipeline.md)。
+>
+> **本页定位：** **Reference / Contracts** 区的数据契约（report schema 与字段定义）；review 流程本身的叙述见 Foundations / [Review Pipeline](../review/review-pipeline.md)。
 
 本文档定义反驳报告（RebuttalReport）的数据契约。当审查发现阻塞性问题时，作者或 agent 提交反驳，ReviewService 据此重新评估。
 

--- a/docs/foundations/contracts/review-report.md
+++ b/docs/foundations/contracts/review-report.md
@@ -1,6 +1,8 @@
 # 审查报告契约
 
 > **Status:** Legacy / future-service contract, not the current v0.5 local CLI path
+>
+> **本页定位：** **Reference / Contracts** 区的数据契约（report schema 与字段定义）；review 流程本身的叙述见 Foundations / [Review Pipeline](../review/review-pipeline.md)。
 
 本文档定义旧版 `ReviewOutput` 审查报告的数据契约。它描述的是早期
 agent self-review / future ReviewService 可能输出的概率化报告格式，不是

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -6,6 +6,8 @@ since: v0.5
 
 # Knowledge Types and Reasoning Semantics
 
+> **本页定位：** **Foundations / Gaia Lang Design** 区的语言设计文档（Knowledge 本体、Reasoning lowering 规则、设计动机）；面向作者的 DSL 速查见 Reference / [Language Reference](../../for-users/language-reference.md)。
+
 This document bridges the Gaia Lang v0.5 Python DSL to the Gaia IR semantics layer. It covers:
 
 - The **Knowledge** hierarchy authors declare (`Claim`, `Note`, `Question`, plus `ClaimKind` shape discriminators).

--- a/docs/foundations/review/review-pipeline.md
+++ b/docs/foundations/review/review-pipeline.md
@@ -6,6 +6,8 @@ since: v0.5
 
 # Review Pipeline
 
+> **本页定位：** **Foundations** 区的 review 流程叙述（结构化编译 vs review 判断、本地工作流分层）；review / rebuttal 报告的数据契约见 Reference / Contracts ([review-report](../contracts/review-report.md), [rebuttal-report](../contracts/rebuttal-report.md))。
+
 Gaia separates **structural compilation** (objective, deterministic) from
 **review** (qualitative judgment about whether an authored action's warrant is
 acceptable for publication-quality workflows). Review is a per-action decision:

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1,6 +1,8 @@
 # Gaia CLI
 
 > **Status:** Reference layer for the `gaia` command-line app.
+>
+> **本页定位：** **Reference / CLI Internals** 区的 engine-internal invocation specs；面向作者的命令查询见 Reference / [CLI Commands](../../for-users/cli-commands.md)，CLI workflow 设计见 Foundations / [CLI Workflow](../../foundations/cli/workflow.md)。
 
 The installed entrypoint is `gaia`. Alpha 0 organizes verbs into 6 logical
 groups plus the independent `trace` sub-app:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,64 +50,19 @@ markdown_extensions:
 
 nav:
   - Home: README.md
-  - Start Here:
+
+  - Tutorials:
       - What Is Gaia?: for-visitors/what-is-gaia.md
       - Quick Start: for-users/quick-start.md
-      - Hole And Bridge Tutorial: for-users/hole-bridge-tutorial.md
-  - User Reference:
+
+  - How-To Guides:
+      - Hole And Bridge: for-users/hole-bridge-tutorial.md
+      - Choosing A BP Algorithm: foundations/bp/choosing-algorithm.md
+
+  - Reference:
       - Language Reference: for-users/language-reference.md
       - CLI Commands: for-users/cli-commands.md
-  - Foundational Docs:
-      - Overview: foundations/README.md
-      - Theory:
-          - Plausible Reasoning: foundations/theory/01-plausible-reasoning.md
-          - MaxEnt Grounding: foundations/theory/02-maxent-grounding.md
-          - Propositional Operators: foundations/theory/03-propositional-operators.md
-          - Reasoning Strategies: foundations/theory/04-reasoning-strategies.md
-          - Formalization Methodology: foundations/theory/05-formalization-methodology.md
-          - Factor Graphs: foundations/theory/06-factor-graphs.md
-          - Belief Propagation: foundations/theory/07-belief-propagation.md
-          - Causality And Jaynes: foundations/theory/08-causality-and-jaynes.md
-      - Ecosystem:
-          - Product Scope: foundations/ecosystem/01-product-scope.md
-          - Decentralized Architecture: foundations/ecosystem/02-decentralized-architecture.md
-          - Authoring And Publishing: foundations/ecosystem/03-authoring-and-publishing.md
-          - Registry Operations: foundations/ecosystem/04-registry-operations.md
-          - Review And Curation: foundations/ecosystem/05-review-and-curation.md
-          - Belief Flow And Quality: foundations/ecosystem/06-belief-flow-and-quality.md
-          - Related Systems: foundations/ecosystem/07-related-systems.md
-      - Gaia Lang Design:
-          - Knowledge And Reasoning: foundations/gaia-lang/knowledge-and-reasoning.md
-          - Predicate Logic: foundations/gaia-lang/predicate-logic.md
-          - Bayes Semantics: foundations/gaia-lang/bayes.md
-          - Package Model: foundations/gaia-lang/package.md
-      - Gaia IR Design:
-          - Overview: foundations/gaia-ir/01-overview.md
-          - Structure Contract: foundations/gaia-ir/02-gaia-ir.md
-          - Identity And Hashing: foundations/gaia-ir/03-identity-and-hashing.md
-          - Helper Claims: foundations/gaia-ir/04-helper-claims.md
-          - Canonicalization: foundations/gaia-ir/05-canonicalization.md
-          - Parameterization: foundations/gaia-ir/06-parameterization.md
-          - Lowering: foundations/gaia-ir/07-lowering.md
-          - Validation: foundations/gaia-ir/08-validation.md
-      - Belief Propagation:
-          - Belief State: foundations/bp/belief-state.md
-          - Formal Strategy Lowering: foundations/bp/formal-strategy-lowering.md
-          - Inference: foundations/bp/inference.md
-          - Choosing An Algorithm: foundations/bp/choosing-algorithm.md
-          - Local Vs Global: foundations/bp/local-vs-global.md
-          - Potentials: foundations/bp/potentials.md
-      - Review:
-          - Review Pipeline: foundations/review/review-pipeline.md
-          - Review Report Contract: foundations/contracts/review-report.md
-          - Rebuttal Report Contract: foundations/contracts/rebuttal-report.md
-      - CLI:
-          - Workflow: foundations/cli/workflow.md
-          - Compilation: foundations/cli/compilation.md
-          - Inference: foundations/cli/inference.md
-          - Registration: foundations/cli/registration.md
-  - API Reference:
-      - Engine:
+      - Engine API:
           - Overview: reference/engine/index.md
           - bayes: reference/engine/bayes.md
           - bp: reference/engine/bp.md
@@ -124,7 +79,7 @@ nav:
               - Formula AST: reference/engine/lang/formula.md
               - Compiler: reference/engine/lang/compiler.md
               - References: reference/engine/lang/refs.md
-      - CLI:
+      - CLI Internals:
           - Overview: reference/cli/index.md
           - build: reference/cli/build.md
           - run: reference/cli/run.md
@@ -134,5 +89,56 @@ nav:
           - pkg: reference/cli/pkg.md
           - trace: reference/cli/trace.md
           - Internals: reference/cli/internals.md
+      - Contracts:
+          - Review Report Contract: foundations/contracts/review-report.md
+          - Rebuttal Report Contract: foundations/contracts/rebuttal-report.md
+
+  - Foundations:
+      - Overview: foundations/README.md
+      - Theory:
+          - Plausible Reasoning: foundations/theory/01-plausible-reasoning.md
+          - MaxEnt Grounding: foundations/theory/02-maxent-grounding.md
+          - Propositional Operators: foundations/theory/03-propositional-operators.md
+          - Reasoning Strategies: foundations/theory/04-reasoning-strategies.md
+          - Formalization Methodology: foundations/theory/05-formalization-methodology.md
+          - Factor Graphs: foundations/theory/06-factor-graphs.md
+          - Belief Propagation: foundations/theory/07-belief-propagation.md
+          - Causality And Jaynes: foundations/theory/08-causality-and-jaynes.md
+      - Belief Propagation:
+          - Belief State: foundations/bp/belief-state.md
+          - Formal Strategy Lowering: foundations/bp/formal-strategy-lowering.md
+          - Inference: foundations/bp/inference.md
+          - Local Vs Global: foundations/bp/local-vs-global.md
+          - Potentials: foundations/bp/potentials.md
+      - Gaia Lang Design:
+          - Knowledge And Reasoning: foundations/gaia-lang/knowledge-and-reasoning.md
+          - Predicate Logic: foundations/gaia-lang/predicate-logic.md
+          - Bayes Semantics: foundations/gaia-lang/bayes.md
+          - Package Model: foundations/gaia-lang/package.md
+      - Gaia IR Design:
+          - Overview: foundations/gaia-ir/01-overview.md
+          - Structure Contract: foundations/gaia-ir/02-gaia-ir.md
+          - Identity And Hashing: foundations/gaia-ir/03-identity-and-hashing.md
+          - Helper Claims: foundations/gaia-ir/04-helper-claims.md
+          - Canonicalization: foundations/gaia-ir/05-canonicalization.md
+          - Parameterization: foundations/gaia-ir/06-parameterization.md
+          - Lowering: foundations/gaia-ir/07-lowering.md
+          - Validation: foundations/gaia-ir/08-validation.md
+      - Ecosystem:
+          - Product Scope: foundations/ecosystem/01-product-scope.md
+          - Decentralized Architecture: foundations/ecosystem/02-decentralized-architecture.md
+          - Authoring And Publishing: foundations/ecosystem/03-authoring-and-publishing.md
+          - Registry Operations: foundations/ecosystem/04-registry-operations.md
+          - Review And Curation: foundations/ecosystem/05-review-and-curation.md
+          - Belief Flow And Quality: foundations/ecosystem/06-belief-flow-and-quality.md
+          - Related Systems: foundations/ecosystem/07-related-systems.md
+      - Review Pipeline: foundations/review/review-pipeline.md
+      - CLI Workflow:
+          - Workflow: foundations/cli/workflow.md
+          - Compilation: foundations/cli/compilation.md
+          - Inference: foundations/cli/inference.md
+          - Registration: foundations/cli/registration.md
+
+  - Policy & Migration:
+      - Documentation Policy: documentation-policy.md
       - Migration to alpha 0: migration.md
-  - Documentation Policy: documentation-policy.md


### PR DESCRIPTION
## Summary

Implements [RFC #647](https://github.com/SiliconEinstein/Gaia/issues/647). Closes #610.

Reorganises the mkdocs nav from the historical four-axis mix (Start Here / User Reference / Foundational Docs / API Reference / Documentation Policy) into 5 top-level regions keyed off **what the reader is asking**:

| Region | Question |
|---|---|
| **Tutorials** | "Walk me through Gaia for the first time" |
| **How-To Guides** | "I have a task — show me the recipe" |
| **Reference** | "Look up the exact spec / API / command" |
| **Foundations** | "Show me the derivation chain — theory / IR / BP / ecosystem" |
| **Policy & Migration** | "Meta-rules for the docs themselves and version transitions" |

## Base branch

This PR is **stacked on top of [PR #646](https://github.com/SiliconEinstein/Gaia/pull/646)** (`docs/choosing-bp-algorithm`) — the new nav references `foundations/bp/choosing-algorithm.md`, which is created by #646. Two paths to land:

- **Preferred:** merge #646 first, then GitHub will auto-rebase this PR onto `v0.5` and the diff reduces to just the IA changes (mkdocs.yml + README + 8 preambles).
- **Alternative:** if reviewers prefer a single combined PR, this PR's commit (`9638fcce`) can be cherry-picked onto v0.5 once #646 lands. Either way, no manual rebase is required from contributors.

The PR base is set to `docs/choosing-bp-algorithm` so GitHub renders only the IA delta (10 files / +120 / −79); set base to `v0.5` after #646 merges and the diff stays unchanged.

## What changed

**`mkdocs.yml`** — full nav rewrite to the 5-region YAML in [RFC § 2](https://github.com/SiliconEinstein/Gaia/issues/647#issue).

**`docs/README.md`** — homepage rewritten so its 5-region table mirrors the sidebar exactly. The three "Choose your path" personas are re-anchored on the new region names. The "Deep Reference" → "Foundations" rename is now applied consistently between sidebar and homepage (resolves #610 § 5).

**8 straddling-page preambles** (1 admonition each, no narrative rewrites):

| Page | Preamble points to |
|---|---|
| `for-users/language-reference.md` | Foundations / Knowledge And Reasoning |
| `foundations/gaia-lang/knowledge-and-reasoning.md` | Reference / Language Reference |
| `foundations/contracts/review-report.md` | Foundations / Review Pipeline |
| `foundations/contracts/rebuttal-report.md` | Foundations / Review Pipeline |
| `foundations/review/review-pipeline.md` | Reference / Contracts (review-report, rebuttal-report) |
| `for-users/cli-commands.md` | Foundations / CLI Workflow + Reference / CLI Internals |
| `foundations/cli/workflow.md` | Reference / CLI Commands + Reference / CLI Internals |
| `reference/cli/index.md` | Reference / CLI Commands + Foundations / CLI Workflow |

## How this resolves #610

| #610 sub-point | Resolution in this PR |
|---|---|
| 1. CLI 内容在三处重复 | One CLI home per audience: **Reference / CLI Commands** (users), **Foundations / CLI Workflow** (design), **Reference / CLI Internals** (engine-internal invocation). Three preambles make the boundary explicit. |
| 2. Language Reference vs Gaia Lang Design 重叠 | Language Reference stays in **Reference**, knowledge-and-reasoning stays in **Foundations / Gaia Lang Design**. Both pages get a preamble pointing at the other. |
| 3. Review 流程在两处重复 | Process narrative → **Foundations / Review Pipeline**; report contracts → **Reference / Contracts**. Three preambles make the boundary explicit. |
| 4. Hole And Bridge 错位 | Moved from Start Here into **How-To Guides** as "Hole And Bridge" (label drops the misleading "Tutorial" suffix; URL unchanged). |
| 5. Foundational Docs ↔ Deep Reference 命名不一致 | Both renamed to **Foundations** in sidebar and homepage. |
| 6. URL 前缀不体现到导航 | Acknowledged as a non-goal; URL prefixes (`for-visitors/`, `for-users/`) become an implementation detail. The new nav cuts on task. **No URLs change**, so external inbound links still resolve. |
| 7. 缺少教程/概念/参考分层 | This is the entire PR. |

## Zero file moves on disk

Critically, **no markdown file is moved or renamed in this PR** — only `mkdocs.yml` (nav), `docs/README.md` (homepage), and 8 in-place preamble inserts. URL paths are unchanged, so:

- External inbound links from `gaia-lkm` repo, `gaia-spec.cn`, third-party citations, etc. still resolve.
- Search-engine-indexed URLs continue to work.
- The mkdocs site's own deep links (e.g. anchor links between theory pages) are unaffected.

## Verification

- [x] `uv run --extra docs mkdocs build --strict` — green, no anchor warnings.
- [x] Pre-commit gate green (mypy, ruff, suppression budget, claude-md symlink).
- [x] Pre-push gate green (full ruff, ruff format, ir-schema bump, `pytest -n auto tests/baseline tests/cli -v -m "not slow"`).
- [ ] Reviewer can run `make docs-serve` locally and walk the new sidebar; expected behaviour: each top-level region answers one question without overlap, and clicking through the homepage's "Choose your path" landing flows leads to coherent reading paths.

Closes #610.
Implements RFC #647.

Made with [Cursor](https://cursor.com)