### PR TITLE
docs(release): prepare v0.5.0a1 alpha

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -6,7 +6,7 @@ description: >-
 
 inputs:
   version:
-    description: "PEP 440 version string (e.g. 0.5.1a1, 0.5.1, 0.5.1rc1)"
+    description: "PEP 440 version string (e.g. 0.5.0a1, 0.5.0, 0.5.0rc1)"
     required: true
   channel:
     description: "Release channel: a, b, rc, stable"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,10 +3,8 @@ name: Nightly
 on:
   schedule:
     # 20:00 UTC = 04:00 Asia/Shanghai (next day). Daily nightly cadence.
-    # Workflow body runs full validation gates including corpus runner;
-    # with current galileo --gate red, scheduled runs will fail until
-    # the galileo fixture is reviewed — accepted noise as a daily
-    # reminder that the fixture review is pending.
+    # Workflow body runs full validation gates including the package corpus
+    # runner; a red corpus blocks artifact upload.
     - cron: "0 20 * * *"
   workflow_dispatch:
 
@@ -52,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      # Spec §3 mandates Nightly version form `0.5.1.dev<YYYYMMDD>` (PEP 440
+      # Spec §3 mandates Nightly version form `0.5.0.dev<YYYYMMDD>` (PEP 440
       # dev tag). Without this bump the daily wheel filename collides at
       # `gaia_lang-0.5.0-*.whl` and nightlies are indistinguishable. The sed
       # is pinned to the literal current dev version ('0.5.0'); the grep
@@ -62,8 +60,8 @@ jobs:
       - name: Bump version to nightly dev form
         run: |
           dev_date=$(date -u +%Y%m%d)
