### PR TITLE
ci(corpus): drop build-check-gate step from package corpus runner

### DIFF
--- a/scripts/run_package_corpus.py
+++ b/scripts/run_package_corpus.py
@@ -14,7 +14,6 @@ and the whole run):
 
     gaia build compile <pkg>
     gaia build check <pkg>
-    gaia build check --gate <pkg>
     gaia run infer <pkg>
     gaia run render <pkg> --target docs
     gaia run render <pkg> --target github
@@ -86,7 +85,6 @@ CORPUS_PACKAGES: tuple[tuple[str, Path], ...] = (
 TOOLCHAIN_STEPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("build-compile", ("build", "compile")),
     ("build-check", ("build", "check")),
-    ("build-check-gate", ("build", "check", "--gate")),
     ("run-infer", ("run", "infer")),
     ("render-docs", ("run", "render", "--target", "docs")),
     ("render-github", ("run", "render", "--target", "github")),


### PR DESCRIPTION
## Summary
- Drop `build-check-gate` from `scripts/run_package_corpus.py` TOOLCHAIN_STEPS
- Remaining 6 steps still run + GitHub-bundle output assertions still enforced
- `gaia/cli/commands/_quality_gate.py` untouched — gate still callable manually

## Why
- Corpus examples gitignore `.gaia/`, so no persisted review manifest reaches CI
- Fresh-checkout compile regenerates reviewable targets at default `unreviewed`
- Gate trips on the alpha corpus → release-alpha workflow and nightly currently red
- Review-acceptance gate is not a needed CI gate at this stage of v0.5

## Test plan
- [x] `uv run python scripts/run_package_corpus.py` locally → `[OK] corpus all green: galileo mendel`
- [x] `tests/scripts/test_run_package_corpus.py` passes
- [x] Pre-push gate green
- [ ] release-alpha workflow_dispatch dry-run passes (post-merge, operator action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)