### PR TITLE
ci(release): publish from top-level workflows

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -1,8 +1,8 @@
-name: Release
+name: Release validation
 description: >-
-  Build, validate, and (if not dry-run) publish a gaia-lang wheel/sdist for a
-  given channel. Stage 6 of spec §8 step 5: factor shared release logic out of
-  the four manual caller workflows (alpha/beta/rc/stable).
+  Build and validate a gaia-lang wheel/sdist for a given channel. Publishing
+  stays in the top-level caller workflow because PyPA Trusted Publishing does
+  not support being invoked from a composite action.
 
 inputs:
   version:
@@ -17,12 +17,6 @@ inputs:
   dry_run:
     description: "true|false — skip publish, only build+validate"
     required: true
-  do_git_tag:
-    description: "true|false — only true for stable channel"
-    required: true
-  github_token:
-    description: "GITHUB_TOKEN for gh release create; required if do_git_tag=true and dry_run=false"
-    required: false
 
 runs:
   using: composite
@@ -110,37 +104,10 @@ runs:
       shell: bash
       run: uv run python scripts/run_package_corpus.py
 
-    - name: Publish to PyPI (OIDC trusted publishing)
-      if: inputs.dry_run != 'true'
-      uses: pypa/gh-action-pypi-publish@release/v1
-
-    # Stable-only: tag and GitHub release. Both gated on dry_run too so a
-    # dry-run stable dispatch never touches refs or releases.
-    - name: Create git tag (stable only)
-      if: inputs.dry_run != 'true' && inputs.do_git_tag == 'true'
-      shell: bash
-      run: |
-        git tag -a "v${{ inputs.version }}" -m "gaia-lang v${{ inputs.version }}"
-        git push origin "v${{ inputs.version }}"
-
-    - name: Create GitHub release (stable only)
-      if: inputs.dry_run != 'true' && inputs.do_git_tag == 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-      run: |
-        gh release create "v${{ inputs.version }}" \
-          --title "v${{ inputs.version }}" \
-          --generate-notes \
-          dist/*.whl dist/*.tar.gz
-
     - name: Dry-run summary
       if: inputs.dry_run == 'true'
       shell: bash
       run: |
         echo "::notice::dry-run: built artifacts (not published):"
         ls -la dist/
-        echo "::notice::Would have published to PyPI"
-        if [ "${{ inputs.do_git_tag }}" = "true" ]; then
-          echo "::notice::Would have tagged v${{ inputs.version }} and created GitHub release"
-        fi
+        echo "::notice::Caller workflow would publish these artifacts to PyPI"

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -19,10 +19,8 @@ on:
         default: false
 
 permissions:
-  # `contents: write` is needed only by stable for tag push + gh release create;
-  # harmless on alpha/beta/rc since those code paths are guarded by do_git_tag.
-  # `id-token: write` is required for OIDC trusted publishing to PyPI via
-  # pypa/gh-action-pypi-publish inside the composite action.
+  # `contents: write` is harmless on alpha and keeps the release workflows
+  # uniform. `id-token: write` is required for PyPI Trusted Publishing.
   contents: write
   id-token: write
 
@@ -58,5 +56,7 @@ jobs:
           channel: "a"
           commit: ${{ github.sha }}
           dry_run: ${{ inputs.dry_run }}
-          do_git_tag: "false"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        if: ${{ inputs.dry_run == false }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -19,8 +19,7 @@ on:
 
 permissions:
   # `contents: write` kept for uniformity with stable (unused on beta).
-  # `id-token: write` is required for OIDC trusted publishing to PyPI via
-  # pypa/gh-action-pypi-publish inside the composite action.
+  # `id-token: write` is required for PyPI Trusted Publishing.
   contents: write
   id-token: write
 
@@ -56,5 +55,7 @@ jobs:
           channel: "b"
           commit: ${{ github.sha }}
           dry_run: ${{ inputs.dry_run }}
-          do_git_tag: "false"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        if: ${{ inputs.dry_run == false }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -20,8 +20,7 @@ on:
 
 permissions:
   # `contents: write` kept for uniformity with stable (unused on rc).
-  # `id-token: write` is required for OIDC trusted publishing to PyPI via
-  # pypa/gh-action-pypi-publish inside the composite action.
+  # `id-token: write` is required for PyPI Trusted Publishing.
   contents: write
   id-token: write
 
@@ -57,5 +56,7 @@ jobs:
           channel: "rc"
           commit: ${{ github.sha }}
           dry_run: ${{ inputs.dry_run }}
-          do_git_tag: "false"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        if: ${{ inputs.dry_run == false }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -4,7 +4,7 @@ name: Release (stable)
 # auto-trigger. 协作单 五·Q7 + 七 locks: pre-release artifacts are durable
 # (never retracted from PyPI). Stable is the only channel that creates a
 # git tag (`v<version>`) and a GitHub release; both steps are gated on
-# `dry_run != 'true'` inside the composite action.
+# `inputs.dry_run == false` after PyPI publish succeeds.
 
 on:
   workflow_dispatch:
@@ -21,8 +21,7 @@ on:
 
 permissions:
   # `contents: write` is needed for the stable-only git tag push + gh release create.
-  # `id-token: write` is required for OIDC trusted publishing to PyPI via
-  # pypa/gh-action-pypi-publish inside the composite action.
+  # `id-token: write` is required for PyPI Trusted Publishing.
   contents: write
   id-token: write
 
@@ -58,5 +57,23 @@ jobs:
           channel: "stable"
           commit: ${{ github.sha }}
           dry_run: ${{ inputs.dry_run }}
-          do_git_tag: "true"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        if: ${{ inputs.dry_run == false }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create git tag
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          git tag -a "v${{ inputs.version }}" -m "gaia-lang v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Create GitHub release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "v${{ inputs.version }}" \
+            --generate-notes \
+            dist/*.whl dist/*.tar.gz

--- a/docs/specs/2026-05-16-gaia-release-channel-strategy.md
+++ b/docs/specs/2026-05-16-gaia-release-channel-strategy.md
@@ -4,7 +4,7 @@
 >
 > **Date:** 2026-05-16
 >
-> **Last updated:** 2026-05-16 (post-implementation amend per chenkun review on PR #620).
+> **Last updated:** 2026-05-19 (PyPI Trusted Publishing must run in the top-level release workflow, not inside a composite action).
 >
 > **Scope:** Release channels, CI validation layers, package-corpus e2e checks, and version naming for gaia-lang.
 >
@@ -111,7 +111,14 @@ It also bumps `pyproject.toml` (transiently) to `0.5.0.dev<YYYYMMDD>`, injects `
 
 ### Release CI
 
-Release CI is nightly CI plus publishing checks, factored into a composite action (`.github/actions/release/action.yml`) invoked by four manual caller workflows (`release-alpha.yml`, `release-beta.yml`, `release-rc.yml`, `release-stable.yml`). The composite enforces the six release invariants:
+Release CI is nightly CI plus publishing checks. Build + validation are
+factored into a composite action (`.github/actions/release/action.yml`) invoked
+by four manual caller workflows (`release-alpha.yml`, `release-beta.yml`,
+`release-rc.yml`, `release-stable.yml`). PyPI Trusted Publishing runs in the
+top-level caller workflow after the composite completes, because
+`pypa/gh-action-pypi-publish` does not support Trusted Publishing from inside a
+composite action. Together, the composite and caller workflow enforce the six
+release invariants:
 
 | Invariant | Enforcement |
 |---|---|
@@ -120,9 +127,12 @@ Release CI is nightly CI plus publishing checks, factored into a composite actio
 | Docs build | `uv run --extra docs mkdocs build --strict` runs as a release gate before publish. |
 | Package corpus e2e passes | `uv run python scripts/run_package_corpus.py` runs as a release gate before publish. |
 | Artifacts include source commit and channel metadata | `_build_info.py` injection writes `CHANNEL` + `COMMIT`; `gaia --version` exposes both (asserted). |
-| Publishing target matches the channel | Caller workflow drives `inputs.channel`; only `do_git_tag=true` (stable) triggers `git tag` + `gh release create`. All four callers use the same OIDC trusted-publishing target on PyPI. |
+| Publishing target matches the channel | Caller workflow drives `inputs.channel`; all four callers use the same top-level OIDC trusted-publishing target on PyPI. Only `release-stable.yml` creates `git tag` + `gh release create`, and only after PyPI publish succeeds. |
 
-The composite also runs `make test-all` as a release gate alongside docs build and corpus runner. Gates run in both dry-run and non-dry-run modes — dry-run skips publish/tag/release, but the validation gates are themselves the pipeline being verified, so they always run.
+The composite also runs `make test-all` as a release gate alongside docs build
+and corpus runner. Gates run in both dry-run and non-dry-run modes — dry-run
+skips publish/tag/release, but the validation gates are themselves the pipeline
+being verified, so they always run.
 
 ## 5. Package Corpus E2E
 
@@ -220,7 +230,7 @@ PR #620 (merged 2026-05-16) landed the implementation; this section records what
 
 4. `gaia --version` reports `channel`, `commit`, and `ir_schema` (the `ir-vN+<12-hex>` form, see §6).
 
-5. Four manual caller workflows (`release-alpha.yml`, `release-beta.yml`, `release-rc.yml`, `release-stable.yml`) all invoke `.github/actions/release/action.yml` (composite). The composite enforces version assertion (sed + grep-q), `_build_info.py` injection, `gaia --version` channel + version asserts, `uv build`, wheel-smoke, `make test-all`, docs strict build, package corpus e2e, then conditional PyPI publish / git tag / GH release.
+5. Four manual caller workflows (`release-alpha.yml`, `release-beta.yml`, `release-rc.yml`, `release-stable.yml`) all invoke `.github/actions/release/action.yml` (composite). The composite enforces version assertion (sed + grep-q), `_build_info.py` injection, `gaia --version` channel + version asserts, `uv build`, wheel-smoke, `make test-all`, docs strict build, and package corpus e2e. The caller workflow then conditionally performs top-level PyPI publish; the stable caller additionally creates the git tag and GitHub Release after publish succeeds.
 
 ## 9. Open Questions (resolved at implementation time)
 


### PR DESCRIPTION
## Summary
- move PyPI Trusted Publishing out of the composite release action and into the top-level release workflows
- keep the composite focused on build and validation gates
- keep stable tag and GitHub release creation after PyPI publish succeeds
- update the release-channel strategy doc with the supported PyPA topology

## Why
The first non-dry-run alpha attempt passed all gates but failed in pypa/gh-action-pypi-publish because Trusted Publishing was invoked from the composite action. PyPA documents this as unsupported. The generated Docker action used ghcr.io/SiliconEinstein/Gaia:v0.5, which Docker rejects because image repository names must be lowercase.

## Validation
- YAML parse check for release action and release workflows
- uv run --extra docs mkdocs build --strict
- git diff --check