-          sed -i 's/^version = "0\.5\.0"$/version = "0.5.1.dev'${dev_date}'"/' pyproject.toml
-          grep -q "^version = \"0\.5\.1\.dev${dev_date}\"$" pyproject.toml || {
+          sed -i 's/^version = "0\.5\.0"$/version = "0.5.0.dev'${dev_date}'"/' pyproject.toml
+          grep -q "^version = \"0\.5\.0\.dev${dev_date}\"$" pyproject.toml || {
             echo "::error::Failed to bump pyproject.toml version (current: $(grep ^version pyproject.toml))"
             exit 1
           }
@@ -115,9 +113,9 @@ jobs:
       # Stage 3 corpus runner. Step id is referenced by the artifact-upload
       # condition below: a red corpus must block artifact upload per R1
       # dispatch lock ("package-corpus failures block nightly artifact
-      # upload"). NOTE: the first nightly run is expected to fail here on
-      # `gaia build check --gate` for galileo (8 unreviewed claims); fixture
-      # review is a separate follow-up (Stage 7 territory).
+      # upload"). The alpha corpus exercises compile/check/infer/render
+      # workflow compatibility; ReviewManifest acceptance remains a separate
+      # local quality-gate preview, not a release-corpus requirement.
       - name: Package corpus e2e
         id: corpus
         run: uv run python scripts/run_package_corpus.py

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "PEP 440 version (alpha example: 0.5.1a1)"
+        description: "PEP 440 version (alpha example: 0.5.0a1)"
         required: true
         type: string
       dry_run:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "PEP 440 version (beta example: 0.5.1b1)"
+        description: "PEP 440 version (beta example: 0.5.0b1)"
         required: true
         type: string
       dry_run:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "PEP 440 version (rc example: 0.5.1rc1)"
+        description: "PEP 440 version (rc example: 0.5.0rc1)"
         required: true
         type: string
       dry_run:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "PEP 440 version (stable example: 0.5.1)"
+        description: "PEP 440 version (stable example: 0.5.0)"
         required: true
         type: string
       dry_run:

--- a/docs/releases/0.5.0a1.md
+++ b/docs/releases/0.5.0a1.md
@@ -1,0 +1,216 @@
+# Gaia Lang v0.5.0a1 Alpha Release Notes
+
+Gaia Lang v0.5.0a1 is the first public alpha preview of the v0.5 release line.
+It is intended for Gaia package authors, contributors, and early adopters who
+want to test the new authoring, inference, Bayes, rendering, and package
+workflow before the v0.5 API is frozen.
+
+This is not a stable release. Command names, Python import surfaces, Bayes
+helpers, review tooling, and package workflow details may still change before
+beta.
+
+## Install
+
+Use a fresh Python 3.12+ environment:
+
+```bash
+python -m venv /tmp/gaia-v05-alpha
+source /tmp/gaia-v05-alpha/bin/activate
+pip install gaia-lang==0.5.0a1
+```
+
+Or, if you intentionally allow prereleases:
+
+```bash
+pip install --pre gaia-lang
+```
+
+After installation, include `gaia --version` output in bug reports:
+
+```bash
+gaia --version
+```
+
+The alpha wheel should report `gaia-lang 0.5.0a1`, `channel: a`, the source
+commit used to build the wheel, and the current IR schema string.
+
+## Who Should Try This
+
+Try this alpha if you are:
+
+- building or migrating Gaia knowledge packages
+- testing the grouped v0.5 CLI
+- evaluating the new `gaia.engine.*` Python import surface
+- trying the Bayes model/compare workflow on real examples
+- helping find stale documentation, migration gaps, or package-corpus failures
+
+Stay on `gaia-lang==0.4.4` if you need the current stable install target or do
+not want to adjust package code yet.
+
+## Major Changes Since v0.4
+
+### Grouped CLI Surface
+
+The old flat CLI verbs are no longer the primary interface. v0.5 organizes the
+CLI by workflow:
+
+- `gaia build ...` for package initialization, compilation, and checking
+- `gaia run ...` for inference and rendering
+- `gaia inspect ...` for graph inspection
+- `gaia pkg ...` for package dependencies, scaffolds, and registration
+- `gaia author ...` for agent-friendly DSL authoring
+- `gaia bayes ...` for Bayes model and distribution helpers
+- `gaia inquiry ...` and `gaia trace ...` for local review/debugging workflows
+
+See [Migration to alpha 0](../migration.md) for the old-to-new command mapping.
+
+### Canonical `gaia.engine.*` Python API
+
+The canonical Python API now lives under `gaia.engine.*`. The historical
+top-level namespaces such as `gaia.lang`, `gaia.bp`, and `gaia.ir` are not the
+v0.5 contract. Existing packages should update imports to the new engine
+facades, for example:
+
+```python
+from gaia.engine.lang import claim, derive, note, observe
+```
+
+The engine facades are documented under [Gaia Engine API](../reference/engine/index.md).
+
+### Agent-Friendly Authoring
+
+v0.5 adds a structured authoring surface for agents and humans who want to
+modify packages without hand-editing every DSL statement:
+
+- `gaia author claim`
+- `gaia author observe`
+- `gaia author derive`
+- `gaia author compute`
+- `gaia author infer`
+- `gaia author compose`
+- `gaia pkg scaffold`
+- `gaia pkg add-module`
+- `gaia pkg add-import`
+
+This surface is useful for reproducible package edits, but it is still alpha.
+Please report confusing command output, unsafe prewrite behavior, or generated
+source that is hard to review.
+
+### Unified Bayes Model Comparison
+
+The Bayes surface has moved toward a clearer model/data comparison contract:
+
+- define parameter-value hypotheses with `parameter(...)`
+- define predictive models with `bayes.model(...)`
+- record observations with `observe(...)`
+- compare competing models with `bayes.compare(...)`
+- use distribution factories such as `Binomial`, `BetaBinomial`, and `Normal`
+  from `gaia.engine.lang`
+
+The Mendel example package exercises this path with a Bayesian comparison
+between Mendelian segregation and a diffuse alternative. See
+[Bayes Module And Continuous Quantities](../foundations/gaia-lang/bayes.md).
+
+### Package Corpus Validation
+
+The release pipeline validates real Gaia packages, not only unit tests. The
+locked alpha corpus currently includes:
+
+- `examples/galileo-v0-5-gaia`
+- `examples/mendel-v0-5-gaia`
+
+For each package, the corpus runner checks that Gaia can compile, structurally
+check, infer, and render docs/GitHub/Obsidian outputs. The corpus gate does not
+yet require every review warrant to be accepted; ReviewManifest remains an
+alpha preview rather than a complete publication ecosystem.
+
+## ReviewManifest And Quality Gate Preview
+
+v0.5 includes local plumbing for action-level review state through
+`ReviewManifest`, `gaia build check --warrants`, `gaia inquiry review`, and
+`gaia build check --gate`.
+
+This is an alpha preview, not a finished reviewer ecosystem. The mechanism can
+generate and consume `.gaia/review_manifest.json`, and the quality gate is useful
+for local package hardening. However, the end-to-end author/reviewer workflow,
+registry-level reviewer assignment, and smooth package-publication policy are
+still being hardened.
+
+Important caveats for v0.5.0a1:
+
+- release corpus validation does not currently require accepted
+  `.gaia/review_manifest.json` entries
+- local preview inference can run without treating review status as a hard gate
+- `gaia review` is a help-visible skeleton, while `gaia inquiry review` is the
+  current local review command
+- review UX and docs are expected to change before beta
+
+Treat this as an experimental integrity layer and report cases where the gate is
+unclear, too strict, or hard to satisfy.
+
+## Breaking Changes And Migration Notes
+
+v0.5 is a breaking release line relative to v0.4.
+
+Expected migration work:
+
+- update flat CLI invocations such as `gaia compile` to grouped commands such
+  as `gaia build compile`
+- update imports to `gaia.engine.*`
+- recompile `.gaia/ir.json` and `.gaia/ir_hash` with v0.5
+- rerun `gaia build check`, `gaia run infer`, and render commands before
+  comparing output to older package artifacts
+- move new code away from legacy compatibility helpers and toward
+  `claim`, `note`, `derive`, `compute`, `infer`, relation verbs, and the Bayes
+  model/compare surface
+
+See [Migration to alpha 0](../migration.md) for detailed command and import
+tables.
+
+## Known Limitations
+
+- v0.5.0a1 is an alpha release; APIs and semantics may change before beta.
+- The review ecosystem is local and experimental; registry-level review
+  assignment is not complete.
+- Some downstream packages will require import-path and CLI-command migration.
+- Bayes model comparison is ready for early testing, but external backend
+  adapters and richer probabilistic-programming integrations are not part of
+  this alpha.
+- Normal users should not expect `pip install gaia-lang` to resolve this alpha
+  unless they use `--pre` or pin `gaia-lang==0.5.0a1`.
+
+## Release Validation Contract
+
+The v0.5.0a1 artifact should only be published after these gates pass on the
+release commit:
+
+- release workflows are reachable from GitHub Actions, either because the
+  repository default branch is `v0.5` or because an equivalent default-branch
+  dispatcher invokes the v0.5 workflows
+- PR CI on `v0.5`
+- docs build
+- wheel smoke from a fresh virtual environment
+- full test suite via `make test-all`
+- package corpus via `uv run python scripts/run_package_corpus.py`
+- release workflow dry run for `version=0.5.0a1`, `channel=a`
+
+After publication, maintainers should run a fresh PyPI install smoke:
+
+```bash
+python -m venv /tmp/gaia-v05-alpha-smoke
+source /tmp/gaia-v05-alpha-smoke/bin/activate
+pip install gaia-lang==0.5.0a1
+gaia --version
+gaia --help
+```
+
+## Feedback Wanted
+
+Please open issues or PRs for:
+
+- unclear v0.4 to v0.5 migration steps
+- broken grouped CLI commands
+- stale documentation
+- confusing `gaia author` or `gaia bayes` behavior
+- example package failures
+- quality-gate false positives or hard-to-satisfy review states

--- a/docs/specs/2026-05-16-gaia-release-channel-strategy.md
+++ b/docs/specs/2026-05-16-gaia-release-channel-strategy.md
@@ -49,16 +49,23 @@ Release channels are stability contracts. They should answer:
 | Channel | Version form | Trigger | Intended users | Stability contract |
 |---|---|---|---|---|
 | PR/dev | none | Pull request to `main` / `v0.5`, or push to `main` / `v0.5`; also `workflow_dispatch` | Contributors | Not published; fast feedback only. |
-| Nightly | `0.5.1.dev20260516` | Scheduled daily at 20:00 UTC (04:00 Asia/Shanghai next day) via `schedule`, plus on-demand via `workflow_dispatch`; runs against the default branch (`v0.5`) tip (see §9 Q-schedule) | Package authors and maintainers | Rolling snapshot; may break APIs, but must identify the exact commit and validation result. |
-| Alpha | `0.5.1a1` | Manual `workflow_dispatch` of `release-alpha.yml` (post-nightly green) | Early adopters trying real packages | Recognized preview; APIs and semantics may still change, but known breakages must be listed. |
-| Beta | `0.5.1b1` | Manual `workflow_dispatch` of `release-beta.yml` (post-alpha) | Users preparing migration | Feature and semantic surface should be mostly frozen; migration docs expected. |
-| Release candidate | `0.5.1rc1` | Manual `workflow_dispatch` of `release-rc.yml` (post-beta) | Final validators | Only release-blocking bug fixes should land after this point. |
-| Stable | `0.5.1` | Manual `workflow_dispatch` of `release-stable.yml` (post-rc) | Default users and registry workflows | Default install target; must pass release validation and publish durable artifacts. |
+| Nightly | `0.5.0.dev20260516` | Scheduled daily at 20:00 UTC (04:00 Asia/Shanghai next day) via `schedule`, plus on-demand via `workflow_dispatch`; runs against the default branch (`v0.5`) tip (see §9 Q-schedule) | Package authors and maintainers | Rolling snapshot; may break APIs, but must identify the exact commit and validation result. |
+| Alpha | `0.5.0a1` | Manual `workflow_dispatch` of `release-alpha.yml` (post-nightly green) | Early adopters trying real packages | Recognized preview; APIs and semantics may still change, but known breakages must be listed. |
+| Beta | `0.5.0b1` | Manual `workflow_dispatch` of `release-beta.yml` (post-alpha) | Users preparing migration | Feature and semantic surface should be mostly frozen; migration docs expected. |
+| Release candidate | `0.5.0rc1` | Manual `workflow_dispatch` of `release-rc.yml` (post-beta) | Final validators | Only release-blocking bug fixes should land after this point. |
+| Stable | `0.5.0` | Manual `workflow_dispatch` of `release-stable.yml` (post-rc) | Default users and registry workflows | Default install target; must pass release validation and publish durable artifacts. |
 
 Nightly and alpha are different:
 
 - Nightly is a timestamped snapshot of the active branch (runs daily at 20:00 UTC via `schedule`, plus operator-initiated `workflow_dispatch`).
 - Alpha is a human decision that a snapshot is worth broader early testing.
+
+Operational prerequisite: GitHub only exposes `workflow_dispatch` and
+`schedule` workflows from the repository default branch. Before v0.5 alpha
+promotion, the repository default branch must be switched to `v0.5`, or an
+equivalent default-branch dispatcher must invoke the v0.5 release workflows.
+Otherwise `release-alpha.yml` and `nightly.yml` can exist on `v0.5` while still
+being unavailable from the Actions UI/API.
 
 ## 4. CI Layers
 
@@ -100,7 +107,7 @@ uv run --extra docs mkdocs build --strict
 uv run python scripts/run_package_corpus.py
 ```
 
-It also bumps `pyproject.toml` (transiently) to `0.5.1.dev<YYYYMMDD>`, injects `_build_info.py` (CHANNEL=nightly, COMMIT=<sha>), and uploads the wheel/sdist as a GHA artifact gated on corpus success. The corpus runner is the artifact-upload gate per R1 dispatch lock: a red corpus blocks artifact upload.
+It also bumps `pyproject.toml` (transiently) to `0.5.0.dev<YYYYMMDD>`, injects `_build_info.py` (CHANNEL=nightly, COMMIT=<sha>), and uploads the wheel/sdist as a GHA artifact gated on corpus success. The corpus runner is the artifact-upload gate per R1 dispatch lock: a red corpus blocks artifact upload.
 
 ### Release CI
 
@@ -109,7 +116,7 @@ Release CI is nightly CI plus publishing checks, factored into a composite actio
 | Invariant | Enforcement |
 |---|---|
 | Version is valid PEP 440 | Caller workflow passes the version string into `inputs.version`; the composite asserts the post-`sed` `pyproject.toml` line matches exactly via `grep -q`, and additionally asserts `gaia --version` reports the same version string (defense-in-depth against a busted `_build_info.py` or version-injection bug). |
-| Changelog / release notes exist | For stable, `gh release create --generate-notes` auto-generates release notes from merged PRs. The release does not currently consume a curated `CHANGELOG.md` — the auto-generated notes are the chosen approach (see §9). |
+| Release notes exist | Alpha and later channels should have a curated note under `docs/releases/`; stable additionally uses `gh release create --generate-notes` for the GitHub Release artifact. |
 | Docs build | `uv run --extra docs mkdocs build --strict` runs as a release gate before publish. |
 | Package corpus e2e passes | `uv run python scripts/run_package_corpus.py` runs as a release gate before publish. |
 | Artifacts include source commit and channel metadata | `_build_info.py` injection writes `CHANNEL` + `COMMIT`; `gaia --version` exposes both (asserted). |
@@ -134,7 +141,6 @@ For each package, the e2e command sequence should be:
 ```bash
 gaia build compile <pkg>
 gaia build check <pkg>
-gaia build check --gate <pkg>
 gaia run infer <pkg>
 gaia run render <pkg> --target docs
 gaia run render <pkg> --target github
@@ -156,17 +162,17 @@ The GitHub render check should assert the current publication-bundle contract:
 Use one package name, `gaia-lang`, with PEP 440 versions:
 
 ```text
-0.5.1.dev20260516
-0.5.1a1
-0.5.1b1
-0.5.1rc1
-0.5.1
+0.5.0.dev20260516
+0.5.0a1
+0.5.0b1
+0.5.0rc1
+0.5.0
 ```
 
 `gaia --version` exposes enough provenance to reproduce the build:
 
 ```text
-gaia-lang 0.5.1.dev20260516
+gaia-lang 0.5.0.dev20260516
 channel: nightly
 commit: <git sha>
 ir_schema: ir-v1+<12-hex-digest>
@@ -241,4 +247,4 @@ PR #620 (merged 2026-05-16) landed the implementation; this section records what
 
 - **Q-codecov (added 2026-05-16, resolved).** Codecov was discussed during the PR-CI narrowing decision. Resolution: Codecov retired entirely — no `--cov-report=xml`, no Codecov upload step, Codecov GitHub App removed as a required check. PR CI is positioned as a change detector, not a coverage gate; the policy is "if we want coverage, it lives under nightly, not on PR latency".
 
-- **Q-schedule (added 2026-05-16, resolved 2026-05-17).** Whether nightly should run on a schedule cron. Resolution: daily `schedule` cron at `0 20 * * *` (20:00 UTC = 04:00 Asia/Shanghai next day) plus `workflow_dispatch` for on-demand runs. Earlier resolution was `workflow_dispatch`-only — that was reconsidered post-#620: a daily auto-run surfaces fixture / corpus regressions on the README badge without requiring an operator to remember to dispatch. Note: while the galileo fixture `--gate` is red, scheduled runs will fail at the corpus runner step (blocking artifact upload by design); this noise is accepted as a daily reminder that the fixture review is pending.
+- **Q-schedule (added 2026-05-16, resolved 2026-05-17).** Whether nightly should run on a schedule cron. Resolution: daily `schedule` cron at `0 20 * * *` (20:00 UTC = 04:00 Asia/Shanghai next day) plus `workflow_dispatch` for on-demand runs. Earlier resolution was `workflow_dispatch`-only — that was reconsidered post-#620: a daily auto-run surfaces fixture / corpus regressions on the README badge without requiring an operator to remember to dispatch.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,8 @@ nav:
   - User Reference:
       - Language Reference: for-users/language-reference.md
       - CLI Commands: for-users/cli-commands.md
+  - Release Notes:
+      - v0.5.0a1 Alpha: releases/0.5.0a1.md
   - Foundational Docs:
       - Overview: foundations/README.md
       - Theory:

--- a/scripts/run_package_corpus.py
+++ b/scripts/run_package_corpus.py
@@ -138,8 +138,8 @@ def _format_output_tail(stderr: str, stdout: str, *, max_lines: int = 5) -> str:
     """Return the last ``max_lines`` non-empty output lines, single-line.
 
     Prefers ``stderr`` when populated; falls back to ``stdout`` because the
-    gaia CLI emits some failure detail (e.g. ``gaia build check --gate``
-    quality-gate report) on stdout, and a single-line diagnostic shouldn't
+    gaia CLI emits some failure detail (for example structural check reports)
+    on stdout, and a single-line diagnostic shouldn't
     appear empty when the CI logs clearly show the failure.
     """
     stream = stderr if stderr.strip() else stdout


### PR DESCRIPTION
## Summary

- add curated v0.5.0a1 alpha release notes and expose them in MkDocs nav
- align release-channel docs and workflow input examples with first v0.5 prerelease versions (`0.5.0a1` / `0.5.0b1` / `0.5.0rc1` / `0.5.0`)
- document the GitHub Actions default-branch prerequisite for dispatching v0.5 release workflows
- remove stale corpus-gate wording that implied ReviewManifest acceptance is required for the alpha corpus

## Validation

- `git diff --check`
- `uv run --extra docs mkdocs build --strict`
- `uv run python scripts/run_package_corpus.py`
- `uv build`
- fresh venv install of local wheel, `gaia --help`, `gaia --version`, and facade-import smoke

## Notes

`release-alpha.yml` is still a `workflow_dispatch` workflow on `v0.5`. Since GitHub currently exposes manual workflows from the repository default branch, operators still need to switch the default branch to `v0.5` or add an equivalent default-branch dispatcher before the alpha dry-run/publication can be launched from Actions.
