### PR TITLE
Add diagnostic probability scoring over BP joint queries

### DIFF
--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -62,6 +62,7 @@ Gaia 的概念性基础文档，按理论、生态系统、Gaia Lang 设计、Ga
 
 - [因子势函数](bp/potentials.md) — 各因子类型的势函数
 - [推理](bp/inference.md) — BP 算法应用于 Gaia IR
+- [Diagnostic Probabilities](bp/diagnostic-probabilities.md) — 用 joint query 为 logic warning 计算 reviewer-facing 概率
 - [局部与全局](bp/local-vs-global.md) — CLI 局部推理 vs LKM 全局推理
 - [BeliefState](bp/belief-state.md) — BP 输出、可重现性
 

--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -41,6 +41,7 @@ Gaia 的概念性基础文档，按理论、生态系统、Gaia Lang 设计、Ga
 ## Gaia Lang — 编著语言设计
 
 - [知识类型与推理语义](gaia-lang/knowledge-and-reasoning.md) — Gaia Lang 的心智模型、Action 层、helper claim 和 legacy 边界
+- [Formula Logic](gaia-lang/formula-logic.md) — `claim(formula=...)`、FormulaGraph、formula diagnostics 与 BP/probability 的分工
 - [谓词逻辑](gaia-lang/predicate-logic.md) — Variable、Domain、Formula AST、forall/exists 与 grounding/lowering 边界
 - [Bayes 语义](gaia-lang/bayes.md) — 模型、预测分布、似然和 Bayes action 的语义边界
 - [包模型](gaia-lang/package.md) — pyproject.toml、命名规范、目录布局、priors.py

--- a/docs/foundations/bp/diagnostic-probabilities.md
+++ b/docs/foundations/bp/diagnostic-probabilities.md
@@ -1,0 +1,250 @@
+# Diagnostic Probabilities
+
+> **Status:** Current canonical (v0.5 + logic diagnostics probability scoring, 2026-05-17)
+>
+> **定位：** 本页说明如何给 reviewer-facing logic warning 计算概率。它是 BP
+> 层的契约文档，不是完整 API reference；具体 signature 和 Pydantic 字段见
+> [Python API Reference](../../reference/engine/index.md)。
+
+Formula diagnostics answer a structural question:
+
+```text
+Which logic condition would be bad if it were active?
+```
+
+Diagnostic probabilities answer a different probabilistic question:
+
+```text
+Under the current belief graph, how much joint probability mass makes that
+logic warning active?
+```
+
+This separation matters. A cross-claim hard-logic conflict is a review warning,
+not a compile-time contradiction, because each claim can carry its own prior and
+belief. The probability scorer ranks that warning by the joint belief that both
+claims are currently true.
+
+## 1. First-principles contract
+
+Every probability is computed from a joint distribution over the variables in
+the diagnostic condition:
+
+```text
+Pr(E) = sum_x q(x) * 1[E(x)]
+```
+
+where:
+
+- `E` is the JSON Boolean event carried by `DiagnosticCondition.expression`.
+- `q(x)` is a joint table over exactly the variables in the condition.
+- `1[E(x)]` is 1 when the assignment satisfies the event and 0 otherwise.
+
+Gaia deliberately does **not** recover diagnostic probabilities from marginal
+beliefs. In particular, it does not use `P(A) * P(B)`, Frechet bounds, or an
+independence assumption unless a provider explicitly returns a joint table whose
+basis is factorized, such as mean-field's variational distribution.
+
+No joint table means no diagnostic probability. Provider failures are returned
+as explicit unavailable results rather than synthetic estimates.
+
+## 2. Layer boundaries
+
+| Layer | Responsibility |
+|---|---|
+| `inspect_formula_graphs(graph)` | Emits `FormulaDiagnostic` objects from compiled `FormulaGraph` structure. |
+| `DiagnosticCondition` | Carries the Boolean event to score, such as `A and B`. |
+| `lower_local_graph(graph)` | Builds the `FactorGraph` that represents the current belief model. |
+| `joint_over(...)` / `compare_joint_over(...)` | Produces method-specific joint distributions over the condition variables. |
+| `event_probability(...)` | Sums the joint mass satisfying the event. |
+| `score_diagnostic_conditions(...)` | Runs joint providers and returns per-method probabilities for each diagnostic condition. |
+| Reviewer policy | Decides how to rank, display, suppress, or gate scored warnings. |
+
+The diagnostics layer stays independent from BP. Probability scoring is an
+optional downstream pass over diagnostics that already have a machine-readable
+condition.
+
+## 3. Warning vs fatal semantics
+
+The logic diagnostics API distinguishes claim-local defects from cross-claim
+tension:
+
+| Situation | Operational status |
+|---|---|
+| One claim's own formula is internally unsatisfiable | `fatal` for that claim |
+| Two different claims cannot both hold under hard formula logic | `warning` |
+| A soft constraint is crossed | legal `warning` |
+
+The probability scorer does not change severity. A high-probability warning is
+still a warning; it is simply more important for a reviewer to inspect.
+
+## 4. Choosing the belief graph to score
+
+Score the diagnostic under the current belief graph, not under the formula
+operators that generated the diagnostic itself.
+
+For example, suppose two formula-bearing claims are logically incompatible. The
+formula diagnostics layer may discover the warning by comparing their formula
+graphs. If the same hard formula operators are also used as evidence in the
+scoring graph, the bad event will be Cromwell-clamped close to zero because the
+graph already encodes that the claims cannot jointly hold.
+
+For reviewer prioritization, the more useful question is usually:
+
+```text
+How much current belief mass is assigned to the two incompatible claims both
+being true before this warning is enforced as a hard correction?
+```
+
+That graph can still include independent priors, evidence, and probabilistic
+associations between the claim variables. It should not include the warning
+itself as conditioning evidence.
+
+## 5. Python DSL example
+
+The following example is intentionally self-contained: each interpretation claim
+explains the physics jargon it uses.
+
+```python
+from gaia.engine.bp import lower_local_graph
+from gaia.engine.ir.logic import inspect_formula_graphs, score_diagnostic_conditions
+from gaia.engine.lang import ClaimAtom, associate, claim, land, lnot
+from gaia.engine.lang.compiler import compile_package_artifact
+from gaia.engine.lang.runtime.package import CollectedPackage
+
+with CollectedPackage("cmb_bmode_logic_e2e", namespace="physics", version="0.1.0") as pkg:
+    bmode_excess = claim(
+        "BICEP2 reports a degree-scale CMB B-mode excess, meaning an unexpectedly "
+        "strong curl-like polarization pattern in the cosmic microwave background "
+        "on degree angular scales.",
+        prior=0.9,
+    )
+    bmode_excess.label = "bmode_excess"
+
+    primordial_tensor = claim(
+        "The B-mode excess is dominated by primordial tensor modes, meaning "
+        "gravitational-wave fluctuations from early-universe inflation rather than "
+        "later astrophysical foregrounds.",
+        prior=0.4,
+    )
+    primordial_tensor.label = "primordial_tensor"
+
+    tensor_interpretation = claim(
+        "BICEP2 interpretation: BICEP2 reports a degree-scale CMB B-mode excess, "
+        "meaning an unexpectedly strong curl-like polarization pattern in the "
+        "cosmic microwave background; this claim says the excess is mainly a "
+        "primordial tensor signal, meaning gravitational-wave fluctuations from "
+        "early-universe inflation rather than later astrophysical foregrounds.",
+        formula=land(ClaimAtom(bmode_excess), ClaimAtom(primordial_tensor)),
+        prior=0.4,
+    )
+    tensor_interpretation.label = "bicep2_tensor_interpretation"
+
+    dust_interpretation = claim(
+        "Planck foreground interpretation: BICEP2 reports a degree-scale CMB "
+        "B-mode excess, meaning an unexpectedly strong curl-like polarization "
+        "pattern in the cosmic microwave background; this claim says the excess "
+        "is mainly Galactic dust foreground, meaning polarized emission from "
+        "dust in the Milky Way, not primordial tensor modes from inflationary "
+        "gravitational waves.",
+        formula=land(ClaimAtom(bmode_excess), lnot(ClaimAtom(primordial_tensor))),
+        prior=0.6,
+    )
+    dust_interpretation.label = "planck_dust_interpretation"
+
+    tension = associate(
+        tensor_interpretation,
+        dust_interpretation,
+        p_a_given_b=0.5,
+        p_b_given_a=0.75,
+        pattern=None,
+        rationale=(
+            "Corpus/reviewer state still gives nontrivial belief to both historical "
+            "interpretations, so the logic warning should be probability-scored."
+        ),
+        label="bmode_interpretation_tension",
+    )
+    tension.label = "bmode_tension_helper"
+
+artifact = compile_package_artifact(pkg)
+report = inspect_formula_graphs(artifact.graph)
+
+belief_graph_ir = artifact.graph.model_copy(
+    update={
+        "operators": [
+            op
+            for op in artifact.graph.operators
+            if not (op.metadata or {}).get("formula_lowering")
+        ]
+    }
+)
+factor_graph = lower_local_graph(belief_graph_ir)
+
+scored = score_diagnostic_conditions(
+    report.diagnostics,
+    factor_graph,
+    methods=("exact", "junction_tree", "trw_bp", "mean_field"),
+)
+```
+
+Formula diagnostics emit a `cross_claim_incompatibility` warning because:
+
+```text
+tensor interpretation = bmode_excess AND primordial_tensor
+dust interpretation   = bmode_excess AND NOT primordial_tensor
+```
+
+The warning condition is:
+
+```text
+tensor_interpretation AND dust_interpretation
+```
+
+The `associate(...)` call models the current belief relation between the two
+claim variables. With `P(tensor)=0.4`, `P(dust)=0.6`,
+`P(tensor | dust)=0.5`, and `P(dust | tensor)=0.75`, the exact joint warning
+probability is:
+
+```text
+P(tensor AND dust) = 0.5 * 0.6 = 0.75 * 0.4 = 0.3
+```
+
+In the regression test for this contract, exact enumeration and junction tree
+both return `0.3`; TRW-BP and mean-field return approximate joint estimates with
+their method provenance attached.
+
+## 6. Provider semantics
+
+`score_diagnostic_conditions(...)` can compare several joint providers:
+
+| Method | Basis | Exact? | Notes |
+|---|---|---:|---|
+| `exact` | `exact_joint_distribution` | yes | Brute-force enumeration; suitable for small condition scopes and tests. |
+| `junction_tree` | `calibrated_clique_marginal` | yes | Uses a calibrated clique containing the requested variables; independent singleton graphs are handled as products of calibrated singleton priors. |
+| `trw_bp` | `approximate_joint_distribution` | no | Uses an available factor-scope joint approximation when the requested variables sit inside a TRW factor belief. |
+| `mean_field` | `variational_joint_distribution` | no | Uses the factorized variational joint defined by mean-field VI. |
+
+Unavailable providers are not errors in comparison mode. They appear in the
+`unavailable` list with a reason and diagnostics payload.
+
+## 7. Interpretation guidelines
+
+- Use `exact_spread` to catch disagreements among exact providers. It should be
+  zero or near numerical tolerance when both exact and junction tree are
+  available.
+- Use `spread` to see how far approximate providers are from each other and from
+  exact providers.
+- Treat a high diagnostic probability as a reviewer-priority signal, not as an
+  automatic rejection.
+- Keep claim text self-contained. If a warning involves scientific jargon, each
+  participating claim should explain enough context for the reviewer to
+  understand the conflict without chasing earlier package declarations.
+
+## 8. Related docs and code
+
+- [`../gaia-lang/predicate-logic.md`](../gaia-lang/predicate-logic.md) — authoring formulas that compile to `FormulaGraph`.
+- [`inference.md`](inference.md) — FactorGraph construction, priors, Cromwell clamp, and inference algorithms.
+- [`potentials.md`](potentials.md) — FactorType potential definitions, including pairwise potentials.
+- [`../gaia-ir/07-lowering.md`](../gaia-ir/07-lowering.md) — backend-facing lowering boundary.
+- `gaia.engine.ir.logic.diagnostics` — formula diagnostics and `DiagnosticCondition`.
+- `gaia.engine.ir.logic.probability` — event scoring and diagnostic probability results.
+- `gaia.engine.bp.joint_query` — method-specific joint query providers.

--- a/docs/foundations/bp/diagnostic-probabilities.md
+++ b/docs/foundations/bp/diagnostic-probabilities.md
@@ -56,6 +56,7 @@ as explicit unavailable results rather than synthetic estimates.
 | `inspect_formula_graphs(graph)` | Emits `FormulaDiagnostic` objects from compiled `FormulaGraph` structure. |
 | `DiagnosticCondition` | Carries the Boolean event to score, such as `A and B`. |
 | `lower_local_graph(graph)` | Builds the `FactorGraph` that represents the current belief model. |
+| `belief_graph_for_formula_scoring(graph)` | Filters compiler-generated formula operators and lowers a reviewer-safe scoring graph. |
 | `joint_over(...)` / `compare_joint_over(...)` | Produces method-specific joint distributions over the condition variables. |
 | `event_probability(...)` | Sums the joint mass satisfying the event. |
 | `score_diagnostic_conditions(...)` | Runs joint providers and returns per-method probabilities for each diagnostic condition. |
@@ -99,7 +100,8 @@ being true before this warning is enforced as a hard correction?
 
 That graph can still include independent priors, evidence, and probabilistic
 associations between the claim variables. It should not include the warning
-itself as conditioning evidence.
+itself as conditioning evidence. Use `belief_graph_for_formula_scoring(...)`
+for this common reviewer path.
 
 ## 5. Python DSL example
 
@@ -107,8 +109,11 @@ The following example is intentionally self-contained: each interpretation claim
 explains the physics jargon it uses.
 
 ```python
-from gaia.engine.bp import lower_local_graph
-from gaia.engine.ir.logic import inspect_formula_graphs, score_diagnostic_conditions
+from gaia.engine.ir.logic import (
+    belief_graph_for_formula_scoring,
+    inspect_formula_graphs,
+    score_diagnostic_conditions,
+)
 from gaia.engine.lang import ClaimAtom, associate, claim, land, lnot
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
@@ -169,17 +174,7 @@ with CollectedPackage("cmb_bmode_logic_e2e", namespace="physics", version="0.1.0
 
 artifact = compile_package_artifact(pkg)
 report = inspect_formula_graphs(artifact.graph)
-
-belief_graph_ir = artifact.graph.model_copy(
-    update={
-        "operators": [
-            op
-            for op in artifact.graph.operators
-            if not (op.metadata or {}).get("formula_lowering")
-        ]
-    }
-)
-factor_graph = lower_local_graph(belief_graph_ir)
+factor_graph = belief_graph_for_formula_scoring(artifact.graph)
 
 scored = score_diagnostic_conditions(
     report.diagnostics,
@@ -207,7 +202,8 @@ claim variables. With `P(tensor)=0.4`, `P(dust)=0.6`,
 probability is:
 
 ```text
