### PR TITLE
feat(bayes): add observed data helper

### DIFF
--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -224,17 +224,20 @@ hypothesis predicts the observed data better?"
 
 ```python
 import gaia.engine.bayes as bayes
-from gaia.engine.lang import Constant, Nat, Probability, Variable, claim, equals, observe, parameter
+from gaia.engine.lang import Nat, Probability, Variable, parameter
 
 theta = Variable(symbol="theta", domain=Probability)
-k = Variable(symbol="k", domain=Nat, value=295)
+k = Variable(symbol="k", domain=Nat)
 n = 395
 
 h_3_1 = parameter(theta, 0.75, describe="Mendelian 3:1 segregation.")
 h_null = parameter(theta, 0.5, describe="Null 1:1 segregation.")
 
-data = claim("Observed k = 295 dominant plants.", formula=equals(k, Constant(295, Nat)))
-observe(data, rationale="F2 count table reports 295 dominant phenotypes.")
+data = bayes.data(
+    k,
+    value=295,
+    rationale="F2 count table reports 295 dominant phenotypes.",
+)
 
 model_3_1 = bayes.model(
     h_3_1,
@@ -538,17 +541,20 @@ like "which hypothesis makes this count, measurement, or dataset more likely?"
 
 ```python
 import gaia.engine.bayes as bayes
-from gaia.engine.lang import Constant, Nat, Probability, Variable, claim, equals, observe, parameter
+from gaia.engine.lang import Nat, Probability, Variable, parameter
 
 theta = Variable(symbol="theta", domain=Probability)
-k = Variable(symbol="k", domain=Nat, value=295)
+k = Variable(symbol="k", domain=Nat)
 n = 395
 
 h_3_1 = parameter(theta, 0.75, describe="Mendelian 3:1 segregation.")
 h_null = parameter(theta, 0.5, describe="Null 1:1 segregation.")
 
