### PR TITLE
ci(release): require tags for prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, v0.5]
+    branches: [main]
   pull_request:
-    branches: [main, v0.5]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -2,8 +2,9 @@ name: Release (alpha)
 
 # Manual alpha promotion per spec §8 step 5. workflow_dispatch only; no
 # auto-trigger (no schedule, no tag-push, no PR). 协作单 五·Q7 + 七 locks:
-# pre-release artifacts are durable (never retracted from PyPI); alpha does
-# not tag or create a GitHub release.
+# pre-release artifacts are durable (never retracted from PyPI), so every
+# non-dry-run alpha publish also creates a matching `v<version>` tag and
+# GitHub prerelease.
 
 on:
   workflow_dispatch:
@@ -60,3 +61,20 @@ jobs:
       - name: Publish to PyPI (OIDC trusted publishing)
         if: ${{ inputs.dry_run == false }}
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create git tag
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          git tag -a "v${{ inputs.version }}" -m "gaia-lang v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Create GitHub prerelease
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "Gaia Lang v${{ inputs.version }}" \
+            --prerelease \
+            --generate-notes \
+            dist/*.whl dist/*.tar.gz

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -2,7 +2,8 @@ name: Release (beta)
 
 # Manual beta promotion per spec §8 step 5. workflow_dispatch only; no
 # auto-trigger. 协作单 五·Q7 + 七 locks: pre-release artifacts are durable
-# (never retracted from PyPI); beta does not tag or create a GitHub release.
+# (never retracted from PyPI), so every non-dry-run beta publish also creates
+# a matching `v<version>` tag and GitHub prerelease.
 
 on:
   workflow_dispatch:
@@ -18,7 +19,7 @@ on:
         default: false
 
 permissions:
-  # `contents: write` kept for uniformity with stable (unused on beta).
+  # `contents: write` is needed for the git tag push + GitHub prerelease.
   # `id-token: write` is required for PyPI Trusted Publishing.
   contents: write
   id-token: write
@@ -59,3 +60,20 @@ jobs:
       - name: Publish to PyPI (OIDC trusted publishing)
         if: ${{ inputs.dry_run == false }}
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create git tag
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          git tag -a "v${{ inputs.version }}" -m "gaia-lang v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Create GitHub prerelease
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "Gaia Lang v${{ inputs.version }}" \
+            --prerelease \
+            --generate-notes \
+            dist/*.whl dist/*.tar.gz

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -2,8 +2,8 @@ name: Release (rc)
 
 # Manual release-candidate promotion per spec §8 step 5. workflow_dispatch
 # only; no auto-trigger. 协作单 五·Q7 + 七 locks: pre-release artifacts are
-# durable (never retracted from PyPI); rc does not tag or create a GitHub
-# release (only stable does).
+# durable (never retracted from PyPI), so every non-dry-run rc publish also
+# creates a matching `v<version>` tag and GitHub prerelease.
 
 on:
   workflow_dispatch:
@@ -19,7 +19,7 @@ on:
         default: false
 
 permissions:
-  # `contents: write` kept for uniformity with stable (unused on rc).
+  # `contents: write` is needed for the git tag push + GitHub prerelease.
   # `id-token: write` is required for PyPI Trusted Publishing.
   contents: write
   id-token: write
@@ -60,3 +60,20 @@ jobs:
       - name: Publish to PyPI (OIDC trusted publishing)
         if: ${{ inputs.dry_run == false }}
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create git tag
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          git tag -a "v${{ inputs.version }}" -m "gaia-lang v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Create GitHub prerelease
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "Gaia Lang v${{ inputs.version }}" \
+            --prerelease \
+            --generate-notes \
+            dist/*.whl dist/*.tar.gz

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,10 +1,9 @@
 name: Release (stable)
 
 # Manual stable promotion per spec §8 step 5. workflow_dispatch only; no
-# auto-trigger. 协作单 五·Q7 + 七 locks: pre-release artifacts are durable
-# (never retracted from PyPI). Stable is the only channel that creates a
-# git tag (`v<version>`) and a GitHub release; both steps are gated on
-# `inputs.dry_run == false` after PyPI publish succeeds.
+# auto-trigger. 协作单 五·Q7 + 七 locks: release artifacts are durable
+# (never retracted from PyPI), so every non-dry-run stable publish creates a
+# git tag (`v<version>`) and a GitHub release after PyPI publish succeeds.
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ the upcoming `0.5.0` line until the stable v0.5 release is cut.
 
 - Use `gaia-lang==0.5.0a1` or `pip install --pre gaia-lang` if you want the
   current v0.5 alpha CLI, DSL, Bayes, and package workflow.
+- The exact alpha source is the
+  [`v0.5.0a1`](https://github.com/SiliconEinstein/Gaia/releases/tag/v0.5.0a1)
+  tag at `803c0918`.
 - Use `gaia-lang==0.4.4` and the [`release/0.4`](https://github.com/SiliconEinstein/Gaia/tree/release/0.4)
   branch if you need the stable v0.4.x line.
 - v0.5 is breaking relative to v0.4; see the
@@ -32,6 +35,12 @@ the upcoming `0.5.0` line until the stable v0.5 release is cut.
   [migration guide](docs/migration.md).
 - The historical `v0.5` branch is a temporary release-train branch; new PRs
   should target `main`.
+
+| Channel | Install | Source |
+|---------|---------|--------|
+| v0.5 alpha | `pip install gaia-lang==0.5.0a1` | [`v0.5.0a1`](https://github.com/SiliconEinstein/Gaia/releases/tag/v0.5.0a1) |
+| v0.5 nightly | install from `main` or use the nightly artifact | [`main`](https://github.com/SiliconEinstein/Gaia/tree/main) |
+| v0.4 stable | `pip install gaia-lang==0.4.4` | [`release/0.4`](https://github.com/SiliconEinstein/Gaia/tree/release/0.4) |
 
 ## What Gaia Does
 

--- a/docs/releases/0.5.0a1.md
+++ b/docs/releases/0.5.0a1.md
@@ -34,6 +34,13 @@ gaia --version
 The alpha wheel should report `gaia-lang 0.5.0a1`, `channel: a`, the source
 commit used to build the wheel, and the current IR schema string.
 
+Release provenance:
+
+- Git tag / GitHub prerelease:
+  [`v0.5.0a1`](https://github.com/SiliconEinstein/Gaia/releases/tag/v0.5.0a1)
+- Source commit: `803c0918a54f4a5f4f9530296605f19b8510b3a4`
+- PyPI release: <https://pypi.org/project/gaia-lang/0.5.0a1/>
+
 ## Who Should Try This
 
 Try this alpha if you are:
@@ -181,18 +188,20 @@ tables.
 
 ## Release Validation Contract
 
-The v0.5.0a1 artifact should only be published after these gates pass on the
-release commit:
+The v0.5.0a1 artifact was published after these gates passed on the release
+commit:
 
-- release workflows are reachable from GitHub Actions, either because the
-  repository default branch is `v0.5` or because an equivalent default-branch
-  dispatcher invokes the v0.5 workflows
-- PR CI on `v0.5`
+- release workflow run:
+  <https://github.com/SiliconEinstein/Gaia/actions/runs/26069929917>
+- PR/push CI on the release line before publication
 - docs build
 - wheel smoke from a fresh virtual environment
 - full test suite via `make test-all`
 - package corpus via `uv run python scripts/run_package_corpus.py`
 - release workflow dry run for `version=0.5.0a1`, `channel=a`
+
+Every published PyPI artifact should also have a matching `v<version>` tag.
+Prereleases use GitHub prereleases; stable releases use normal GitHub releases.
 
 After publication, maintainers should run a fresh PyPI install smoke:
 


### PR DESCRIPTION
## Summary

Close the release-traceability gap for the v0.5 alpha line.

- Add a GitHub-homepage package/channel table to the README.
- Record `v0.5.0a1` provenance in the alpha release notes.
- Remove `v0.5` from PR/push CI triggers now that `main` is the active trunk.
- Make alpha/beta/rc release workflows create a matching `v<version>` tag and GitHub prerelease after a successful PyPI publish.
- Update stable workflow comments so the channel rules are explicit.

This intentionally does **not** rename `v0.5` to `release/0.5.0a1`: exact alpha releases are immutable tags, not mutable branches. A future `release/0.5` maintenance branch should be created when `0.5.0` stable is cut.

## Already Done Outside This PR

- Created annotated tag `v0.5.0a1` at the PyPI wheel's recorded source commit `803c0918a54f4a5f4f9530296605f19b8510b3a4`.
- Created GitHub prerelease: https://github.com/SiliconEinstein/Gaia/releases/tag/v0.5.0a1

## Verification

- `git diff --check`
- `uv run --extra docs mkdocs build --strict`