-P(tensor AND dust) = 0.5 * 0.6 = 0.75 * 0.4 = 0.3
+P(tensor AND dust) = P(tensor | dust) * P(dust) = 0.5 * 0.6 = 0.3
+P(tensor AND dust) = P(dust | tensor) * P(tensor) = 0.75 * 0.4 = 0.3
 ```
 
 In the regression test for this contract, exact enumeration and junction tree
@@ -227,6 +223,13 @@ their method provenance attached.
 
 Unavailable providers are not errors in comparison mode. They appear in the
 `unavailable` list with a reason and diagnostics payload.
+
+The current `score_diagnostic_conditions(...)` helper is intentionally simple:
+it runs the requested providers once per scored diagnostic. Its cost model is
+`O(number_of_scored_diagnostics * inference_cost(methods))`. Bulk reviewer
+tools should either score a small candidate set or cache provider state in a
+higher-level orchestration layer until Gaia grows a dedicated cached query
+context.
 
 ## 7. Interpretation guidelines
 

--- a/docs/foundations/bp/diagnostic-probabilities.md
+++ b/docs/foundations/bp/diagnostic-probabilities.md
@@ -2,8 +2,10 @@
 
 > **Status:** Current canonical (v0.5 + logic diagnostics probability scoring, 2026-05-17)
 >
-> **定位：** 本页说明如何给 reviewer-facing logic warning 计算概率。它是 BP
-> 层的契约文档，不是完整 API reference；具体 signature 和 Pydantic 字段见
+> **定位：** 本页说明如何给 reviewer-facing logic warning 计算概率。上游
+> formula logic 的作者/编译/诊断语义见
+> [Formula Logic In Gaia Lang](../gaia-lang/formula-logic.md)。本页是 BP 层的
+> 契约文档，不是完整 API reference；具体 signature 和 Pydantic 字段见
 > [Python API Reference](../../reference/engine/index.md)。
 
 Formula diagnostics answer a structural question:
@@ -241,7 +243,8 @@ Unavailable providers are not errors in comparison mode. They appear in the
 
 ## 8. Related docs and code
 
-- [`../gaia-lang/predicate-logic.md`](../gaia-lang/predicate-logic.md) — authoring formulas that compile to `FormulaGraph`.
+- [`../gaia-lang/formula-logic.md`](../gaia-lang/formula-logic.md) — formula-bearing claims, `FormulaGraph`, and logic diagnostics.
+- [`../gaia-lang/predicate-logic.md`](../gaia-lang/predicate-logic.md) — variables, domains, predicates, and quantifiers used inside formulas.
 - [`inference.md`](inference.md) — FactorGraph construction, priors, Cromwell clamp, and inference algorithms.
 - [`potentials.md`](potentials.md) — FactorType potential definitions, including pairwise potentials.
 - [`../gaia-ir/07-lowering.md`](../gaia-ir/07-lowering.md) — backend-facing lowering boundary.

--- a/docs/foundations/gaia-lang/formula-logic.md
+++ b/docs/foundations/gaia-lang/formula-logic.md
@@ -279,7 +279,9 @@ Formula diagnostics therefore emit a `cross_claim_incompatibility` warning. The
 warning is not fatal because the incompatible statements are separate claims.
 The optional `associate(...)` relation belongs to the belief graph; it lets a
 reviewer-facing layer score how likely the active warning is under current
-beliefs.
+beliefs. When scoring formula diagnostics, use
+`belief_graph_for_formula_scoring(artifact.graph)` so compiler-generated formula
+operators do not condition on the warning being scored.
 
 ---
 

--- a/docs/foundations/gaia-lang/formula-logic.md
+++ b/docs/foundations/gaia-lang/formula-logic.md
@@ -1,0 +1,313 @@
+---
+status: current-canonical
+layer: gaia-lang
+since: v0.5
+---
+
+# Formula Logic In Gaia Lang
+
+Formula logic is Gaia's bridge between human-readable scientific claims and
+machine-readable logical structure. It lets an author attach a `Formula` AST to
+a `Claim`:
+
+```python
+claim("A and B are both true.", formula=land(ClaimAtom(a), ClaimAtom(b)))
+```
+
+The prose remains the reviewer-facing scientific statement. The formula is the
+structured contract that Gaia can compile, validate, lower, and inspect.
+
+This page explains where formula logic sits in the Gaia stack. The detailed
+syntax for variables, domains, predicates, and quantifiers is in
+[Predicate Logic In Gaia Lang](predicate-logic.md). BP-side probability scoring
+for logic warnings is in [Diagnostic Probabilities](../bp/diagnostic-probabilities.md).
+
+Source references:
+
+- `gaia/engine/lang/runtime/knowledge.py`
+- `gaia/engine/lang/formula/`
+- `gaia/engine/lang/dsl/formula.py`
+- `gaia/engine/lang/compiler/lower_formula.py`
+- `gaia/engine/lang/compiler/compile.py`
+- `gaia/engine/ir/formula.py`
+- `gaia/engine/ir/logic/diagnostics.py`
+- `tests/gaia/lang/test_formula_lowering.py`
+- `tests/gaia/logic/test_formula_diagnostics.py`
+
+---
+
+## 1. What Formula Logic Defines
+
+Formula logic defines the internal shape of a claim. It answers questions like:
+
+- Which existing claims are being combined?
+- Is the claim an alias of another claim?
+- Is it a conjunction, disjunction, negation, implication, or equivalence?
+- Does a finite quantifier expand into grounded instances?
+- Is one claim's formula internally inconsistent?
+- Do two different claims make formula-level commitments that cannot both hold?
+
+Formula logic does **not** decide whether the claim is scientifically true. That
+belongs to priors, evidence, reasoning actions, BP, and reviewer judgment.
+
+| Layer | Owns |
+|---|---|
+| Claim prose | The self-contained scientific statement a reviewer reads. |
+| `formula=` AST | The machine-readable logical shape of that statement. |
+| `FormulaGraph` | The compiled, persistent formula structure in Gaia IR. |
+| Formula lowering | Generated operators, helper claims, and metadata for the supported subset. |
+| Formula diagnostics | Fatal local defects and non-fatal cross-claim warnings. |
+| BP probability scoring | Optional ranking of diagnostic warnings under a belief graph. |
+
+The key authoring rule is: **a formula should make a claim more inspectable, not
+replace the claim text.** Formula-bearing claims should still be self-contained
+prose statements.
+
+---
+
+## 2. Authoring Model
+
+A formula is attached to a claim:
+
+```python
+from gaia.engine.lang import ClaimAtom, claim, land, lnot
+
+a = claim("A is true.")
+a.label = "a"
+b = claim("B is true.")
+b.label = "b"
+
+both = claim(
+    "A is true and B is false.",
+    formula=land(ClaimAtom(a), lnot(ClaimAtom(b))),
+)
+both.label = "a_and_not_b"
+```
+
+`ClaimAtom(x)` is the bridge from ordinary claim truth values into formula land.
+Connectives such as `land`, `lor`, `lnot`, `implies`, and `iff` build a Boolean
+formula over those atoms.
+
+For predicate logic, the formula can instead be built from variables, domains,
+predicates, comparisons, and quantifiers. See
+[Predicate Logic In Gaia Lang](predicate-logic.md) for the term-level details.
+
+Formula logic is different from reasoning actions:
+
+| Use this | When |
+|---|---|
+| `claim(formula=...)` | The formula is part of the claim's internal logical shape. |
+| `derive(...)`, `observe(...)`, `compute(...)` | You are asserting a reviewable support step between claims. |
+| `contradict(...)`, `equal(...)`, `exclusive(...)` | You are asserting a relation between claims as authored reasoning. |
+| `associate(...)` | You are adding a probabilistic relation between claim variables. |
+
+---
+
+## 3. Compilation Contract
+
+During `compile_package_artifact(pkg)`, the compiler processes local claims that
+carry `formula`.
+
+For each formula claim, Gaia currently does two things:
+
+1. It records a `FormulaGraph` in the compiled `LocalCanonicalGraph`.
+2. It lowers the supported subset into ordinary Gaia IR objects:
+   - `ClaimAtom(x)` can become an alias relation to claim `x`.
+   - `land`, `lor`, `lnot`, `implies`, and `iff` lower to deterministic
+     operators.
+   - atomic predicate/comparison formulas record formula metadata and may
+     generate formula-atom helper claims when they appear inside connectives.
+   - finite-domain `forall` and `exists` lower to grounded instance claims plus
+     implication, disjunction, or equivalence operators depending on shape.
+
+The compiled graph remains a Gaia claim graph. There is no separate theorem
+prover hidden inside Gaia Lang. Formula logic gives the compiler and reviewers a
+structured object to inspect.
+
+Generated formula helpers use metadata such as:
+
+- `formula_lowering`
+- `generated_kind`
+- `helper_kind`
+- `source_claim`
+- `formula_atom`
+- `formula_bindings`
+
+These helpers are implementation artifacts. Package authors should not treat
+them as independent scientific claims or assign them manual priors.
+
+---
+
+## 4. FormulaGraph
+
+`FormulaGraph` is the persistent IR representation of a formula. It stores:
+
+- `source_claim` — the claim whose formula produced the graph
+- `root` — the root formula node id
+- `nodes` — atoms, operators, quantifiers, variables, and related descriptors
+- `edges` — roles such as `operand`, `antecedent`, `consequent`,
+  `bound_variable`, and `body`
+
+Why keep a `FormulaGraph` if lowering already emits operators?
+
+- Lowering serves BP and inference.
+- `FormulaGraph` preserves the author's formula shape for validation,
+  diagnostics, review, and future richer logic tools.
+
+This is why diagnostics inspect `LocalCanonicalGraph.formula_graphs` directly
+instead of trying to reconstruct formula intent from BP factors.
+
+---
+
+## 5. Diagnostics Semantics
+
+Formula diagnostics inspect formula structure and return a
+`FormulaDiagnosticReport`:
+
+```python
+from gaia.engine.ir.logic import inspect_formula_graphs
+
+report = inspect_formula_graphs(compiled.graph)
+```
+
+The current diagnostics subset projects propositional formula graphs to SymPy.
+It supports claim atoms and Boolean connectives. Quantifier roots and other
+unsupported shapes are preserved in `FormulaGraph`, but formula diagnostics
+report them as outside the current propositional subset rather than pretending
+to prove first-order statements.
+
+Severity follows a small operational contract:
+
+| Situation | Severity | Why |
+|---|---|---|
+| One claim's own formula is unsatisfiable | `fatal` | The claim is malformed as a logical object. |
+| One claim's own formula is tautological | `warning` | The claim may be uninformative, but it is not invalid. |
+| One formula repeats operands | `info` | Cleanup signal. |
+| Two claims cannot both hold | `warning` | Cross-claim conflict is review evidence, not a compile failure. |
+| One claim entails another | `info` | Useful relation; policy may rank it later. |
+
+The important boundary is same-claim vs cross-claim:
+
+- `claim("A and not A", formula=land(ClaimAtom(a), lnot(ClaimAtom(a))))`
+  is fatal for that claim.
+- A pair of separately authored claims whose formulas are `A` and `not A`
+  produces a warning, because each claim has its own prior and belief.
+
+Cross-claim diagnostics carry a `DiagnosticCondition`, such as `A and B`, that
+downstream BP code can score. The diagnostics layer itself does not run BP.
+
+---
+
+## 6. Worked Physics Example
+
+This example uses two self-contained claims about the BICEP2 CMB B-mode result.
+Each claim explains the jargon it uses, so a reviewer can read either one
+without chasing earlier declarations.
+
+```python
+from gaia.engine.lang import ClaimAtom, associate, claim, land, lnot
+from gaia.engine.lang.compiler import compile_package_artifact
+from gaia.engine.lang.runtime.package import CollectedPackage
+from gaia.engine.ir.logic import inspect_formula_graphs
+
+with CollectedPackage("cmb_bmode_logic_e2e", namespace="physics", version="0.1.0") as pkg:
+    bmode_excess = claim(
+        "BICEP2 reports a degree-scale CMB B-mode excess, meaning an unexpectedly "
+        "strong curl-like polarization pattern in the cosmic microwave background "
+        "on degree angular scales.",
+        prior=0.9,
+    )
+    bmode_excess.label = "bmode_excess"
+
+    primordial_tensor = claim(
+        "The B-mode excess is dominated by primordial tensor modes, meaning "
+        "gravitational-wave fluctuations from early-universe inflation rather than "
+        "later astrophysical foregrounds.",
+        prior=0.4,
+    )
+    primordial_tensor.label = "primordial_tensor"
+
+    tensor_interpretation = claim(
+        "BICEP2 interpretation: BICEP2 reports a degree-scale CMB B-mode excess, "
+        "meaning an unexpectedly strong curl-like polarization pattern in the "
+        "cosmic microwave background; this claim says the excess is mainly a "
+        "primordial tensor signal, meaning gravitational-wave fluctuations from "
+        "early-universe inflation rather than later astrophysical foregrounds.",
+        formula=land(ClaimAtom(bmode_excess), ClaimAtom(primordial_tensor)),
+        prior=0.4,
+    )
+    tensor_interpretation.label = "bicep2_tensor_interpretation"
+
+    dust_interpretation = claim(
+        "Planck foreground interpretation: BICEP2 reports a degree-scale CMB "
+        "B-mode excess, meaning an unexpectedly strong curl-like polarization "
+        "pattern in the cosmic microwave background; this claim says the excess "
+        "is mainly Galactic dust foreground, meaning polarized emission from "
+        "dust in the Milky Way, not primordial tensor modes from inflationary "
+        "gravitational waves.",
+        formula=land(ClaimAtom(bmode_excess), lnot(ClaimAtom(primordial_tensor))),
+        prior=0.6,
+    )
+    dust_interpretation.label = "planck_dust_interpretation"
+
+    tension = associate(
+        tensor_interpretation,
+        dust_interpretation,
+        p_a_given_b=0.5,
+        p_b_given_a=0.75,
+        pattern=None,
+        rationale=(
+            "Corpus/reviewer state still gives nontrivial belief to both historical "
+            "interpretations, so the logic warning should be probability-scored."
+        ),
+        label="bmode_interpretation_tension",
+    )
+    tension.label = "bmode_tension_helper"
+
+artifact = compile_package_artifact(pkg)
+report = inspect_formula_graphs(artifact.graph)
+```
+
+The formulas state:
+
+```text
+tensor interpretation = bmode_excess AND primordial_tensor
+dust interpretation   = bmode_excess AND NOT primordial_tensor
+```
+
+Formula diagnostics therefore emit a `cross_claim_incompatibility` warning. The
+warning is not fatal because the incompatible statements are separate claims.
+The optional `associate(...)` relation belongs to the belief graph; it lets a
+reviewer-facing layer score how likely the active warning is under current
+beliefs.
+
+---
+
+## 7. Design Boundaries
+
+Formula logic defines structure, not truth:
+
+- It does not assign priors. Priors belong on independent claim variables.
+- It does not make generated helpers independent scientific facts.
+- It does not decide whether a physical explanation is correct.
+- It does not turn cross-claim disagreement into a compile error.
+- It does not replace review policy.
+
+Formula logic also does not replace reasoning actions. If an author wants to
+assert that one claim supports another, use a support action. If an author wants
+to assert that two claims cannot both be true, use `contradict(...)`. If the
+author wants a claim's own internal statement to expose a Boolean or predicate
+shape, use `claim(formula=...)`.
+
+## 8. Related Docs
+
+- [Predicate Logic In Gaia Lang](predicate-logic.md) — variables, domains,
+  predicates, comparisons, and quantifiers.
+- [Knowledge Types and Reasoning Semantics](knowledge-and-reasoning.md) —
+  relation between Knowledge, Reasoning, actions, and formula claims.
+- [Gaia IR — FormulaGraph validation](../gaia-ir/08-validation.md) — structural
+  validation for formula graphs.
+- [Gaia IR Lowering](../gaia-ir/07-lowering.md) — backend-facing lowering
+  boundary.
+- [Diagnostic Probabilities](../bp/diagnostic-probabilities.md) — downstream BP
+  scoring of diagnostic conditions.

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -78,7 +78,7 @@ Each `Claim` has a **shape discriminator** `kind: ClaimKind` and an optional str
 | `PARAMETER` | asserts a `Variable` takes a specific value | `parameter(var, value, ...)` sugar |
 | `QUANTIFIED` | top-level `Forall` / `Exists` in `formula` | `claim(formula=Forall(...))` |
 
-`ClaimKind` is **not** a role label (hypothesis / prediction / observation-as-evidence) — those live on action graph nodes (see `roles_for_claim`). It is a structural shape so the compiler can lower the formula payload appropriately. See [§5 Formula Claims](#5-formula-claims) and [Predicate Logic In Gaia Lang](predicate-logic.md).
+`ClaimKind` is **not** a role label (hypothesis / prediction / observation-as-evidence) — those live on action graph nodes (see `roles_for_claim`). It is a structural shape so the compiler can lower the formula payload appropriately. See [§5 Formula Claims](#5-formula-claims), [Formula Logic In Gaia Lang](formula-logic.md), and [Predicate Logic In Gaia Lang](predicate-logic.md).
 
 A `Claim` is **closed** if `parameters=[]` and **universal** if quantified `Variables` appear. Opaque universal prose can record `parameters=[...]`; executable finite-domain quantification should use `claim(formula=Forall(...))` / `claim(formula=Exists(...))`, which the compiler lowers as described in [§5 Formula Claims](#5-formula-claims).
 
@@ -268,7 +268,11 @@ authority for this hook.
 - **Quantifiers.** `Forall(var, body)`, `Exists(var, body)`.
 - **Domains.** `Bool`, `Nat`, `Real`, `Probability` (in `gaia.engine.lang.formula.primitives`).
 
-For a reader-facing explanation of the predicate-logic model, including the difference between opaque `parameters=[...]` and executable `claim(formula=...)`, see [Predicate Logic In Gaia Lang](predicate-logic.md).
+For a reader-facing explanation of where formula-bearing claims sit in the
+authoring/compile/review stack, see [Formula Logic In Gaia Lang](formula-logic.md).
+For the term-level predicate model, including the difference between opaque
+`parameters=[...]` and executable `claim(formula=...)`, see
+[Predicate Logic In Gaia Lang](predicate-logic.md).
 
 The compiler handles formula claims via `gaia/engine/lang/compiler/lower_formula.py` after the action pass. It (a) emits IR operators for each connective node (`conjunction / disjunction / negation / implication / equivalence`), (b) records variable bindings on the source Claim's `metadata.formula_bindings`, (c) generates intermediate helper Claims for sub-expressions.
 

--- a/docs/superpowers/plans/2026-05-17-joint-query-diagnostic-probability.md
+++ b/docs/superpowers/plans/2026-05-17-joint-query-diagnostic-probability.md
@@ -1,0 +1,1453 @@
+# Joint Query Diagnostic Probability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a joint-distribution query layer and use it to score formula logic diagnostic conditions from PR #648.
+
+**Architecture:** Add `gaia.engine.bp.joint_query` as the BP-facing joint distribution provider, then add `gaia.engine.ir.logic.probability` as the BP-independent event scorer for `DiagnosticCondition`. Exact enumeration, junction tree, mean field, and TRW-BP all expose the same `JointDistribution` contract; unavailable method results are explicit and never replaced by marginal-only estimates.
+
+**Tech Stack:** Python 3.12, Pydantic v2, NumPy, Gaia `FactorGraph`, exact enumeration, Junction Tree, TRW-BP, Mean Field VI, pytest, ruff, mypy.
+
+---
+
+## File Structure
+
+- Create `gaia/engine/bp/joint_query.py`
+  - Owns `JointDistribution`, `JointQueryUnavailable`, `joint_over`, and `compare_joint_over`.
+  - Wraps exact enumeration, junction-tree calibrated clique marginals, TRW-BP factor pseudo-joints, and mean-field variational joints.
+- Modify `gaia/engine/bp/junction_tree.py`
+  - Exposes a reusable `calibrate_junction_tree(graph)` helper so joint queries can reuse calibrated cliques without duplicating inference code.
+- Modify `gaia/engine/bp/trw_bp.py`
+  - Records normalized factor-scope pseudo-joints in diagnostics after convergence.
+- Modify `gaia/engine/bp/__init__.py`
+  - Exports the stable joint-query API.
+- Create `gaia/engine/ir/logic/probability.py`
+  - Owns Boolean AST event evaluation and diagnostic condition scoring over supplied joint tables.
+- Modify `gaia/engine/ir/logic/__init__.py`
+  - Exports stable diagnostic-probability models and scoring helpers.
+- Create `tests/gaia/bp/test_joint_query.py`
+  - Tests joint provider behavior and method provenance.
+- Create `tests/gaia/logic/test_diagnostic_probability.py`
+  - Tests event probability, diagnostic scoring, missing-variable handling, and #648-style diagnostics.
+
+All new test files should include:
+
+```python
+pytestmark = pytest.mark.pr_gate
+```
+
+This keeps the new coverage active under PR CI slicing.
+
+## Task 1: Joint Query Models, Exact Provider, Mean-Field Provider
+
+**Files:**
+- Create: `gaia/engine/bp/joint_query.py`
+- Create: `tests/gaia/bp/test_joint_query.py`
+
+- [ ] **Step 1: Add failing joint-query tests**
+
+Create `tests/gaia/bp/test_joint_query.py`:
+
+```python
+import pytest
+
+from gaia.engine.bp.factor_graph import FactorGraph, FactorType
+from gaia.engine.bp.joint_query import (
+    JointDistribution,
+    JointQueryUnavailable,
+    compare_joint_over,
+    joint_over,
+)
+
+pytestmark = pytest.mark.pr_gate
+
+
+def _two_variable_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.7)
+    graph.add_variable("B", 0.2)
+    return graph
+
+
+def _entailment_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.8)
+    graph.add_variable("B", 0.5)
+    graph.add_factor("f:a_to_b", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=0.9, p2=0.9)
+    return graph
+
+
+def test_joint_distribution_validates_bit_order_and_normalization():
+    joint = JointDistribution(
+        variables=["A", "B"],
+        probabilities=[0.24, 0.56, 0.06, 0.14],
+        method="exact",
+        is_exact=True,
+        basis="exact_joint_distribution",
+    )
+
+    assert joint.variables == ["A", "B"]
+    assert joint.probabilities[3] == pytest.approx(0.14)
+
+
+def test_exact_joint_over_preserves_existing_bit_order():
+    joint = joint_over(_two_variable_graph(), ["A", "B"], method="exact")
+
+    assert joint.method == "exact"
+    assert joint.is_exact is True
+    assert joint.basis == "exact_joint_distribution"
+    assert joint.variables == ["A", "B"]
+    assert joint.probabilities == pytest.approx([0.24, 0.56, 0.06, 0.14])
+
+
+def test_mean_field_joint_is_variational_product_distribution():
+    joint = joint_over(_two_variable_graph(), ["A", "B"], method="mean_field")
+
+    assert joint.method == "mean_field"
+    assert joint.is_exact is False
+    assert joint.basis == "variational_joint_distribution"
+    assert joint.probabilities == pytest.approx([0.24, 0.56, 0.06, 0.14])
+    assert joint.diagnostics["converged"] is True
+
+
+def test_compare_joint_over_collects_unavailable_methods():
+    results = compare_joint_over(
+        _two_variable_graph(),
+        ["A", "B"],
+        methods=("exact", "trw_bp", "mean_field"),
+    )
+
+    estimates = [result for result in results if isinstance(result, JointDistribution)]
+    unavailable = [result for result in results if isinstance(result, JointQueryUnavailable)]
+
+    assert {estimate.method for estimate in estimates} == {"exact", "mean_field"}
+    assert {item.method for item in unavailable} == {"trw_bp"}
+    assert all(item.variables == ["A", "B"] for item in unavailable)
+
+
+def test_unknown_variable_is_collected_as_unavailable():
+    results = compare_joint_over(_two_variable_graph(), ["A", "missing"], methods=("exact",))
+
+    assert len(results) == 1
+    unavailable = results[0]
+    assert isinstance(unavailable, JointQueryUnavailable)
+    assert unavailable.method == "exact"
+    assert "unknown variables" in unavailable.reason
+
+
+def test_mean_field_on_entailment_graph_returns_normalized_joint():
+    joint = joint_over(_entailment_graph(), ["A", "B"], method="mean_field")
+
+    assert sum(joint.probabilities) == pytest.approx(1.0)
+    assert all(0.0 <= value <= 1.0 for value in joint.probabilities)
+    assert joint.diagnostics["iterations_run"] >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py -q --no-cov
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'gaia.engine.bp.joint_query'`.
+
+- [ ] **Step 3: Add joint-query models and exact/mean-field providers**
+
+Create `gaia/engine/bp/joint_query.py`:
+
+```python
+"""Joint distribution queries for Gaia factor-graph inference."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import product as cartesian_product
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from gaia.engine.bp.exact import exact_joint_over
+from gaia.engine.bp.factor_graph import CROMWELL_EPS, FactorGraph
+from gaia.engine.bp.mean_field import MeanFieldVI
+
+JointQueryMethod = Literal["exact", "junction_tree", "trw_bp", "mean_field"]
+JointDistributionBasis = Literal[
+    "exact_joint_distribution",
+    "calibrated_clique_marginal",
+    "approximate_joint_distribution",
+    "variational_joint_distribution",
+]
+
+_NORMALIZATION_TOLERANCE = 1e-9
+
+
+class JointQueryUnavailableError(RuntimeError):
+    """Raised when a method cannot provide a requested joint distribution."""
+
+    def __init__(
+        self,
+        method: JointQueryMethod,
+        variables: Sequence[str],
+        reason: str,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(reason)
+        self.method = method
+        self.variables = list(variables)
+        self.reason = reason
+        self.diagnostics = diagnostics or {}
+
+
+class JointDistribution(BaseModel):
+    """A normalized joint table over a binary variable set."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    variables: list[str]
+    probabilities: list[float]
+    method: JointQueryMethod
+    is_exact: bool
+    basis: JointDistributionBasis
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_distribution(self) -> "JointDistribution":
+        expected = 1 << len(self.variables)
+        if len(self.probabilities) != expected:
+            raise ValueError(
+                f"JointDistribution over {len(self.variables)} variables requires "
+                f"{expected} probabilities, got {len(self.probabilities)}."
+            )
+        if len(set(self.variables)) != len(self.variables):
+            raise ValueError("JointDistribution variables must be unique.")
+        if any(value < -_NORMALIZATION_TOLERANCE for value in self.probabilities):
+            raise ValueError("JointDistribution probabilities must be non-negative.")
+        total = sum(self.probabilities)
+        if abs(total - 1.0) > _NORMALIZATION_TOLERANCE:
+            raise ValueError(f"JointDistribution probabilities must sum to 1, got {total}.")
+        self.probabilities = [
+            0.0 if abs(value) < _NORMALIZATION_TOLERANCE else value
+            for value in self.probabilities
+        ]
+        return self
+
+
+class JointQueryUnavailable(BaseModel):
+    """A method-specific joint query miss."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    variables: list[str]
+    method: JointQueryMethod
+    reason: str
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+
+def joint_over(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    *,
+    method: JointQueryMethod,
+) -> JointDistribution:
+    """Return a joint table over ``variables`` using one inference method."""
+    requested = _normalized_variables(variables)
+    _require_known_variables(graph, requested, method)
+
+    if method == "exact":
+        return _exact_joint_over(graph, requested)
+    if method == "mean_field":
+        return _mean_field_joint_over(graph, requested)
+    if method == "junction_tree":
+        raise JointQueryUnavailableError(
+            method,
+            requested,
+            "junction_tree joint queries are added in Task 2",
+        )
+    if method == "trw_bp":
+        raise JointQueryUnavailableError(
+            method,
+            requested,
+            "trw_bp factor-scope joint queries are added in Task 3",
+        )
+
+    raise ValueError(f"Unknown joint query method: {method!r}")
+
+
+def compare_joint_over(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    *,
+    methods: Sequence[JointQueryMethod] = ("exact", "junction_tree", "trw_bp", "mean_field"),
+) -> list[JointDistribution | JointQueryUnavailable]:
+    """Run several joint providers and collect unavailable methods explicitly."""
+    requested = _normalized_variables(variables)
+    results: list[JointDistribution | JointQueryUnavailable] = []
+    for method in methods:
+        try:
+            results.append(joint_over(graph, requested, method=method))
+        except JointQueryUnavailableError as error:
+            results.append(
+                JointQueryUnavailable(
+                    variables=error.variables,
+                    method=error.method,
+                    reason=error.reason,
+                    diagnostics=error.diagnostics,
+                )
+            )
+    return results
+
+
+def _normalized_variables(variables: Sequence[str]) -> list[str]:
+    requested = list(variables)
+    if not requested:
+        raise ValueError("joint_over requires at least one variable.")
+    if not all(isinstance(variable, str) and variable for variable in requested):
+        raise ValueError("joint_over variables must be non-empty strings.")
+    if len(set(requested)) != len(requested):
+        raise ValueError("joint_over variables must be unique.")
+    return requested
+
+
+def _require_known_variables(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    method: JointQueryMethod,
+) -> None:
+    missing = [variable for variable in variables if variable not in graph.variables]
+    if missing:
+        raise JointQueryUnavailableError(
+            method,
+            variables,
+            f"unknown variables in factor graph: {missing!r}",
+            diagnostics={"missing": missing},
+        )
+
+
+def _exact_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    try:
+        probs = exact_joint_over(graph, variables)
+    except (KeyError, ValueError, RuntimeError) as error:
+        raise JointQueryUnavailableError(
+            "exact",
+            variables,
+            str(error),
+            diagnostics={"exception": type(error).__name__},
+        ) from error
+    return JointDistribution(
+        variables=variables,
+        probabilities=[float(value) for value in probs.tolist()],
+        method="exact",
+        is_exact=True,
+        basis="exact_joint_distribution",
+    )
+
+
+def _mean_field_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    result = MeanFieldVI().run(graph)
+    missing = [variable for variable in variables if variable not in result.beliefs]
+    if missing:
+        raise JointQueryUnavailableError(
+            "mean_field",
+            variables,
+            f"mean_field result missing variables: {missing!r}",
+            diagnostics={"missing": missing},
+        )
+
+    probabilities: list[float] = []
+    for values in cartesian_product((0, 1), repeat=len(variables)):
+        probability = 1.0
+        for variable, value in zip(variables, values, strict=True):
+            belief = result.beliefs[variable]
+            probability *= belief if value == 1 else (1.0 - belief)
+        probabilities.append(float(probability))
+
+    return JointDistribution(
+        variables=variables,
+        probabilities=probabilities,
+        method="mean_field",
+        is_exact=False,
+        basis="variational_joint_distribution",
+        diagnostics={
+            "converged": result.diagnostics.converged,
+            "iterations_run": result.diagnostics.iterations_run,
+            "max_change_at_stop": result.diagnostics.max_change_at_stop,
+            "cromwell_eps": CROMWELL_EPS,
+        },
+    )
+```
+
+- [ ] **Step 4: Run joint-query tests**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py -q --no-cov
+```
+
+Expected: PASS for Task 1 tests.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add gaia/engine/bp/joint_query.py tests/gaia/bp/test_joint_query.py
+git commit -m "feat: add joint query exact and mean-field providers"
+```
+
+## Task 2: Junction-Tree Joint Provider
+
+**Files:**
+- Modify: `gaia/engine/bp/junction_tree.py`
+- Modify: `gaia/engine/bp/joint_query.py`
+- Modify: `tests/gaia/bp/test_joint_query.py`
+
+- [ ] **Step 1: Add failing junction-tree tests**
+
+Append to `tests/gaia/bp/test_joint_query.py`:
+
+```python
+def _chain_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.8)
+    graph.add_variable("B", 0.5)
+    graph.add_variable("C", 0.5)
+    graph.add_factor("f:a_to_b", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=0.9, p2=0.9)
+    graph.add_factor("f:b_to_c", FactorType.SOFT_ENTAILMENT, ["B"], "C", p1=0.85, p2=0.9)
+    return graph
+
+
+def test_junction_tree_joint_matches_exact_when_clique_contains_query():
+    graph = _chain_graph()
+
+    exact = joint_over(graph, ["A", "B"], method="exact")
+    jt = joint_over(graph, ["A", "B"], method="junction_tree")
+
+    assert jt.method == "junction_tree"
+    assert jt.is_exact is True
+    assert jt.basis == "calibrated_clique_marginal"
+    assert jt.variables == ["A", "B"]
+    assert jt.probabilities == pytest.approx(exact.probabilities, abs=1e-9)
+    assert jt.diagnostics["treewidth"] >= 1
+
+
+def test_junction_tree_returns_unavailable_without_covering_clique():
+    results = compare_joint_over(_chain_graph(), ["A", "C"], methods=("junction_tree",))
+
+    assert len(results) == 1
+    unavailable = results[0]
+    assert isinstance(unavailable, JointQueryUnavailable)
+    assert unavailable.method == "junction_tree"
+    assert "single calibrated clique" in unavailable.reason
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py::test_junction_tree_joint_matches_exact_when_clique_contains_query tests/gaia/bp/test_joint_query.py::test_junction_tree_returns_unavailable_without_covering_clique -q --no-cov
+```
+
+Expected: FAIL because `junction_tree` still reports Task 2 unavailable.
+
+- [ ] **Step 3: Expose junction-tree calibration helper**
+
+Modify `gaia/engine/bp/junction_tree.py`.
+
+Add `dataclass` import:
+
+```python
+from dataclasses import dataclass
+```
+
+Update `__all__`:
+
+```python
+__all__ = [
+    "JunctionTreeCalibration",
+    "JunctionTreeInference",
+    "calibrate_junction_tree",
+    "jt_treewidth",
+]
+```
+
+Add below the type aliases:
+
+```python
+@dataclass(frozen=True)
+class JunctionTreeCalibration:
+    """Calibrated clique tables from a junction-tree run."""
+
+    cliques: list[frozenset[str]]
+    clique_var_lists: list[list[str]]
+    calibrated: list[PotentialTable]
+    treewidth: int
+```
+
+Add before `class JunctionTreeInference`:
+
+```python
+def calibrate_junction_tree(graph: FactorGraph) -> JunctionTreeCalibration:
+    """Return calibrated junction-tree clique tables for a factor graph."""
+    if not graph.variables:
+        return JunctionTreeCalibration(
+            cliques=[],
+            clique_var_lists=[],
+            calibrated=[],
+            treewidth=0,
+        )
+    if not graph.factors:
+        clique = frozenset(graph.variables.keys())
+        variables = sorted(clique)
+        table: PotentialTable = {}
+        for vals in cartesian_product((0, 1), repeat=len(variables)):
+            probability = 1.0
+            for variable, value in zip(variables, vals, strict=True):
+                if variable in graph.hard_evidence:
+                    belief = (
+                        (1.0 - CROMWELL_EPS)
+                        if graph.hard_evidence[variable] == 1
+                        else CROMWELL_EPS
+                    )
+                else:
+                    belief = graph.unary_factors.get(variable, 0.5)
+                probability *= belief if value == 1 else (1.0 - belief)
+            table[vals] = probability
+        return JunctionTreeCalibration(
+            cliques=[clique],
+            clique_var_lists=[variables],
+            calibrated=[table],
+            treewidth=max(len(variables) - 1, 0),
+        )
+
+    moral_adj = _build_moral_graph(graph)
+    _, elim_cliques = _triangulate_min_fill(moral_adj)
+    cliques = _maximal_cliques(elim_cliques)
+    n_cliques = len(cliques)
+    clique_var_lists = [sorted(c) for c in cliques]
+    treewidth = max(len(c) for c in cliques) - 1
+
+    tree_edges = _build_junction_tree(cliques)
+    tree_adj = _tree_adjacency(n_cliques, tree_edges)
+    factor_assignment = _assign_factors_to_cliques(cliques, graph)
+
+    unary_assigned: set[str] = set()
+    clique_potentials: list[PotentialTable] = []
+    for i, clique in enumerate(cliques):
+        var_list = clique_var_lists[i]
+        local_priors: dict[str, float] = {}
+        for variable in var_list:
+            if variable in graph.hard_evidence and variable not in unary_assigned:
+                local_priors[variable] = (
+                    (1.0 - CROMWELL_EPS)
+                    if graph.hard_evidence[variable] == 1
+                    else CROMWELL_EPS
+                )
+                unary_assigned.add(variable)
+            elif variable in graph.unary_factors and variable not in unary_assigned:
+                local_priors[variable] = graph.unary_factors[variable]
+                unary_assigned.add(variable)
+
+        clique_potentials.append(
+            _compute_clique_potential(clique, factor_assignment[i], local_priors)
+        )
+
+    calibrated = _collect_distribute(
+        cliques,
+        clique_potentials,
+        clique_var_lists,
+        tree_adj,
+        n_cliques,
+    )
+    return JunctionTreeCalibration(
+        cliques=cliques,
+        clique_var_lists=clique_var_lists,
+        calibrated=calibrated,
+        treewidth=treewidth,
+    )
+```
+
+In `JunctionTreeInference.run`, replace the main graph-with-factors body from
+`# Step 1: Moral graph` through the `_extract_beliefs(...)` call with:
+
+```python
+        calibration = calibrate_junction_tree(graph)
+        diag.treewidth = calibration.treewidth
+        diag.iterations_run = 2
+        logger.debug(
+            "JT: %d variables, %d cliques, treewidth=%d",
+            len(graph.variables),
+            len(calibration.cliques),
+            calibration.treewidth,
+        )
+        beliefs = _extract_beliefs(
+            calibration.cliques,
+            calibration.calibrated,
+            calibration.clique_var_lists,
+            set(graph.variables.keys()),
+        )
+```
+
+Keep the existing empty-graph, no-factor, diagnostic-finalization, and return
+logic unchanged around this replacement.
+
+- [ ] **Step 4: Add junction-tree provider to joint_query**
+
+Modify imports in `gaia/engine/bp/joint_query.py`:
+
+```python
+from gaia.engine.bp.junction_tree import calibrate_junction_tree
+```
+
+In `joint_over`, replace the `junction_tree` branch with:
+
+```python
+    if method == "junction_tree":
+        return _junction_tree_joint_over(graph, requested)
+```
+
+Add helper functions:
+
+```python
+def _junction_tree_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    try:
+        calibration = calibrate_junction_tree(graph)
+    except (ValueError, RuntimeError) as error:
+        raise JointQueryUnavailableError(
+            "junction_tree",
+            variables,
+            str(error),
+            diagnostics={"exception": type(error).__name__},
+        ) from error
+
+    requested = set(variables)
+    for clique, var_list, table in zip(
+        calibration.cliques,
+        calibration.clique_var_lists,
+        calibration.calibrated,
+        strict=True,
+    ):
+        if requested <= clique:
+            probabilities = _marginalize_table_to_variables(table, var_list, variables)
+            return JointDistribution(
+                variables=variables,
+                probabilities=probabilities,
+                method="junction_tree",
+                is_exact=True,
+                basis="calibrated_clique_marginal",
+                diagnostics={
+                    "treewidth": calibration.treewidth,
+                    "clique_size": len(var_list),
+                    "source_clique": var_list,
+                },
+            )
+
+    raise JointQueryUnavailableError(
+        "junction_tree",
+        variables,
+        "requested variables are not contained in a single calibrated clique",
+        diagnostics={
+            "treewidth": calibration.treewidth,
+            "available_cliques": [sorted(clique) for clique in calibration.cliques],
+        },
+    )
+
+
+def _marginalize_table_to_variables(
+    table: dict[tuple[int, ...], float],
+    table_variables: list[str],
+    variables: list[str],
+) -> list[float]:
+    indices = [table_variables.index(variable) for variable in variables]
+    probabilities = [0.0 for _ in range(1 << len(variables))]
+    for assignment, probability in table.items():
+        out_index = 0
+        for bit, table_index in enumerate(indices):
+            out_index |= assignment[table_index] << bit
+        probabilities[out_index] += float(probability)
+    total = sum(probabilities)
+    if total <= 0.0:
+        raise ValueError("marginalized joint table has zero total mass")
+    return [probability / total for probability in probabilities]
+```
+
+- [ ] **Step 5: Run junction-tree tests**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py::test_junction_tree_joint_matches_exact_when_clique_contains_query tests/gaia/bp/test_joint_query.py::test_junction_tree_returns_unavailable_without_covering_clique -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full joint-query tests**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add gaia/engine/bp/junction_tree.py gaia/engine/bp/joint_query.py tests/gaia/bp/test_joint_query.py
+git commit -m "feat: add junction-tree joint queries"
+```
+
+## Task 3: TRW-BP Factor-Scope Pseudo-Joint Provider
+
+**Files:**
+- Modify: `gaia/engine/bp/trw_bp.py`
+- Modify: `gaia/engine/bp/joint_query.py`
+- Modify: `tests/gaia/bp/test_joint_query.py`
+
+- [ ] **Step 1: Add failing TRW joint tests**
+
+Append to `tests/gaia/bp/test_joint_query.py`:
+
+```python
+def _contradiction_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.7)
+    graph.add_variable("B", 0.3)
+    graph.add_variable("H", 0.5)
+    graph.add_factor("f:contradiction", FactorType.CONTRADICTION, ["A", "B"], "H")
+    return graph
+
+
+def test_trw_bp_returns_factor_scope_pseudo_joint():
+    joint = joint_over(_contradiction_graph(), ["A", "B"], method="trw_bp")
+
+    assert joint.method == "trw_bp"
+    assert joint.is_exact is False
+    assert joint.basis == "approximate_joint_distribution"
+    assert joint.variables == ["A", "B"]
+    assert sum(joint.probabilities) == pytest.approx(1.0)
+    assert all(0.0 <= value <= 1.0 for value in joint.probabilities)
+    assert joint.diagnostics["source_factor_id"] == "f:contradiction"
+
+
+def test_trw_bp_returns_unavailable_without_factor_scope_joint():
+    results = compare_joint_over(_chain_graph(), ["A", "C"], methods=("trw_bp",))
+
+    assert len(results) == 1
+    unavailable = results[0]
+    assert isinstance(unavailable, JointQueryUnavailable)
+    assert unavailable.method == "trw_bp"
+    assert "factor-scope pseudo-joint" in unavailable.reason
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py::test_trw_bp_returns_factor_scope_pseudo_joint tests/gaia/bp/test_joint_query.py::test_trw_bp_returns_unavailable_without_factor_scope_joint -q --no-cov
+```
+
+Expected: FAIL because `trw_bp` still reports Task 3 unavailable.
+
+- [ ] **Step 3: Record TRW factor pseudo-joints**
+
+Modify `gaia/engine/bp/trw_bp.py`.
+
+In `TRWDiagnostics`, add:
+
+```python
+    factor_joint_tables: dict[str, dict[str, object]] = field(default_factory=dict)
+```
+
+Add helper below `_compute_beliefs_trw`:
+
+```python
+def _compute_factor_joint_tables_trw(
+    graph: FactorGraph,
+    v2f_msgs: dict[tuple[str, int], Msg],
+    rho: dict[int, float],
+) -> dict[str, dict[str, object]]:
+    """Compute normalized factor-scope pseudo-joints from converged TRW messages."""
+    tables: dict[str, dict[str, object]] = {}
+    for factor_idx, factor in enumerate(graph.factors):
+        variables = factor.all_vars
+        probabilities: list[float] = []
+        rho_f = rho.get(factor_idx, 1.0)
+        for values in cartesian_product((0, 1), repeat=len(variables)):
+            assignment = dict(zip(variables, values, strict=True))
+            potential = evaluate_potential(factor, assignment)
+            weight = potential**rho_f
+            for variable, value in zip(variables, values, strict=True):
+                message = v2f_msgs.get((variable, factor_idx))
+                if message is not None:
+                    weight *= float(message[value])
+            probabilities.append(float(weight))
+        total = sum(probabilities)
+        if total <= 0.0:
+            continue
+        tables[factor.factor_id] = {
+            "factor_index": factor_idx,
+            "factor_type": factor.factor_type.name,
+            "variables": variables,
+            "probabilities": [probability / total for probability in probabilities],
+            "rho": rho_f,
+        }
+    return tables
+```
+
+In `_run_synchronous`, before every `return TRWResult(...)`, populate diagnostics:
+
+```python
+                diag.factor_joint_tables = _compute_factor_joint_tables_trw(
+                    graph,
+                    v2f_msgs,
+                    rho,
+                )
+```
+
+for the converged return, and:
+
+```python
+        diag.factor_joint_tables = _compute_factor_joint_tables_trw(
+            graph,
+            v2f_msgs,
+            rho,
+        )
+```
+
+for the max-iteration return.
+
+If `_run_residual` is still present, add the same assignment before its final
+`return TRWResult(...)`. Keep the public constructor behavior unchanged.
+
+- [ ] **Step 4: Add TRW provider to joint_query**
+
+Modify imports in `gaia/engine/bp/joint_query.py`:
+
+```python
+from gaia.engine.bp.trw_bp import TRWBeliefPropagation
+```
+
+In `joint_over`, replace the `trw_bp` branch with:
+
+```python
+    if method == "trw_bp":
+        return _trw_bp_joint_over(graph, requested)
+```
+
+Add helper:
+
+```python
+def _trw_bp_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    result = TRWBeliefPropagation().run(graph)
+    requested = set(variables)
+    for factor_id, payload in result.diagnostics.factor_joint_tables.items():
+        factor_variables = list(payload["variables"])
+        if requested <= set(factor_variables):
+            probabilities = _marginalize_table_to_variables(
+                _table_from_probability_list(list(payload["probabilities"]), factor_variables),
+                factor_variables,
+                variables,
+            )
+            return JointDistribution(
+                variables=variables,
+                probabilities=probabilities,
+                method="trw_bp",
+                is_exact=False,
+                basis="approximate_joint_distribution",
+                diagnostics={
+                    "converged": result.diagnostics.converged,
+                    "iterations_run": result.diagnostics.iterations_run,
+                    "max_change_at_stop": result.diagnostics.max_change_at_stop,
+                    "source_factor_id": factor_id,
+                    "source_factor_variables": factor_variables,
+                    "rho": payload.get("rho"),
+                },
+            )
+
+    raise JointQueryUnavailableError(
+        "trw_bp",
+        variables,
+        "no factor-scope pseudo-joint contains all query variables",
+        diagnostics={
+            "available_factor_scopes": {
+                factor_id: list(payload["variables"])
+                for factor_id, payload in result.diagnostics.factor_joint_tables.items()
+            }
+        },
+    )
+
+
+def _table_from_probability_list(
+    probabilities: list[float],
+    variables: list[str],
+) -> dict[tuple[int, ...], float]:
+    expected = 1 << len(variables)
+    if len(probabilities) != expected:
+        raise ValueError(
+            f"expected {expected} probabilities for {variables}, got {len(probabilities)}"
+        )
+    return {
+        values: float(probabilities[index])
+        for index, values in enumerate(cartesian_product((0, 1), repeat=len(variables)))
+    }
+```
+
+- [ ] **Step 5: Run TRW tests**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py::test_trw_bp_returns_factor_scope_pseudo_joint tests/gaia/bp/test_joint_query.py::test_trw_bp_returns_unavailable_without_factor_scope_joint -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full joint-query tests**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add gaia/engine/bp/trw_bp.py gaia/engine/bp/joint_query.py tests/gaia/bp/test_joint_query.py
+git commit -m "feat: add trw factor-scope joint queries"
+```
+
+## Task 4: Diagnostic Condition Probability Scoring
+
+**Files:**
+- Create: `gaia/engine/ir/logic/probability.py`
+- Create: `tests/gaia/logic/test_diagnostic_probability.py`
+
+- [ ] **Step 1: Add failing diagnostic probability tests**
+
+Create `tests/gaia/logic/test_diagnostic_probability.py`:
+
+```python
+import pytest
+
+from gaia.engine.bp.factor_graph import FactorGraph
+from gaia.engine.bp.joint_query import JointDistribution, JointQueryUnavailable
+from gaia.engine.ir.logic.diagnostics import DiagnosticCondition, FormulaDiagnostic
+from gaia.engine.ir.logic.probability import (
+    DiagnosticProbability,
+    event_probability,
+    score_condition,
+    score_diagnostic_conditions,
+)
+
+pytestmark = pytest.mark.pr_gate
+
+
+def _explicit_joint() -> JointDistribution:
+    return JointDistribution(
+        variables=["A", "B"],
+        probabilities=[0.3, 0.2, 0.1, 0.4],
+        method="exact",
+        is_exact=True,
+        basis="exact_joint_distribution",
+    )
+
+
+def _and_condition() -> DiagnosticCondition:
+    return DiagnosticCondition(
+        kind="joint_incompatibility",
+        variables=["A", "B"],
+        expression={"op": "and", "args": [{"var": "A"}, {"var": "B"}]},
+        confidence_basis="hard_logic",
+    )
+
+
+def test_event_probability_computes_and_event_from_joint_table():
+    probability = event_probability(
+        {"op": "and", "args": [{"var": "A"}, {"var": "B"}]},
+        _explicit_joint(),
+    )
+
+    assert probability == pytest.approx(0.4)
+
+
+def test_event_probability_computes_entailment_violation_event():
+    probability = event_probability(
+        {"op": "and", "args": [{"var": "A"}, {"op": "not", "arg": {"var": "B"}}]},
+        _explicit_joint(),
+    )
+
+    assert probability == pytest.approx(0.2)
+
+
+def test_event_probability_computes_equivalence_mismatch_event():
+    probability = event_probability(
+        {
+            "op": "or",
+            "args": [
+                {"op": "and", "args": [{"var": "A"}, {"op": "not", "arg": {"var": "B"}}]},
+                {"op": "and", "args": [{"var": "B"}, {"op": "not", "arg": {"var": "A"}}]},
+            ],
+        },
+        _explicit_joint(),
+    )
+
+    assert probability == pytest.approx(0.3)
+
+
+def test_event_probability_rejects_missing_joint_variable():
+    with pytest.raises(ValueError, match="missing from joint distribution"):
+        event_probability({"var": "C"}, _explicit_joint())
+
+
+def test_score_condition_preserves_estimates_unavailable_and_spread():
+    exact = _explicit_joint()
+    mean_field = JointDistribution(
+        variables=["A", "B"],
+        probabilities=[0.2, 0.3, 0.2, 0.3],
+        method="mean_field",
+        is_exact=False,
+        basis="variational_joint_distribution",
+    )
+    unavailable = JointQueryUnavailable(
+        variables=["A", "B"],
+        method="trw_bp",
+        reason="no factor-scope pseudo-joint contains all query variables",
+    )
+
+    scored = score_condition(
+        _and_condition(),
+        [exact, mean_field, unavailable],
+        diagnostic_code="cross_claim_incompatibility",
+    )
+
+    assert isinstance(scored, DiagnosticProbability)
+    assert scored.diagnostic_code == "cross_claim_incompatibility"
+    assert [estimate.method for estimate in scored.estimates] == ["exact", "mean_field"]
+    assert [estimate.probability for estimate in scored.estimates] == pytest.approx([0.4, 0.3])
+    assert scored.spread == pytest.approx(0.1)
+    assert scored.exact_spread == pytest.approx(0.0)
+    assert scored.unavailable == [unavailable]
+
+
+def test_score_diagnostic_conditions_scores_formula_diagnostic_condition():
+    graph = FactorGraph()
+    graph.add_variable("A", 0.7)
+    graph.add_variable("B", 0.2)
+    diagnostic = FormulaDiagnostic(
+        code="cross_claim_incompatibility",
+        severity="warning",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim="A",
+        related_claims=["B"],
+        formula_nodes=["fg:a", "fg:b"],
+        condition=_and_condition(),
+        message="A and B cannot both hold.",
+    )
+
+    scored = score_diagnostic_conditions([diagnostic], graph, methods=("exact",))
+
+    assert len(scored) == 1
+    assert scored[0].diagnostic_code == "cross_claim_incompatibility"
+    assert scored[0].estimates[0].probability == pytest.approx(0.14)
+
+
+def test_score_diagnostic_conditions_skips_diagnostics_without_conditions():
+    graph = FactorGraph()
+    graph.add_variable("A", 0.7)
+    diagnostic = FormulaDiagnostic(
+        code="formula_projection_unsupported",
+        severity="info",
+        scope="claim",
+        logic_strength="unknown",
+        source_claim="A",
+        formula_nodes=["fg:a"],
+        message="Unsupported formula.",
+    )
+
+    assert score_diagnostic_conditions([diagnostic], graph, methods=("exact",)) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/logic/test_diagnostic_probability.py -q --no-cov
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'gaia.engine.ir.logic.probability'`.
+
+- [ ] **Step 3: Implement diagnostic probability scoring**
+
+Create `gaia/engine/ir/logic/probability.py`:
+
+```python
+"""Probability scoring for formula diagnostic conditions."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import product as cartesian_product
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from gaia.engine.bp.factor_graph import FactorGraph
+from gaia.engine.bp.joint_query import (
+    JointDistribution,
+    JointDistributionBasis,
+    JointQueryMethod,
+    JointQueryUnavailable,
+    compare_joint_over,
+)
+from gaia.engine.ir.logic.diagnostics import DiagnosticCondition, FormulaDiagnostic
+
+
+class ConditionProbabilityEstimate(BaseModel):
+    """One method-specific event probability estimate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    method: JointQueryMethod
+    probability: float
+    is_exact: bool
+    basis: JointDistributionBasis
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+
+class DiagnosticProbability(BaseModel):
+    """Probability scoring result for one diagnostic condition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    diagnostic_code: str | None = None
+    condition_kind: str
+    variables: list[str]
+    event_expression: dict[str, Any]
+    estimates: list[ConditionProbabilityEstimate] = Field(default_factory=list)
+    unavailable: list[JointQueryUnavailable] = Field(default_factory=list)
+    spread: float | None = None
+    exact_spread: float | None = None
+
+
+def event_probability(expression: dict[str, Any], joint: JointDistribution) -> float:
+    """Evaluate a Boolean event over a joint distribution table."""
+    total = 0.0
+    for values, probability in zip(
+        cartesian_product((0, 1), repeat=len(joint.variables)),
+        joint.probabilities,
+        strict=True,
+    ):
+        assignment = {
+            variable: bool(value)
+            for variable, value in zip(joint.variables, values, strict=True)
+        }
+        if _eval_event_expression(expression, assignment):
+            total += probability
+    return float(total)
+
+
+def score_condition(
+    condition: DiagnosticCondition,
+    joints: Sequence[JointDistribution | JointQueryUnavailable],
+    *,
+    diagnostic_code: str | None = None,
+) -> DiagnosticProbability:
+    """Score a diagnostic condition against supplied joint query results."""
+    estimates: list[ConditionProbabilityEstimate] = []
+    unavailable: list[JointQueryUnavailable] = []
+
+    for item in joints:
+        if isinstance(item, JointQueryUnavailable):
+            unavailable.append(item)
+            continue
+        probability = event_probability(condition.expression, item)
+        estimates.append(
+            ConditionProbabilityEstimate(
+                method=item.method,
+                probability=probability,
+                is_exact=item.is_exact,
+                basis=item.basis,
+                diagnostics=item.diagnostics,
+            )
+        )
+
+    probabilities = [estimate.probability for estimate in estimates]
+    exact_probabilities = [
+        estimate.probability for estimate in estimates if estimate.is_exact
+    ]
+    spread = _spread(probabilities)
+    exact_spread = _spread(exact_probabilities)
+
+    return DiagnosticProbability(
+        diagnostic_code=diagnostic_code,
+        condition_kind=condition.kind,
+        variables=condition.variables,
+        event_expression=condition.expression,
+        estimates=estimates,
+        unavailable=unavailable,
+        spread=spread,
+        exact_spread=exact_spread,
+    )
+
+
+def score_diagnostic_conditions(
+    diagnostics: Sequence[FormulaDiagnostic],
+    graph: FactorGraph,
+    *,
+    methods: Sequence[JointQueryMethod] = ("exact", "junction_tree", "trw_bp", "mean_field"),
+) -> list[DiagnosticProbability]:
+    """Score all condition-bearing formula diagnostics against a factor graph."""
+    scored: list[DiagnosticProbability] = []
+    for diagnostic in diagnostics:
+        if diagnostic.condition is None:
+            continue
+        joints = compare_joint_over(graph, diagnostic.condition.variables, methods=methods)
+        scored.append(
+            score_condition(
+                diagnostic.condition,
+                joints,
+                diagnostic_code=diagnostic.code,
+            )
+        )
+    return scored
+
+
+def _eval_event_expression(expression: dict[str, Any], assignment: dict[str, bool]) -> bool:
+    if "var" in expression:
+        variable = expression["var"]
+        if not isinstance(variable, str):
+            raise ValueError("event variable must be a string")
+        if variable not in assignment:
+            raise ValueError(f"event variable {variable!r} is missing from joint distribution")
+        return assignment[variable]
+
+    operator = expression.get("op")
+    if operator == "not":
+        arg = expression.get("arg")
+        if not isinstance(arg, dict):
+            raise ValueError("event 'not' expression requires object arg")
+        return not _eval_event_expression(arg, assignment)
+
+    if operator == "and":
+        args = expression.get("args")
+        if not isinstance(args, list) or not args:
+            raise ValueError("event 'and' expression requires non-empty args")
+        if not all(isinstance(arg, dict) for arg in args):
+            raise ValueError("event 'and' args must be objects")
+        return all(_eval_event_expression(arg, assignment) for arg in args)
+
+    if operator == "or":
+        args = expression.get("args")
+        if not isinstance(args, list) or not args:
+            raise ValueError("event 'or' expression requires non-empty args")
+        if not all(isinstance(arg, dict) for arg in args):
+            raise ValueError("event 'or' args must be objects")
+        return any(_eval_event_expression(arg, assignment) for arg in args)
+
+    raise ValueError(f"unsupported event expression operator: {operator!r}")
+
+
+def _spread(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return float(max(values) - min(values))
+```
+
+- [ ] **Step 4: Run diagnostic probability tests**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/logic/test_diagnostic_probability.py -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add gaia/engine/ir/logic/probability.py tests/gaia/logic/test_diagnostic_probability.py
+git commit -m "feat: score diagnostic conditions from joint tables"
+```
+
+## Task 5: Public Exports And End-to-End Verification
+
+**Files:**
+- Modify: `gaia/engine/bp/__init__.py`
+- Modify: `gaia/engine/ir/logic/__init__.py`
+- Modify: `tests/gaia/bp/test_joint_query.py`
+- Modify: `tests/gaia/logic/test_diagnostic_probability.py`
+
+- [ ] **Step 1: Add export tests**
+
+Append to `tests/gaia/bp/test_joint_query.py`:
+
+```python
+def test_bp_package_exports_joint_query_api():
+    from gaia.engine.bp import JointDistribution as ExportedJointDistribution
+    from gaia.engine.bp import compare_joint_over as exported_compare_joint_over
+    from gaia.engine.bp import joint_over as exported_joint_over
+
+    assert ExportedJointDistribution is JointDistribution
+    assert exported_joint_over is joint_over
+    assert exported_compare_joint_over is compare_joint_over
+```
+
+Append to `tests/gaia/logic/test_diagnostic_probability.py`:
+
+```python
+def test_logic_package_exports_diagnostic_probability_api():
+    from gaia.engine.ir.logic import DiagnosticProbability as ExportedDiagnosticProbability
+    from gaia.engine.ir.logic import event_probability as exported_event_probability
+    from gaia.engine.ir.logic import score_condition as exported_score_condition
+
+    assert ExportedDiagnosticProbability is DiagnosticProbability
+    assert exported_event_probability is event_probability
+    assert exported_score_condition is score_condition
+```
+
+- [ ] **Step 2: Run export tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py::test_bp_package_exports_joint_query_api tests/gaia/logic/test_diagnostic_probability.py::test_logic_package_exports_diagnostic_probability_api -q --no-cov
+```
+
+Expected: FAIL because exports have not been added.
+
+- [ ] **Step 3: Export BP joint-query API**
+
+Modify `gaia/engine/bp/__init__.py`.
+
+Add import block:
+
+```python
+from gaia.engine.bp.joint_query import (
+    JointDistribution,
+    JointDistributionBasis,
+    JointQueryMethod,
+    JointQueryUnavailable,
+    JointQueryUnavailableError,
+    compare_joint_over,
+    joint_over,
+)
+```
+
+Add these names to `__all__`:
+
+```python
+    "JointDistribution",
+    "JointDistributionBasis",
+    "JointQueryMethod",
+    "JointQueryUnavailable",
+    "JointQueryUnavailableError",
+    "compare_joint_over",
+    "joint_over",
+```
+
+- [ ] **Step 4: Export logic probability API**
+
+Modify `gaia/engine/ir/logic/__init__.py`.
+
+Add import block:
+
+```python
+from gaia.engine.ir.logic.probability import (
+    ConditionProbabilityEstimate,
+    DiagnosticProbability,
+    event_probability,
+    score_condition,
+    score_diagnostic_conditions,
+)
+```
+
+Add these names to `__all__`:
+
+```python
+    "ConditionProbabilityEstimate",
+    "DiagnosticProbability",
+    "event_probability",
+    "score_condition",
+    "score_diagnostic_conditions",
+```
+
+- [ ] **Step 5: Run export tests**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py::test_bp_package_exports_joint_query_api tests/gaia/logic/test_diagnostic_probability.py::test_logic_package_exports_diagnostic_probability_api -q --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused test suite**
+
+Run:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py tests/gaia/logic/test_diagnostic_probability.py tests/gaia/logic/test_formula_diagnostics.py tests/gaia/bp/test_inference.py -q --no-cov
+```
+
+Expected: PASS. Existing deprecation warnings from old formula sugar are acceptable.
+
+- [ ] **Step 7: Run formatting and linting**
+
+Run:
+
+```bash
+uv run ruff check gaia/engine/bp/joint_query.py gaia/engine/bp/junction_tree.py gaia/engine/bp/trw_bp.py gaia/engine/ir/logic/probability.py gaia/engine/bp/__init__.py gaia/engine/ir/logic/__init__.py tests/gaia/bp/test_joint_query.py tests/gaia/logic/test_diagnostic_probability.py
+uv run ruff format --check gaia/engine/bp/joint_query.py gaia/engine/bp/junction_tree.py gaia/engine/bp/trw_bp.py gaia/engine/ir/logic/probability.py gaia/engine/bp/__init__.py gaia/engine/ir/logic/__init__.py tests/gaia/bp/test_joint_query.py tests/gaia/logic/test_diagnostic_probability.py
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 8: Run focused type checks**
+
+Run:
+
+```bash
+uv run mypy gaia/engine/bp/joint_query.py gaia/engine/ir/logic/probability.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 5**
+
+```bash
+git add gaia/engine/bp/__init__.py gaia/engine/ir/logic/__init__.py tests/gaia/bp/test_joint_query.py tests/gaia/logic/test_diagnostic_probability.py
+git commit -m "feat: export diagnostic probability APIs"
+```
+
+## Completion Criteria
+
+- `joint_over(..., method="exact")` returns the exact joint marginal from the factor graph.
+- `joint_over(..., method="junction_tree")` returns an exact calibrated clique marginal when a clique covers the requested variables.
+- `joint_over(..., method="mean_field")` returns the variational joint defined by Mean Field VI.
+- `joint_over(..., method="trw_bp")` returns a method-consistent factor-scope pseudo-joint when available and explicit unavailable otherwise.
+- No code path computes diagnostic condition probability from marginal-only substitutes.
+- `event_probability` scores Boolean AST events by summing joint-table rows.
+- `score_diagnostic_conditions` scores #648-style `FormulaDiagnostic.condition` objects and preserves per-method provenance.
+- Cross-method output includes exact/approximate method estimates, unavailable provider records, `spread`, and `exact_spread`.
+- New tests are marked `pr_gate`.
+
+## Final Verification Commands
+
+Run these before opening or updating the PR:
+
+```bash
+uv run pytest tests/gaia/bp/test_joint_query.py tests/gaia/logic/test_diagnostic_probability.py tests/gaia/logic/test_formula_diagnostics.py tests/gaia/bp/test_inference.py -q --no-cov
+uv run ruff check gaia/engine/bp/joint_query.py gaia/engine/bp/junction_tree.py gaia/engine/bp/trw_bp.py gaia/engine/ir/logic/probability.py gaia/engine/bp/__init__.py gaia/engine/ir/logic/__init__.py tests/gaia/bp/test_joint_query.py tests/gaia/logic/test_diagnostic_probability.py
+uv run ruff format --check gaia/engine/bp/joint_query.py gaia/engine/bp/junction_tree.py gaia/engine/bp/trw_bp.py gaia/engine/ir/logic/probability.py gaia/engine/bp/__init__.py gaia/engine/ir/logic/__init__.py tests/gaia/bp/test_joint_query.py tests/gaia/logic/test_diagnostic_probability.py
+uv run mypy gaia/engine/bp/joint_query.py gaia/engine/ir/logic/probability.py
+```

--- a/docs/superpowers/specs/2026-05-17-joint-query-diagnostic-probability-design.md
+++ b/docs/superpowers/specs/2026-05-17-joint-query-diagnostic-probability-design.md
@@ -1,0 +1,443 @@
+# Joint Query Diagnostic Probability Design
+
+**Status:** Draft for review
+**Date:** 2026-05-17
+**Branch:** `codex/joint-query-diagnostic-probability-design`
+**Scope:** Gaia v0.5, BP-backed probability scoring for formula logic diagnostics
+**Depends on:** PR #648, `gaia.engine.ir.logic.diagnostics`
+**Non-goals:** No marginal fallback, no ad hoc independence assumption over posterior marginals, no policy that turns cross-claim warnings into fatal errors.
+
+## 1. Goal
+
+PR #648 added reviewer-facing formula logic diagnostics. Those diagnostics emit
+machine-readable `DiagnosticCondition.expression` values such as:
+
+- `A and B` for cross-claim incompatibility.
+- `A and not B` for entailment violation.
+- `(A and not B) or (B and not A)` for equivalence mismatch.
+
+The next step is to compute the probability that each diagnostic condition is
+active. The first-principles definition is:
+
+```text
+Pr(E) = sum_x q(x) * 1[E(x)]
+```
+
+where `q(x)` is a joint distribution over the variables in the condition. The
+probability scorer should evaluate the event over a joint distribution. It
+should not infer a joint distribution from independent marginals.
+
+## 2. First Principles
+
+Logic diagnostics and probabilistic inference must remain separate:
+
+| Layer | Responsibility |
+|---|---|
+| `DiagnosticCondition` | Describes the Boolean bad event. |
+| Joint query provider | Produces a joint distribution over a requested variable set. |
+| Event scorer | Sums joint probability mass for assignments that satisfy the event. |
+| Reviewer policy | Decides how to rank, display, or gate the scored diagnostics. |
+
+The event scorer is exact relative to its input joint table. If the joint table
+comes from an approximate inference method, the scored probability is the event
+probability under that approximate joint distribution. That provenance must be
+visible in the result.
+
+The core invariant is:
+
+```text
+No joint table, no diagnostic probability.
+```
+
+The implementation must not use `P(A) * P(B)`, Frechet bounds, or any other
+marginal-only substitute as a probability for a logic condition. Provider-defined
+approximate joints are allowed only when the provider explicitly defines a joint
+distribution, such as mean field's factorized variational `q`. Marginal-only
+substitutes may be useful in separate exploratory analysis, but not in this
+diagnostic probability contract.
+
+## 3. Proposed Modules
+
+Add two small modules:
+
+```python
+gaia.engine.bp.joint_query
+gaia.engine.ir.logic.probability
+```
+
+`joint_query` owns inference-method-specific joint distribution providers.
+`logic.probability` owns diagnostic-condition event evaluation and cross-method
+comparison.
+
+This keeps `gaia.engine.ir.logic.diagnostics` independent from BP. The formula
+diagnostics API continues to report structure. Probability scoring is an
+optional downstream pass.
+
+## 4. Data Models
+
+### 4.1 Joint Distribution
+
+```python
+JointQueryMethod = Literal[
+    "exact",
+    "junction_tree",
+    "trw_bp",
+    "mean_field",
+]
+
+JointDistributionBasis = Literal[
+    "exact_joint_distribution",
+    "calibrated_clique_marginal",
+    "approximate_joint_distribution",
+    "variational_joint_distribution",
+]
+
+
+class JointDistribution(BaseModel):
+    variables: list[str]
+    probabilities: list[float]
+    method: JointQueryMethod
+    is_exact: bool
+    basis: JointDistributionBasis
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+```
+
+`probabilities` uses the same bit-index convention as
+`exact_joint_over(graph, free_vars)`:
+
+```text
+index = sum(value_i << i for i, value_i in enumerate(variables))
+```
+
+For `variables=["A", "B"]`:
+
+| Index | Assignment |
+|---:|---|
+| 0 | `A=0, B=0` |
+| 1 | `A=1, B=0` |
+| 2 | `A=0, B=1` |
+| 3 | `A=1, B=1` |
+
+### 4.2 Unavailable Results
+
+Cross-method comparison should not fail because one provider cannot produce a
+joint table. Use an explicit unavailable result:
+
+```python
+class JointQueryUnavailable(BaseModel):
+    variables: list[str]
+    method: JointQueryMethod
+    reason: str
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+```
+
+This is distinct from a probability value. A method that cannot provide a joint
+distribution must not emit a synthetic estimate.
+
+### 4.3 Condition Probability
+
+```python
+class ConditionProbabilityEstimate(BaseModel):
+    method: JointQueryMethod
+    probability: float
+    is_exact: bool
+    basis: JointDistributionBasis
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+
+class DiagnosticProbability(BaseModel):
+    diagnostic_code: str | None = None
+    condition_kind: str
+    variables: list[str]
+    event_expression: dict[str, Any]
+    estimates: list[ConditionProbabilityEstimate] = Field(default_factory=list)
+    unavailable: list[JointQueryUnavailable] = Field(default_factory=list)
+    spread: float | None = None
+    exact_spread: float | None = None
+```
+
+`spread` is `max(estimates.probability) - min(estimates.probability)` across
+all available methods. `exact_spread` is the same computation restricted to
+`is_exact=True` estimates, useful for catching implementation disagreement
+between exact enumeration and junction tree.
+
+## 5. Public API
+
+### 5.1 Joint Query
+
+```python
+def joint_over(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    *,
+    method: JointQueryMethod,
+) -> JointDistribution:
+    ...
+```
+
+The function either returns a normalized joint table for exactly the requested
+variables or raises a controlled `JointQueryUnavailableError`.
+
+```python
+def compare_joint_over(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    *,
+    methods: Sequence[JointQueryMethod] = (
+        "exact",
+        "junction_tree",
+        "trw_bp",
+        "mean_field",
+    ),
+) -> list[JointDistribution | JointQueryUnavailable]:
+    ...
+```
+
+This helper collects unavailable providers instead of raising.
+
+### 5.2 Condition Scoring
+
+```python
+def event_probability(
+    expression: dict[str, Any],
+    joint: JointDistribution,
+) -> float:
+    ...
+```
+
+This function evaluates the Boolean AST over every assignment in `joint` and
+sums the probability mass for satisfying assignments.
+
+```python
+def score_condition(
+    condition: DiagnosticCondition,
+    joints: Sequence[JointDistribution | JointQueryUnavailable],
+    *,
+    diagnostic_code: str | None = None,
+) -> DiagnosticProbability:
+    ...
+```
+
+```python
+def score_diagnostic_conditions(
+    diagnostics: Sequence[FormulaDiagnostic],
+    graph: FactorGraph,
+    *,
+    methods: Sequence[JointQueryMethod] = (
+        "exact",
+        "junction_tree",
+        "trw_bp",
+        "mean_field",
+    ),
+) -> list[DiagnosticProbability]:
+    ...
+```
+
+`score_diagnostic_conditions` skips diagnostics without a condition and returns
+one probability report for each condition-bearing diagnostic.
+
+## 6. Joint Provider Semantics
+
+### 6.1 Exact Enumeration
+
+Use the existing `exact_joint_over(graph, variables)`.
+
+- `basis="exact_joint_distribution"`
+- `is_exact=True`
+- Failure mode: too many variables for brute-force enumeration.
+
+This method marginalizes the full factor-graph joint distribution to the
+requested variables. It is the reference implementation for small graphs.
+
+### 6.2 Junction Tree
+
+Use calibrated clique potentials from `JunctionTreeInference`.
+
+The first implementation may expose a lower-level helper that returns the
+calibrated cliques, then `joint_over(..., method="junction_tree")` should:
+
+1. Run junction tree calibration.
+2. Find a calibrated clique whose variable set contains the requested variables.
+3. Marginalize that clique table down to the requested variables.
+4. Normalize the result.
+
+- `basis="calibrated_clique_marginal"`
+- `is_exact=True`
+- Failure mode: requested variables are not contained in a single available
+  calibrated clique.
+
+The single-clique limitation is acceptable for the first pass because many
+diagnostic events involve one or two claims. A later implementation can add
+general clique-tree marginal queries for arbitrary variable subsets.
+
+### 6.3 Mean Field
+
+Run `MeanFieldVI` and use the variational distribution:
+
+```text
+q(x_1, ..., x_k) = product_i q_i(x_i)
+```
+
+This is not a marginal fallback from arbitrary posterior beliefs. It is the
+joint distribution defined by the mean-field approximation itself.
+
+- `basis="variational_joint_distribution"`
+- `is_exact=False`
+- Failure mode: mean-field inference fails to converge or lacks a variable.
+
+The result should include convergence diagnostics and method metadata.
+
+### 6.4 TRW-BP
+
+TRW-BP should only return a joint table when it can construct one from its own
+approximate inference state.
+
+First implementation target:
+
+- If the requested variables are contained in a factor scope, construct a
+  normalized factor-scope pseudo-joint from the converged messages and
+  marginalize to the requested variables.
+- Otherwise return `JointQueryUnavailable`.
+
+- `basis="approximate_joint_distribution"`
+- `is_exact=False`
+
+The implementation must not multiply final single-variable beliefs to create a
+TRW joint table. If TRW cannot expose a method-consistent pseudo-joint for the
+requested scope, it is unavailable for that query.
+
+## 7. Event Expression Evaluation
+
+Supported Boolean AST shapes are the phase-1 diagnostic condition shapes:
+
+```json
+{"var": "A"}
+{"op": "not", "arg": {"var": "A"}}
+{"op": "and", "args": [{"var": "A"}, {"var": "B"}]}
+{"op": "or", "args": [{"var": "A"}, {"var": "B"}]}
+```
+
+Evaluation rules:
+
+- A variable must appear in `joint.variables`.
+- `not` requires exactly one `arg`.
+- `and` and `or` require non-empty `args`.
+- Unknown operators raise a validation error.
+- The event probability is the sum of all assignment probabilities where the
+  expression evaluates true.
+
+This evaluator should live outside `diagnostics.py` so the structural
+diagnostics module remains BP-free.
+
+## 8. Cross-Check Output
+
+For a condition such as `A and B`, the scored output should preserve per-method
+provenance:
+
+```json
+{
+  "diagnostic_code": "cross_claim_incompatibility",
+  "condition_kind": "joint_incompatibility",
+  "variables": ["A", "B"],
+  "event_expression": {
+    "op": "and",
+    "args": [{"var": "A"}, {"var": "B"}]
+  },
+  "estimates": [
+    {
+      "method": "exact",
+      "probability": 0.071,
+      "is_exact": true,
+      "basis": "exact_joint_distribution"
+    },
+    {
+      "method": "junction_tree",
+      "probability": 0.071,
+      "is_exact": true,
+      "basis": "calibrated_clique_marginal"
+    },
+    {
+      "method": "mean_field",
+      "probability": 0.119,
+      "is_exact": false,
+      "basis": "variational_joint_distribution"
+    }
+  ],
+  "unavailable": [
+    {
+      "method": "trw_bp",
+      "variables": ["A", "B"],
+      "reason": "no converged factor-scope joint contains all query variables"
+    }
+  ],
+  "spread": 0.048,
+  "exact_spread": 0.0
+}
+```
+
+High spread is a reviewer signal about inference-method sensitivity. It is not
+itself a logic contradiction.
+
+## 9. Reviewer Semantics
+
+Scored probabilities refine warning priority; they do not change the
+underlying diagnostic severity.
+
+- Claim-local `fatal` diagnostics remain fatal because the formula is
+  structurally malformed.
+- Cross-claim incompatibility remains a warning, even when its bad-event
+  probability is high.
+- Soft-constraint violations remain legal warnings.
+- Reviewer or package policy may rank high-probability warnings first, but that
+  policy lives above the scoring API.
+
+## 10. Error Handling
+
+Use controlled failure modes:
+
+- Missing variable in factor graph: unavailable for that method.
+- Unsupported expression shape: validation error in the event scorer.
+- Provider cannot construct a joint table: `JointQueryUnavailable`.
+- Provider numerical failure: unavailable with diagnostics.
+- Joint table not normalized within tolerance: validation error.
+
+`compare_joint_over` should collect provider-level unavailability so one failed
+method does not hide other useful estimates.
+
+## 11. Testing
+
+Add focused tests in two groups.
+
+### 11.1 Joint Query Tests
+
+- `exact` wraps `exact_joint_over` and preserves bit ordering.
+- `junction_tree` matches `exact` on small graphs where both can answer.
+- `mean_field` returns a normalized variational joint and records
+  `is_exact=False`.
+- `trw_bp` returns unavailable when no factor-scope pseudo-joint is available.
+- Unknown variables produce controlled unavailable results.
+
+### 11.2 Diagnostic Probability Tests
+
+- `event_probability` computes `P(A and B)` from an explicit joint table.
+- `event_probability` computes `P(A and not B)`.
+- `event_probability` computes `(A and not B) or (B and not A)`.
+- `score_condition` refuses missing variables rather than using marginals.
+- `score_diagnostic_conditions` scores #648-style cross-claim diagnostics.
+- Cross-method output includes `spread`, `exact_spread`, and unavailable
+  provider records.
+
+## 12. Rollout Plan
+
+The design should be implemented as one focused PR after this spec is reviewed:
+
+1. Add data models and explicit joint-table event evaluator.
+2. Add `exact` and `mean_field` joint providers.
+3. Add junction-tree calibrated-clique provider.
+4. Add conservative TRW provider or explicit unavailable path.
+5. Add diagnostic-condition scoring and cross-method comparison.
+6. Add tests and export only the stable public API.
+
+The first PR should avoid CLI or review-manifest integration. Once the scoring
+contract is stable, a later B-lite PR can expose these probabilities in
+`gaia check --logic` or reviewer output.

--- a/gaia/engine/bp/__init__.py
+++ b/gaia/engine/bp/__init__.py
@@ -30,6 +30,15 @@ from gaia.engine.bp.exact import (
     exact_joint_over,
 )
 from gaia.engine.bp.factor_graph import CROMWELL_EPS, Factor, FactorGraph, FactorType
+from gaia.engine.bp.joint_query import (
+    JointDistribution,
+    JointDistributionBasis,
+    JointQueryMethod,
+    JointQueryUnavailable,
+    JointQueryUnavailableError,
+    compare_joint_over,
+    joint_over,
+)
 from gaia.engine.bp.junction_tree import JunctionTreeInference, jt_treewidth
 from gaia.engine.bp.lowering import (
     lower_local_graph,
@@ -56,12 +65,19 @@ __all__ = [
     "FactorType",
     "InferenceEngine",
     "InferenceResult",
+    "JointDistribution",
+    "JointDistributionBasis",
+    "JointQueryMethod",
+    "JointQueryUnavailable",
+    "JointQueryUnavailableError",
     "JunctionTreeInference",
     "MeanFieldVI",
     "TRWBeliefPropagation",
+    "compare_joint_over",
     "exact_inference",
     "exact_joint_over",
     "infer",
+    "joint_over",
     "jt_treewidth",
     "lower_local_graph",
     "merge_factor_graphs",

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from math import isfinite
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -63,6 +64,8 @@ class JointDistribution(BaseModel):
             )
         if len(set(self.variables)) != len(self.variables):
             raise ValueError("JointDistribution variables must be unique.")
+        if any(not isfinite(value) for value in self.probabilities):
+            raise ValueError("JointDistribution probabilities must be finite.")
         if any(value < -_NORMALIZATION_TOLERANCE for value in self.probabilities):
             raise ValueError("JointDistribution probabilities must be non-negative.")
         total = sum(self.probabilities)

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from gaia.engine.bp.exact import exact_joint_over
 from gaia.engine.bp.factor_graph import CROMWELL_EPS, FactorGraph
-from gaia.engine.bp.junction_tree import calibrate_junction_tree
+from gaia.engine.bp.junction_tree import JunctionTreeCalibration, calibrate_junction_tree
 from gaia.engine.bp.mean_field import MeanFieldVI
 
 JointQueryMethod = Literal["exact", "junction_tree", "trw_bp", "mean_field"]
@@ -188,15 +188,7 @@ def _exact_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribu
 
 
 def _junction_tree_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
-    try:
-        calibration = calibrate_junction_tree(graph)
-    except (ValueError, RuntimeError) as error:
-        raise JointQueryUnavailableError(
-            "junction_tree",
-            variables,
-            str(error),
-            diagnostics={"exception": type(error).__name__},
-        ) from error
+    calibration = calibrate_junction_tree(graph)
 
     requested = set(variables)
     for clique, var_list, table in zip(
@@ -220,6 +212,9 @@ def _junction_tree_joint_over(graph: FactorGraph, variables: list[str]) -> Joint
                 },
             )
 
+    if not graph.factors:
+        return _independent_junction_tree_joint_over(calibration, variables)
+
     raise JointQueryUnavailableError(
         "junction_tree",
         variables,
@@ -228,6 +223,66 @@ def _junction_tree_joint_over(graph: FactorGraph, variables: list[str]) -> Joint
             "treewidth": calibration.treewidth,
             "available_cliques": [sorted(clique) for clique in calibration.cliques],
         },
+    )
+
+
+def _independent_junction_tree_joint_over(
+    calibration: JunctionTreeCalibration,
+    variables: list[str],
+) -> JointDistribution:
+    singleton_tables = {
+        var_list[0]: table
+        for clique, var_list, table in zip(
+            calibration.cliques,
+            calibration.clique_var_lists,
+            calibration.calibrated,
+            strict=True,
+        )
+        if len(clique) == 1 and len(var_list) == 1
+    }
+    missing = [variable for variable in variables if variable not in singleton_tables]
+    if missing:
+        raise JointQueryUnavailableError(
+            "junction_tree",
+            variables,
+            "requested variables are not contained in calibrated singleton priors",
+            diagnostics={
+                "treewidth": calibration.treewidth,
+                "missing": missing,
+                "available_cliques": [sorted(clique) for clique in calibration.cliques],
+            },
+        )
+
+    probabilities: list[float] = []
+    for assignment_index in range(1 << len(variables)):
+        probability = 1.0
+        for bit, variable in enumerate(variables):
+            table = singleton_tables[variable]
+            value = (assignment_index >> bit) & 1
+            probability *= float(table[(value,)])
+        probabilities.append(probability)
+
+    total = sum(probabilities)
+    if total <= 0.0:
+        raise ValueError("independent joint table has zero total mass")
+    probabilities = [probability / total for probability in probabilities]
+
+    diagnostics: dict[str, Any] = {
+        "treewidth": calibration.treewidth,
+        "clique_size": 1,
+        "source_cliques": [[variable] for variable in variables],
+    }
+    if len(variables) == 1:
+        diagnostics["source_clique"] = [variables[0]]
+        diagnostics.pop("source_cliques")
+
+    return JointDistribution(
+        variables=variables,
+        probabilities=probabilities,
+        method="junction_tree",
+        is_exact=True,
+        basis="calibrated_clique_marginal",
+        diagnostics=diagnostics,
     )
 
 

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -318,37 +318,41 @@ def _trw_bp_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistrib
     factor_joint_tables = result.diagnostics.factor_joint_tables
     available_scopes = [list(table["variables"]) for table in factor_joint_tables]
 
