### PR TITLE
feat(lang): coerce Claim to ClaimAtom in connectives; dunder ops return Formula

### DIFF
--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -599,32 +599,36 @@ records, or deterministic relation helpers.
 
 ### Structured formula replacements
 
-For new packages, prefer explicit formula claims when you need a structural
-Boolean expression over existing claims. Wrap referenced claims in `ClaimAtom`
-so the compiler can connect the formula truth variable to the existing IR node.
+For new packages, prefer formula claims when you need a structural Boolean
+expression over existing claims. Propositional connectives auto-wrap referenced
+`Claim` operands as `ClaimAtom(...)`, so the compiler can connect the formula
+truth variable to the existing IR node without extra boilerplate. You can still
+write `ClaimAtom(...)` explicitly when you want the bridge to be visible.
 
 ```python
-from gaia.engine.lang import ClaimAtom, claim, land, lnot, lor
+from gaia.engine.lang import ClaimAtom, claim, land, lor
 
 not_classical = claim(
     "The classical prediction does not hold.",
-    formula=lnot(ClaimAtom(classical_prediction)),
+    formula=~classical_prediction,
 )
 joint_case = claim(
     "Both pieces of evidence hold.",
-    formula=land(ClaimAtom(evidence_a), ClaimAtom(evidence_b)),
+    formula=land(evidence_a, evidence_b),  # equivalent to evidence_a & evidence_b
 )
 either_mechanism = claim(
     "At least one mechanism holds.",
-    formula=lor(ClaimAtom(mech_a), ClaimAtom(mech_b)),
+    formula=lor(ClaimAtom(mech_a), ClaimAtom(mech_b)),  # explicit bridge still works
 )
 ```
 
-The legacy shortcuts `~a`, `a & b`, `a | b`, `not_(a)`, `and_(...)`, and
-`or_(...)` still compile to structural helper claims, but they now emit
-`DeprecationWarning`. Python keywords `not`, `and`, and `or` still cannot be
-overloaded, and `Claim` objects intentionally reject truth-value checks such as
-`if claim:`.
+The modern `Claim` shortcuts `~a`, `a & b`, and `a | b` return Formula nodes and
+do not emit `DeprecationWarning`. They do not create first-class `Claim` nodes
+until you wrap them in `claim(..., formula=...)`. The deprecated function-call
+helpers `not_(a)`, `and_(...)`, and `or_(...)` remain compatibility-only: they
+still compile to structural helper claims and still emit `DeprecationWarning`.
+Python keywords `not`, `and`, and `or` still cannot be overloaded, and `Claim`
+objects intentionally reject truth-value checks such as `if claim:`.
 
 ### First-order quantifiers
 