-data = claim("Observed k = 295 dominant plants.", formula=equals(k, Constant(295, Nat)))
-observe(data, rationale="F2 count table reports 295 dominant phenotypes.")
+data = bayes.data(
+    k,
+    value=295,
+    rationale="F2 count table reports 295 dominant phenotypes.",
+)
 
 model_3_1 = bayes.model(
     h_3_1,

--- a/docs/foundations/gaia-lang/bayes.md
+++ b/docs/foundations/gaia-lang/bayes.md
@@ -48,8 +48,8 @@ updates. It decomposes the paper narrative into reviewable Gaia claims:
 1. `parameter(variable, value)` declares the hypothesis shape.
 2. `bayes.model(hypothesis, observable=..., distribution=...)` declares one
    predictive model helper for one hypothesis.
-3. A formula `claim(...)` plus zero-premise `observe(...)` records measured
-   data, optionally with Normal additive noise metadata.
+3. `bayes.data(observable, value=..., error=...)` records measured data as an
+   observed formula Claim, optionally with Normal additive noise metadata.
 4. `bayes.likelihood(data, model=..., against=[...])` computes likelihood
    factors and lowers them to existing IR `infer` strategies and deterministic
    exclusivity operators.
@@ -135,7 +135,7 @@ override the structural pattern by writing the relation by hand.
 from gaia.engine.bp.exact import exact_inference
 from gaia.engine.bp.lowering import lower_local_graph
 import gaia.engine.bayes as bayes
-from gaia.engine.lang import Constant, Nat, Probability, Variable, claim, equals, observe, parameter
+from gaia.engine.lang import Nat, Probability, Variable, parameter
 from gaia.engine.lang.compiler.compile import compile_package_artifact
 from gaia.engine.lang.runtime.knowledge import _current_package
 from gaia.engine.lang.runtime.package import CollectedPackage
@@ -144,13 +144,11 @@ pkg = CollectedPackage(name="bayes_doc_mendel_pkg", namespace="docs")
 token = _current_package.set(pkg)
 try:
     theta = Variable(symbol="theta", domain=Probability)
-    k = Variable(symbol="k", domain=Nat, value=295)
+    k = Variable(symbol="k", domain=Nat)
 
     h_3_1 = parameter(theta, 0.75, content="theta = 0.75.", prior=0.5, label="h_3_1")
     h_null = parameter(theta, 0.5, content="theta = 0.5.", prior=0.5, label="h_null")
-    data = claim("Observed k = 295.", formula=equals(k, Constant(295, Nat)))
-    observe(data, rationale="Observed k = 295.", label="observe_data")
-    data.label = "data"
+    data = bayes.data(k, value=295, label="data", rationale="Observed k = 295.")
     model_3_1 = bayes.model(
         h_3_1,
         observable=k,
@@ -230,15 +228,11 @@ All of these are rigid operators. Probability lives only in claim priors and
 
 ## Noise And Escape Hatch
 
-For measurement noise, store a Normal additive model on the observed claim:
+For measurement noise, pass `error=` to `bayes.data(...)`. A scalar is
+interpreted as a zero-mean Normal additive standard deviation:
 
 ```python
-data = claim(
-    "Observed y = 3.0.",
-    formula=equals(y, Constant(3.0, Real)),
-    metadata={"bayes": {"noise": bayes.Normal(mu=0, sigma=sigma).model_dump()}},
-)
-observe(data, rationale="Observed y = 3.0.", label="observe_data")
+data = bayes.data(y, value=3.0, error=sigma, label="data")
 ```
 
 The compiler convolves the predictive distribution with that noise model before

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -297,6 +297,7 @@ Schema reference: `docs/specs/2026-05-04-claim-formula-schema-design.md`.
 
 - **Distribution literals.** `bayes.Normal(mu=..., sigma=...)`, `bayes.Binomial(n=..., p=...)`, etc., backed by `scipy.stats`. They are typed values, not Knowledge nodes.
 - **`bayes.model(hypothesis, observable=..., distribution=...)`.** Returns a predictive-model helper Claim backed by a `PredictiveModel(BayesInference)` record that ties one hypothesis Claim to one predictive distribution over an observable Variable.
+- **`bayes.data(observable, value=..., error=...)`.** Returns an observed formula Claim consumable by `bayes.likelihood(...)`; scalar `error` is stored as zero-mean Normal additive noise.
 - **`bayes.likelihood(data, model=..., against=[...], exclusivity=...)`.** Returns a model-preference helper Claim backed by a `Likelihood(BayesInference)` record. Lowers to `infer` strategies plus rigid relation operators expressing the chosen exclusivity contract (e.g., `exhaustive_pairwise_complement`).
 
 `bayes.model / bayes.likelihood` helper records go through the standard action lowering pipeline ([§4](#4-action-lowering)); they share the `action_label_map` table and emit helper Claims that the reviewer sees. See [bayes.md](bayes.md) for the executable Mendel example, the full distribution list, and `gaia build check` diagnostics.

--- a/docs/reference/engine/index.md
+++ b/docs/reference/engine/index.md
@@ -8,7 +8,7 @@ Bayes hypothesis-data helpers, semantic-inquiry state, ARM Trace primitives, and
 behind seven facade submodules, each with an explicit `__all__`.
 
 The facade pattern lets package authors and downstream tooling import
-stable public names without depending on internal file layout. The 226
+stable public names without depending on internal file layout. The 227
 symbols below are the **only** alpha-0 stable surface — anything reachable
 through deeper paths (`gaia.engine.bp.bp.X`, `gaia.engine.lang.dsl.X`, etc.)
 is implementation detail.
@@ -17,7 +17,7 @@ is implementation detail.
 
 | Module | Symbols | Use it for |
 |---|---|---|
-| [bayes](bayes.md) | 19 | Hypothesis-data model comparison, likelihood helpers, and Bayes distribution literals |
+| [bayes](bayes.md) | 20 | Hypothesis-data model comparison, likelihood helpers, observed-data helpers, and Bayes distribution literals |
 | [bp](bp.md) | 17 | Factor-graph lowering, exact inference, junction tree, TRW-BP, Mean Field VI, and engine results |
 | [ir](ir.md) | 36 | Pydantic IR models, graph contracts, strategies, operators, parameterization, and schemas |
 | [lang](lang.md) | 93 | Top-level imports exposed to package authors — current claims, actions, relations, formula helpers, distributions, and runtime entities |
@@ -25,7 +25,7 @@ is implementation detail.
 | [trace](trace.md) | 7 | ARM Trace schema, manifests, and review primitives |
 | [packaging](packaging.md) | 9 | Gaia package loading, compilation, and prior application |
 
-**Grand total: 226 symbols across 7 facades.**
+**Grand total: 227 symbols across 7 facades.**
 
 The `lang` facade subdivides further for browsability — see the supplementary
 pages under `engine/lang/` for DSL, runtime, formula, compiler, and refs

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -421,9 +421,9 @@ def _check_bayes_prediction(
         diagnostics.warnings.append(
             "bayes:unobserved-prediction-target: "
             f"PredictiveModel {prediction_name} observable {symbol!r} has no "
-            "matching observed formula claim. Fix: declare a claim whose formula "
-            "binds that Variable and mark it with observe(...), or import observed "
-            "data from another package."
+            "matching observed formula claim. Fix: use bayes.data(observable, value=...), "
+            "or declare a claim whose formula binds that Variable and mark it with "
+            "observe(...)."
         )
 
 
@@ -457,9 +457,8 @@ def _check_bayes_comparison_data(
                 "bayes:likelihood-without-data: "
                 f"likelihood {comparison_name} references data {_node_name(data_node)} "
                 f"without a bound value for observable {observable_symbol!r}. "
-                "Fix: use claim(..., formula=...) plus observe(...) for the measured "
-                "Variable, or pass precomputed likelihoods with a reviewable "
-                "observation Claim."
+                "Fix: use bayes.data(observable, value=...) for the measured Variable, "
+                "or pass precomputed likelihoods with a reviewable observation Claim."
             )
 
 

--- a/gaia/engine/bayes/README.md
+++ b/gaia/engine/bayes/README.md
@@ -4,6 +4,7 @@
 
 - distribution literals backed by `scipy.stats`
 - `model(...)` for one-hypothesis predictive-model helpers
+- `data(...)` for observed values consumable by likelihood lowering
 - `likelihood(...)` for model-preference helpers and IR `infer` lowering
 
 The module intentionally keeps distribution recipes as typed values rather than
@@ -18,6 +19,7 @@ import gaia.engine.bayes as bayes
 
 model_a = bayes.model(h_a, observable=x, distribution=bayes.Normal(mu=mu, sigma=1.0))
 model_b = bayes.model(h_b, observable=x, distribution=bayes.Normal(mu=mu, sigma=1.0))
+data = bayes.data(x, value=3.0, error=0.2)
 comparison = bayes.likelihood(data, model=model_a, against=[model_b])
 ```
 

--- a/gaia/engine/bayes/__init__.py
+++ b/gaia/engine/bayes/__init__.py
@@ -19,6 +19,7 @@ from gaia.engine.bayes.distributions import (
     StudentT,
     UnresolvedParameterError,
 )
+from gaia.engine.bayes.dsl.data import data
 from gaia.engine.bayes.dsl.likelihood import likelihood
 from gaia.engine.bayes.dsl.model import model
 from gaia.engine.bayes.runtime import BayesInference, Likelihood, PredictiveModel
@@ -69,6 +70,7 @@ __all__ = [
     "PredictiveModel",
     "StudentT",
     "UnresolvedParameterError",
+    "data",
     "likelihood",
     "model",
 ]

--- a/gaia/engine/bayes/dsl/__init__.py
+++ b/gaia/engine/bayes/dsl/__init__.py
@@ -1,6 +1,7 @@
 """Bayes DSL verbs."""
 
+from gaia.engine.bayes.dsl.data import data
 from gaia.engine.bayes.dsl.likelihood import likelihood
 from gaia.engine.bayes.dsl.model import model
 
-__all__ = ["likelihood", "model"]
+__all__ = ["data", "likelihood", "model"]

--- a/gaia/engine/bayes/dsl/data.py
+++ b/gaia/engine/bayes/dsl/data.py
@@ -1,0 +1,109 @@
+"""Bayes observed-data helper."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from gaia.engine.bayes.distributions.continuous import Normal
+from gaia.engine.bayes.distributions.protocol import Distribution
+from gaia.engine.lang.dsl.formula import equals
+from gaia.engine.lang.dsl.support import observe
+from gaia.engine.lang.formula.primitives import PrimitiveType
+from gaia.engine.lang.formula.term import Constant
+from gaia.engine.lang.runtime import Claim, Knowledge, Variable
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int | float):
+        return format(value, "g")
+    return repr(value)
+
+
+def _noise_payload(error: Any) -> dict[str, Any] | None:
+    if error is None:
+        return None
+    if isinstance(error, bool):
+        raise TypeError("bayes.data() error must be a positive numeric sigma or a Normal noise")
+    if isinstance(error, int | float):
+        sigma = float(error)
+        if not math.isfinite(sigma) or sigma <= 0.0:
+            raise ValueError(f"bayes.data() error=sigma requires sigma > 0, got {error!r}")
+        return Normal(mu=0.0, sigma=sigma).model_dump()
+    if isinstance(error, Distribution):
+        payload = error.model_dump()
+        if payload.get("kind") != "normal":
+            raise ValueError("bayes.data() error currently supports only Normal additive noise")
+        return payload
+    raise TypeError("bayes.data() error must be a positive numeric sigma or a Normal noise")
+
+
+def _merged_metadata(
+    metadata: dict[str, Any] | None, noise_payload: dict[str, Any] | None
+) -> dict[str, Any]:
+    merged = dict(metadata or {})
+    if noise_payload is None:
+        return merged
+
+    bayes_meta = merged.get("bayes")
+    if bayes_meta is None:
+        bayes_meta = {}
+    elif not isinstance(bayes_meta, dict):
+        raise TypeError("bayes.data() metadata['bayes'] must be a dict when present")
+    else:
+        bayes_meta = dict(bayes_meta)
+
+    if "noise" in bayes_meta:
+        raise ValueError("bayes.data() got both error= and metadata['bayes']['noise']")
+    bayes_meta["noise"] = noise_payload
+    merged["bayes"] = bayes_meta
+    return merged
+
+
+def _default_content(observable: Variable, value: Any, error: Any) -> str:
+    content = f"Observed {observable.symbol} = {_format_value(value)}"
+    if error is None:
+        return content + "."
+    if isinstance(error, int | float) and not isinstance(error, bool):
+        return content + f" +/- {_format_value(error)}."
+    if isinstance(error, Distribution):
+        return content + f" with {error.kind} additive noise."
+    return content + "."
+
+
+def data(
+    observable: Variable,
+    *,
+    value: Any,
+    error: Any = None,
+    content: str | None = None,
+    background: list[Knowledge] | None = None,
+    source_refs: list[str] | None = None,
+    rationale: str = "",
+    label: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Claim:
+    """Declare an observed value claim consumable by ``bayes.likelihood()``."""
+    if not isinstance(observable, Variable):
+        raise TypeError("bayes.data() observable must be a Variable")
+    if not isinstance(observable.domain, PrimitiveType):
+        raise TypeError("bayes.data() observable must have a PrimitiveType domain")
+
+    payload = _noise_payload(error)
+    observed = Claim(
+        content or _default_content(observable, value, error),
+        background=background or [],
+        formula=equals(observable, Constant(value, observable.domain)),
+        metadata=_merged_metadata(metadata, payload),
+    )
+    observed.label = label
+    observe(
+        observed,
+        background=background,
+        source_refs=source_refs,
+        rationale=rationale or observed.content,
+        label=f"observe_{label}" if label else None,
+    )
+    return observed

--- a/tests/baseline/test_l2_facade.py
+++ b/tests/baseline/test_l2_facade.py
@@ -2,7 +2,7 @@
 
 Locks the 7-submodule public surface after the PR b engine reorg:
 
-- `gaia.engine.bayes` (19)
+- `gaia.engine.bayes` (20)
 - `gaia.engine.bp` (17)
 - `gaia.engine.ir` (36)
 - `gaia.engine.lang` (93)
@@ -10,7 +10,7 @@ Locks the 7-submodule public surface after the PR b engine reorg:
 - `gaia.engine.trace` (7)
 - `gaia.engine.packaging` (9)
 
-Total 226. Adding or removing a symbol from a facade `__all__` requires
+Total 227. Adding or removing a symbol from a facade `__all__` requires
 updating both `docs/reference/engine/index.md` and these counts.
 """
 
@@ -23,7 +23,7 @@ import pytest
 pytestmark = pytest.mark.pr_gate
 
 EXPECTED = {
-    "gaia.engine.bayes": 19,
+    "gaia.engine.bayes": 20,
     "gaia.engine.bp": 17,
     "gaia.engine.ir": 36,
     "gaia.engine.lang": 93,
@@ -43,4 +43,4 @@ def test_facade_surface(module_name: str, expected: int) -> None:
 
 def test_grand_total() -> None:
     total = sum(len(importlib.import_module(m).__all__) for m in EXPECTED)
-    assert total == 226
+    assert total == 227

--- a/tests/gaia/bayes/check/test_gaia_check_bayes.py
+++ b/tests/gaia/bayes/check/test_gaia_check_bayes.py
@@ -46,6 +46,7 @@ __all__ = ["h", "model"]
     assert "model" in result.output
     assert "bayes:unobserved-prediction-target" in result.output
     assert "k" in result.output
+    assert "bayes.data(observable, value=...)" in result.output
     assert "observe(...)" in result.output
     assert "observation()" not in result.output
 
@@ -154,5 +155,5 @@ __all__ = ["h1", "h2", "data", "model1", "model2", "cmp"]
     assert result.exit_code != 0
     assert "bayes:likelihood-without-data" in result.output
     assert "data" in result.output
-    assert "observe(...)" in result.output
+    assert "bayes.data(observable, value=...)" in result.output
     assert "observation()" not in result.output

--- a/tests/gaia/bayes/test_public_surface.py
+++ b/tests/gaia/bayes/test_public_surface.py
@@ -25,14 +25,18 @@ def cleanup_bayes_modules() -> Generator[None, None, None]:
 
 
 def test_bayes_canonical_peer_module_imports() -> None:
-    from gaia.engine.bayes import likelihood, model
+    import gaia.engine.bayes as bayes
+    from gaia.engine.bayes import data, likelihood, model
+    from gaia.engine.bayes.dsl import data as dsl_data
     from gaia.engine.bayes.dsl import likelihood as dsl_likelihood
     from gaia.engine.bayes.dsl import model as dsl_model
     from gaia.engine.bayes.runtime import BayesInference, Likelihood, PredictiveModel
     from gaia.engine.lang.runtime.action import Reasoning
 
+    assert data is dsl_data
     assert model is dsl_model
     assert likelihood is dsl_likelihood
+    assert "data" in bayes.__all__
     assert issubclass(BayesInference, Reasoning)
     assert issubclass(PredictiveModel, BayesInference)
     assert issubclass(Likelihood, BayesInference)

--- a/tests/gaia/bayes/test_runtime_and_lowering.py
+++ b/tests/gaia/bayes/test_runtime_and_lowering.py
@@ -13,6 +13,7 @@ from gaia.engine.bp.exact import exact_inference
 from gaia.engine.bp.factor_graph import FactorType
 from gaia.engine.bp.lowering import lower_local_graph
 from gaia.engine.ir.operator import OperatorType
+from gaia.engine.ir.parameterization import CROMWELL_EPS
 from gaia.engine.lang import (
     Constant,
     Nat,
@@ -26,6 +27,7 @@ from gaia.engine.lang import (
     parameter,
 )
 from gaia.engine.lang.compiler.compile import compile_package_artifact
+from gaia.engine.lang.runtime.action import Observe
 from gaia.engine.lang.runtime.knowledge import _current_package
 from gaia.engine.lang.runtime.package import CollectedPackage
 from gaia.engine.lang.runtime.roles import roles_for_package
@@ -144,6 +146,32 @@ def test_observation_noise_metadata_serializes_distribution_literal():
         "kind": "normal",
         "params": {"mu": 0.0, "sigma": 0.1},
     }
+
+
+def test_data_helper_builds_observed_formula_claim_for_likelihood():
+    pkg = CollectedPackage(name="bayes_data_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        y = Variable(symbol="log_rr", domain=Real)
+        data = bayes.data(y, value=-0.151, error=0.05, label="measured_log_rr")
+    finally:
+        _current_package.reset(token)
+
+    assert data.label == "measured_log_rr"
+    assert data.formula == equals(y, Constant(-0.151, Real))
+    assert data.prior == pytest.approx(1.0 - CROMWELL_EPS)
+    assert data.metadata["bayes"]["noise"] == {
+        "kind": "normal",
+        "params": {"mu": 0.0, "sigma": 0.05},
+    }
+    assert data in pkg.knowledge
+
+    observe_action = data.from_actions[0]
+    assert isinstance(observe_action, Observe)
+    assert observe_action.label == "observe_measured_log_rr"
+    assert observe_action.conclusion is data
+    assert observe_action.given == ()
+    assert observe_action in pkg.actions
 
 
 def test_likelihood_compiles_to_reviewable_infer_strategies_and_exhaustive_complement():
@@ -275,6 +303,49 @@ def test_continuous_normal_noise_likelihood_uses_convolution():
             noise=bayes.Normal(mu=0.0, sigma=2.0),
             label="data",
         )
+        model_near = bayes.model(
+            h_near,
+            observable=y,
+            distribution=bayes.Normal(mu=mu, sigma=1.0),
+            label="model_near",
+        )
+        model_far = bayes.model(
+            h_far,
+            observable=y,
+            distribution=bayes.Normal(mu=mu, sigma=1.0),
+            label="model_far",
+        )
+        cmp_result = bayes.likelihood(data, model=model_near, against=[model_far], label="cmp")
+    finally:
+        _current_package.reset(token)
+
+    compiled = compile_package_artifact(pkg)
+    h_near_id = compiled.knowledge_ids_by_object[id(h_near)]
+    h_far_id = compiled.knowledge_ids_by_object[id(h_far)]
+    cmp_id = compiled.knowledge_ids_by_object[id(cmp_result)]
+    cmp_ir = next(k for k in compiled.graph.knowledges if k.id == cmp_id)
+
+    likelihoods = cmp_ir.metadata["bayes"]["likelihoods"]
+    convolved_sigma = math.sqrt(1.0**2 + 2.0**2)
+    assert likelihoods[h_near_id] == pytest.approx(
+        stats.norm.logpdf(3.0, loc=2.5, scale=convolved_sigma),
+        rel=1e-5,
+    )
+    assert likelihoods[h_far_id] == pytest.approx(
+        stats.norm.logpdf(3.0, loc=0.0, scale=convolved_sigma),
+        rel=1e-5,
+    )
+
+
+def test_data_helper_noise_is_consumed_by_likelihood_lowering():
+    pkg = CollectedPackage(name="bayes_data_noise_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        mu = Variable(symbol="mu", domain=Real)
+        y = Variable(symbol="y", domain=Real)
+        h_near = parameter(mu, 2.5, content="mu = 2.5.", prior=0.5, label="h_near")
+        h_far = parameter(mu, 0.0, content="mu = 0.", prior=0.5, label="h_far")
+        data = bayes.data(y, value=3.0, error=2.0, label="data")
         model_near = bayes.model(
             h_near,
             observable=y,


### PR DESCRIPTION
## Summary

- add `bayes.data(observable, value=..., error=...)` for observed formula Claims consumed by `bayes.likelihood(...)`
- store scalar `error` as zero-mean Normal additive-noise metadata and preserve the existing likelihood lowerer contract
- export the helper from the Bayes facade and update user/foundation/reference docs

## Tests

- `uv run --project /private/tmp/gaia_bayes_data_pr --extra dev python -m pytest -q`
- `uv run --project /private/tmp/gaia_bayes_data_pr --extra dev python -m ruff check .`
- `uv run --project /private/tmp/gaia_bayes_data_pr --extra dev python -m ruff format --check .`
- `uv run --project /private/tmp/gaia_bayes_data_pr --extra dev cz check --rev-range origin/v0.5..HEAD`
