### PR TITLE
docs(readme): point badges at main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: Docs
 
 on:
   push:
-    branches: [v0.5]
+    branches: [main]
   pull_request:
-    branches: [main, v0.5]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -31,19 +31,19 @@ jobs:
         run: make docs-build
 
       - name: Configure Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/v0.5'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
         with:
           enablement: true
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/v0.5'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/v0.5'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Gaia Lang
 
-[![CI](https://github.com/SiliconEinstein/Gaia/actions/workflows/ci.yml/badge.svg)](https://github.com/SiliconEinstein/Gaia/actions/workflows/ci.yml)
+[![CI](https://github.com/SiliconEinstein/Gaia/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/SiliconEinstein/Gaia/actions/workflows/ci.yml)
 [![Nightly](https://github.com/SiliconEinstein/Gaia/actions/workflows/nightly.yml/badge.svg?branch=main)](https://github.com/SiliconEinstein/Gaia/actions/workflows/nightly.yml)
-[![Docs](https://github.com/SiliconEinstein/Gaia/actions/workflows/docs.yml/badge.svg)](https://siliconeinstein.github.io/Gaia/)
-[![PyPI](https://img.shields.io/pypi/v/gaia-lang.svg)](https://pypi.org/project/gaia-lang/)
+[![Docs](https://github.com/SiliconEinstein/Gaia/actions/workflows/docs.yml/badge.svg?branch=main)](https://siliconeinstein.github.io/Gaia/)
+[![PyPI alpha](https://img.shields.io/badge/pypi-0.5.0a1-orange)](https://pypi.org/project/gaia-lang/0.5.0a1/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **Contributing?** Read [`AGENTS.md`](AGENTS.md).


### PR DESCRIPTION
## Summary

Finish the README badge migration after promoting v0.5 to `main`.

- Point the CI and Docs workflow badges explicitly at `main`.
- Replace the dynamic PyPI badge, which still renders the stable `0.4.4` release, with an explicit `0.5.0a1` alpha badge.
- Move the docs workflow push/deploy trigger from `v0.5` to `main`, so the Docs badge and GitHub Pages deployment follow the new trunk.

## Verification

- `git diff --check`
- Confirmed `https://img.shields.io/pypi/v/gaia-lang?include_prereleases` still renders `v0.4.4`, so the alpha badge needs to be explicit.