@@ -808,7 +812,7 @@ from gaia.engine.lang.compat import (
 | `composite(..., sub_strategies=[...])` | Plain `derive(...)` chains plus `@compose` for the workflow boundary | Sub-strategy priors are no longer the v0.5 surface for soft leaves; use `infer(...)` / `bayes.likelihood(...)` instead. |
 | `infer([premises], conclusion, ...)` (legacy positional) | `infer(evidence, hypothesis=..., given=..., p_e_given_h=..., p_e_given_not_h=...)` | The legacy positional form is preserved as a deprecated path; the keyword form is the v0.5 contract. |
 | `contradiction(a, b)` / `equivalence(a, b)` / `complement(a, b)` | `contradict(a, b)` / `equal(a, b)` / `exclusive(a, b)` | The relation-verb forms appear in review manifests and emit reviewable warrant helpers. |
-| `disjunction(*claims)` / `and_(...)` / `or_(...)` / `not_(...)` | `lor(...)` / `land(...)` / `lnot(...)` formula helpers, or explicit `Operator(disjunction, ...)` | Formula AST is the v0.5 way to express structural Boolean expressions. |
+| `disjunction(*claims)` / `and_(...)` / `or_(...)` / `not_(...)` | `claim(..., formula=lor(...))` / `claim(..., formula=land(...))` / `claim(..., formula=lnot(...))`, or the dunder formula sugar `a \| b`, `a & b`, `~a` | Formula AST is the v0.5 way to express structural Boolean expressions; dunders now return Formula nodes, not legacy helper claims. |
 | `noisy_and(...)` | `derive(...)` for deterministic conjunction; `infer(...)` / `bayes.likelihood(...)` for probabilistic evidence aggregation | Currently delegates to legacy `support()`. |
 
 `fills(...)` (cross-package interface bridging) is still the v0.5 surface for

--- a/docs/foundations/bp/inference.md
+++ b/docs/foundations/bp/inference.md
@@ -62,7 +62,7 @@ FactorGraph 是一个**概念**，不绑定特定的存储或运行方式：
 
 Lowering 时，每个 Claim 变量的 prior 按以下优先级确定：
 
-1. **Expression helper**（`~A`, `A & B` 等结构化辅助变量）→ 无 prior（MaxEnt 0.5）
+1. **Expression / formula helper claim**（兼容函数 `not_(A)` / `and_(A, B)` / `or_(A, B)` 生成的 `*_result` helper，或 `claim(formula=...)` 为嵌套 connective 生成的 `__...` helper；现代 `~A` / `A & B` / `A | B` 自身只是 Formula AST）→ 无 prior（MaxEnt 0.5）
 2. **Relation conclusion**（EQUIVALENCE/CONTRADICTION/COMPLEMENT/IMPLICATION 的 conclusion）→ `add_evidence(1)`（hard evidence，Cromwell-softened 为 `1 - ε`）；graph relation assertion 优先于 `node_priors`
 3. **`node_priors` 字典**（调用方显式传入）→ 用户指定值
 4. **`metadata[prior]`** → 使用编译后的 claim prior。它可能来自 `priors.py`、inline `claim(prior=...)` compatibility shortcut、continuous predicate records、或 legacy `reason+prior` compatibility paths

--- a/docs/foundations/gaia-ir/04-helper-claims.md
+++ b/docs/foundations/gaia-ir/04-helper-claims.md
@@ -37,7 +37,7 @@ Knowledge(type=claim)
 
 ## 2. 当前范围
 
-当前 contract 下，helper claim 主要包括以下结构型结果。其中 **expression 类**（`negation_result` / `conjunction_result` / `disjunction_result`）也是 `gaia.engine.ir.knowledge.STRUCTURAL_EXPRESSION_HELPER_KINDS` frozenset 的成员，由 `is_structural_expression_helper(...)` 标记为 **non-reviewable**（来自废弃的 `~A` / `A & B` / `A | B` 快捷写法的兼容路径）；**relation 类**（`equivalence_result` / `contradiction_result` / `complement_result`）默认参与 review manifest。
+当前 contract 下，helper claim 主要包括以下结构型结果。其中 **expression 类**（`negation_result` / `conjunction_result` / `disjunction_result`）也是 `gaia.engine.ir.knowledge.STRUCTURAL_EXPRESSION_HELPER_KINDS` frozenset 的成员，由 `is_structural_expression_helper(...)` 标记为 **non-reviewable**（来自废弃的兼容函数 `not_(A)` / `and_(A, B)` / `or_(A, B)`）；现代 `~A` / `A & B` / `A | B` 快捷写法只返回 Formula AST，不直接生成 helper claim。**relation 类**（`equivalence_result` / `contradiction_result` / `complement_result`）默认参与 review manifest。
 
 | helper_kind | 来源 | 例子 | reviewable |
 |-------------|------|------|------------|

--- a/docs/foundations/gaia-lang/knowledge-and-reasoning.md
+++ b/docs/foundations/gaia-lang/knowledge-and-reasoning.md
@@ -226,7 +226,9 @@ The compiler (`gaia/engine/lang/compiler/compile.py`) walks the package's regist
 
 Most action helpers carry `metadata["review"] = true` and `metadata["helper_kind"]` indicating the lowering origin (`implication_warrant`, `equivalence_result`, `association`, ...). Reviewers see them in the review manifest. They carry no independent prior — their distribution is fully determined by the IR operator they back, except for `infer` / `associate` warrants which encode the author's CPT.
 
-Structural-expression helpers from the deprecated `~A`, `A & B`, `A | B` shortcuts use `metadata["review"] = false` and the kinds `negation_result / conjunction_result / disjunction_result`; they are non-reviewable scaffolding for propositional algebra and are detected by `gaia.engine.ir.knowledge.is_structural_expression_helper`.
+Structural-expression helpers from the deprecated function-call compatibility helpers `not_(A)`, `and_(A, B)`, and `or_(A, B)` use `metadata["review"] = false` and the kinds `negation_result / conjunction_result / disjunction_result`; they are non-reviewable scaffolding for propositional algebra and are detected by `gaia.engine.ir.knowledge.is_structural_expression_helper`.
+
+The modern `Claim` dunder shortcuts `~A`, `A & B`, and `A | B` no longer create helper `Claim` objects. They return Formula AST nodes (`Lnot`, `Land`, `Lor`) that become graph structure only when attached to an authored claim with `claim(..., formula=...)`.
 
 The IR-side public/private boundary for these helpers — including which helper Claims may be referenced from outside their FormalStrategy and which must stay encapsulated — is defined in [gaia-ir/04-helper-claims.md](../gaia-ir/04-helper-claims.md). Action lowering follows that boundary: the warrant helper for a `Derive` / `Observe` / `Compute` / `Infer` / `Associate` is a public Claim (reviewable, addressable via `[@label]`); the intermediate `conjunction_result` of a multi-premise `Derive` lives inside the FormalStrategy's `formal_expr` as a private node and is not addressable.
 
@@ -275,6 +277,8 @@ For the term-level predicate model, including the difference between opaque
 [Predicate Logic In Gaia Lang](predicate-logic.md).
 
 The compiler handles formula claims via `gaia/engine/lang/compiler/lower_formula.py` after the action pass. It (a) emits IR operators for each connective node (`conjunction / disjunction / negation / implication / equivalence`), (b) records variable bindings on the source Claim's `metadata.formula_bindings`, (c) generates intermediate helper Claims for sub-expressions.
+
+As authoring sugar, propositional connectives accept raw `Claim` operands and coerce them to `ClaimAtom(...)`; explicit `ClaimAtom` remains the canonical bridge in the AST. Thus `claim("A and B.", formula=a & b)`, `claim("A and B.", formula=land(a, b))`, and `claim("A and B.", formula=land(ClaimAtom(a), ClaimAtom(b)))` lower to the same connective operator shape.
 
 One sugar helper in `gaia/engine/lang/dsl/sugar.py` maps directly onto a
 non-default `ClaimKind` value:

--- a/docs/foundations/gaia-lang/predicate-logic.md
+++ b/docs/foundations/gaia-lang/predicate-logic.md
@@ -286,11 +286,14 @@ from gaia.engine.lang import ClaimAtom, claim, implies
 
 a = claim("A holds.")
 b = claim("B holds.")
-rule = claim("A implies B.", formula=implies(ClaimAtom(a), ClaimAtom(b)))
+rule = claim("A implies B.", formula=implies(a, b))
 ```
 
 `ClaimAtom` is the bridge. It says "use the truth value of this existing Gaia
-claim as an atom inside the formula."
+claim as an atom inside the formula." Propositional connectives auto-wrap raw
+`Claim` operands as `ClaimAtom(...)`, so `implies(a, b)` is equivalent to
+`implies(ClaimAtom(a), ClaimAtom(b))`; use explicit `ClaimAtom(...)` when you
+want the bridge to be visible.
 
 ### Quantifier
 
@@ -510,11 +513,11 @@ nodes instead of generating new atom nodes.
 Connectives lower to deterministic IR operators:
 
 ```python
-from gaia.engine.lang import ClaimAtom, claim, land
+from gaia.engine.lang import claim, land
 
 a = claim("A.")
 b = claim("B.")
-both = claim("A and B.", formula=land(ClaimAtom(a), ClaimAtom(b)))
+both = claim("A and B.", formula=land(a, b))  # equivalent to formula=a & b
 both.label = "both"
 ```
 
@@ -528,11 +531,11 @@ For a nested formula, Gaia generates private helper claims for intermediate
 sub-expressions:
 
 ```python
-from gaia.engine.lang import ClaimAtom, claim, implies, land
+from gaia.engine.lang import claim, implies, land
 
 rule = claim(
     "A and B imply C.",
-    formula=implies(land(ClaimAtom(a), ClaimAtom(b)), ClaimAtom(c)),
+    formula=implies(land(a, b), c),
 )
 ```
 

--- a/docs/foundations/review/review-pipeline.md
+++ b/docs/foundations/review/review-pipeline.md
@@ -29,7 +29,7 @@ Every authored Action that survives lowering produces at least one **review targ
 | `Compose` | `compose` | "Is the composed workflow &lt;action_label&gt; well-formed and faithful to its child actions?" |
 | Reviewable helper claims (e.g. `bayes` likelihood comparison) | `knowledge` | "Does the helper claim &lt;label&gt; correctly summarize the underlying lifted likelihood update?" |
 
-`DependsOn` and `CandidateRelation` (`Scaffold`) are intentionally not reviewable — they are authoring metadata only and never enter the IR. Structural-expression helpers from the deprecated `~A` / `A & B` / `A | B` shortcuts carry `metadata["review"] = false` and are also skipped.
+`DependsOn` and `CandidateRelation` (`Scaffold`) are intentionally not reviewable — they are authoring metadata only and never enter the IR. Structural-expression helper claims from the deprecated compatibility functions `not_(...)`, `and_(...)`, and `or_(...)` carry `metadata["review"] = false` and are also skipped. Modern `~A` / `A & B` / `A | B` shortcuts return Formula nodes, not review targets by themselves; once wrapped in `claim(..., formula=...)`, the authored claim and lowered formula operators follow the normal formula-claim path.
 
 ## 2. Data Model
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -201,7 +201,7 @@ a `DeprecationWarning`.
 | `analogy(...)` / `extrapolation(...)` / `elimination(...)` / `case_analysis(...)` / `mathematical_induction(...)` | Author the deterministic skeleton with `derive(...)` plus relation verbs |
 | `noisy_and(...)` | `derive(...)` for deterministic conjunction, or `infer(...)` / `bayes.likelihood(...)` for probabilistic evidence links |
 | `contradiction(a, b)` / `equivalence(a, b)` / `complement(a, b)` | `contradict(a, b)` / `equal(a, b)` / `exclusive(a, b)` |
-| `disjunction(*claims)` / `and_(...)` / `or_(...)` / `not_(...)` | Formula AST helpers such as `lor(...)`, `land(...)`, and `lnot(...)` |
+| `disjunction(*claims)` / `and_(...)` / `or_(...)` / `not_(...)` | Formula claims such as `claim(..., formula=lor(...))`, `claim(..., formula=land(...))`, and `claim(..., formula=lnot(...))`; `a \| b`, `a & b`, and `~a` are Formula-returning sugar |
 
 See `docs/foundations/gaia-lang/knowledge-and-reasoning.md` §7 for the fuller
 compatibility surface and the reasoning contract behind each replacement.

--- a/docs/specs/2026-05-04-claim-formula-schema-design.md
+++ b/docs/specs/2026-05-04-claim-formula-schema-design.md
@@ -454,15 +454,17 @@ This is what eliminates the duplicate-numbers pain: numbers live in Variable def
 
 ### 8.1 What must change
 
-Today's helper-creating DSL functions are subsumed by formula AST. When a
-formula refers to an existing claim, wrap the claim in `ClaimAtom(...)`; raw
-`Claim` objects are not formula leaves.
+Today's helper-creating DSL functions are subsumed by formula AST. `ClaimAtom`
+remains the canonical AST bridge for referring to an existing claim, but
+propositional connectives now accept raw `Claim` operands and coerce them to
+`ClaimAtom(...)` as authoring sugar. Raw `Claim` objects are accepted only at
+propositional connective boundaries; term-level predicates stay strict.
 
 | Today (v0.5) | Tomorrow (v0.6) |
 |---|---|
-| `helper = and_(P, Q)` | `claim(..., formula=land(ClaimAtom(P), ClaimAtom(Q)))` |
-| `helper = or_(P, Q)` | `claim(..., formula=lor(ClaimAtom(P), ClaimAtom(Q)))` |
-| `helper = not_(P)` | `claim(..., formula=lnot(ClaimAtom(P)))` |
+| `helper = and_(P, Q)` | `claim(..., formula=land(P, Q))` or `claim(..., formula=P & Q)` |
+| `helper = or_(P, Q)` | `claim(..., formula=lor(P, Q))` or `claim(..., formula=P \| Q)` |
+| `helper = not_(P)` | `claim(..., formula=~P)` |
 | `helper = contradiction(P, Q, prior=0.99)` | `claim(..., formula=lnot(land(ClaimAtom(P), ClaimAtom(Q))), prior=0.99)` |
 | `helper = equivalence(P, Q, prior=0.99)` | `claim(..., formula=iff(ClaimAtom(P), ClaimAtom(Q)), prior=0.99)` |
 | `helper = complement(P, Q)` | `claim(..., formula=lnot(iff(ClaimAtom(P), ClaimAtom(Q))))` (XOR) |

--- a/gaia/engine/lang/formula/connective.py
+++ b/gaia/engine/lang/formula/connective.py
@@ -1,4 +1,13 @@
-"""Connectives — compound formulas built from sub-formulas."""
+"""Connectives — compound formulas built from sub-formulas.
+
+Propositional connectives (``Land``, ``Lor``, ``Lnot``, ``Implies``, ``Iff``)
+accept either Formula operands or raw ``Claim`` objects; the latter are
+auto-wrapped as ``ClaimAtom(claim)`` to remove the boilerplate of writing
+``ClaimAtom(...)`` explicitly at every reference site. Term-level predicates
+(``Equals``, ``Greater``, ``UserPredicate``, ...) stay strict and accept Terms
+only — coercion is intentionally scoped to propositional connectives where
+``Claim`` operands are unambiguous.
+"""
 
 from __future__ import annotations
 
@@ -8,9 +17,25 @@ from typing import Any, ClassVar
 from gaia.engine.lang.formula.predicate import is_formula
 
 
-def _check_formula(name: str, value: object) -> None:
-    if not is_formula(value):
-        raise TypeError(f"{name} is not a Formula: {value!r}")
+def _coerce_formula(name: str, value: object) -> Any:
+    """Return a Formula node for ``value``.
+
+    Already-formula inputs pass through unchanged. ``Claim`` operands are
+    wrapped as ``ClaimAtom(value)`` so callers can write
+    ``land(claim_a, claim_b)`` instead of
+    ``land(ClaimAtom(claim_a), ClaimAtom(claim_b))``. Anything else raises
+    ``TypeError`` — including ``Note``/``Question``/``Setting`` which lack
+    well-defined propositional truth.
+    """
+    if is_formula(value):
+        return value
+
+    from gaia.engine.lang.formula.predicate import ClaimAtom
+    from gaia.engine.lang.runtime.knowledge import Claim
+
+    if isinstance(value, Claim):
+        return ClaimAtom(value)
+    raise TypeError(f"{name} is not a Formula: {value!r}")
 
 
 @dataclass(frozen=True)
@@ -21,12 +46,14 @@ class Land:
     __gaia_formula__: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
-        """Validate conjunction arity and operand formula markers."""
+        """Validate conjunction arity and coerce/validate operand formulas."""
         if len(self.operands) < 2:
             raise ValueError("Land requires at least two operands")
-        for i, op in enumerate(self.operands):
-            if not is_formula(op):
-                raise TypeError(f"Land.operands[{i}] is not a Formula: {op!r}")
+        coerced = tuple(
+            _coerce_formula(f"Land.operands[{i}]", op) for i, op in enumerate(self.operands)
+        )
+        if coerced != self.operands:
+            object.__setattr__(self, "operands", coerced)
 
 
 @dataclass(frozen=True)
@@ -37,12 +64,14 @@ class Lor:
     __gaia_formula__: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
-        """Validate disjunction arity and operand formula markers."""
+        """Validate disjunction arity and coerce/validate operand formulas."""
         if len(self.operands) < 2:
             raise ValueError("Lor requires at least two operands")
-        for i, op in enumerate(self.operands):
-            if not is_formula(op):
-                raise TypeError(f"Lor.operands[{i}] is not a Formula: {op!r}")
+        coerced = tuple(
+            _coerce_formula(f"Lor.operands[{i}]", op) for i, op in enumerate(self.operands)
+        )
+        if coerced != self.operands:
+            object.__setattr__(self, "operands", coerced)
 
 
 @dataclass(frozen=True)
@@ -53,8 +82,10 @@ class Lnot:
     __gaia_formula__: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
-        """Validate that the operand is a Formula."""
-        _check_formula("operand", self.operand)
+        """Coerce/validate the operand as a Formula."""
+        coerced = _coerce_formula("operand", self.operand)
+        if coerced is not self.operand:
+            object.__setattr__(self, "operand", coerced)
 
 
 @dataclass(frozen=True)
@@ -66,9 +97,13 @@ class Implies:
     __gaia_formula__: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
-        """Validate implication operands as Formula nodes."""
-        _check_formula("antecedent", self.antecedent)
-        _check_formula("consequent", self.consequent)
+        """Coerce/validate implication operands as Formula nodes."""
+        coerced_antecedent = _coerce_formula("antecedent", self.antecedent)
+        coerced_consequent = _coerce_formula("consequent", self.consequent)
+        if coerced_antecedent is not self.antecedent:
+            object.__setattr__(self, "antecedent", coerced_antecedent)
+        if coerced_consequent is not self.consequent:
+            object.__setattr__(self, "consequent", coerced_consequent)
 
 
 @dataclass(frozen=True)
@@ -80,6 +115,10 @@ class Iff:
     __gaia_formula__: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
-        """Validate equivalence operands as Formula nodes."""
-        _check_formula("left", self.left)
-        _check_formula("right", self.right)
+        """Coerce/validate equivalence operands as Formula nodes."""
+        coerced_left = _coerce_formula("left", self.left)
+        coerced_right = _coerce_formula("right", self.right)
+        if coerced_left is not self.left:
+            object.__setattr__(self, "left", coerced_left)
+        if coerced_right is not self.right:
+            object.__setattr__(self, "right", coerced_right)

--- a/gaia/engine/lang/runtime/knowledge.py
+++ b/gaia/engine/lang/runtime/knowledge.py
@@ -229,31 +229,76 @@ class Claim(Knowledge):
         raise TypeError(
             "Claim objects do not have Python truth values. Use claim(formula=...) "
             "with ClaimAtom/land/lor/lnot to build structured formula claims; "
-            "legacy ~A, A & B, and A | B shortcuts still exist but emit "
-            "DeprecationWarning."
+            "the ~A, A & B, A | B shortcuts return Formula nodes (Lnot/Land/Lor) "
+            "wrapping ClaimAtom, not Claim helpers."
         )
 
-    def __invert__(self) -> Claim:
-        """Create the deprecated propositional negation helper."""
-        from gaia.engine.lang.dsl.propositional import not_
+    def __invert__(self) -> Any:
+        """Return the Formula ``Lnot(ClaimAtom(self))``.
 
-        return not_(self)
+        Use as ``claim(content, formula=~a)`` to assert the negation as a
+        first-class compound Claim node. Does not register any IR side
+        effects on its own; lowering happens via the surrounding
+        ``claim(formula=...)``.
+        """
+        from gaia.engine.lang.formula.connective import Lnot
 
-    def __and__(self, other: Claim) -> Claim:
-        """Create the deprecated propositional conjunction helper."""
-        if not isinstance(other, Claim):
+        return Lnot(operand=self)
+
+    def __and__(self, other: Any) -> Any:
+        """Return the Formula ``Land(ClaimAtom(self), <other>)``.
+
+        ``other`` may be a ``Claim`` (auto-wrapped) or any Formula node.
+        Returns ``NotImplemented`` for unsupported types so Python can try
+        ``other.__rand__``.
+        """
+        from gaia.engine.lang.formula.connective import Land
+        from gaia.engine.lang.formula.predicate import is_formula
+
+        if not (isinstance(other, Claim) or is_formula(other)):
             return NotImplemented
-        from gaia.engine.lang.dsl.propositional import and_
+        return Land(operands=(self, other))
 
-        return and_(self, other)
+    def __or__(self, other: Any) -> Any:
+        """Return the Formula ``Lor(ClaimAtom(self), <other>)``.
 
-    def __or__(self, other: Claim) -> Claim:
-        """Create the deprecated propositional disjunction helper."""
-        if not isinstance(other, Claim):
+        ``other`` may be a ``Claim`` (auto-wrapped) or any Formula node.
+        Returns ``NotImplemented`` for unsupported types so Python can try
+        ``other.__ror__``.
+        """
+        from gaia.engine.lang.formula.connective import Lor
+        from gaia.engine.lang.formula.predicate import is_formula
+
+        if not (isinstance(other, Claim) or is_formula(other)):
             return NotImplemented
-        from gaia.engine.lang.dsl.propositional import or_
+        return Lor(operands=(self, other))
 
-        return or_(self, other)
+    def __rand__(self, other: Any) -> Any:
+        """Right-side conjunction for ``<formula> & claim`` chains.
+
+        Lets expressions like ``~a & b`` work: ``~a`` is a ``Lnot`` Formula
+        with no ``__and__`` of its own, so Python falls back to
+        ``b.__rand__(Lnot(...))`` which returns ``Land(Lnot(...), ClaimAtom(b))``.
+        """
+        from gaia.engine.lang.formula.connective import Land
+        from gaia.engine.lang.formula.predicate import is_formula
+
+        if not is_formula(other):
+            return NotImplemented
+        return Land(operands=(other, self))
+
+    def __ror__(self, other: Any) -> Any:
+        """Right-side disjunction for ``<formula> | claim`` chains.
+
+        Lets expressions like ``~a | b`` work via the same reflected-dispatch
+        mechanism as ``__rand__``.
+        """
+        from gaia.engine.lang.formula.connective import Lor
+        from gaia.engine.lang.formula.predicate import is_formula
+
+        if not is_formula(other):
+            return NotImplemented
+        return Lor(operands=(other, self))
 
     def __init__(
         self,

--- a/tests/gaia/lang/test_formula_claim_sugar.py
+++ b/tests/gaia/lang/test_formula_claim_sugar.py
@@ -1,0 +1,385 @@
+"""Tests for Claim<->Formula authoring sugar.
+
+Covers two ergonomic improvements that remove `ClaimAtom(...)` boilerplate
+without merging the Formula and Claim layers:
+
+* Sugar A: ``Land/Lor/Lnot/Implies/Iff`` auto-coerce ``Claim`` operands into
+  ``ClaimAtom(claim)``. Operands that are already Formula nodes (including
+  ``ClaimAtom``, ``Equals``, ``UserPredicate``, nested connectives) pass
+  through unchanged. Non-Claim non-Formula operands still raise ``TypeError``.
+
+* Sugar B: ``Claim.__invert__/__and__/__or__`` produce modern Formula nodes
+  (``Lnot/Land/Lor`` wrapping ``ClaimAtom``) instead of the deprecated
+  propositional helper claims, and emit no ``DeprecationWarning``. The
+  deprecated function-call API (``and_/or_/not_`` in ``gaia.engine.lang.compat``)
+  continues to work for explicit legacy callers and is covered separately in
+  ``test_propositional.py``.
+"""
+
+import warnings
+
+import pytest
+
+from gaia.engine.lang import (
+    ClaimAtom,
+    Constant,
+    Equals,
+    Iff,
+    Implies,
+    Land,
+    Lnot,
+    Lor,
+    Nat,
+    Variable,
+    claim,
+    equals,
+    iff,
+    implies,
+    land,
+    lnot,
+    lor,
+)
+from gaia.engine.lang.compiler.compile import compile_package_artifact
+from gaia.engine.lang.runtime.knowledge import Claim, _current_package
+from gaia.engine.lang.runtime.package import CollectedPackage
+
+# ---------------------------------------------------------------------------
+# Sugar A: connective auto-coercion of Claim -> ClaimAtom
+# ---------------------------------------------------------------------------
+
+
+def test_land_auto_wraps_claim_operands_into_claim_atoms():
+    pkg = CollectedPackage(name="sugar_a_land_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        formula = land(a, b)
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Land)
+    assert len(formula.operands) == 2
+    for op, original in zip(formula.operands, (a, b), strict=True):
+        assert isinstance(op, ClaimAtom)
+        assert op.claim is original
+
+
+def test_lor_auto_wraps_claim_operands_into_claim_atoms():
+    pkg = CollectedPackage(name="sugar_a_lor_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        formula = lor(a, b)
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Lor)
+    assert all(isinstance(op, ClaimAtom) for op in formula.operands)
+    assert [op.claim for op in formula.operands] == [a, b]
+
+
+def test_lnot_auto_wraps_claim_operand_into_claim_atom():
+    pkg = CollectedPackage(name="sugar_a_lnot_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        formula = lnot(a)
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Lnot)
+    assert isinstance(formula.operand, ClaimAtom)
+    assert formula.operand.claim is a
+
+
+def test_implies_auto_wraps_claim_operands_into_claim_atoms():
+    pkg = CollectedPackage(name="sugar_a_implies_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        formula = implies(a, b)
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Implies)
+    assert isinstance(formula.antecedent, ClaimAtom)
+    assert isinstance(formula.consequent, ClaimAtom)
+    assert formula.antecedent.claim is a
+    assert formula.consequent.claim is b
+
+
+def test_iff_auto_wraps_claim_operands_into_claim_atoms():
+    pkg = CollectedPackage(name="sugar_a_iff_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        formula = iff(a, b)
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Iff)
+    assert isinstance(formula.left, ClaimAtom)
+    assert isinstance(formula.right, ClaimAtom)
+    assert formula.left.claim is a
+    assert formula.right.claim is b
+
+
+def test_land_passes_through_already_formula_operands_untouched():
+    pkg = CollectedPackage(name="sugar_a_passthrough_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        n = Variable(symbol="n", domain=Nat)
+        existing_atom = ClaimAtom(a)
+        existing_equals = equals(n, Constant(395, Nat))
+        formula = land(existing_atom, existing_equals)
+    finally:
+        _current_package.reset(token)
+
+    assert formula.operands[0] is existing_atom
+    assert formula.operands[1] is existing_equals
+
+
+def test_land_mixes_claim_and_term_formula_operands():
+    pkg = CollectedPackage(name="sugar_a_mixed_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        n = Variable(symbol="n", domain=Nat)
+        formula = land(a, equals(n, Constant(395, Nat)))
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula.operands[0], ClaimAtom)
+    assert formula.operands[0].claim is a
+    assert isinstance(formula.operands[1], Equals)
+
+
+def test_land_rejects_non_claim_non_formula_operand():
+    pkg = CollectedPackage(name="sugar_a_reject_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        with pytest.raises(TypeError, match="not a Formula"):
+            land(a, "not a formula")
+        with pytest.raises(TypeError, match="not a Formula"):
+            land(a, 42)
+    finally:
+        _current_package.reset(token)
+
+
+def test_lnot_rejects_non_claim_non_formula_operand():
+    with pytest.raises(TypeError, match="not a Formula"):
+        lnot("not a formula")
+    with pytest.raises(TypeError, match="not a Formula"):
+        lnot(42)
+
+
+def test_land_arity_validation_still_applies_after_coercion():
+    pkg = CollectedPackage(name="sugar_a_arity_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        with pytest.raises(ValueError, match="at least two operands"):
+            land(a)
+    finally:
+        _current_package.reset(token)
+
+
+def test_claim_with_coerced_land_formula_compiles_to_conjunction_operator():
+    pkg = CollectedPackage(name="sugar_a_compile_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        both = claim("A and B.", formula=land(a, b))
+        both.label = "both"
+    finally:
+        _current_package.reset(token)
+
+    artifact = compile_package_artifact(pkg)
+    op = next(
+        op
+        for op in artifact.graph.operators
+        if (op.metadata or {}).get("formula_lowering") == "connective"
+    )
+    assert op.operator == "conjunction"
+    assert op.variables == ["t:sugar_a_compile_pkg::a", "t:sugar_a_compile_pkg::b"]
+    assert op.conclusion == "t:sugar_a_compile_pkg::both"
+
+
+# ---------------------------------------------------------------------------
+# Sugar B: Claim dunder operators return modern Formula nodes (no warning)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_invert_returns_lnot_formula_without_deprecation_warning():
+    pkg = CollectedPackage(name="sugar_b_invert_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            formula = ~a
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Lnot)
+    assert isinstance(formula.operand, ClaimAtom)
+    assert formula.operand.claim is a
+
+
+def test_claim_and_returns_land_formula_without_deprecation_warning():
+    pkg = CollectedPackage(name="sugar_b_and_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            formula = a & b
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Land)
+    assert [op.claim for op in formula.operands] == [a, b]
+
+
+def test_claim_or_returns_lor_formula_without_deprecation_warning():
+    pkg = CollectedPackage(name="sugar_b_or_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            formula = a | b
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Lor)
+    assert [op.claim for op in formula.operands] == [a, b]
+
+
+def test_claim_and_with_formula_operand_passes_through():
+    pkg = CollectedPackage(name="sugar_b_and_mixed_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        existing = ClaimAtom(b)
+        formula = a & existing
+    finally:
+        _current_package.reset(token)
+
+    assert isinstance(formula, Land)
+    assert isinstance(formula.operands[0], ClaimAtom)
+    assert formula.operands[0].claim is a
+    assert formula.operands[1] is existing
+
+
+def test_claim_and_with_non_claim_non_formula_returns_not_implemented():
+    pkg = CollectedPackage(name="sugar_b_and_reject_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        with pytest.raises(TypeError):
+            a & "not a claim"
+        with pytest.raises(TypeError):
+            a | 42
+    finally:
+        _current_package.reset(token)
+
+
+def test_claim_dunder_chain_compiles_end_to_end():
+    """Compile ``claim(formula=~a | b)`` into the expected disjunction operator.
+
+    The compiled IR should record both a negation helper for ``a`` and a
+    top-level disjunction whose conclusion is the user-named compound Claim.
+    """
+    pkg = CollectedPackage(name="sugar_b_chain_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        either = claim("not A or B.", formula=~a | b)
+        either.label = "either"
+    finally:
+        _current_package.reset(token)
+
+    artifact = compile_package_artifact(pkg)
+    connective_ops = [
+        op
+        for op in artifact.graph.operators
+        if (op.metadata or {}).get("formula_lowering") == "connective"
+    ]
+    operator_names = sorted(op.operator for op in connective_ops)
+    assert operator_names == ["disjunction", "negation"]
+
+    disjunction_op = next(op for op in connective_ops if op.operator == "disjunction")
+    assert disjunction_op.conclusion == "t:sugar_b_chain_pkg::either"
+
+
+def test_claim_and_compiles_to_same_shape_as_explicit_land_form():
+    """Show structural parity between the dunder form and the explicit form.
+
+    ``a & b`` and ``land(ClaimAtom(a), ClaimAtom(b))`` must lower to the same
+    operator (conjunction), the same operand identifiers, and the same
+    conclusion identifier.
+    """
+
+    def _build(pkg_name: str, *, use_dunder: bool):
+        pkg = CollectedPackage(name=pkg_name, namespace="t")
+        token = _current_package.set(pkg)
+        try:
+            a = claim("A.")
+            a.label = "a"
+            b = claim("B.")
+            b.label = "b"
+            both = claim(
+                "A and B.",
+                formula=(a & b) if use_dunder else land(ClaimAtom(a), ClaimAtom(b)),
+            )
+            both.label = "both"
+        finally:
+            _current_package.reset(token)
+        artifact = compile_package_artifact(pkg)
+        return next(
+            op
+            for op in artifact.graph.operators
+            if (op.metadata or {}).get("formula_lowering") == "connective"
+        )
+
+    dunder_op = _build("sugar_b_parity_dunder_pkg", use_dunder=True)
+    explicit_op = _build("sugar_b_parity_explicit_pkg", use_dunder=False)
+
+    assert dunder_op.operator == explicit_op.operator == "conjunction"
+    assert [v.split("::", 1)[1] for v in dunder_op.variables] == [
+        v.split("::", 1)[1] for v in explicit_op.variables
+    ]
+    assert dunder_op.conclusion.split("::", 1)[1] == explicit_op.conclusion.split("::", 1)[1]
+
+
+# ---------------------------------------------------------------------------
+# Claim is still not truthy in a Python sense (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_bool_still_raises_after_dunder_modernization():
+    """Confirm Sugar B leaves ``__bool__`` rejecting accidental truth tests.
+
+    Even though ``~ & |`` are now well-defined formula constructors, ``bool(a)``
+    must continue to raise so that accidental ``if a:`` patterns surface as
+    errors rather than truthy passes.
+    """
+    a = Claim("A.")
+    with pytest.raises(TypeError, match="structured formula claims"):
+        bool(a)

--- a/tests/gaia/lang/test_propositional.py
+++ b/tests/gaia/lang/test_propositional.py
@@ -2,8 +2,6 @@ import pytest
 
 from gaia.engine.lang import Claim
 from gaia.engine.lang.compat import and_, or_
-from gaia.engine.lang.compiler import compile_package_artifact
-from gaia.engine.lang.runtime.package import CollectedPackage
 
 pytestmark = pytest.mark.legacy_dsl
 
@@ -14,26 +12,15 @@ def test_claim_boolean_truth_value_is_not_allowed():
         bool(a)
 
 
-def test_claim_logical_operator_overloads_create_expression_helpers():
-    a = Claim("A.")
-    b = Claim("B.")
-
-    with pytest.warns(DeprecationWarning, match="not_\\(\\) is deprecated"):
-        not_a = ~a
-    with pytest.warns(DeprecationWarning, match="and_\\(\\) is deprecated"):
-        both = a & b
-    with pytest.warns(DeprecationWarning, match="or_\\(\\) is deprecated"):
-        either = a | b
-
-    assert not_a.metadata["helper_kind"] == "negation_result"
-    assert both.metadata["helper_kind"] == "conjunction_result"
-    assert either.metadata["helper_kind"] == "disjunction_result"
-    assert not_a.metadata["review"] is False
-    assert both.metadata["review"] is False
-    assert either.metadata["review"] is False
-
-
 def test_explicit_and_or_functions_accept_multiple_claims():
+    """``and_``/``or_`` remain available as deprecated v5-compat functions.
+
+    They still return helper Claim nodes (the legacy shape) and still emit
+    ``DeprecationWarning`` so explicit callers learn to migrate to
+    ``claim(formula=land(...))``. The modern dunder operators ``~ & |`` no
+    longer route through these helpers; see ``test_formula_claim_sugar.py``
+    for their Formula-returning behavior.
+    """
     a = Claim("A.")
     b = Claim("B.")
     c = Claim("C.")
@@ -59,31 +46,3 @@ def test_propositional_functions_reject_non_claim_inputs():
         pytest.raises(TypeError, match="Claim"),
     ):
         or_(a, object())
-
-
-def test_compile_propositional_expression_helpers_to_nonreviewed_operators():
-    with CollectedPackage("prop_pkg") as pkg:
-        a = Claim("A.")
-        a.label = "a"
-        b = Claim("B.")
-        b.label = "b"
-        with pytest.warns(DeprecationWarning, match="not_\\(\\) is deprecated"):
-            not_a = ~a
-        not_a.label = "not_a"
-        with pytest.warns(DeprecationWarning, match="and_\\(\\) is deprecated"):
-            both = a & b
-        both.label = "both"
-        with pytest.warns(DeprecationWarning, match="or_\\(\\) is deprecated"):
-            either = a | b
-        either.label = "either"
-
-    compiled = compile_package_artifact(pkg)
-    by_conclusion = {op.conclusion: op for op in compiled.graph.operators}
-
-    assert by_conclusion["github:prop_pkg::not_a"].operator == "negation"
-    assert by_conclusion["github:prop_pkg::not_a"].variables == ["github:prop_pkg::a"]
-    assert by_conclusion["github:prop_pkg::both"].operator == "conjunction"
-    assert by_conclusion["github:prop_pkg::either"].operator == "disjunction"
-    assert all("action_label" not in (op.metadata or {}) for op in compiled.graph.operators)
-    assert compiled.review is not None
-    assert compiled.review.reviews == []

--- a/tests/gaia/logic/test_propositional.py
+++ b/tests/gaia/logic/test_propositional.py
@@ -7,7 +7,7 @@ from gaia.engine.ir.logic.propositional import (
     simplify_proposition,
     to_cnf_proposition,
 )
-from gaia.engine.lang import Claim, exclusive
+from gaia.engine.lang import Claim, claim, exclusive, lnot
 from gaia.engine.lang.compiler import compile_package_artifact
 from gaia.engine.lang.runtime.package import CollectedPackage
 
@@ -20,7 +20,7 @@ def test_simplify_proposition_collapses_double_negation():
     with CollectedPackage("logic_double_negation") as pkg:
         a = Claim("A.")
         a.label = "a"
-        double = ~~a
+        double = claim("not not A.", formula=lnot(~a))
         double.label = "double"
 
     graph = compile_package_artifact(pkg).graph
@@ -36,15 +36,15 @@ def test_cnf_and_equivalence_use_demorgan_law():
         a.label = "a"
         b = Claim("B.")
         b.label = "b"
-        both = a & b
+        both = claim("A and B.", formula=a & b)
         both.label = "both"
-        left = ~both
+        left = claim("not (A and B).", formula=lnot(both))
         left.label = "left"
-        not_a = ~a
+        not_a = claim("not A.", formula=~a)
         not_a.label = "not_a"
-        not_b = ~b
+        not_b = claim("not B.", formula=~b)
         not_b.label = "not_b"
-        right = not_a | not_b
+        right = claim("not A or not B.", formula=not_a | not_b)
         right.label = "right"
 
     graph = compile_package_artifact(pkg).graph
@@ -60,9 +60,9 @@ def test_satisfiability_detects_contradictory_formula():
     with CollectedPackage("logic_unsat") as pkg:
         a = Claim("A.")
         a.label = "a"
-        not_a = ~a
+        not_a = claim("not A.", formula=~a)
         not_a.label = "not_a"
-        impossible = a & not_a
+        impossible = claim("A and not A.", formula=a & not_a)
         impossible.label = "impossible"
 
     graph = compile_package_artifact(pkg).graph
@@ -79,13 +79,13 @@ def test_exclusive_relation_is_equivalent_to_or_and_not_both():
         b.label = "b"
         one_of = exclusive(a, b, rationale="closed binary split")
         one_of.label = "one_of"
-        either = a | b
+        either = claim("A or B.", formula=a | b)
         either.label = "either"
-        both = a & b
+        both = claim("A and B.", formula=a & b)
         both.label = "both"
-        not_both = ~both
+        not_both = claim("not (A and B).", formula=lnot(both))
         not_both.label = "not_both"
-        formula = either & not_both
+        formula = claim("either and not both.", formula=either & not_both)
         formula.label = "formula"
 
     graph = compile_package_artifact(pkg).graph


### PR DESCRIPTION
## Summary

Two ergonomic improvements that remove `ClaimAtom(...)` boilerplate without merging the Formula and Claim layers. Motivated by the observation that the canonical compound-Claim pattern

```python
both = claim(\"A and B.\", formula=land(ClaimAtom(a), ClaimAtom(b)))
```

forces two pieces of boilerplate (`ClaimAtom(...)` at every reference site, and the legacy `Claim.__and__/__or__/__invert__` dunder operators still routed through deprecated `dsl.propositional.{and_,or_,not_}` helpers with `DeprecationWarning`).

After this PR the two equivalent author-facing forms are:

```python
# explicit (still works)
both = claim(\"A and B.\", formula=land(ClaimAtom(a), ClaimAtom(b)))

# Sugar A — connectives auto-wrap Claim operands
both = claim(\"A and B.\", formula=land(a, b))

# Sugar B — dunders return Formula nodes (no DeprecationWarning)
both = claim(\"A and B.\", formula=a & b)
either = claim(\"A or B.\", formula=a | b)
not_a = claim(\"not A.\", formula=~a)
```

The Formula/Claim layer separation is **deliberately preserved**: connectives still emit Formula AST (no probability, no node identity, no BP side effects); only `claim(formula=...)` materializes a first-class probabilistic node. Term-level predicates (`Equals`, `Greater`, `UserPredicate`, ...) stay strict and accept Terms only — coercion is scoped to propositional connectives where a `Claim` operand is unambiguous.

### Sugar A — `gaia/engine/lang/formula/connective.py`

`Land`/`Lor`/`Lnot`/`Implies`/`Iff` `__post_init__` now coerce `Claim` operands to `ClaimAtom(claim)` via a shared `_coerce_formula(name, value)` helper (lazy imports of `ClaimAtom`/`Claim` to avoid the circular with `runtime.knowledge`). Already-formula inputs pass through unchanged; non-`Claim` non-Formula inputs still `TypeError`. Mendel-style `land(equals(n, Constant(395, Nat)), equals(k, Constant(295, Nat)))` keeps working exactly as before because both operands are already Formulas.

### Sugar B — `gaia/engine/lang/runtime/knowledge.py`

`Claim.__invert__/__and__/__or__` now return `Lnot/Land/Lor` Formula nodes (no DeprecationWarning, no IR side effects on their own; lowering still happens via the surrounding `claim(formula=...)`). Adds `__rand__/__ror__` so left-side-Formula chains like `~a | b` work via reflected dispatch. `Claim.__bool__` guard is preserved so accidental truth tests still raise; the error message is updated to describe the new Formula-returning behavior.

The deprecated function-call API `and_/or_/not_` in `gaia.engine.lang.compat` is **untouched** — explicit callers of those functions still get the same `DeprecationWarning`, and `tests/gaia/lang/test_propositional.py` keeps covering that path. The dunder-specific assertions in that file (which exercised the now-gone legacy dunder behavior) are removed; new dunder semantics are covered by `tests/gaia/lang/test_formula_claim_sugar.py`.

### Test migration

`tests/gaia/logic/test_propositional.py` is migrated to the new dunder semantics: each `~a` / `a & b` / `~~a` / `a & not_a` expression is wrapped in `claim(formula=...)`. Resulting compiled IR graph structure is unchanged, so the sympy-based `simplify_proposition`/`are_equivalent`/`is_satisfiable` assertions hold without modification.

## Coverage

New file `tests/gaia/lang/test_formula_claim_sugar.py` (19 tests):

- **Sugar A** (10 tests): each connective auto-wraps Claim operands; passthrough of already-Formula operands; mixed Claim + Term-equality operands; non-Formula operand rejection; arity validation after coercion; end-to-end compile to `conjunction` operator.
- **Sugar B** (8 tests): `~/&/|` return Formula nodes without DeprecationWarning; `__rand__/__ror__` support left-side Formula chains; `NotImplemented` for unsupported types; end-to-end compile of `~a | b`; structural parity between `claim(formula=a & b)` and `claim(formula=land(ClaimAtom(a), ClaimAtom(b)))`.
- **1 regression guard**: `bool(claim)` still raises after dunder modernization.

## Test plan

- [x] `uv run pytest tests/gaia/lang/test_formula_claim_sugar.py` — 19 passed
- [x] `uv run pytest tests/gaia/lang/test_propositional.py tests/gaia/logic/test_propositional.py` — 8 passed
- [x] `uv run pytest --no-cov` (full fast suite) — 2046 passed, 3 skipped, 0 failed
- [x] `uv run ruff check` on touched files — clean
- [x] `uv run mypy` (full project) — Success, no issues in 319 source files

## Out of scope / non-goals

- No `__invert__` added to Formula classes — `~Land(...)` keeps `TypeError`-ing; users write `lnot(a & b)`. This keeps Formula nodes as a pure read-only AST.
- No `Formula1 & Formula2` operator-overload — that case is fine as `land(f1, f2)`.
- `Claim.__rand__/__ror__` accept Formula operands only; the `claim & claim` case is already resolved by the left side's `__and__`.

Made with [Cursor](https://cursor.com)