-    for table in factor_joint_tables:
+    covering_tables = [
+        table for table in factor_joint_tables if requested <= set(table["variables"])
+    ]
+    covering_tables.sort(key=lambda table: (len(table["variables"]), table["factor_index"]))
+
+    for table in covering_tables:
         table_variables = list(table["variables"])
-        if requested <= set(table_variables):
-            assignment_table = _probability_list_to_assignment_table(
-                list(table["probabilities"]),
-                table_variables,
-            )
-            probabilities = _marginalize_table_to_variables(
-                assignment_table,
-                table_variables,
-                variables,
-            )
-            return JointDistribution(
-                variables=variables,
-                probabilities=probabilities,
-                method="trw_bp",
-                is_exact=False,
-                basis="approximate_joint_distribution",
-                diagnostics={
-                    "source_factor_index": table["factor_index"],
-                    "source_factor_id": table["factor_id"],
-                    "source_factor_variables": table_variables,
-                    "source_factor_rho": table["rho"],
-                    "converged": result.diagnostics.converged,
-                    "iterations_run": result.diagnostics.iterations_run,
-                    "max_change_at_stop": result.diagnostics.max_change_at_stop,
-                    "available_scopes": available_scopes,
-                    "factor_joint_table_count": len(factor_joint_tables),
-                    "cromwell_eps": CROMWELL_EPS,
-                },
-            )
+        assignment_table = _probability_list_to_assignment_table(
+            list(table["probabilities"]),
+            table_variables,
+        )
+        probabilities = _marginalize_table_to_variables(
+            assignment_table,
+            table_variables,
+            variables,
+        )
+        return JointDistribution(
+            variables=variables,
+            probabilities=probabilities,
+            method="trw_bp",
+            is_exact=False,
+            basis="approximate_joint_distribution",
+            diagnostics={
+                "source_factor_index": table["factor_index"],
+                "source_factor_id": table["factor_id"],
+                "source_factor_variables": table_variables,
+                "source_factor_rho": table["rho"],
+                "converged": result.diagnostics.converged,
+                "iterations_run": result.diagnostics.iterations_run,
+                "max_change_at_stop": result.diagnostics.max_change_at_stop,
+                "available_scopes": available_scopes,
+                "factor_joint_table_count": len(factor_joint_tables),
+                "cromwell_eps": CROMWELL_EPS,
+            },
+        )
 
     raise JointQueryUnavailableError(
         "trw_bp",

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -74,8 +74,7 @@ class JointDistribution(BaseModel):
         if abs(total - 1.0) > _NORMALIZATION_TOLERANCE:
             raise ValueError(f"JointDistribution probabilities must sum to 1, got {total}.")
         self.probabilities = [
-            0.0 if abs(value) < _NORMALIZATION_TOLERANCE else value
-            for value in self.probabilities
+            0.0 if abs(value) < _NORMALIZATION_TOLERANCE else value for value in self.probabilities
         ]
         return self
 

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -22,7 +22,7 @@ JointDistributionBasis = Literal[
     "variational_joint_distribution",
 ]
 
-_NORMALIZATION_TOLERANCE = 1e-9
+_JOINT_NORMALIZATION_TOLERANCE = 1e-9
 _EXACT_TOO_MANY_VARIABLES_MESSAGE = "Exact inference requires 2^n enumeration"
 
 
@@ -68,13 +68,14 @@ class JointDistribution(BaseModel):
             raise ValueError("JointDistribution variables must be unique.")
         if any(not isfinite(value) for value in self.probabilities):
             raise ValueError("JointDistribution probabilities must be finite.")
-        if any(value < -_NORMALIZATION_TOLERANCE for value in self.probabilities):
+        if any(value < -_JOINT_NORMALIZATION_TOLERANCE for value in self.probabilities):
             raise ValueError("JointDistribution probabilities must be non-negative.")
         total = sum(self.probabilities)
-        if abs(total - 1.0) > _NORMALIZATION_TOLERANCE:
+        if abs(total - 1.0) > _JOINT_NORMALIZATION_TOLERANCE:
             raise ValueError(f"JointDistribution probabilities must sum to 1, got {total}.")
         self.probabilities = [
-            0.0 if abs(value) < _NORMALIZATION_TOLERANCE else value for value in self.probabilities
+            0.0 if abs(value) < _JOINT_NORMALIZATION_TOLERANCE else value
+            for value in self.probabilities
         ]
         return self
 

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -1,0 +1,219 @@
+"""Joint distribution queries for Gaia factor-graph inference."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from gaia.engine.bp.exact import exact_joint_over
+from gaia.engine.bp.factor_graph import CROMWELL_EPS, FactorGraph
+from gaia.engine.bp.mean_field import MeanFieldVI
+
+JointQueryMethod = Literal["exact", "junction_tree", "trw_bp", "mean_field"]
+JointDistributionBasis = Literal[
+    "exact_joint_distribution",
+    "calibrated_clique_marginal",
+    "approximate_joint_distribution",
+    "variational_joint_distribution",
+]
+
+_NORMALIZATION_TOLERANCE = 1e-9
+
+
+class JointQueryUnavailableError(RuntimeError):
+    """Raised when a method cannot provide a requested joint distribution."""
+
+    def __init__(
+        self,
+        method: JointQueryMethod,
+        variables: Sequence[str],
+        reason: str,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize an unavailable joint-query error."""
+        super().__init__(reason)
+        self.method = method
+        self.variables = list(variables)
+        self.reason = reason
+        self.diagnostics = diagnostics or {}
+
+
+class JointDistribution(BaseModel):
+    """A normalized joint table over a binary variable set."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    variables: list[str]
+    probabilities: list[float]
+    method: JointQueryMethod
+    is_exact: bool
+    basis: JointDistributionBasis
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_distribution(self) -> JointDistribution:
+        expected = 1 << len(self.variables)
+        if len(self.probabilities) != expected:
+            raise ValueError(
+                f"JointDistribution over {len(self.variables)} variables requires "
+                f"{expected} probabilities, got {len(self.probabilities)}."
+            )
+        if len(set(self.variables)) != len(self.variables):
+            raise ValueError("JointDistribution variables must be unique.")
+        if any(value < -_NORMALIZATION_TOLERANCE for value in self.probabilities):
+            raise ValueError("JointDistribution probabilities must be non-negative.")
+        total = sum(self.probabilities)
+        if abs(total - 1.0) > _NORMALIZATION_TOLERANCE:
+            raise ValueError(f"JointDistribution probabilities must sum to 1, got {total}.")
+        self.probabilities = [
+            0.0 if abs(value) < _NORMALIZATION_TOLERANCE else value
+            for value in self.probabilities
+        ]
+        return self
+
+
+class JointQueryUnavailable(BaseModel):
+    """A method-specific joint query miss."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    variables: list[str]
+    method: JointQueryMethod
+    reason: str
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+
+def joint_over(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    *,
+    method: JointQueryMethod,
+) -> JointDistribution:
+    """Return a joint table over ``variables`` using one inference method."""
+    requested = _normalized_variables(variables)
+    _require_known_variables(graph, requested, method)
+
+    if method == "exact":
+        return _exact_joint_over(graph, requested)
+    if method == "mean_field":
+        return _mean_field_joint_over(graph, requested)
+    if method == "junction_tree":
+        raise JointQueryUnavailableError(
+            method,
+            requested,
+            "junction_tree joint queries are added in Task 2",
+        )
+    if method == "trw_bp":
+        raise JointQueryUnavailableError(
+            method,
+            requested,
+            "trw_bp factor-scope joint queries are added in Task 3",
+        )
+
+    raise ValueError(f"Unknown joint query method: {method!r}")
+
+
+def compare_joint_over(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    *,
+    methods: Sequence[JointQueryMethod] = ("exact", "junction_tree", "trw_bp", "mean_field"),
+) -> list[JointDistribution | JointQueryUnavailable]:
+    """Run several joint providers and collect unavailable methods explicitly."""
+    requested = _normalized_variables(variables)
+    results: list[JointDistribution | JointQueryUnavailable] = []
+    for method in methods:
+        try:
+            results.append(joint_over(graph, requested, method=method))
+        except JointQueryUnavailableError as error:
+            results.append(
+                JointQueryUnavailable(
+                    variables=error.variables,
+                    method=error.method,
+                    reason=error.reason,
+                    diagnostics=error.diagnostics,
+                )
+            )
+    return results
+
+
+def _normalized_variables(variables: Sequence[str]) -> list[str]:
+    requested = list(variables)
+    if not requested:
+        raise ValueError("joint_over requires at least one variable.")
+    if not all(isinstance(variable, str) and variable for variable in requested):
+        raise ValueError("joint_over variables must be non-empty strings.")
+    if len(set(requested)) != len(requested):
+        raise ValueError("joint_over variables must be unique.")
+    return requested
+
+
+def _require_known_variables(
+    graph: FactorGraph,
+    variables: Sequence[str],
+    method: JointQueryMethod,
+) -> None:
+    missing = [variable for variable in variables if variable not in graph.variables]
+    if missing:
+        raise JointQueryUnavailableError(
+            method,
+            variables,
+            f"unknown variables in factor graph: {missing!r}",
+            diagnostics={"missing": missing},
+        )
+
+
+def _exact_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    try:
+        probs = exact_joint_over(graph, variables)
+    except (KeyError, ValueError, RuntimeError) as error:
+        raise JointQueryUnavailableError(
+            "exact",
+            variables,
+            str(error),
+            diagnostics={"exception": type(error).__name__},
+        ) from error
+    return JointDistribution(
+        variables=variables,
+        probabilities=[float(value) for value in probs.tolist()],
+        method="exact",
+        is_exact=True,
+        basis="exact_joint_distribution",
+    )
+
+
+def _mean_field_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    result = MeanFieldVI().run(graph)
+    missing = [variable for variable in variables if variable not in result.beliefs]
+    if missing:
+        raise JointQueryUnavailableError(
+            "mean_field",
+            variables,
+            f"mean_field result missing variables: {missing!r}",
+            diagnostics={"missing": missing},
+        )
+
+    probabilities: list[float] = []
+    for assignment_index in range(1 << len(variables)):
+        probability = 1.0
+        for bit, variable in enumerate(variables):
+            belief = result.beliefs[variable]
+            value = (assignment_index >> bit) & 1
+            probability *= belief if value == 1 else (1.0 - belief)
+        probabilities.append(float(probability))
+
+    return JointDistribution(
+        variables=variables,
+        probabilities=probabilities,
+        method="mean_field",
+        is_exact=False,
+        basis="variational_joint_distribution",
+        diagnostics={
+            "converged": result.diagnostics.converged,
+            "iterations_run": result.diagnostics.iterations_run,
+            "max_change_at_stop": result.diagnostics.max_change_at_stop,
+            "cromwell_eps": CROMWELL_EPS,
+        },
+    )

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -12,6 +12,7 @@ from gaia.engine.bp.exact import exact_joint_over
 from gaia.engine.bp.factor_graph import CROMWELL_EPS, FactorGraph
 from gaia.engine.bp.junction_tree import JunctionTreeCalibration, calibrate_junction_tree
 from gaia.engine.bp.mean_field import MeanFieldVI
+from gaia.engine.bp.trw_bp import TRWBeliefPropagation
 
 JointQueryMethod = Literal["exact", "junction_tree", "trw_bp", "mean_field"]
 JointDistributionBasis = Literal[
@@ -107,11 +108,7 @@ def joint_over(
     if method == "junction_tree":
         return _junction_tree_joint_over(graph, requested)
     if method == "trw_bp":
-        raise JointQueryUnavailableError(
-            method,
-            requested,
-            "trw_bp factor-scope joint queries are added in Task 3",
-        )
+        return _trw_bp_joint_over(graph, requested)
 
     raise ValueError(f"Unknown joint query method: {method!r}")
 
@@ -302,6 +299,69 @@ def _marginalize_table_to_variables(
     if total <= 0.0:
         raise ValueError("marginalized joint table has zero total mass")
     return [probability / total for probability in probabilities]
+
+
+def _probability_list_to_assignment_table(
+    probabilities: list[float],
+    variables: list[str],
+) -> dict[tuple[int, ...], float]:
+    table: dict[tuple[int, ...], float] = {}
+    for assignment_index, probability in enumerate(probabilities):
+        values = tuple((assignment_index >> bit) & 1 for bit in range(len(variables)))
+        table[values] = float(probability)
+    return table
+
+
+def _trw_bp_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    result = TRWBeliefPropagation().run(graph)
+    requested = set(variables)
+    factor_joint_tables = result.diagnostics.factor_joint_tables
+    available_scopes = [list(table["variables"]) for table in factor_joint_tables]
+
+    for table in factor_joint_tables:
+        table_variables = list(table["variables"])
+        if requested <= set(table_variables):
+            assignment_table = _probability_list_to_assignment_table(
+                list(table["probabilities"]),
+                table_variables,
+            )
+            probabilities = _marginalize_table_to_variables(
+                assignment_table,
+                table_variables,
+                variables,
+            )
+            return JointDistribution(
+                variables=variables,
+                probabilities=probabilities,
+                method="trw_bp",
+                is_exact=False,
+                basis="approximate_joint_distribution",
+                diagnostics={
+                    "source_factor_index": table["factor_index"],
+                    "source_factor_id": table["factor_id"],
+                    "source_factor_variables": table_variables,
+                    "source_factor_rho": table["rho"],
+                    "converged": result.diagnostics.converged,
+                    "iterations_run": result.diagnostics.iterations_run,
+                    "max_change_at_stop": result.diagnostics.max_change_at_stop,
+                    "available_scopes": available_scopes,
+                    "factor_joint_table_count": len(factor_joint_tables),
+                    "cromwell_eps": CROMWELL_EPS,
+                },
+            )
+
+    raise JointQueryUnavailableError(
+        "trw_bp",
+        variables,
+        "requested variables are not contained in a single factor-scope pseudo-joint",
+        diagnostics={
+            "available_scopes": available_scopes,
+            "converged": result.diagnostics.converged,
+            "iterations_run": result.diagnostics.iterations_run,
+            "max_change_at_stop": result.diagnostics.max_change_at_stop,
+            "factor_joint_table_count": len(factor_joint_tables),
+        },
+    )
 
 
 def _mean_field_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -20,6 +20,7 @@ JointDistributionBasis = Literal[
 ]
 
 _NORMALIZATION_TOLERANCE = 1e-9
+_EXACT_TOO_MANY_VARIABLES_MESSAGE = "Exact inference requires 2^n enumeration"
 
 
 class JointQueryUnavailableError(RuntimeError):
@@ -168,7 +169,9 @@ def _require_known_variables(
 def _exact_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
     try:
         probs = exact_joint_over(graph, variables)
-    except (KeyError, ValueError, RuntimeError) as error:
+    except ValueError as error:
+        if _EXACT_TOO_MANY_VARIABLES_MESSAGE not in str(error):
+            raise
         raise JointQueryUnavailableError(
             "exact",
             variables,

--- a/gaia/engine/bp/joint_query.py
+++ b/gaia/engine/bp/joint_query.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from gaia.engine.bp.exact import exact_joint_over
 from gaia.engine.bp.factor_graph import CROMWELL_EPS, FactorGraph
+from gaia.engine.bp.junction_tree import calibrate_junction_tree
 from gaia.engine.bp.mean_field import MeanFieldVI
 
 JointQueryMethod = Literal["exact", "junction_tree", "trw_bp", "mean_field"]
@@ -104,11 +105,7 @@ def joint_over(
     if method == "mean_field":
         return _mean_field_joint_over(graph, requested)
     if method == "junction_tree":
-        raise JointQueryUnavailableError(
-            method,
-            requested,
-            "junction_tree joint queries are added in Task 2",
-        )
+        return _junction_tree_joint_over(graph, requested)
     if method == "trw_bp":
         raise JointQueryUnavailableError(
             method,
@@ -188,6 +185,68 @@ def _exact_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribu
         is_exact=True,
         basis="exact_joint_distribution",
     )
+
+
+def _junction_tree_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:
+    try:
+        calibration = calibrate_junction_tree(graph)
+    except (ValueError, RuntimeError) as error:
+        raise JointQueryUnavailableError(
+            "junction_tree",
+            variables,
+            str(error),
+            diagnostics={"exception": type(error).__name__},
+        ) from error
+
+    requested = set(variables)
+    for clique, var_list, table in zip(
+        calibration.cliques,
+        calibration.clique_var_lists,
+        calibration.calibrated,
+        strict=True,
+    ):
+        if requested <= clique:
+            probabilities = _marginalize_table_to_variables(table, var_list, variables)
+            return JointDistribution(
+                variables=variables,
+                probabilities=probabilities,
+                method="junction_tree",
+                is_exact=True,
+                basis="calibrated_clique_marginal",
+                diagnostics={
+                    "treewidth": calibration.treewidth,
+                    "clique_size": len(var_list),
+                    "source_clique": var_list,
+                },
+            )
+
+    raise JointQueryUnavailableError(
+        "junction_tree",
+        variables,
+        "requested variables are not contained in a single calibrated clique",
+        diagnostics={
+            "treewidth": calibration.treewidth,
+            "available_cliques": [sorted(clique) for clique in calibration.cliques],
+        },
+    )
+
+
+def _marginalize_table_to_variables(
+    table: dict[tuple[int, ...], float],
+    table_variables: list[str],
+    variables: list[str],
+) -> list[float]:
+    indices = [table_variables.index(variable) for variable in variables]
+    probabilities = [0.0 for _ in range(1 << len(variables))]
+    for assignment, probability in table.items():
+        out_index = 0
+        for bit, table_index in enumerate(indices):
+            out_index |= assignment[table_index] << bit
+        probabilities[out_index] += float(probability)
+    total = sum(probabilities)
+    if total <= 0.0:
+        raise ValueError("marginalized joint table has zero total mass")
+    return [probability / total for probability in probabilities]
 
 
 def _mean_field_joint_over(graph: FactorGraph, variables: list[str]) -> JointDistribution:

--- a/gaia/engine/bp/junction_tree.py
+++ b/gaia/engine/bp/junction_tree.py
@@ -40,6 +40,7 @@ gaia.engine.bp.factor_graph.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 from itertools import product as cartesian_product
 
@@ -47,11 +48,26 @@ from gaia.engine.bp.factor_graph import CROMWELL_EPS, Factor, FactorGraph
 from gaia.engine.bp.potentials import evaluate_potential
 from gaia.engine.bp.trw_bp import TRWDiagnostics, TRWResult
 
-__all__ = ["JunctionTreeInference", "jt_treewidth"]
+__all__ = [
+    "JunctionTreeCalibration",
+    "JunctionTreeInference",
+    "calibrate_junction_tree",
+    "jt_treewidth",
+]
 
 logger = logging.getLogger(__name__)
 type PotentialTable = dict[tuple[int, ...], float]
 type JunctionMessages = dict[tuple[int, int], tuple[PotentialTable, list[str]]]
+
+
+@dataclass(frozen=True)
+class JunctionTreeCalibration:
+    """Calibrated clique tables from a junction-tree run."""
+
+    cliques: list[frozenset[str]]
+    clique_var_lists: list[list[str]]
+    calibrated: list[PotentialTable]
+    treewidth: int
 
 
 # ---------------------------------------------------------------------------
@@ -632,6 +648,86 @@ def jt_treewidth(graph: FactorGraph) -> int:
     return max(len(c) for c in max_cliques) - 1
 
 
+def calibrate_junction_tree(graph: FactorGraph) -> JunctionTreeCalibration:
+    """Return calibrated junction-tree clique tables for a factor graph."""
+    if not graph.variables:
+        return JunctionTreeCalibration(
+            cliques=[],
+            clique_var_lists=[],
+            calibrated=[],
+            treewidth=0,
+        )
+    if not graph.factors:
+        clique = frozenset(graph.variables.keys())
+        variables = sorted(clique)
+        table: PotentialTable = {}
+        for vals in cartesian_product((0, 1), repeat=len(variables)):
+            probability = 1.0
+            for variable, value in zip(variables, vals, strict=True):
+                if variable in graph.hard_evidence:
+                    belief = (
+                        (1.0 - CROMWELL_EPS)
+                        if graph.hard_evidence[variable] == 1
+                        else CROMWELL_EPS
+                    )
+                else:
+                    belief = graph.unary_factors.get(variable, 0.5)
+                probability *= belief if value == 1 else (1.0 - belief)
+            table[vals] = probability
+        return JunctionTreeCalibration(
+            cliques=[clique],
+            clique_var_lists=[variables],
+            calibrated=[table],
+            treewidth=max(len(variables) - 1, 0),
+        )
+
+    moral_adj = _build_moral_graph(graph)
+    _, elim_cliques = _triangulate_min_fill(moral_adj)
+    cliques = _maximal_cliques(elim_cliques)
+    n_cliques = len(cliques)
+    clique_var_lists = [sorted(c) for c in cliques]
+    treewidth = max(len(c) for c in cliques) - 1
+
+    tree_edges = _build_junction_tree(cliques)
+    tree_adj = _tree_adjacency(n_cliques, tree_edges)
+    factor_assignment = _assign_factors_to_cliques(cliques, graph)
+
+    unary_assigned: set[str] = set()
+    clique_potentials: list[PotentialTable] = []
+    for i, clique in enumerate(cliques):
+        var_list = clique_var_lists[i]
+        local_priors: dict[str, float] = {}
+        for variable in var_list:
+            if variable in graph.hard_evidence and variable not in unary_assigned:
+                local_priors[variable] = (
+                    (1.0 - CROMWELL_EPS)
+                    if graph.hard_evidence[variable] == 1
+                    else CROMWELL_EPS
+                )
+                unary_assigned.add(variable)
+            elif variable in graph.unary_factors and variable not in unary_assigned:
+                local_priors[variable] = graph.unary_factors[variable]
+                unary_assigned.add(variable)
+
+        clique_potentials.append(
+            _compute_clique_potential(clique, factor_assignment[i], local_priors)
+        )
+
+    calibrated = _collect_distribute(
+        cliques,
+        clique_potentials,
+        clique_var_lists,
+        tree_adj,
+        n_cliques,
+    )
+    return JunctionTreeCalibration(
+        cliques=cliques,
+        clique_var_lists=clique_var_lists,
+        calibrated=calibrated,
+        treewidth=treewidth,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Main class
 # ---------------------------------------------------------------------------
@@ -685,65 +781,20 @@ class JunctionTreeInference:
                 diag.belief_history[vid] = [p]
             return TRWResult(beliefs=beliefs, diagnostics=diag)
 
-        # Step 1: Moral graph
-        moral_adj = _build_moral_graph(graph)
-
-        # Step 2: Triangulate
-        _, elim_cliques = _triangulate_min_fill(moral_adj)
-
-        # Step 3: Maximal cliques
-        cliques = _maximal_cliques(elim_cliques)
-        n_cliques = len(cliques)
-        clique_var_lists = [sorted(c) for c in cliques]
-
-        treewidth = max(len(c) for c in cliques) - 1
-        diag.treewidth = treewidth
-        diag.iterations_run = 2  # JT does exactly 2 passes: collect + distribute
-
+        calibration = calibrate_junction_tree(graph)
+        diag.treewidth = calibration.treewidth
+        diag.iterations_run = 2
         logger.debug(
-            "JT: %d variables, %d cliques, treewidth=%d", len(graph.variables), n_cliques, treewidth
+            "JT: %d variables, %d cliques, treewidth=%d",
+            len(graph.variables),
+            len(calibration.cliques),
+            calibration.treewidth,
         )
-
-        # Step 4: Junction tree edges
-        tree_edges = _build_junction_tree(cliques)
-        tree_adj = _tree_adjacency(n_cliques, tree_edges)
-
-        # Step 5: Assign factors to cliques
-        factor_assignment = _assign_factors_to_cliques(cliques, graph)
-
-        # Step 6: Compute clique potentials
-        # Each explicit unary factor is applied in exactly one clique — the
-        # first clique found that contains it. Variables without unary factors
-        # contribute the base counting measure.
-        unary_assigned: set[str] = set()
-        clique_potentials: list[PotentialTable] = []
-
-        for i, clique in enumerate(cliques):
-            var_list = clique_var_lists[i]
-            # Determine which explicit unary factors to apply in this clique.
-            local_priors: dict[str, float] = {}
-            for v in var_list:
-                if v in graph.hard_evidence and v not in unary_assigned:
-                    # Hard evidence: use δ function (0.0 or 1.0, no Cromwell ε)
-                    local_priors[v] = (
-                        (1.0 - CROMWELL_EPS) if graph.hard_evidence[v] == 1 else CROMWELL_EPS
-                    )
-                    unary_assigned.add(v)
-                elif v in graph.unary_factors and v not in unary_assigned:
-                    local_priors[v] = graph.unary_factors[v]
-                    unary_assigned.add(v)
-
-            pot_table = _compute_clique_potential(clique, factor_assignment[i], local_priors)
-            clique_potentials.append(pot_table)
-
-        # Step 7: Two-pass message passing
-        calibrated = _collect_distribute(
-            cliques, clique_potentials, clique_var_lists, tree_adj, n_cliques
-        )
-
-        # Step 8: Extract beliefs
         beliefs = _extract_beliefs(
-            cliques, calibrated, clique_var_lists, set(graph.variables.keys())
+            calibration.cliques,
+            calibration.calibrated,
+            calibration.clique_var_lists,
+            set(graph.variables.keys()),
         )
 
         # NOTE: Do NOT apply Cromwell clamping to the output beliefs.

--- a/gaia/engine/bp/junction_tree.py
+++ b/gaia/engine/bp/junction_tree.py
@@ -658,27 +658,24 @@ def calibrate_junction_tree(graph: FactorGraph) -> JunctionTreeCalibration:
             treewidth=0,
         )
     if not graph.factors:
-        clique = frozenset(graph.variables.keys())
-        variables = sorted(clique)
-        table: PotentialTable = {}
-        for vals in cartesian_product((0, 1), repeat=len(variables)):
-            probability = 1.0
-            for variable, value in zip(variables, vals, strict=True):
-                if variable in graph.hard_evidence:
-                    belief = (
-                        (1.0 - CROMWELL_EPS)
-                        if graph.hard_evidence[variable] == 1
-                        else CROMWELL_EPS
-                    )
-                else:
-                    belief = graph.unary_factors.get(variable, 0.5)
-                probability *= belief if value == 1 else (1.0 - belief)
-            table[vals] = probability
+        cliques = [frozenset([variable]) for variable in sorted(graph.variables)]
+        clique_var_lists = [[variable] for variable in sorted(graph.variables)]
+        calibrated: list[PotentialTable] = []
+        for variable in sorted(graph.variables):
+            if variable in graph.hard_evidence:
+                belief = (
+                    (1.0 - CROMWELL_EPS)
+                    if graph.hard_evidence[variable] == 1
+                    else CROMWELL_EPS
+                )
+            else:
+                belief = graph.unary_factors.get(variable, 0.5)
+            calibrated.append({(0,): 1.0 - belief, (1,): belief})
         return JunctionTreeCalibration(
-            cliques=[clique],
-            clique_var_lists=[variables],
-            calibrated=[table],
-            treewidth=max(len(variables) - 1, 0),
+            cliques=cliques,
+            clique_var_lists=clique_var_lists,
+            calibrated=calibrated,
+            treewidth=0,
         )
 
     moral_adj = _build_moral_graph(graph)

--- a/gaia/engine/bp/junction_tree.py
+++ b/gaia/engine/bp/junction_tree.py
@@ -44,7 +44,7 @@ import logging
 from dataclasses import dataclass
 from itertools import product as cartesian_product
 
-from gaia.engine.bp.factor_graph import CROMWELL_EPS, Factor, FactorGraph
+from gaia.engine.bp.factor_graph import CROMWELL_EPS, Factor, FactorGraph, FactorType
 from gaia.engine.bp.potentials import evaluate_potential
 from gaia.engine.bp.trw_bp import TRWDiagnostics, TRWResult
 
@@ -58,6 +58,15 @@ __all__ = [
 logger = logging.getLogger(__name__)
 type PotentialTable = dict[tuple[int, ...], float]
 type JunctionMessages = dict[tuple[int, int], tuple[PotentialTable, list[str]]]
+_DETERMINISTIC_FACTOR_TYPES = {
+    FactorType.IMPLICATION,
+    FactorType.NEGATION,
+    FactorType.CONJUNCTION,
+    FactorType.DISJUNCTION,
+    FactorType.EQUIVALENCE,
+    FactorType.CONTRADICTION,
+    FactorType.COMPLEMENT,
+}
 
 
 @dataclass(frozen=True)
@@ -317,11 +326,19 @@ def _compute_clique_potential(
 
         # Factor potential contributions
         for factor in factors:
-            pot *= evaluate_potential(factor, assignment)
+            pot *= _evaluate_junction_tree_potential(factor, assignment)
 
         table[vals] = pot
 
     return table
+
+
+def _evaluate_junction_tree_potential(factor: Factor, assignment: dict[str, int]) -> float:
+    """Evaluate factors with the same Cromwell semantics as exact enumeration."""
+    potential = evaluate_potential(factor, assignment)
+    if factor.factor_type in _DETERMINISTIC_FACTOR_TYPES:
+        return (1.0 - CROMWELL_EPS) if potential > 0.0 else CROMWELL_EPS
+    return potential
 
 
 # ---------------------------------------------------------------------------

--- a/gaia/engine/bp/junction_tree.py
+++ b/gaia/engine/bp/junction_tree.py
@@ -762,6 +762,7 @@ class JunctionTreeInference:
         if not graph.factors:
             # No factors: beliefs are explicit unary factors or neutral MaxEnt.
             diag.converged = True
+            diag.treewidth = 0
 
             # Priority: hard_evidence > unary_factors > neutral MaxEnt
             def _belief0(vid: str) -> float:

--- a/gaia/engine/bp/junction_tree.py
+++ b/gaia/engine/bp/junction_tree.py
@@ -40,8 +40,8 @@ gaia.engine.bp.factor_graph.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from itertools import product as cartesian_product
 
 from gaia.engine.bp.factor_graph import CROMWELL_EPS, Factor, FactorGraph
@@ -664,9 +664,7 @@ def calibrate_junction_tree(graph: FactorGraph) -> JunctionTreeCalibration:
         for variable in sorted(graph.variables):
             if variable in graph.hard_evidence:
                 belief = (
-                    (1.0 - CROMWELL_EPS)
-                    if graph.hard_evidence[variable] == 1
-                    else CROMWELL_EPS
+                    (1.0 - CROMWELL_EPS) if graph.hard_evidence[variable] == 1 else CROMWELL_EPS
                 )
             else:
                 belief = graph.unary_factors.get(variable, 0.5)
@@ -697,9 +695,7 @@ def calibrate_junction_tree(graph: FactorGraph) -> JunctionTreeCalibration:
         for variable in var_list:
             if variable in graph.hard_evidence and variable not in unary_assigned:
                 local_priors[variable] = (
-                    (1.0 - CROMWELL_EPS)
-                    if graph.hard_evidence[variable] == 1
-                    else CROMWELL_EPS
+                    (1.0 - CROMWELL_EPS) if graph.hard_evidence[variable] == 1 else CROMWELL_EPS
                 )
                 unary_assigned.add(variable)
             elif variable in graph.unary_factors and variable not in unary_assigned:

--- a/gaia/engine/bp/trw_bp.py
+++ b/gaia/engine/bp/trw_bp.py
@@ -251,8 +251,7 @@ def _compute_factor_joint_tables(
         probabilities: list[float] = []
         for assignment_index in range(1 << len(variables)):
             assignment = {
-                variable: (assignment_index >> bit) & 1
-                for bit, variable in enumerate(variables)
+                variable: (assignment_index >> bit) & 1 for bit, variable in enumerate(variables)
             }
             potential = evaluate_potential(factor, assignment)
             if potential <= 0.0:

--- a/gaia/engine/bp/trw_bp.py
+++ b/gaia/engine/bp/trw_bp.py
@@ -239,7 +239,13 @@ def _compute_factor_joint_tables(
     v2f_msgs: dict[tuple[str, int], Msg],
     rho: dict[int, float],
 ) -> list[dict[str, Any]]:
-    """Compute normalized factor-scope pseudo-joints from current TRW messages."""
+    """Compute normalized factor-scope pseudo-joints from current TRW messages.
+
+    Gaia records the factor belief convention
+    ``b_f(x_f) ∝ psi_f(x_f) * prod_v m_{v->f}(x_v)``. The tree-reweighting
+    factor weight ``rho_f`` is already baked into message updates, so this
+    diagnostic table deliberately does not raise ``psi_f`` to ``1 / rho_f``.
+    """
     tables: list[dict[str, Any]] = []
 
     for fi, factor in enumerate(graph.factors):
@@ -258,6 +264,8 @@ def _compute_factor_joint_tables(
                 probabilities.append(0.0)
                 continue
 
+            # Keep the recorded pseudo-joint on the message convention above;
+            # do not reweight the potential again at diagnostic extraction time.
             weight = float(potential)
             for variable, value in assignment.items():
                 v2f = v2f_msgs.get((variable, fi))

--- a/gaia/engine/bp/trw_bp.py
+++ b/gaia/engine/bp/trw_bp.py
@@ -259,7 +259,7 @@ def _compute_factor_joint_tables(
                 probabilities.append(0.0)
                 continue
 
-            weight = float(potential**rho_f)
+            weight = float(potential)
             for variable, value in assignment.items():
                 v2f = v2f_msgs.get((variable, fi))
                 if v2f is not None:
@@ -297,9 +297,9 @@ class TRWDiagnostics:
     max_change_at_stop: float = 0.0
     belief_history: dict[str, list[float]] = field(default_factory=dict)
     direction_changes: dict[str, int] = field(default_factory=dict)
-    factor_joint_tables: list[dict[str, Any]] = field(default_factory=list)
     rho: float = 1.0  # factor weight used (uniform scheme)
     treewidth: int | None = None  # junction tree width (JT only)
+    factor_joint_tables: list[dict[str, Any]] = field(default_factory=list)
 
     def compute_direction_changes(self) -> None:
         """Compute direction changes in belief updates for oscillation detection."""
@@ -399,6 +399,8 @@ class TRWBeliefPropagation:
                     beliefs[vid] = graph.unary_factors.get(vid, 0.5)
             for vid, b in beliefs.items():
                 diag.belief_history[vid] = [b]
+            diag.converged = True
+            diag.factor_joint_tables = []
             return TRWResult(beliefs=beliefs, diagnostics=diag)
 
         var_to_factors = graph.get_var_to_factors()

--- a/gaia/engine/bp/trw_bp.py
+++ b/gaia/engine/bp/trw_bp.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import heapq
 from dataclasses import dataclass, field
 from itertools import product as cartesian_product
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -234,6 +234,55 @@ def _compute_beliefs_trw(
     return beliefs
 
 
+def _compute_factor_joint_tables(
+    graph: FactorGraph,
+    v2f_msgs: dict[tuple[str, int], Msg],
+    rho: dict[int, float],
+) -> list[dict[str, Any]]:
+    """Compute normalized factor-scope pseudo-joints from current TRW messages."""
+    tables: list[dict[str, Any]] = []
+
+    for fi, factor in enumerate(graph.factors):
+        variables = [variable for variable in factor.all_vars if variable in graph.variables]
+        if not variables:
+            continue
+
+        rho_f = rho.get(fi, 1.0)
+        probabilities: list[float] = []
+        for assignment_index in range(1 << len(variables)):
+            assignment = {
+                variable: (assignment_index >> bit) & 1
+                for bit, variable in enumerate(variables)
+            }
+            potential = evaluate_potential(factor, assignment)
+            if potential <= 0.0:
+                probabilities.append(0.0)
+                continue
+
+            weight = float(potential**rho_f)
+            for variable, value in assignment.items():
+                v2f = v2f_msgs.get((variable, fi))
+                if v2f is not None:
+                    weight *= float(v2f[value])
+            probabilities.append(weight)
+
+        total = sum(probabilities)
+        if total <= 0.0:
+            continue
+
+        tables.append(
+            {
+                "factor_index": fi,
+                "factor_id": factor.factor_id,
+                "variables": variables,
+                "rho": float(rho_f),
+                "probabilities": [probability / total for probability in probabilities],
+            }
+        )
+
+    return tables
+
+
 # ---------------------------------------------------------------------------
 # Diagnostics
 # ---------------------------------------------------------------------------
@@ -248,6 +297,7 @@ class TRWDiagnostics:
     max_change_at_stop: float = 0.0
     belief_history: dict[str, list[float]] = field(default_factory=dict)
     direction_changes: dict[str, int] = field(default_factory=dict)
+    factor_joint_tables: list[dict[str, Any]] = field(default_factory=list)
     rho: float = 1.0  # factor weight used (uniform scheme)
     treewidth: int | None = None  # junction tree width (JT only)
 
@@ -459,12 +509,14 @@ class TRWBeliefPropagation:
                 diag.iterations_run = iteration + 1
                 diag.max_change_at_stop = max_change
                 diag.compute_direction_changes()
+                diag.factor_joint_tables = _compute_factor_joint_tables(graph, v2f_msgs, rho)
                 return TRWResult(beliefs=beliefs, diagnostics=diag)
 
         diag.converged = False
         diag.iterations_run = self._max_iter
         diag.max_change_at_stop = max_change
         diag.compute_direction_changes()
+        diag.factor_joint_tables = _compute_factor_joint_tables(graph, v2f_msgs, rho)
         return TRWResult(beliefs=prev_beliefs, diagnostics=diag)
 
     def _run_residual(  # noqa: C901
@@ -590,4 +642,5 @@ class TRWBeliefPropagation:
         diag.iterations_run = total_updates // check_interval
         diag.max_change_at_stop = max_change
         diag.compute_direction_changes()
+        diag.factor_joint_tables = _compute_factor_joint_tables(graph, v2f_msgs, rho)
         return TRWResult(beliefs=beliefs, diagnostics=diag)

--- a/gaia/engine/ir/logic/__init__.py
+++ b/gaia/engine/ir/logic/__init__.py
@@ -22,18 +22,14 @@ See docs/specs/2026-05-16-engine-module-reorg-design.md §5 for the three-scope
 taxonomy.
 """
 
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
 from gaia.engine.ir.logic.diagnostics import (
     DiagnosticCondition,
     FormulaDiagnostic,
     FormulaDiagnosticReport,
     inspect_formula_graphs,
-)
-from gaia.engine.ir.logic.probability import (
-    ConditionProbabilityEstimate,
-    DiagnosticProbability,
-    event_probability,
-    score_condition,
-    score_diagnostic_conditions,
 )
 from gaia.engine.ir.logic.propositional import (
     are_equivalent,
@@ -44,6 +40,23 @@ from gaia.engine.ir.logic.propositional import (
     to_nnf_proposition,
     to_sympy_proposition,
 )
+
+if TYPE_CHECKING:
+    from gaia.engine.ir.logic.probability import (
+        ConditionProbabilityEstimate,
+        DiagnosticProbability,
+        event_probability,
+        score_condition,
+        score_diagnostic_conditions,
+    )
+
+_LAZY_PROBABILITY_EXPORTS = {
+    "ConditionProbabilityEstimate",
+    "DiagnosticProbability",
+    "event_probability",
+    "score_condition",
+    "score_diagnostic_conditions",
+}
 
 __all__ = [
     "ConditionProbabilityEstimate",
@@ -63,3 +76,13 @@ __all__ = [
     "to_nnf_proposition",
     "to_sympy_proposition",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose probability helpers without loading BP for pure logic imports."""
+    if name in _LAZY_PROBABILITY_EXPORTS:
+        probability_module = import_module("gaia.engine.ir.logic.probability")
+        value = getattr(probability_module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/gaia/engine/ir/logic/__init__.py
+++ b/gaia/engine/ir/logic/__init__.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from gaia.engine.ir.logic.probability import (
         ConditionProbabilityEstimate,
         DiagnosticProbability,
+        belief_graph_for_formula_scoring,
         event_probability,
         score_condition,
         score_diagnostic_conditions,
@@ -53,6 +54,7 @@ if TYPE_CHECKING:
 _LAZY_PROBABILITY_EXPORTS = {
     "ConditionProbabilityEstimate",
     "DiagnosticProbability",
+    "belief_graph_for_formula_scoring",
     "event_probability",
     "score_condition",
     "score_diagnostic_conditions",
@@ -65,6 +67,7 @@ __all__ = [
     "FormulaDiagnostic",
     "FormulaDiagnosticReport",
     "are_equivalent",
+    "belief_graph_for_formula_scoring",
     "event_probability",
     "inspect_formula_graphs",
     "is_satisfiable",

--- a/gaia/engine/ir/logic/__init__.py
+++ b/gaia/engine/ir/logic/__init__.py
@@ -28,6 +28,13 @@ from gaia.engine.ir.logic.diagnostics import (
     FormulaDiagnosticReport,
     inspect_formula_graphs,
 )
+from gaia.engine.ir.logic.probability import (
+    ConditionProbabilityEstimate,
+    DiagnosticProbability,
+    event_probability,
+    score_condition,
+    score_diagnostic_conditions,
+)
 from gaia.engine.ir.logic.propositional import (
     are_equivalent,
     is_satisfiable,
@@ -39,12 +46,17 @@ from gaia.engine.ir.logic.propositional import (
 )
 
 __all__ = [
+    "ConditionProbabilityEstimate",
     "DiagnosticCondition",
+    "DiagnosticProbability",
     "FormulaDiagnostic",
     "FormulaDiagnosticReport",
     "are_equivalent",
+    "event_probability",
     "inspect_formula_graphs",
     "is_satisfiable",
+    "score_condition",
+    "score_diagnostic_conditions",
     "simplify_proposition",
     "to_cnf_proposition",
     "to_dnf_proposition",

--- a/gaia/engine/ir/logic/probability.py
+++ b/gaia/engine/ir/logic/probability.py
@@ -16,6 +16,8 @@ from gaia.engine.bp.joint_query import (
     JointQueryUnavailable,
     compare_joint_over,
 )
+from gaia.engine.bp.lowering import lower_local_graph
+from gaia.engine.ir.graphs import LocalCanonicalGraph
 from gaia.engine.ir.logic.diagnostics import (
     DiagnosticCondition,
     DiagnosticConditionKind,
@@ -118,7 +120,14 @@ def score_diagnostic_conditions(
     *,
     methods: Sequence[JointQueryMethod] = ("exact", "junction_tree", "trw_bp", "mean_field"),
 ) -> list[DiagnosticProbability]:
-    """Score diagnostics that carry machine-readable conditions."""
+    """Score diagnostics that carry machine-readable conditions.
+
+    This v1 helper intentionally runs the requested joint providers once per
+    scored diagnostic, so its cost model is
+    ``O(number_of_scored_diagnostics * inference_cost(methods))``. Batch
+    reviewer tools that score many warnings should cache provider state above
+    this API or use a future cached query context.
+    """
     scored: list[DiagnosticProbability] = []
     for diagnostic in diagnostics:
         condition = diagnostic.condition
@@ -133,6 +142,26 @@ def score_diagnostic_conditions(
             )
         )
     return scored
+
+
+def belief_graph_for_formula_scoring(graph: LocalCanonicalGraph) -> FactorGraph:
+    """Lower a reviewer scoring graph without formula-generated logic operators.
+
+    Formula diagnostics discover warnings from ``FormulaGraph`` structure. When
+    those warnings are probability-scored, the belief graph should represent the
+    current belief state before enforcing the warning itself. Compiler-generated
+    formula operators therefore stay out of the scoring graph.
+    """
+    belief_graph = graph.model_copy(
+        update={
+            "operators": [
+                operator
+                for operator in graph.operators
+                if not (operator.metadata or {}).get("formula_lowering")
+            ]
+        }
+    )
+    return lower_local_graph(belief_graph)
 
 
 def _spread(probabilities: Sequence[float]) -> float | None:

--- a/gaia/engine/ir/logic/probability.py
+++ b/gaia/engine/ir/logic/probability.py
@@ -1,0 +1,200 @@
+"""Probability scoring for formula diagnostic conditions."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from gaia.engine.bp.factor_graph import FactorGraph
+from gaia.engine.bp.joint_query import (
+    JointDistribution,
+    JointDistributionBasis,
+    JointQueryMethod,
+    JointQueryUnavailable,
+    compare_joint_over,
+)
+from gaia.engine.ir.logic.diagnostics import DiagnosticCondition, FormulaDiagnostic
+
+
+class ConditionProbabilityEstimate(BaseModel):
+    """A method-specific probability for one diagnostic Boolean event."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    variables: list[str]
+    method: JointQueryMethod
+    probability: float
+    is_exact: bool
+    basis: JointDistributionBasis
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+
+class DiagnosticProbability(BaseModel):
+    """Probability scoring result for a diagnostic condition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    condition: DiagnosticCondition
+    estimates: list[ConditionProbabilityEstimate | JointQueryUnavailable]
+    spread: float | None = None
+    exact_spread: float | None = None
+    diagnostic: FormulaDiagnostic | None = None
+
+
+def event_probability(expression: dict[str, Any], joint: JointDistribution) -> float:
+    """Sum full-joint probability mass satisfying ``expression``.
+
+    The joint table is decoded with Gaia's bit-index convention:
+    ``joint.variables[bit]`` has value ``(assignment_index >> bit) & 1``.
+    """
+    variable_bits = {variable: bit for bit, variable in enumerate(joint.variables)}
+    _validate_expression(expression, set(variable_bits))
+
+    probability = 0.0
+    for assignment_index, mass in enumerate(joint.probabilities):
+        if _evaluate_expression(expression, variable_bits, assignment_index):
+            probability += mass
+    return float(probability)
+
+
+def score_condition(
+    condition: DiagnosticCondition,
+    joint_results: Sequence[JointDistribution | JointQueryUnavailable],
+) -> DiagnosticProbability:
+    """Score a diagnostic condition against available joint query results."""
+    estimates: list[ConditionProbabilityEstimate | JointQueryUnavailable] = []
+    probabilities: list[float] = []
+    exact_probabilities: list[float] = []
+
+    for result in joint_results:
+        if isinstance(result, JointQueryUnavailable):
+            estimates.append(result)
+            continue
+
+        probability = event_probability(condition.expression, result)
+        estimate = ConditionProbabilityEstimate(
+            variables=result.variables,
+            method=result.method,
+            probability=probability,
+            is_exact=result.is_exact,
+            basis=result.basis,
+            diagnostics=result.diagnostics,
+        )
+        estimates.append(estimate)
+        probabilities.append(probability)
+        if result.is_exact:
+            exact_probabilities.append(probability)
+
+    return DiagnosticProbability(
+        condition=condition,
+        estimates=estimates,
+        spread=_spread(probabilities),
+        exact_spread=_spread(exact_probabilities),
+    )
+
+
+def score_diagnostic_conditions(
+    graph: FactorGraph,
+    diagnostics: Sequence[FormulaDiagnostic],
+    *,
+    methods: Sequence[JointQueryMethod] = ("exact", "junction_tree", "trw_bp", "mean_field"),
+) -> list[DiagnosticProbability]:
+    """Score diagnostics that carry machine-readable conditions."""
+    scored: list[DiagnosticProbability] = []
+    for diagnostic in diagnostics:
+        condition = diagnostic.condition
+        if condition is None:
+            continue
+        joint_results = compare_joint_over(graph, condition.variables, methods=methods)
+        scored_condition = score_condition(condition, joint_results)
+        scored.append(scored_condition.model_copy(update={"diagnostic": diagnostic}))
+    return scored
+
+
+def _spread(probabilities: Sequence[float]) -> float | None:
+    if not probabilities:
+        return None
+    return float(max(probabilities) - min(probabilities))
+
+
+def _validate_expression(expression: Any, known_variables: set[str]) -> None:
+    if not isinstance(expression, dict):
+        raise ValueError("diagnostic condition expression must be a mapping.")
+
+    has_var = "var" in expression
+    has_op = "op" in expression
+    if has_var == has_op:
+        raise ValueError(
+            "diagnostic condition expression must contain exactly one of 'var' or 'op'."
+        )
+
+    if has_var:
+        _validate_var_expression(expression, known_variables)
+        return
+
+    _validate_operator_expression(expression, known_variables)
+
+
+def _validate_var_expression(expression: dict[str, Any], known_variables: set[str]) -> None:
+    if set(expression) != {"var"}:
+        raise ValueError("var expression must contain only 'var'.")
+    variable = expression["var"]
+    if not isinstance(variable, str) or not variable:
+        raise ValueError("diagnostic condition variable must be a non-empty string.")
+    if variable not in known_variables:
+        raise ValueError(
+            f"unknown variable {variable!r} in diagnostic condition expression; "
+            f"joint variables are {sorted(known_variables)!r}."
+        )
+
+
+def _validate_operator_expression(expression: dict[str, Any], known_variables: set[str]) -> None:
+    operator = expression["op"]
+    if not isinstance(operator, str):
+        raise ValueError("diagnostic condition operator must be a string.")
+
+    if operator == "not":
+        if set(expression) != {"op", "arg"}:
+            raise ValueError("not expression requires exactly 'op' and 'arg'.")
+        _validate_expression(expression["arg"], known_variables)
+        return
+
+    if operator in {"and", "or"}:
+        if set(expression) != {"op", "args"}:
+            raise ValueError(f"{operator} expression requires exactly 'op' and 'args'.")
+        args = expression.get("args")
+        if not isinstance(args, list) or not args:
+            raise ValueError(f"{operator} expression requires a non-empty 'args' list.")
+        for arg in args:
+            _validate_expression(arg, known_variables)
+        return
+
+    raise ValueError(f"unsupported diagnostic condition operator {operator!r}.")
+
+
+def _evaluate_expression(
+    expression: dict[str, Any],
+    variable_bits: dict[str, int],
+    assignment_index: int,
+) -> bool:
+    if "var" in expression:
+        bit = variable_bits[expression["var"]]
+        return bool((assignment_index >> bit) & 1)
+
+    operator = expression["op"]
+    if operator == "not":
+        return not _evaluate_expression(expression["arg"], variable_bits, assignment_index)
+    if operator == "and":
+        return all(
+            _evaluate_expression(arg, variable_bits, assignment_index)
+            for arg in expression["args"]
+        )
+    if operator == "or":
+        return any(
+            _evaluate_expression(arg, variable_bits, assignment_index)
+            for arg in expression["args"]
+        )
+
+    raise ValueError(f"unsupported diagnostic condition operator {operator!r}.")

--- a/gaia/engine/ir/logic/probability.py
+++ b/gaia/engine/ir/logic/probability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from math import fsum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -15,7 +16,11 @@ from gaia.engine.bp.joint_query import (
     JointQueryUnavailable,
     compare_joint_over,
 )
-from gaia.engine.ir.logic.diagnostics import DiagnosticCondition, FormulaDiagnostic
+from gaia.engine.ir.logic.diagnostics import (
+    DiagnosticCondition,
+    DiagnosticConditionKind,
+    FormulaDiagnostic,
+)
 
 
 class ConditionProbabilityEstimate(BaseModel):
@@ -36,11 +41,14 @@ class DiagnosticProbability(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    condition: DiagnosticCondition
-    estimates: list[ConditionProbabilityEstimate | JointQueryUnavailable]
+    diagnostic_code: str | None = None
+    condition_kind: DiagnosticConditionKind
+    variables: list[str]
+    event_expression: dict[str, Any]
+    estimates: list[ConditionProbabilityEstimate]
+    unavailable: list[JointQueryUnavailable]
     spread: float | None = None
     exact_spread: float | None = None
-    diagnostic: FormulaDiagnostic | None = None
 
 
 def event_probability(expression: dict[str, Any], joint: JointDistribution) -> float:
@@ -52,25 +60,30 @@ def event_probability(expression: dict[str, Any], joint: JointDistribution) -> f
     variable_bits = {variable: bit for bit, variable in enumerate(joint.variables)}
     _validate_expression(expression, set(variable_bits))
 
-    probability = 0.0
-    for assignment_index, mass in enumerate(joint.probabilities):
-        if _evaluate_expression(expression, variable_bits, assignment_index):
-            probability += mass
-    return float(probability)
+    return float(
+        fsum(
+            mass
+            for assignment_index, mass in enumerate(joint.probabilities)
+            if _evaluate_expression(expression, variable_bits, assignment_index)
+        )
+    )
 
 
 def score_condition(
     condition: DiagnosticCondition,
     joint_results: Sequence[JointDistribution | JointQueryUnavailable],
+    *,
+    diagnostic_code: str | None = None,
 ) -> DiagnosticProbability:
     """Score a diagnostic condition against available joint query results."""
-    estimates: list[ConditionProbabilityEstimate | JointQueryUnavailable] = []
+    estimates: list[ConditionProbabilityEstimate] = []
+    unavailable: list[JointQueryUnavailable] = []
     probabilities: list[float] = []
     exact_probabilities: list[float] = []
 
     for result in joint_results:
         if isinstance(result, JointQueryUnavailable):
-            estimates.append(result)
+            unavailable.append(result)
             continue
 
         probability = event_probability(condition.expression, result)
@@ -88,16 +101,20 @@ def score_condition(
             exact_probabilities.append(probability)
 
     return DiagnosticProbability(
-        condition=condition,
+        diagnostic_code=diagnostic_code,
+        condition_kind=condition.kind,
+        variables=condition.variables,
+        event_expression=condition.expression,
         estimates=estimates,
+        unavailable=unavailable,
         spread=_spread(probabilities),
         exact_spread=_spread(exact_probabilities),
     )
 
 
 def score_diagnostic_conditions(
-    graph: FactorGraph,
     diagnostics: Sequence[FormulaDiagnostic],
+    graph: FactorGraph,
     *,
     methods: Sequence[JointQueryMethod] = ("exact", "junction_tree", "trw_bp", "mean_field"),
 ) -> list[DiagnosticProbability]:
@@ -108,8 +125,13 @@ def score_diagnostic_conditions(
         if condition is None:
             continue
         joint_results = compare_joint_over(graph, condition.variables, methods=methods)
-        scored_condition = score_condition(condition, joint_results)
-        scored.append(scored_condition.model_copy(update={"diagnostic": diagnostic}))
+        scored.append(
+            score_condition(
+                condition,
+                joint_results,
+                diagnostic_code=diagnostic.code,
+            )
+        )
     return scored
 
 
@@ -188,13 +210,11 @@ def _evaluate_expression(
         return not _evaluate_expression(expression["arg"], variable_bits, assignment_index)
     if operator == "and":
         return all(
-            _evaluate_expression(arg, variable_bits, assignment_index)
-            for arg in expression["args"]
+            _evaluate_expression(arg, variable_bits, assignment_index) for arg in expression["args"]
         )
     if operator == "or":
         return any(
-            _evaluate_expression(arg, variable_bits, assignment_index)
-            for arg in expression["args"]
+            _evaluate_expression(arg, variable_bits, assignment_index) for arg in expression["args"]
         )
 
     raise ValueError(f"unsupported diagnostic condition operator {operator!r}.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
           - Belief State: foundations/bp/belief-state.md
           - Formal Strategy Lowering: foundations/bp/formal-strategy-lowering.md
           - Inference: foundations/bp/inference.md
+          - Diagnostic Probabilities: foundations/bp/diagnostic-probabilities.md
           - Choosing An Algorithm: foundations/bp/choosing-algorithm.md
           - Local Vs Global: foundations/bp/local-vs-global.md
           - Potentials: foundations/bp/potentials.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
           - Related Systems: foundations/ecosystem/07-related-systems.md
       - Gaia Lang Design:
           - Knowledge And Reasoning: foundations/gaia-lang/knowledge-and-reasoning.md
+          - Formula Logic: foundations/gaia-lang/formula-logic.md
           - Predicate Logic: foundations/gaia-lang/predicate-logic.md
           - Bayes Semantics: foundations/gaia-lang/bayes.md
           - Package Model: foundations/gaia-lang/package.md

--- a/tests/gaia/bp/test_inference.py
+++ b/tests/gaia/bp/test_inference.py
@@ -233,6 +233,17 @@ class TestJunctionTree:
         assert isinstance(result, TRWResult)
         assert 0 < result.beliefs["A"] < 1
 
+    def test_no_factors_reports_zero_treewidth(self):
+        fg = FactorGraph()
+        fg.add_variable("A", 0.7)
+        fg.add_variable("B", 0.3)
+
+        result = JunctionTreeInference().run(fg)
+
+        assert result.beliefs == {"A": pytest.approx(0.7), "B": pytest.approx(0.3)}
+        assert result.diagnostics.converged is True
+        assert result.diagnostics.treewidth == 0
+
     def test_jt_matches_exact(self):
         fg = _diamond_graph()
         exact_beliefs, _ = exact_inference(fg)

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from gaia.engine.bp.factor_graph import FactorGraph, FactorType
@@ -7,6 +8,11 @@ from gaia.engine.bp.joint_query import (
     JointQueryUnavailableError,
     compare_joint_over,
     joint_over,
+)
+from gaia.engine.bp.trw_bp import (
+    TRWBeliefPropagation,
+    TRWDiagnostics,
+    _compute_factor_joint_tables,
 )
 
 pytestmark = pytest.mark.pr_gate
@@ -43,6 +49,16 @@ def _contradiction_graph() -> FactorGraph:
     graph.add_variable("B", 0.25)
     graph.add_variable("H", 0.7)
     graph.add_factor("f:not_both", FactorType.CONTRADICTION, ["A", "B"], "H")
+    return graph
+
+
+def _nested_covering_factor_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.8)
+    graph.add_variable("B", 0.25)
+    graph.add_variable("H", 0.7)
+    graph.add_factor("f:larger", FactorType.CONTRADICTION, ["A", "B"], "H")
+    graph.add_factor("f:smaller", FactorType.PAIRWISE_POTENTIAL, ["A"], "B", cpt=[1, 4, 2, 8])
     return graph
 
 
@@ -119,9 +135,26 @@ def test_compare_joint_over_collects_unavailable_methods():
     assert {estimate.method for estimate in estimates} == {"exact", "junction_tree", "mean_field"}
     assert {item.method for item in unavailable} == {"trw_bp"}
     assert all(item.variables == ["A", "B"] for item in unavailable)
+    assert unavailable[0].diagnostics["converged"] is True
+    assert unavailable[0].diagnostics["available_scopes"] == []
     exact = next(estimate for estimate in estimates if estimate.method == "exact")
     junction_tree = next(estimate for estimate in estimates if estimate.method == "junction_tree")
     assert junction_tree.probabilities == pytest.approx(exact.probabilities)
+
+
+def test_trw_no_factor_diagnostics_are_converged_with_empty_factor_tables():
+    result = TRWBeliefPropagation().run(_two_variable_graph())
+
+    assert result.diagnostics.converged is True
+    assert result.diagnostics.factor_joint_tables == []
+
+
+def test_trw_diagnostics_positional_constructor_keeps_rho_and_treewidth_order():
+    diagnostics = TRWDiagnostics(False, 3, 0.25, {}, {}, 0.5, 7)
+
+    assert diagnostics.rho == pytest.approx(0.5)
+    assert diagnostics.treewidth == 7
+    assert diagnostics.factor_joint_tables == []
 
 
 def test_junction_tree_no_factor_singleton_query_uses_singleton_scope():
@@ -253,6 +286,14 @@ def test_trw_bp_returns_factor_scope_pseudo_joint():
     assert joint.diagnostics["iterations_run"] >= 1
 
 
+def test_trw_bp_chooses_smallest_covering_factor_scope():
+    joint = joint_over(_nested_covering_factor_graph(), ["A", "B"], method="trw_bp")
+
+    assert joint.diagnostics["source_factor_id"] == "f:smaller"
+    assert joint.diagnostics["source_factor_index"] == 1
+    assert joint.diagnostics["source_factor_variables"] == ["A", "B"]
+
+
 def test_trw_bp_returns_unavailable_without_factor_scope_joint():
     with pytest.raises(JointQueryUnavailableError, match="factor-scope pseudo-joint") as exc_info:
         joint_over(_chain_graph(), ["A", "C"], method="trw_bp")
@@ -261,3 +302,26 @@ def test_trw_bp_returns_unavailable_without_factor_scope_joint():
     assert error.method == "trw_bp"
     assert error.variables == ["A", "C"]
     assert error.diagnostics["available_scopes"] == [["A", "B"], ["B", "C"]]
+
+
+def test_trw_factor_joint_tables_do_not_raise_potential_to_rho():
+    graph = FactorGraph()
+    graph.add_variable("A", 0.5)
+    graph.add_variable("B", 0.5)
+    graph.add_factor(
+        "f:weighted",
+        FactorType.PAIRWISE_POTENTIAL,
+        ["A"],
+        "B",
+        cpt=[1.0, 4.0, 2.0, 8.0],
+    )
+    uniform_messages = {
+        ("A", 0): np.array([0.5, 0.5]),
+        ("B", 0): np.array([0.5, 0.5]),
+    }
+
+    tables = _compute_factor_joint_tables(graph, uniform_messages, {0: 0.5})
+
+    assert len(tables) == 1
+    assert tables[0]["rho"] == pytest.approx(0.5)
+    assert tables[0]["probabilities"] == pytest.approx([1 / 15, 4 / 15, 2 / 15, 8 / 15])

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -47,6 +47,15 @@ def test_joint_distribution_validates_bit_order_and_normalization():
             basis="exact_joint_distribution",
         )
 
+    with pytest.raises(ValueError, match="must be finite"):
+        JointDistribution(
+            variables=["A"],
+            probabilities=[float("nan"), 1.0],
+            method="exact",
+            is_exact=True,
+            basis="exact_joint_distribution",
+        )
+
     with pytest.raises(ValueError, match="must be unique"):
         JointDistribution(
             variables=["A", "A"],

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -38,6 +38,24 @@ def test_joint_distribution_validates_bit_order_and_normalization():
     assert joint.variables == ["A", "B"]
     assert joint.probabilities[3] == pytest.approx(0.14)
 
+    with pytest.raises(ValueError, match="must sum to 1"):
+        JointDistribution(
+            variables=["A", "B"],
+            probabilities=[0.25, 0.25, 0.25, 0.30],
+            method="exact",
+            is_exact=True,
+            basis="exact_joint_distribution",
+        )
+
+    with pytest.raises(ValueError, match="must be unique"):
+        JointDistribution(
+            variables=["A", "A"],
+            probabilities=[0.25, 0.25, 0.25, 0.25],
+            method="exact",
+            is_exact=True,
+            basis="exact_joint_distribution",
+        )
+
 
 def test_exact_joint_over_preserves_existing_bit_order():
     joint = joint_over(_two_variable_graph(), ["A", "B"], method="exact")
@@ -63,14 +81,14 @@ def test_compare_joint_over_collects_unavailable_methods():
     results = compare_joint_over(
         _two_variable_graph(),
         ["A", "B"],
-        methods=("exact", "trw_bp", "mean_field"),
+        methods=("exact", "junction_tree", "trw_bp", "mean_field"),
     )
 
     estimates = [result for result in results if isinstance(result, JointDistribution)]
     unavailable = [result for result in results if isinstance(result, JointQueryUnavailable)]
 
     assert {estimate.method for estimate in estimates} == {"exact", "mean_field"}
-    assert {item.method for item in unavailable} == {"trw_bp"}
+    assert {item.method for item in unavailable} == {"junction_tree", "trw_bp"}
     assert all(item.variables == ["A", "B"] for item in unavailable)
 
 
@@ -82,6 +100,34 @@ def test_unknown_variable_is_collected_as_unavailable():
     assert isinstance(unavailable, JointQueryUnavailable)
     assert unavailable.method == "exact"
     assert "unknown variables" in unavailable.reason
+
+
+def test_exact_too_many_variables_is_collected_as_unavailable():
+    graph = FactorGraph()
+    variables = [f"V{i}" for i in range(27)]
+    for variable in variables:
+        graph.add_variable(variable, 0.5)
+
+    results = compare_joint_over(graph, variables, methods=("exact",))
+
+    assert len(results) == 1
+    unavailable = results[0]
+    assert isinstance(unavailable, JointQueryUnavailable)
+    assert unavailable.method == "exact"
+    assert "Exact inference requires 2^n enumeration" in unavailable.reason
+
+
+def test_unexpected_exact_provider_errors_propagate(monkeypatch):
+    def raise_unexpected_value_error(_graph, _variables):
+        raise ValueError("internal exact provider bug")
+
+    monkeypatch.setattr(
+        "gaia.engine.bp.joint_query.exact_joint_over",
+        raise_unexpected_value_error,
+    )
+
+    with pytest.raises(ValueError, match="internal exact provider bug"):
+        joint_over(_two_variable_graph(), ["A", "B"], method="exact")
 
 
 def test_mean_field_on_entailment_graph_returns_normalized_joint():

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -1,0 +1,92 @@
+import pytest
+
+from gaia.engine.bp.factor_graph import FactorGraph, FactorType
+from gaia.engine.bp.joint_query import (
+    JointDistribution,
+    JointQueryUnavailable,
+    compare_joint_over,
+    joint_over,
+)
+
+pytestmark = pytest.mark.pr_gate
+
+
+def _two_variable_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.7)
+    graph.add_variable("B", 0.2)
+    return graph
+
+
+def _entailment_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.8)
+    graph.add_variable("B", 0.5)
+    graph.add_factor("f:a_to_b", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=0.9, p2=0.9)
+    return graph
+
+
+def test_joint_distribution_validates_bit_order_and_normalization():
+    joint = JointDistribution(
+        variables=["A", "B"],
+        probabilities=[0.24, 0.56, 0.06, 0.14],
+        method="exact",
+        is_exact=True,
+        basis="exact_joint_distribution",
+    )
+
+    assert joint.variables == ["A", "B"]
+    assert joint.probabilities[3] == pytest.approx(0.14)
+
+
+def test_exact_joint_over_preserves_existing_bit_order():
+    joint = joint_over(_two_variable_graph(), ["A", "B"], method="exact")
+
+    assert joint.method == "exact"
+    assert joint.is_exact is True
+    assert joint.basis == "exact_joint_distribution"
+    assert joint.variables == ["A", "B"]
+    assert joint.probabilities == pytest.approx([0.24, 0.56, 0.06, 0.14])
+
+
+def test_mean_field_joint_is_variational_product_distribution():
+    joint = joint_over(_two_variable_graph(), ["A", "B"], method="mean_field")
+
+    assert joint.method == "mean_field"
+    assert joint.is_exact is False
+    assert joint.basis == "variational_joint_distribution"
+    assert joint.probabilities == pytest.approx([0.24, 0.56, 0.06, 0.14])
+    assert joint.diagnostics["converged"] is True
+
+
+def test_compare_joint_over_collects_unavailable_methods():
+    results = compare_joint_over(
+        _two_variable_graph(),
+        ["A", "B"],
+        methods=("exact", "trw_bp", "mean_field"),
+    )
+
+    estimates = [result for result in results if isinstance(result, JointDistribution)]
+    unavailable = [result for result in results if isinstance(result, JointQueryUnavailable)]
+
+    assert {estimate.method for estimate in estimates} == {"exact", "mean_field"}
+    assert {item.method for item in unavailable} == {"trw_bp"}
+    assert all(item.variables == ["A", "B"] for item in unavailable)
+
+
+def test_unknown_variable_is_collected_as_unavailable():
+    results = compare_joint_over(_two_variable_graph(), ["A", "missing"], methods=("exact",))
+
+    assert len(results) == 1
+    unavailable = results[0]
+    assert isinstance(unavailable, JointQueryUnavailable)
+    assert unavailable.method == "exact"
+    assert "unknown variables" in unavailable.reason
+
+
+def test_mean_field_on_entailment_graph_returns_normalized_joint():
+    joint = joint_over(_entailment_graph(), ["A", "B"], method="mean_field")
+
+    assert sum(joint.probabilities) == pytest.approx(1.0)
+    assert all(0.0 <= value <= 1.0 for value in joint.probabilities)
+    assert joint.diagnostics["iterations_run"] >= 1

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -114,6 +114,32 @@ def test_compare_joint_over_collects_unavailable_methods():
     assert junction_tree.probabilities == pytest.approx(exact.probabilities)
 
 
+def test_junction_tree_no_factor_singleton_query_uses_singleton_scope():
+    joint = joint_over(_two_variable_graph(), ["A"], method="junction_tree")
+
+    assert joint.method == "junction_tree"
+    assert joint.is_exact is True
+    assert joint.probabilities == pytest.approx([0.3, 0.7])
+    assert joint.diagnostics["treewidth"] == 0
+    assert joint.diagnostics["clique_size"] == 1
+    assert joint.diagnostics["source_clique"] == ["A"]
+
+
+def test_junction_tree_no_factor_joint_uses_independent_singleton_scopes():
+    graph = FactorGraph()
+    variables = [f"V{i}" for i in range(12)]
+    for variable in variables:
+        graph.add_variable(variable, 0.5)
+
+    joint = joint_over(graph, ["V0", "V11"], method="junction_tree")
+
+    assert joint.probabilities == pytest.approx([0.25, 0.25, 0.25, 0.25])
+    assert joint.diagnostics["treewidth"] == 0
+    assert joint.diagnostics["clique_size"] == 1
+    assert joint.diagnostics["source_cliques"] == [["V0"], ["V11"]]
+    assert "source_clique" not in joint.diagnostics
+
+
 def test_unknown_variable_is_collected_as_unavailable():
     results = compare_joint_over(_two_variable_graph(), ["A", "missing"], methods=("exact",))
 
@@ -150,6 +176,19 @@ def test_unexpected_exact_provider_errors_propagate(monkeypatch):
 
     with pytest.raises(ValueError, match="internal exact provider bug"):
         joint_over(_two_variable_graph(), ["A", "B"], method="exact")
+
+
+def test_unexpected_junction_tree_provider_errors_propagate(monkeypatch):
+    def raise_unexpected_value_error(_graph):
+        raise ValueError("internal calibration bug")
+
+    monkeypatch.setattr(
+        "gaia.engine.bp.joint_query.calibrate_junction_tree",
+        raise_unexpected_value_error,
+    )
+
+    with pytest.raises(ValueError, match="internal calibration bug"):
+        joint_over(_two_variable_graph(), ["A"], method="junction_tree")
 
 
 def test_mean_field_on_entailment_graph_returns_normalized_joint():

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -64,6 +64,7 @@ def _nested_covering_factor_graph() -> FactorGraph:
 
 
 def test_bp_package_exports_joint_query_api():
+    import gaia.engine.bp as bp_package
     from gaia.engine.bp import (
         JointDistribution as ExportedJointDistribution,
     )
@@ -86,6 +87,16 @@ def test_bp_package_exports_joint_query_api():
         joint_over as exported_joint_over,
     )
 
+    exported_names = {
+        "JointDistribution",
+        "JointDistributionBasis",
+        "JointQueryMethod",
+        "JointQueryUnavailable",
+        "JointQueryUnavailableError",
+        "compare_joint_over",
+        "joint_over",
+    }
+    assert exported_names <= set(bp_package.__all__)
     assert ExportedJointDistribution is joint_query_module.JointDistribution
     assert ExportedJointDistributionBasis is joint_query_module.JointDistributionBasis
     assert ExportedJointQueryMethod is joint_query_module.JointQueryMethod

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import gaia.engine.bp.joint_query as joint_query_module
 from gaia.engine.bp.factor_graph import FactorGraph, FactorType
 from gaia.engine.bp.joint_query import (
     JointDistribution,
@@ -60,6 +61,38 @@ def _nested_covering_factor_graph() -> FactorGraph:
     graph.add_factor("f:larger", FactorType.CONTRADICTION, ["A", "B"], "H")
     graph.add_factor("f:smaller", FactorType.PAIRWISE_POTENTIAL, ["A"], "B", cpt=[1, 4, 2, 8])
     return graph
+
+
+def test_bp_package_exports_joint_query_api():
+    from gaia.engine.bp import (
+        JointDistribution as ExportedJointDistribution,
+    )
+    from gaia.engine.bp import (
+        JointDistributionBasis as ExportedJointDistributionBasis,
+    )
+    from gaia.engine.bp import (
+        JointQueryMethod as ExportedJointQueryMethod,
+    )
+    from gaia.engine.bp import (
+        JointQueryUnavailable as ExportedJointQueryUnavailable,
+    )
+    from gaia.engine.bp import (
+        JointQueryUnavailableError as ExportedJointQueryUnavailableError,
+    )
+    from gaia.engine.bp import (
+        compare_joint_over as exported_compare_joint_over,
+    )
+    from gaia.engine.bp import (
+        joint_over as exported_joint_over,
+    )
+
+    assert ExportedJointDistribution is joint_query_module.JointDistribution
+    assert ExportedJointDistributionBasis is joint_query_module.JointDistributionBasis
+    assert ExportedJointQueryMethod is joint_query_module.JointQueryMethod
+    assert ExportedJointQueryUnavailable is joint_query_module.JointQueryUnavailable
+    assert ExportedJointQueryUnavailableError is joint_query_module.JointQueryUnavailableError
+    assert exported_compare_joint_over is joint_query_module.compare_joint_over
+    assert exported_joint_over is joint_query_module.joint_over
 
 
 def test_joint_distribution_validates_bit_order_and_normalization():

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -300,6 +300,15 @@ def test_junction_tree_joint_matches_exact_when_clique_contains_query():
     assert jt.diagnostics["treewidth"] >= 1
 
 
+def test_junction_tree_joint_matches_exact_for_deterministic_factor():
+    graph = _contradiction_graph()
+
+    exact = joint_over(graph, ["A", "B"], method="exact")
+    jt = joint_over(graph, ["A", "B"], method="junction_tree")
+
+    assert jt.probabilities == pytest.approx(exact.probabilities, abs=1e-9)
+
+
 def test_junction_tree_returns_unavailable_without_covering_clique():
     results = compare_joint_over(_chain_graph(), ["A", "C"], methods=("junction_tree",))
 

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -26,6 +26,16 @@ def _entailment_graph() -> FactorGraph:
     return graph
 
 
+def _chain_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.8)
+    graph.add_variable("B", 0.5)
+    graph.add_variable("C", 0.5)
+    graph.add_factor("f:a_to_b", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=0.9, p2=0.9)
+    graph.add_factor("f:b_to_c", FactorType.SOFT_ENTAILMENT, ["B"], "C", p1=0.85, p2=0.9)
+    return graph
+
+
 def test_joint_distribution_validates_bit_order_and_normalization():
     joint = JointDistribution(
         variables=["A", "B"],
@@ -96,9 +106,12 @@ def test_compare_joint_over_collects_unavailable_methods():
     estimates = [result for result in results if isinstance(result, JointDistribution)]
     unavailable = [result for result in results if isinstance(result, JointQueryUnavailable)]
 
-    assert {estimate.method for estimate in estimates} == {"exact", "mean_field"}
-    assert {item.method for item in unavailable} == {"junction_tree", "trw_bp"}
+    assert {estimate.method for estimate in estimates} == {"exact", "junction_tree", "mean_field"}
+    assert {item.method for item in unavailable} == {"trw_bp"}
     assert all(item.variables == ["A", "B"] for item in unavailable)
+    exact = next(estimate for estimate in estimates if estimate.method == "exact")
+    junction_tree = next(estimate for estimate in estimates if estimate.method == "junction_tree")
+    assert junction_tree.probabilities == pytest.approx(exact.probabilities)
 
 
 def test_unknown_variable_is_collected_as_unavailable():
@@ -145,3 +158,27 @@ def test_mean_field_on_entailment_graph_returns_normalized_joint():
     assert sum(joint.probabilities) == pytest.approx(1.0)
     assert all(0.0 <= value <= 1.0 for value in joint.probabilities)
     assert joint.diagnostics["iterations_run"] >= 1
+
+
+def test_junction_tree_joint_matches_exact_when_clique_contains_query():
+    graph = _chain_graph()
+
+    exact = joint_over(graph, ["A", "B"], method="exact")
+    jt = joint_over(graph, ["A", "B"], method="junction_tree")
+
+    assert jt.method == "junction_tree"
+    assert jt.is_exact is True
+    assert jt.basis == "calibrated_clique_marginal"
+    assert jt.variables == ["A", "B"]
+    assert jt.probabilities == pytest.approx(exact.probabilities, abs=1e-9)
+    assert jt.diagnostics["treewidth"] >= 1
+
+
+def test_junction_tree_returns_unavailable_without_covering_clique():
+    results = compare_joint_over(_chain_graph(), ["A", "C"], methods=("junction_tree",))
+
+    assert len(results) == 1
+    unavailable = results[0]
+    assert isinstance(unavailable, JointQueryUnavailable)
+    assert unavailable.method == "junction_tree"
+    assert "single calibrated clique" in unavailable.reason

--- a/tests/gaia/bp/test_joint_query.py
+++ b/tests/gaia/bp/test_joint_query.py
@@ -4,6 +4,7 @@ from gaia.engine.bp.factor_graph import FactorGraph, FactorType
 from gaia.engine.bp.joint_query import (
     JointDistribution,
     JointQueryUnavailable,
+    JointQueryUnavailableError,
     compare_joint_over,
     joint_over,
 )
@@ -33,6 +34,15 @@ def _chain_graph() -> FactorGraph:
     graph.add_variable("C", 0.5)
     graph.add_factor("f:a_to_b", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=0.9, p2=0.9)
     graph.add_factor("f:b_to_c", FactorType.SOFT_ENTAILMENT, ["B"], "C", p1=0.85, p2=0.9)
+    return graph
+
+
+def _contradiction_graph() -> FactorGraph:
+    graph = FactorGraph()
+    graph.add_variable("A", 0.8)
+    graph.add_variable("B", 0.25)
+    graph.add_variable("H", 0.7)
+    graph.add_factor("f:not_both", FactorType.CONTRADICTION, ["A", "B"], "H")
     return graph
 
 
@@ -221,3 +231,33 @@ def test_junction_tree_returns_unavailable_without_covering_clique():
     assert isinstance(unavailable, JointQueryUnavailable)
     assert unavailable.method == "junction_tree"
     assert "single calibrated clique" in unavailable.reason
+
+
+def test_trw_bp_returns_factor_scope_pseudo_joint():
+    joint = joint_over(_contradiction_graph(), ["A", "B"], method="trw_bp")
+
+    assert joint.method == "trw_bp"
+    assert joint.is_exact is False
+    assert joint.basis == "approximate_joint_distribution"
+    assert joint.variables == ["A", "B"]
+    assert sum(joint.probabilities) == pytest.approx(1.0)
+
+    expected = [0.105 / 0.62, 0.42 / 0.62, 0.035 / 0.62, 0.06 / 0.62]
+    assert joint.probabilities == pytest.approx(expected, abs=1e-5)
+    assert joint.probabilities[1] > joint.probabilities[2]
+
+    assert joint.diagnostics["source_factor_id"] == "f:not_both"
+    assert joint.diagnostics["source_factor_variables"] == ["A", "B", "H"]
+    assert joint.diagnostics["source_factor_rho"] == pytest.approx(1.0)
+    assert joint.diagnostics["converged"] is True
+    assert joint.diagnostics["iterations_run"] >= 1
+
+
+def test_trw_bp_returns_unavailable_without_factor_scope_joint():
+    with pytest.raises(JointQueryUnavailableError, match="factor-scope pseudo-joint") as exc_info:
+        joint_over(_chain_graph(), ["A", "C"], method="trw_bp")
+
+    error = exc_info.value
+    assert error.method == "trw_bp"
+    assert error.variables == ["A", "C"]
+    assert error.diagnostics["available_scopes"] == [["A", "B"], ["B", "C"]]

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -4,9 +4,14 @@ import sys
 import pytest
 
 import gaia.engine.ir.logic.probability as probability_module
+from gaia.engine.bp import lower_local_graph
 from gaia.engine.bp.factor_graph import FactorGraph, FactorType
 from gaia.engine.bp.joint_query import JointDistribution, JointQueryUnavailable
-from gaia.engine.ir.logic.diagnostics import DiagnosticCondition, FormulaDiagnostic
+from gaia.engine.ir.logic.diagnostics import (
+    DiagnosticCondition,
+    FormulaDiagnostic,
+    inspect_formula_graphs,
+)
 from gaia.engine.ir.logic.probability import (
     ConditionProbabilityEstimate,
     DiagnosticProbability,
@@ -14,6 +19,9 @@ from gaia.engine.ir.logic.probability import (
     score_condition,
     score_diagnostic_conditions,
 )
+from gaia.engine.lang import ClaimAtom, claim, contradict, lnot
+from gaia.engine.lang.compiler import compile_package_artifact
+from gaia.engine.lang.runtime.package import CollectedPackage
 
 pytestmark = pytest.mark.pr_gate
 
@@ -248,6 +256,65 @@ def test_score_diagnostic_conditions_queries_graph_and_skips_diagnostics_without
     assert scored[0].unavailable == []
     assert scored[0].spread == pytest.approx(0.0)
     assert scored[0].exact_spread == pytest.approx(0.0)
+
+
+def test_score_diagnostic_conditions_from_python_dsl_e2e():
+    package = "dsl_prob_e2e"
+    with CollectedPackage(package, namespace="t", version="0.1.0") as pkg:
+        a = claim("A base proposition.", prior=0.8)
+        a.label = "a"
+        left = claim("A holds.", formula=ClaimAtom(a), prior=0.7)
+        left.label = "left"
+        right = claim("A does not hold.", formula=lnot(ClaimAtom(a)), prior=0.25)
+        right.label = "right"
+        helper = contradict(
+            left,
+            right,
+            rationale="A and not-A cannot both hold.",
+            label="left_right_conflict",
+        )
+        helper.label = "left_right_conflict_helper"
+
+    artifact = compile_package_artifact(pkg)
+    report = inspect_formula_graphs(artifact.graph)
+    graph = lower_local_graph(artifact.graph)
+
+    left_id = f"t:{package}::left"
+    right_id = f"t:{package}::right"
+    diagnostic = next(d for d in report.diagnostics if d.code == "cross_claim_incompatibility")
+    assert diagnostic.severity == "warning"
+    assert diagnostic.logic_strength == "hard"
+    assert diagnostic.condition is not None
+    assert diagnostic.condition.variables == [left_id, right_id]
+    assert diagnostic.condition.expression == {
+        "op": "and",
+        "args": [{"var": left_id}, {"var": right_id}],
+    }
+
+    factor_types = {factor.factor_type for factor in graph.factors}
+    assert {FactorType.CONTRADICTION, FactorType.EQUIVALENCE, FactorType.NEGATION} <= factor_types
+
+    scored = score_diagnostic_conditions(
+        [diagnostic],
+        graph,
+        methods=("exact", "junction_tree", "trw_bp", "mean_field"),
+    )
+
+    assert len(scored) == 1
+    probability = scored[0]
+    assert probability.diagnostic_code == "cross_claim_incompatibility"
+    assert probability.condition_kind == "joint_incompatibility"
+    assert probability.unavailable == []
+    assert probability.exact_spread == pytest.approx(0.0)
+
+    estimates = {estimate.method: estimate for estimate in probability.estimates}
+    assert set(estimates) == {"exact", "junction_tree", "trw_bp", "mean_field"}
+    assert estimates["exact"].is_exact is True
+    assert estimates["junction_tree"].is_exact is True
+    assert estimates["trw_bp"].is_exact is False
+    assert estimates["mean_field"].is_exact is False
+    assert estimates["junction_tree"].probability == pytest.approx(estimates["exact"].probability)
+    assert 0.0 < estimates["exact"].probability < 1e-5
 
 
 def test_score_diagnostic_conditions_propagates_unexpected_provider_errors(monkeypatch):

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -1,5 +1,6 @@
 import pytest
 
+import gaia.engine.ir.logic.probability as probability_module
 from gaia.engine.bp.factor_graph import FactorGraph, FactorType
 from gaia.engine.bp.joint_query import JointDistribution, JointQueryUnavailable
 from gaia.engine.ir.logic.diagnostics import DiagnosticCondition, FormulaDiagnostic
@@ -20,9 +21,7 @@ def _joint_ab(method: str = "exact", *, is_exact: bool = True) -> JointDistribut
         probabilities=[0.3, 0.2, 0.1, 0.4],
         method=method,
         is_exact=is_exact,
-        basis="exact_joint_distribution"
-        if is_exact
-        else "approximate_joint_distribution",
+        basis="exact_joint_distribution" if is_exact else "approximate_joint_distribution",
     )
 
 
@@ -104,15 +103,50 @@ def test_score_condition_preserves_unavailable_items_and_computes_spreads():
     scored = score_condition(condition, [exact, unavailable, approximate])
 
     assert isinstance(scored, DiagnosticProbability)
-    assert scored.condition == condition
-    assert scored.diagnostic is None
+    assert scored.diagnostic_code is None
+    assert scored.condition_kind == "joint_incompatibility"
+    assert scored.variables == ["A", "B"]
+    assert scored.event_expression == {"var": "A"}
     assert scored.spread == pytest.approx(0.1)
     assert scored.exact_spread == pytest.approx(0.0)
     assert isinstance(scored.estimates[0], ConditionProbabilityEstimate)
     assert scored.estimates[0].probability == pytest.approx(0.6)
-    assert scored.estimates[1] == unavailable
-    assert isinstance(scored.estimates[2], ConditionProbabilityEstimate)
-    assert scored.estimates[2].probability == pytest.approx(0.7)
+    assert isinstance(scored.estimates[1], ConditionProbabilityEstimate)
+    assert scored.estimates[1].probability == pytest.approx(0.7)
+    assert scored.unavailable == [unavailable]
+
+
+def test_score_condition_accepts_diagnostic_code_and_all_unavailable_boundary():
+    unavailable = JointQueryUnavailable(
+        variables=["A", "B"],
+        method="exact",
+        reason="too large",
+        diagnostics={"limit": 26},
+    )
+    condition = _condition({"var": "A"})
+
+    scored = score_condition(condition, [unavailable], diagnostic_code="cross_claim")
+
+    assert scored.diagnostic_code == "cross_claim"
+    assert scored.condition_kind == "joint_incompatibility"
+    assert scored.variables == ["A", "B"]
+    assert scored.event_expression == {"var": "A"}
+    assert scored.estimates == []
+    assert scored.unavailable == [unavailable]
+    assert scored.spread is None
+    assert scored.exact_spread is None
+
+
+def test_score_condition_approximate_only_has_zero_spread_and_no_exact_spread():
+    approximate = _joint_ab("trw_bp", is_exact=False)
+    condition = _condition({"var": "A"})
+
+    scored = score_condition(condition, [approximate])
+
+    assert len(scored.estimates) == 1
+    assert scored.estimates[0].probability == pytest.approx(0.6)
+    assert scored.spread == pytest.approx(0.0)
+    assert scored.exact_spread is None
 
 
 def test_score_diagnostic_conditions_queries_graph_and_skips_diagnostics_without_condition():
@@ -146,12 +180,44 @@ def test_score_diagnostic_conditions_queries_graph_and_skips_diagnostics_without
         message="No condition.",
     )
 
-    scored = score_diagnostic_conditions(graph, [diagnostic, skipped], methods=("exact",))
+    scored = score_diagnostic_conditions([diagnostic, skipped], graph, methods=("exact",))
 
     assert len(scored) == 1
-    assert scored[0].diagnostic == diagnostic
-    assert scored[0].condition == diagnostic.condition
+    assert scored[0].diagnostic_code == "cross_claim_entailment"
+    assert scored[0].condition_kind == "joint_incompatibility"
+    assert scored[0].variables == ["A", "B"]
+    assert scored[0].event_expression == diagnostic.condition.expression
     assert scored[0].estimates[0].method == "exact"
     assert scored[0].estimates[0].probability == pytest.approx(0.08)
+    assert scored[0].unavailable == []
     assert scored[0].spread == pytest.approx(0.0)
     assert scored[0].exact_spread == pytest.approx(0.0)
+
+
+def test_score_diagnostic_conditions_propagates_unexpected_provider_errors(monkeypatch):
+    graph = FactorGraph()
+    graph.add_variable("A", 0.5)
+    graph.add_variable("B", 0.5)
+    diagnostic = FormulaDiagnostic(
+        code="cross_claim_incompatibility",
+        severity="warning",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim="A",
+        related_claims=["B"],
+        formula_nodes=["fg:a", "fg:b"],
+        condition=_condition({"op": "and", "args": [{"var": "A"}, {"var": "B"}]}),
+        message="A and B conflict.",
+    )
+
+    def raise_unexpected_provider_bug(_graph, _variables, *, methods):
+        raise RuntimeError(f"provider bug for {methods!r}")
+
+    monkeypatch.setattr(
+        probability_module,
+        "compare_joint_over",
+        raise_unexpected_provider_bug,
+    )
+
+    with pytest.raises(RuntimeError, match="provider bug"):
+        score_diagnostic_conditions([diagnostic], graph, methods=("exact",))

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -34,6 +34,30 @@ def _condition(expression: dict) -> DiagnosticCondition:
     )
 
 
+def test_logic_package_exports_diagnostic_probability_api():
+    from gaia.engine.ir.logic import (
+        ConditionProbabilityEstimate as ExportedConditionProbabilityEstimate,
+    )
+    from gaia.engine.ir.logic import (
+        DiagnosticProbability as ExportedDiagnosticProbability,
+    )
+    from gaia.engine.ir.logic import (
+        event_probability as exported_event_probability,
+    )
+    from gaia.engine.ir.logic import (
+        score_condition as exported_score_condition,
+    )
+    from gaia.engine.ir.logic import (
+        score_diagnostic_conditions as exported_score_diagnostic_conditions,
+    )
+
+    assert ExportedConditionProbabilityEstimate is probability_module.ConditionProbabilityEstimate
+    assert ExportedDiagnosticProbability is probability_module.DiagnosticProbability
+    assert exported_event_probability is probability_module.event_probability
+    assert exported_score_condition is probability_module.score_condition
+    assert exported_score_diagnostic_conditions is probability_module.score_diagnostic_conditions
+
+
 def test_event_probability_sums_joint_assignments_in_bit_index_order():
     joint = _joint_ab()
 

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -19,7 +19,7 @@ from gaia.engine.ir.logic.probability import (
     score_condition,
     score_diagnostic_conditions,
 )
-from gaia.engine.lang import ClaimAtom, associate, claim, lnot
+from gaia.engine.lang import ClaimAtom, associate, claim, land, lnot
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
 
@@ -258,25 +258,52 @@ def test_score_diagnostic_conditions_queries_graph_and_skips_diagnostics_without
     assert scored[0].exact_spread == pytest.approx(0.0)
 
 
-def test_score_diagnostic_conditions_from_python_dsl_e2e():
-    package = "dsl_prob_e2e"
-    with CollectedPackage(package, namespace="t", version="0.1.0") as pkg:
-        a = claim("A base proposition.", prior=0.8)
-        a.label = "a"
-        left = claim("A holds.", formula=ClaimAtom(a), prior=0.6)
-        left.label = "left"
-        right = claim("A does not hold.", formula=lnot(ClaimAtom(a)), prior=0.5)
-        right.label = "right"
+def test_score_diagnostic_conditions_from_physics_python_dsl_e2e():
+    package = "cmb_bmode_logic_e2e"
+    with CollectedPackage(package, namespace="physics", version="0.1.0") as pkg:
+        bmode_excess = claim(
+            "BICEP2 reports a degree-scale CMB B-mode excess, meaning an unexpectedly "
+            "strong curl-like polarization pattern in the cosmic microwave background "
+            "on degree angular scales.",
+            prior=0.9,
+        )
+        bmode_excess.label = "bmode_excess"
+        primordial_tensor = claim(
+            "The B-mode excess is dominated by primordial tensor modes, meaning "
+            "gravitational-wave fluctuations from early-universe inflation rather than "
+            "later astrophysical foregrounds.",
+            prior=0.4,
+        )
+        primordial_tensor.label = "primordial_tensor"
+        bicep2_tensor_interpretation = claim(
+            "BICEP2 interpretation: the observed B-mode excess is a primordial tensor "
+            "signal, so the curl-like CMB polarization is mainly from inflationary "
+            "gravitational waves.",
+            formula=land(ClaimAtom(bmode_excess), ClaimAtom(primordial_tensor)),
+            prior=0.4,
+        )
+        bicep2_tensor_interpretation.label = "bicep2_tensor_interpretation"
+        planck_dust_interpretation = claim(
+            "Planck foreground interpretation: the same B-mode excess is dominated by "
+            "Galactic dust foreground, meaning polarized emission from dust in the "
+            "Milky Way, not primordial tensor modes.",
+            formula=land(ClaimAtom(bmode_excess), lnot(ClaimAtom(primordial_tensor))),
+            prior=0.6,
+        )
+        planck_dust_interpretation.label = "planck_dust_interpretation"
         helper = associate(
-            left,
-            right,
-            p_a_given_b=0.9,
+            bicep2_tensor_interpretation,
+            planck_dust_interpretation,
+            p_a_given_b=0.5,
             p_b_given_a=0.75,
             pattern=None,
-            rationale="Current belief model says these claims co-occur often enough to inspect.",
-            label="left_right_belief_assoc",
+            rationale=(
+                "Corpus/reviewer state still gives nontrivial belief to both historical "
+                "interpretations, so the logic warning should be probability-scored."
+            ),
+            label="bmode_interpretation_tension",
         )
-        helper.label = "belief_assoc_helper"
+        helper.label = "bmode_tension_helper"
 
     artifact = compile_package_artifact(pkg)
     report = inspect_formula_graphs(artifact.graph)
@@ -294,8 +321,8 @@ def test_score_diagnostic_conditions_from_python_dsl_e2e():
     )
     graph = lower_local_graph(belief_graph_ir)
 
-    left_id = f"t:{package}::left"
-    right_id = f"t:{package}::right"
+    left_id = f"physics:{package}::bicep2_tensor_interpretation"
+    right_id = f"physics:{package}::planck_dust_interpretation"
     diagnostic = next(d for d in report.diagnostics if d.code == "cross_claim_incompatibility")
     assert diagnostic.severity == "warning"
     assert diagnostic.logic_strength == "hard"
@@ -329,9 +356,9 @@ def test_score_diagnostic_conditions_from_python_dsl_e2e():
     assert estimates["trw_bp"].is_exact is False
     assert estimates["mean_field"].is_exact is False
     assert estimates["junction_tree"].probability == pytest.approx(estimates["exact"].probability)
-    assert estimates["exact"].probability == pytest.approx(0.45)
-    assert estimates["trw_bp"].probability > 0.4
-    assert estimates["mean_field"].probability > 0.3
+    assert estimates["exact"].probability == pytest.approx(0.3)
+    assert estimates["trw_bp"].probability > 0.25
+    assert estimates["mean_field"].probability > 0.2
 
 
 def test_score_diagnostic_conditions_propagates_unexpected_provider_errors(monkeypatch):

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -4,7 +4,6 @@ import sys
 import pytest
 
 import gaia.engine.ir.logic.probability as probability_module
-from gaia.engine.bp import lower_local_graph
 from gaia.engine.bp.factor_graph import FactorGraph, FactorType
 from gaia.engine.bp.joint_query import JointDistribution, JointQueryUnavailable
 from gaia.engine.ir.logic.diagnostics import (
@@ -15,6 +14,7 @@ from gaia.engine.ir.logic.diagnostics import (
 from gaia.engine.ir.logic.probability import (
     ConditionProbabilityEstimate,
     DiagnosticProbability,
+    belief_graph_for_formula_scoring,
     event_probability,
     score_condition,
     score_diagnostic_conditions,
@@ -54,6 +54,9 @@ def test_logic_package_exports_diagnostic_probability_api():
         DiagnosticProbability as ExportedDiagnosticProbability,
     )
     from gaia.engine.ir.logic import (
+        belief_graph_for_formula_scoring as exported_belief_graph_for_formula_scoring,
+    )
+    from gaia.engine.ir.logic import (
         event_probability as exported_event_probability,
     )
     from gaia.engine.ir.logic import (
@@ -66,6 +69,7 @@ def test_logic_package_exports_diagnostic_probability_api():
     exported_names = {
         "ConditionProbabilityEstimate",
         "DiagnosticProbability",
+        "belief_graph_for_formula_scoring",
         "event_probability",
         "score_condition",
         "score_diagnostic_conditions",
@@ -73,6 +77,10 @@ def test_logic_package_exports_diagnostic_probability_api():
     assert exported_names <= set(logic_package.__all__)
     assert ExportedConditionProbabilityEstimate is probability_module.ConditionProbabilityEstimate
     assert ExportedDiagnosticProbability is probability_module.DiagnosticProbability
+    assert (
+        exported_belief_graph_for_formula_scoring
+        is probability_module.belief_graph_for_formula_scoring
+    )
     assert exported_event_probability is probability_module.event_probability
     assert exported_score_condition is probability_module.score_condition
     assert exported_score_diagnostic_conditions is probability_module.score_diagnostic_conditions
@@ -120,6 +128,25 @@ def test_event_probability_sums_joint_assignments_in_bit_index_order():
     assert event_probability(both_true, joint) == pytest.approx(0.4)
     assert event_probability(a_without_b, joint) == pytest.approx(0.2)
     assert event_probability(mismatch, joint) == pytest.approx(0.3)
+
+
+def test_event_probability_handles_three_variable_bit_index_order():
+    joint = JointDistribution(
+        variables=["A", "B", "C"],
+        probabilities=[0.05, 0.10, 0.15, 0.20, 0.03, 0.07, 0.25, 0.15],
+        method="exact",
+        is_exact=True,
+        basis="exact_joint_distribution",
+    )
+
+    a_and_c = {"op": "and", "args": [{"var": "A"}, {"var": "C"}]}
+    b_without_a = {
+        "op": "and",
+        "args": [{"op": "not", "arg": {"var": "A"}}, {"var": "B"}],
+    }
+
+    assert event_probability(a_and_c, joint) == pytest.approx(0.07 + 0.15)
+    assert event_probability(b_without_a, joint) == pytest.approx(0.15 + 0.25)
 
 
 def test_event_probability_does_not_use_marginals_or_independence():
@@ -312,19 +339,7 @@ def test_score_diagnostic_conditions_from_physics_python_dsl_e2e():
 
     artifact = compile_package_artifact(pkg)
     report = inspect_formula_graphs(artifact.graph)
-    # Score the warning under the current belief graph, not under the formula
-    # operators that generated the warning itself. Otherwise the hard logic
-    # relation is conditioned on as evidence and Cromwell-clamps the event.
-    belief_graph_ir = artifact.graph.model_copy(
-        update={
-            "operators": [
-                op
-                for op in artifact.graph.operators
-                if not (op.metadata or {}).get("formula_lowering")
-            ]
-        }
-    )
-    graph = lower_local_graph(belief_graph_ir)
+    graph = belief_graph_for_formula_scoring(artifact.graph)
 
     left_id = f"physics:{package}::bicep2_tensor_interpretation"
     right_id = f"physics:{package}::planck_dust_interpretation"

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -1,0 +1,157 @@
+import pytest
+
+from gaia.engine.bp.factor_graph import FactorGraph, FactorType
+from gaia.engine.bp.joint_query import JointDistribution, JointQueryUnavailable
+from gaia.engine.ir.logic.diagnostics import DiagnosticCondition, FormulaDiagnostic
+from gaia.engine.ir.logic.probability import (
+    ConditionProbabilityEstimate,
+    DiagnosticProbability,
+    event_probability,
+    score_condition,
+    score_diagnostic_conditions,
+)
+
+pytestmark = pytest.mark.pr_gate
+
+
+def _joint_ab(method: str = "exact", *, is_exact: bool = True) -> JointDistribution:
+    return JointDistribution(
+        variables=["A", "B"],
+        probabilities=[0.3, 0.2, 0.1, 0.4],
+        method=method,
+        is_exact=is_exact,
+        basis="exact_joint_distribution"
+        if is_exact
+        else "approximate_joint_distribution",
+    )
+
+
+def _condition(expression: dict) -> DiagnosticCondition:
+    return DiagnosticCondition(
+        kind="joint_incompatibility",
+        variables=["A", "B"],
+        expression=expression,
+        confidence_basis="hard_logic",
+    )
+
+
+def test_event_probability_sums_joint_assignments_in_bit_index_order():
+    joint = _joint_ab()
+
+    both_true = {"op": "and", "args": [{"var": "A"}, {"var": "B"}]}
+    a_without_b = {
+        "op": "and",
+        "args": [{"var": "A"}, {"op": "not", "arg": {"var": "B"}}],
+    }
+    mismatch = {
+        "op": "or",
+        "args": [
+            a_without_b,
+            {
+                "op": "and",
+                "args": [{"op": "not", "arg": {"var": "A"}}, {"var": "B"}],
+            },
+        ],
+    }
+
+    assert event_probability(both_true, joint) == pytest.approx(0.4)
+    assert event_probability(a_without_b, joint) == pytest.approx(0.2)
+    assert event_probability(mismatch, joint) == pytest.approx(0.3)
+
+
+def test_event_probability_does_not_use_marginals_or_independence():
+    joint = _joint_ab()
+
+    marginal_a = 0.2 + 0.4
+    marginal_b = 0.1 + 0.4
+    assert marginal_a * marginal_b == pytest.approx(0.3)
+    assert event_probability(
+        {"op": "and", "args": [{"var": "A"}, {"var": "B"}]},
+        joint,
+    ) == pytest.approx(0.4)
+
+
+def test_event_probability_rejects_missing_variables_and_malformed_expressions():
+    joint = _joint_ab()
+
+    with pytest.raises(ValueError, match="unknown variable"):
+        event_probability({"var": "missing"}, joint)
+
+    with pytest.raises(ValueError, match="not expression requires"):
+        event_probability({"op": "not", "args": [{"var": "A"}]}, joint)
+
+    with pytest.raises(ValueError, match="unsupported diagnostic condition operator"):
+        event_probability({"op": "xor", "args": [{"var": "A"}, {"var": "B"}]}, joint)
+
+
+def test_score_condition_preserves_unavailable_items_and_computes_spreads():
+    exact = _joint_ab("exact", is_exact=True)
+    approximate = JointDistribution(
+        variables=["A", "B"],
+        probabilities=[0.2, 0.3, 0.1, 0.4],
+        method="trw_bp",
+        is_exact=False,
+        basis="approximate_joint_distribution",
+    )
+    unavailable = JointQueryUnavailable(
+        variables=["A", "B"],
+        method="junction_tree",
+        reason="not in one clique",
+        diagnostics={"treewidth": 3},
+    )
+    condition = _condition({"var": "A"})
+
+    scored = score_condition(condition, [exact, unavailable, approximate])
+
+    assert isinstance(scored, DiagnosticProbability)
+    assert scored.condition == condition
+    assert scored.diagnostic is None
+    assert scored.spread == pytest.approx(0.1)
+    assert scored.exact_spread == pytest.approx(0.0)
+    assert isinstance(scored.estimates[0], ConditionProbabilityEstimate)
+    assert scored.estimates[0].probability == pytest.approx(0.6)
+    assert scored.estimates[1] == unavailable
+    assert isinstance(scored.estimates[2], ConditionProbabilityEstimate)
+    assert scored.estimates[2].probability == pytest.approx(0.7)
+
+
+def test_score_diagnostic_conditions_queries_graph_and_skips_diagnostics_without_condition():
+    graph = FactorGraph()
+    graph.add_variable("A", 0.8)
+    graph.add_variable("B", 0.5)
+    graph.add_factor("f:a_to_b", FactorType.SOFT_ENTAILMENT, ["A"], "B", p1=0.9, p2=0.9)
+
+    diagnostic = FormulaDiagnostic(
+        code="cross_claim_entailment",
+        severity="info",
+        scope="claim_pair",
+        logic_strength="hard",
+        source_claim="A",
+        related_claims=["B"],
+        formula_nodes=["fg:a", "fg:b"],
+        condition=_condition(
+            {
+                "op": "and",
+                "args": [{"var": "A"}, {"op": "not", "arg": {"var": "B"}}],
+            }
+        ),
+        message="A entails B.",
+    )
+    skipped = FormulaDiagnostic(
+        code="formula_projection_unsupported",
+        severity="info",
+        scope="claim",
+        logic_strength="unknown",
+        source_claim="C",
+        message="No condition.",
+    )
+
+    scored = score_diagnostic_conditions(graph, [diagnostic, skipped], methods=("exact",))
+
+    assert len(scored) == 1
+    assert scored[0].diagnostic == diagnostic
+    assert scored[0].condition == diagnostic.condition
+    assert scored[0].estimates[0].method == "exact"
+    assert scored[0].estimates[0].probability == pytest.approx(0.08)
+    assert scored[0].spread == pytest.approx(0.0)
+    assert scored[0].exact_spread == pytest.approx(0.0)

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -19,7 +19,7 @@ from gaia.engine.ir.logic.probability import (
     score_condition,
     score_diagnostic_conditions,
 )
-from gaia.engine.lang import ClaimAtom, claim, contradict, lnot
+from gaia.engine.lang import ClaimAtom, associate, claim, lnot
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
 
@@ -263,21 +263,36 @@ def test_score_diagnostic_conditions_from_python_dsl_e2e():
     with CollectedPackage(package, namespace="t", version="0.1.0") as pkg:
         a = claim("A base proposition.", prior=0.8)
         a.label = "a"
-        left = claim("A holds.", formula=ClaimAtom(a), prior=0.7)
+        left = claim("A holds.", formula=ClaimAtom(a), prior=0.6)
         left.label = "left"
-        right = claim("A does not hold.", formula=lnot(ClaimAtom(a)), prior=0.25)
+        right = claim("A does not hold.", formula=lnot(ClaimAtom(a)), prior=0.5)
         right.label = "right"
-        helper = contradict(
+        helper = associate(
             left,
             right,
-            rationale="A and not-A cannot both hold.",
-            label="left_right_conflict",
+            p_a_given_b=0.9,
+            p_b_given_a=0.75,
+            pattern=None,
+            rationale="Current belief model says these claims co-occur often enough to inspect.",
+            label="left_right_belief_assoc",
         )
-        helper.label = "left_right_conflict_helper"
+        helper.label = "belief_assoc_helper"
 
     artifact = compile_package_artifact(pkg)
     report = inspect_formula_graphs(artifact.graph)
-    graph = lower_local_graph(artifact.graph)
+    # Score the warning under the current belief graph, not under the formula
+    # operators that generated the warning itself. Otherwise the hard logic
+    # relation is conditioned on as evidence and Cromwell-clamps the event.
+    belief_graph_ir = artifact.graph.model_copy(
+        update={
+            "operators": [
+                op
+                for op in artifact.graph.operators
+                if not (op.metadata or {}).get("formula_lowering")
+            ]
+        }
+    )
+    graph = lower_local_graph(belief_graph_ir)
 
     left_id = f"t:{package}::left"
     right_id = f"t:{package}::right"
@@ -292,7 +307,7 @@ def test_score_diagnostic_conditions_from_python_dsl_e2e():
     }
 
     factor_types = {factor.factor_type for factor in graph.factors}
-    assert {FactorType.CONTRADICTION, FactorType.EQUIVALENCE, FactorType.NEGATION} <= factor_types
+    assert factor_types == {FactorType.PAIRWISE_POTENTIAL}
 
     scored = score_diagnostic_conditions(
         [diagnostic],
@@ -314,7 +329,9 @@ def test_score_diagnostic_conditions_from_python_dsl_e2e():
     assert estimates["trw_bp"].is_exact is False
     assert estimates["mean_field"].is_exact is False
     assert estimates["junction_tree"].probability == pytest.approx(estimates["exact"].probability)
-    assert 0.0 < estimates["exact"].probability < 1e-5
+    assert estimates["exact"].probability == pytest.approx(0.45)
+    assert estimates["trw_bp"].probability > 0.4
+    assert estimates["mean_field"].probability > 0.3
 
 
 def test_score_diagnostic_conditions_propagates_unexpected_provider_errors(monkeypatch):

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import pytest
 
 import gaia.engine.ir.logic.probability as probability_module
@@ -35,6 +38,7 @@ def _condition(expression: dict) -> DiagnosticCondition:
 
 
 def test_logic_package_exports_diagnostic_probability_api():
+    import gaia.engine.ir.logic as logic_package
     from gaia.engine.ir.logic import (
         ConditionProbabilityEstimate as ExportedConditionProbabilityEstimate,
     )
@@ -51,11 +55,39 @@ def test_logic_package_exports_diagnostic_probability_api():
         score_diagnostic_conditions as exported_score_diagnostic_conditions,
     )
 
+    exported_names = {
+        "ConditionProbabilityEstimate",
+        "DiagnosticProbability",
+        "event_probability",
+        "score_condition",
+        "score_diagnostic_conditions",
+    }
+    assert exported_names <= set(logic_package.__all__)
     assert ExportedConditionProbabilityEstimate is probability_module.ConditionProbabilityEstimate
     assert ExportedDiagnosticProbability is probability_module.DiagnosticProbability
     assert exported_event_probability is probability_module.event_probability
     assert exported_score_condition is probability_module.score_condition
     assert exported_score_diagnostic_conditions is probability_module.score_diagnostic_conditions
+
+
+def test_logic_propositional_import_does_not_eagerly_load_bp_package():
+    script = "\n".join(
+        [
+            "import sys",
+            "from gaia.engine.ir.logic import is_satisfiable",
+            "print('gaia.engine.bp' in sys.modules)",
+            "print('gaia.engine.bp.joint_query' in sys.modules)",
+            "print(callable(is_satisfiable))",
+        ]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == ["False", "False", "True"]
 
 
 def test_event_probability_sums_joint_assignments_in_bit_index_order():

--- a/tests/gaia/logic/test_diagnostic_probability.py
+++ b/tests/gaia/logic/test_diagnostic_probability.py
@@ -276,17 +276,22 @@ def test_score_diagnostic_conditions_from_physics_python_dsl_e2e():
         )
         primordial_tensor.label = "primordial_tensor"
         bicep2_tensor_interpretation = claim(
-            "BICEP2 interpretation: the observed B-mode excess is a primordial tensor "
-            "signal, so the curl-like CMB polarization is mainly from inflationary "
-            "gravitational waves.",
+            "BICEP2 interpretation: BICEP2 reports a degree-scale CMB B-mode excess, "
+            "meaning an unexpectedly strong curl-like polarization pattern in the "
+            "cosmic microwave background; this claim says the excess is mainly a "
+            "primordial tensor signal, meaning gravitational-wave fluctuations from "
+            "early-universe inflation rather than later astrophysical foregrounds.",
             formula=land(ClaimAtom(bmode_excess), ClaimAtom(primordial_tensor)),
             prior=0.4,
         )
         bicep2_tensor_interpretation.label = "bicep2_tensor_interpretation"
         planck_dust_interpretation = claim(
-            "Planck foreground interpretation: the same B-mode excess is dominated by "
-            "Galactic dust foreground, meaning polarized emission from dust in the "
-            "Milky Way, not primordial tensor modes.",
+            "Planck foreground interpretation: BICEP2 reports a degree-scale CMB "
+            "B-mode excess, meaning an unexpectedly strong curl-like polarization "
+            "pattern in the cosmic microwave background; this claim says the excess "
+            "is mainly Galactic dust foreground, meaning polarized emission from "
+            "dust in the Milky Way, not primordial tensor modes from inflationary "
+            "gravitational waves.",
             formula=land(ClaimAtom(bmode_excess), lnot(ClaimAtom(primordial_tensor))),
             prior=0.6,
         )


### PR DESCRIPTION
## Summary
- add joint-query APIs for exact, junction-tree, TRW BP, and mean-field providers
- score formula diagnostic conditions by summing event mass from the returned joint distribution
- add Python DSL E2E coverage for a generated logic warning through compile, diagnostics, BP lowering, and probability scoring
- align junction-tree deterministic potentials with exact enumeration under Cromwell semantics

## Tests
- uv run --project . --extra dev python -m pytest tests/gaia/logic/test_diagnostic_probability.py tests/gaia/logic/test_formula_diagnostics.py tests/gaia/bp/test_joint_query.py
- uv run --project . --extra dev ruff check tests/gaia/logic/test_diagnostic_probability.py
- uv run --project . --extra dev ruff format --check tests/gaia/logic/test_diagnostic_probability.py