### PR TITLE
fix: port github render memory improvements to main

### DIFF
--- a/gaia/cli/commands/_github.py
+++ b/gaia/cli/commands/_github.py
@@ -11,11 +11,18 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from gaia.cli.commands._graph_json import generate_graph_json
+from gaia.cli.commands._graph_json import write_graph_json
 from gaia.cli.commands._manifest import generate_manifest
 from gaia.cli.commands._render_priors import format_belief
-from gaia.cli.commands._wiki import generate_all_wiki
+from gaia.cli.commands._wiki import (
+    generate_wiki_home,
+    generate_wiki_inference,
+    generate_wiki_module,
+)
 from gaia.engine.ir.coarsen import coarsen_ir
+
+_MAX_MI_PREMISES = 12
+_MAX_MI_GRAPH_ITEMS = 2500
 
 
 def _write_meta_json(
@@ -52,39 +59,55 @@ def _copy_artifacts(artifacts_dir: Path, assets_dir: Path) -> list[str]:
     return asset_names
 
 
-def _write_section_files(
+def _wiki_module_names(ir: dict[str, Any]) -> list[str]:
+    """Return stable wiki module names, including Root for module-less nodes."""
+    return sorted({k.get("module") or "Root" for k in ir.get("knowledges", [])})
+
+
+def _section_module_names(ir: dict[str, Any]) -> set[str]:
+    """Return modules that should get SPA section files."""
+    return {k["module"] for k in ir.get("knowledges", []) if k.get("module")}
+
+
+def _write_wiki_pages_and_sections(
     *,
     ir: dict[str, Any],
-    wiki_pages: dict[str, str],
+    wiki_dir: Path,
     sections_dir: Path,
-) -> None:
-    """Write one Markdown section file per unique DSL module."""
-    modules = {k.get("module") for k in ir.get("knowledges", []) if k.get("module")}
-    for mod in sorted(modules):
-        section_path = sections_dir / f"{mod}.md"
-        wiki_key = f"Module-{mod.replace('_', '-')}.md"
-        section_content = wiki_pages.get(wiki_key) or _fallback_section_content(ir, mod)
-        section_path.write_text(section_content, encoding="utf-8")
+    beliefs_data: dict[str, Any] | None,
+    param_data: dict[str, Any] | None,
+) -> list[str]:
+    """Write GitHub wiki pages and section markdown without retaining all pages."""
+    wiki_page_names: list[str] = []
 
+    (wiki_dir / "Home.md").write_text(
+        generate_wiki_home(ir, beliefs_data=beliefs_data),
+        encoding="utf-8",
+    )
+    wiki_page_names.append("Home.md")
 
-def _fallback_section_content(ir: dict[str, Any], mod: str) -> str:
-    """Generate simple module section content when no wiki page exists."""
-    module_knowledges = [
-        k
-        for k in ir.get("knowledges", [])
-        if k.get("module") == mod and not k.get("label", "").startswith("__")
-    ]
-    lines = [f"# {mod}", ""]
-    for k in module_knowledges:
-        label = k.get("label", "")
-        content = k.get("content", "")
-        ktype = k.get("type", "")
-        if label and content:
-            lines.append(f"### {label}")
-            lines.append(f"**Type:** {ktype}")
-            lines.append(f"{content}")
-            lines.append("")
-    return "\n".join(lines)
+    section_modules = _section_module_names(ir)
+    for mod in _wiki_module_names(ir):
+        filename = f"Module-{mod.replace('_', '-')}.md"
+        content = generate_wiki_module(
+            ir,
+            mod,
+            beliefs_data=beliefs_data,
+            param_data=param_data,
+        )
+        (wiki_dir / filename).write_text(content, encoding="utf-8")
+        wiki_page_names.append(filename)
+        if mod in section_modules:
+            (sections_dir / f"{mod}.md").write_text(content, encoding="utf-8")
+
+    if beliefs_data is not None:
+        (wiki_dir / "Inference-Results.md").write_text(
+            generate_wiki_inference(ir, beliefs_data, param_data=param_data),
+            encoding="utf-8",
+        )
+        wiki_page_names.append("Inference-Results.md")
+
+    return wiki_page_names
 
 
 def _default_outline_priors(
@@ -112,6 +135,67 @@ def _default_outline_priors(
     return node_priors
 
 
+def _strategy_params_from_param_data(param_data: dict[str, Any] | None) -> dict[str, list[float]]:
+    """Extract strategy conditional parameters from a parameterization payload."""
+    strategy_params: dict[str, list[float]] = {}
+    if not param_data:
+        return strategy_params
+    for item in param_data.get("strategy_params", []):
+        strategy_id = item.get("strategy_id", "")
+        if item.get("conditional_probabilities"):
+            strategy_params[strategy_id] = item["conditional_probabilities"]
+        elif item.get("conditional_probability") is not None:
+            strategy_params[strategy_id] = [item["conditional_probability"]]
+    return strategy_params
+
+
+def _safe_mi_strategy_indices(ir: dict[str, Any], coarse: dict[str, Any]) -> set[int]:
+    """Return coarse strategy indexes whose exact MI computation is bounded."""
+    graph_items = (
+        len(ir.get("knowledges", [])) + len(ir.get("strategies", [])) + len(ir.get("operators", []))
+    )
+    if graph_items > _MAX_MI_GRAPH_ITEMS:
+        return set()
+    return {
+        i
+        for i, strategy in enumerate(coarse.get("strategies", []))
+        if len(strategy.get("premises", [])) <= _MAX_MI_PREMISES
+    }
+
+
+def _coarse_mi_map(
+    *,
+    ir: dict[str, Any],
+    coarse: dict[str, Any],
+    node_priors: dict[str, float],
+    param_data: dict[str, Any] | None,
+) -> dict[int, float]:
+    """Best-effort MI map for bounded-size coarse strategies."""
+    indices = _safe_mi_strategy_indices(ir, coarse)
+    if not indices:
+        return {}
+    try:
+        from gaia.engine.ir.coarsen import compute_coarse_cpts, mutual_information
+
+        cpts = compute_coarse_cpts(
+            ir,
+            coarse,
+            node_priors=node_priors,
+            strategy_params=_strategy_params_from_param_data(param_data),
+            strategy_indices=indices,
+        )
+        return {
+            i: mutual_information(
+                cpt,
+                [node_priors.get(p, 0.5) for p in coarse["strategies"][i]["premises"]],
+            )
+            for i, cpt in cpts.items()
+            if len(cpt) >= 2
+        }
+    except Exception:
+        return {}
+
+
 def _write_narrative_outline(
     *,
     ir: dict[str, Any],
@@ -136,10 +220,11 @@ def _write_narrative_outline(
             coarse_for_outline,
             beliefs=beliefs,
             priors=node_priors,
-            mi_per_strategy=_outline_mi_map(
+            mi_per_strategy=_coarse_mi_map(
                 ir=ir,
-                coarse_for_outline=coarse_for_outline,
+                coarse=coarse_for_outline,
                 node_priors=node_priors,
+                param_data=param_data,
             ),
         )
         (output_dir / "narrative-outline.md").write_text(
@@ -147,32 +232,6 @@ def _write_narrative_outline(
         )
     except Exception:
         pass
-
-
-def _outline_mi_map(
-    *,
-    ir: dict[str, Any],
-    coarse_for_outline: dict[str, Any],
-    node_priors: dict[str, float],
-) -> dict[int, float]:
-    """Best-effort MI map for the narrative outline."""
-    try:
-        from gaia.engine.ir.coarsen import compute_coarse_cpts, mutual_information
-
-        cpts = compute_coarse_cpts(
-            ir,
-            coarse_for_outline,
-            node_priors=node_priors,
-        )
-        return {
-            i: mutual_information(
-                cpts[i],
-                [node_priors.get(p, 0.5) for p in coarse_for_outline["strategies"][i]["premises"]],
-            )
-            for i in cpts
-        }
-    except Exception:
-        return {}
 
 
 def generate_github_output(
@@ -215,26 +274,28 @@ def generate_github_output(
     for d in (wiki_dir, data_dir, assets_dir, sections_dir):
         d.mkdir(parents=True, exist_ok=True)
 
-    # ── 1. Wiki pages ──
-    wiki_pages = generate_all_wiki(ir, beliefs_data=beliefs_data, param_data=param_data)
-    for filename, content in wiki_pages.items():
-        (wiki_dir / filename).write_text(content, encoding="utf-8")
+    # ── 1. Wiki pages + section content ──
+    wiki_page_names = _write_wiki_pages_and_sections(
+        ir=ir,
+        wiki_dir=wiki_dir,
+        sections_dir=sections_dir,
+        beliefs_data=beliefs_data,
+        param_data=param_data,
+    )
 
     # ── 2. graph.json ──
-    graph_json = generate_graph_json(
+    write_graph_json(
+        data_dir / "graph.json",
         ir,
         beliefs_data=beliefs_data,
         param_data=param_data,
         exported_ids=exported,
     )
-    (data_dir / "graph.json").write_text(graph_json, encoding="utf-8")
 
     # ── 3. beliefs.json (if available) ──
     if beliefs_data is not None:
-        (data_dir / "beliefs.json").write_text(
-            json.dumps(beliefs_data, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
+        with (data_dir / "beliefs.json").open("w", encoding="utf-8") as f:
+            json.dump(beliefs_data, f, indent=2, ensure_ascii=False)
 
     # ── 4. meta.json ──
     _write_meta_json(data_dir, ir, metadata)
@@ -242,14 +303,11 @@ def generate_github_output(
     # ── 5. Copy artifacts to assets (recursive) ──
     asset_names = _copy_artifacts(pkg_path / "artifacts", assets_dir)
 
-    # ── 6. Section content (one per unique module) ──
-    _write_section_files(ir=ir, wiki_pages=wiki_pages, sections_dir=sections_dir)
-
     # ── 7. manifest.json ──
     manifest_json = generate_manifest(
         ir,
         exported,
-        list(wiki_pages.keys()),
+        wiki_page_names,
         assets=asset_names,
     )
     (output_dir / "manifest.json").write_text(manifest_json, encoding="utf-8")
@@ -281,6 +339,7 @@ def _render_coarse_mermaid(
     beliefs: dict[str, float],
     priors: dict[str, float],
     exported_ids: set[str],
+    param_data: dict[str, Any] | None = None,
 ) -> tuple[str, float]:
     """Render a coarse-grained Mermaid graph: leaf premises → exported conclusions."""
     coarse = coarsen_ir(ir, exported_ids)
@@ -325,6 +384,7 @@ def _render_coarse_mermaid(
         kid_to_k=kid_to_k,
         beliefs=beliefs,
         priors=priors,
+        param_data=param_data,
     )
     lines.extend(strategy_lines)
     lines.extend(_coarse_operator_lines(coarse, kid_to_k))
@@ -345,6 +405,7 @@ def _coarse_strategy_lines(
     kid_to_k: dict[str, dict[str, Any]],
     beliefs: dict[str, float],
     priors: dict[str, float],
+    param_data: dict[str, Any] | None,
 ) -> tuple[list[str], float]:
     """Render strategy intermediate nodes and return accumulated MI."""
     deterministic = {
@@ -354,17 +415,20 @@ def _coarse_strategy_lines(
         "mathematical_induction",
         "case_analysis",
     }
-    coarse_cpts = _coarse_cpts_for_mermaid(ir, coarse, beliefs, priors)
+    node_priors = _default_outline_priors(ir, param_data)
+    node_priors.update(priors)
+    mi_map = (
+        _coarse_mi_map(ir=ir, coarse=coarse, node_priors=node_priors, param_data=param_data)
+        if beliefs
+        else {}
+    )
     total_mi = 0.0
     lines: list[str] = []
     for i, s in enumerate(coarse["strategies"]):
         stype = s.get("type", "infer")
-        cpt = coarse_cpts.get(i)
+        mi = mi_map.get(i)
         ann = stype
-        if cpt and len(cpt) >= 2:
-            from gaia.engine.ir.coarsen import mutual_information
-
-            mi = mutual_information(cpt, [priors.get(p, 0.5) for p in s["premises"]])
+        if mi is not None:
             total_mi += mi
             ann = f"{stype}\\n{mi:.2f} bits"
         css = "" if stype in deterministic else ":::weak"
@@ -375,29 +439,6 @@ def _coarse_strategy_lines(
         conc = kid_to_k.get(s["conclusion"], {}).get("label", "?").replace("-", "_")
         lines.append(f"    {sid} --> {conc}")
     return lines, total_mi
-
-
-def _coarse_cpts_for_mermaid(
-    ir: dict[str, Any],
-    coarse: dict[str, Any],
-    beliefs: dict[str, float],
-    priors: dict[str, float],
-) -> dict[int, list[float]]:
-    """Compute coarse CPTs for Mermaid MI annotations when beliefs are available."""
-    if not beliefs:
-        return {}
-    try:
-        from gaia.engine.ir.coarsen import compute_coarse_cpts
-
-        node_priors = _default_outline_priors(ir, param_data=None)
-        node_priors.update(priors)
-        return compute_coarse_cpts(
-            ir,
-            coarse,
-            node_priors=node_priors,
-        )
-    except Exception:
-        return {}
 
 
 def _coarse_operator_lines(
@@ -476,6 +517,7 @@ def _generate_readme_skeleton(
             beliefs,
             priors,
             exported,
+            param_data=param_data,
         )
         if total_mi > 0:
             lines.append("> [!TIP]")

--- a/gaia/cli/commands/_graph_json.py
+++ b/gaia/cli/commands/_graph_json.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import json
 from collections import Counter
+from collections.abc import Iterable, Iterator
+from pathlib import Path
 from typing import Any
 
 from gaia.engine.ir.coarsen import HELPER_LABEL_PREFIXES
@@ -35,15 +37,14 @@ def _knowledge_modules(ir: dict[str, Any]) -> dict[str, str]:
     }
 
 
-def _knowledge_nodes(
+def _iter_knowledge_nodes(
     ir: dict[str, Any],
     *,
     beliefs: dict[str, float],
     priors: dict[str, float],
     exported: set[str],
-) -> list[dict[str, Any]]:
-    """Build visible knowledge nodes for graph.json."""
-    nodes: list[dict[str, Any]] = []
+) -> Iterator[dict[str, Any]]:
+    """Yield visible knowledge nodes for graph.json."""
     for k in ir["knowledges"]:
         label = k.get("label", "")
         if label.startswith(HELPER_LABEL_PREFIXES):
@@ -55,109 +56,52 @@ def _knowledge_nodes(
             # helper-label naming convention has a single source of truth.
             continue
         kid = k["id"]
-        nodes.append(
-            {
-                "id": kid,
-                "label": label,
-                "title": k.get("title"),
-                "type": k["type"],
-                "module": k.get("module"),
-                "content": k.get("content", ""),
-                "prior": priors.get(kid),
-                "belief": beliefs.get(kid),
-                "exported": kid in exported,
-                "metadata": k.get("metadata", {}),
-            }
-        )
-    return nodes
+        yield {
+            "id": kid,
+            "label": label,
+            "title": k.get("title"),
+            "type": k["type"],
+            "module": k.get("module"),
+            "content": k.get("content", ""),
+            "prior": priors.get(kid),
+            "belief": beliefs.get(kid),
+            "exported": kid in exported,
+            "metadata": k.get("metadata", {}),
+        }
 
 
-def _append_strategy_graph(
+def _strategy_counts_and_cross_module(
     ir: dict[str, Any],
-    *,
-    nodes: list[dict[str, Any]],
-    edges: list[dict[str, Any]],
     kid_module: dict[str, str],
 ) -> tuple[Counter[str], Counter[tuple[str, str]]]:
-    """Append strategy nodes/edges and return module counters."""
+    """Return strategy and cross-module counters without materializing graph edges."""
     strategy_counts: Counter[str] = Counter()
     cross_module: Counter[tuple[str, str]] = Counter()
-    for i, s in enumerate(ir.get("strategies", [])):
-        conc = s.get("conclusion")
+    for strategy in ir.get("strategies", []):
+        conc = strategy.get("conclusion")
         if not conc:
             continue
         conc_mod = kid_module.get(conc, "")
-        strat_id = f"strat_{i}"
-        nodes.append(
-            {
-                "id": strat_id,
-                "type": "strategy",
-                "strategy_type": s.get("type", ""),
-                "module": conc_mod,
-                "reason": s.get("reason", ""),
-            }
-        )
         strategy_counts[conc_mod] += 1
-        _append_strategy_edges(s, strat_id, conc, conc_mod, edges, kid_module, cross_module)
+        for premise in strategy.get("premises", []):
+            premise_mod = kid_module.get(premise, "")
+            if premise_mod and conc_mod and premise_mod != conc_mod:
+                cross_module[(premise_mod, conc_mod)] += 1
     return strategy_counts, cross_module
 
 
-def _append_strategy_edges(
-    strategy: dict[str, Any],
-    strat_id: str,
-    conc: str,
-    conc_mod: str,
-    edges: list[dict[str, Any]],
-    kid_module: dict[str, str],
-    cross_module: Counter[tuple[str, str]],
-) -> None:
-    """Append premise/background/conclusion edges for one strategy."""
-    for p in strategy.get("premises", []):
-        edges.append({"source": p, "target": strat_id, "role": "premise"})
-        p_mod = kid_module.get(p, "")
-        if p_mod and conc_mod and p_mod != conc_mod:
-            cross_module[(p_mod, conc_mod)] += 1
-    for bg in strategy.get("background", []):
-        edges.append({"source": bg, "target": strat_id, "role": "background"})
-    edges.append({"source": strat_id, "target": conc, "role": "conclusion"})
-
-
-def _append_operator_graph(
+def _module_entries_from_ir(
     ir: dict[str, Any],
     *,
-    nodes: list[dict[str, Any]],
-    edges: list[dict[str, Any]],
-    kid_module: dict[str, str],
-) -> None:
-    """Append operator nodes and edges for graph.json."""
-    for i, o in enumerate(ir.get("operators", [])):
-        conc = o.get("conclusion")
-        oper_id = f"oper_{i}"
-        nodes.append(
-            {
-                "id": oper_id,
-                "type": "operator",
-                "operator_type": o.get("operator", ""),
-                "module": kid_module.get(conc, "") if conc else "",
-            }
-        )
-        for v in o.get("variables", []):
-            edges.append({"source": v, "target": oper_id, "role": "variable"})
-        if conc:
-            edges.append({"source": oper_id, "target": conc, "role": "conclusion"})
-
-
-def _module_entries(
-    *,
-    nodes: list[dict[str, Any]],
     module_order: list[str],
     strategy_counts: Counter[str],
 ) -> list[dict[str, Any]]:
-    """Build graph.json module entries preserving explicit module order first."""
+    """Build module entries directly from visible knowledge nodes."""
     module_node_counts: Counter[str] = Counter()
-    for node in nodes:
-        mod = node.get("module")
-        if mod and node["type"] not in ("strategy", "operator"):
+    for knowledge in ir.get("knowledges", []):
+        label = knowledge.get("label", "")
+        mod = knowledge.get("module")
+        if mod and not label.startswith(HELPER_LABEL_PREFIXES):
             module_node_counts[mod] += 1
 
     seen = set(module_order)
@@ -175,6 +119,167 @@ def _module_entries(
     ]
 
 
+def _graph_context(
+    ir: dict[str, Any],
+    beliefs_data: dict[str, Any] | None = None,
+    param_data: dict[str, Any] | None = None,
+    exported_ids: set[str] | None = None,
+) -> tuple[
+    dict[str, float],
+    dict[str, float],
+    set[str],
+    dict[str, str],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+]:
+    """Build the small graph.json context shared by streaming and string output."""
+    beliefs = _beliefs_from_payload(beliefs_data)
+    priors = _priors_from_payload(param_data)
+    exported = exported_ids or set()
+    kid_module = _knowledge_modules(ir)
+    module_order: list[str] = list(ir.get("module_order") or [])
+    strategy_counts, cross_module = _strategy_counts_and_cross_module(ir, kid_module)
+    modules = _module_entries_from_ir(
+        ir,
+        module_order=module_order,
+        strategy_counts=strategy_counts,
+    )
+    cross_module_edges = [
+        {"from_module": fm, "to_module": tm, "count": cnt}
+        for (fm, tm), cnt in sorted(cross_module.items())
+    ]
+    return beliefs, priors, exported, kid_module, modules, cross_module_edges
+
+
+def _iter_strategy_nodes(
+    ir: dict[str, Any], kid_module: dict[str, str]
+) -> Iterator[dict[str, Any]]:
+    """Yield strategy intermediate nodes for graph.json."""
+    for i, strategy in enumerate(ir.get("strategies", [])):
+        conc = strategy.get("conclusion")
+        if not conc:
+            continue
+        yield {
+            "id": f"strat_{i}",
+            "type": "strategy",
+            "strategy_type": strategy.get("type", ""),
+            "module": kid_module.get(conc, ""),
+            "reason": strategy.get("reason", ""),
+        }
+
+
+def _iter_operator_nodes(
+    ir: dict[str, Any], kid_module: dict[str, str]
+) -> Iterator[dict[str, Any]]:
+    """Yield operator intermediate nodes for graph.json."""
+    for i, operator in enumerate(ir.get("operators", [])):
+        conc = operator.get("conclusion")
+        yield {
+            "id": f"oper_{i}",
+            "type": "operator",
+            "operator_type": operator.get("operator", ""),
+            "module": kid_module.get(conc, "") if conc else "",
+        }
+
+
+def _iter_nodes(
+    ir: dict[str, Any],
+    *,
+    beliefs: dict[str, float],
+    priors: dict[str, float],
+    exported: set[str],
+    kid_module: dict[str, str],
+) -> Iterator[dict[str, Any]]:
+    yield from _iter_knowledge_nodes(ir, beliefs=beliefs, priors=priors, exported=exported)
+    yield from _iter_strategy_nodes(ir, kid_module)
+    yield from _iter_operator_nodes(ir, kid_module)
+
+
+def _iter_edges(ir: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield graph edges without materializing the complete edge list."""
+    for i, strategy in enumerate(ir.get("strategies", [])):
+        conc = strategy.get("conclusion")
+        if not conc:
+            continue
+        strat_id = f"strat_{i}"
+        for premise in strategy.get("premises", []):
+            yield {"source": premise, "target": strat_id, "role": "premise"}
+        for background in strategy.get("background", []):
+            yield {"source": background, "target": strat_id, "role": "background"}
+        yield {"source": strat_id, "target": conc, "role": "conclusion"}
+
+    for i, operator in enumerate(ir.get("operators", [])):
+        conc = operator.get("conclusion")
+        oper_id = f"oper_{i}"
+        for variable in operator.get("variables", []):
+            yield {"source": variable, "target": oper_id, "role": "variable"}
+        if conc:
+            yield {"source": oper_id, "target": conc, "role": "conclusion"}
+
+
+def _iter_json_array(items: Iterable[dict[str, Any]]) -> Iterator[str]:
+    yield "["
+    first = True
+    for item in items:
+        if first:
+            first = False
+        else:
+            yield ","
+        yield json.dumps(item, ensure_ascii=False, separators=(",", ":"))
+    yield "]"
+
+
+def iter_graph_json_chunks(
+    ir: dict[str, Any],
+    beliefs_data: dict[str, Any] | None = None,
+    param_data: dict[str, Any] | None = None,
+    exported_ids: set[str] | None = None,
+) -> Iterator[str]:
+    """Yield graph.json chunks without materializing node/edge arrays."""
+    beliefs, priors, exported, kid_module, modules, cross_module_edges = _graph_context(
+        ir,
+        beliefs_data=beliefs_data,
+        param_data=param_data,
+        exported_ids=exported_ids,
+    )
+
+    yield '{"modules":'
+    yield from _iter_json_array(modules)
+    yield ',"cross_module_edges":'
+    yield from _iter_json_array(cross_module_edges)
+    yield ',"nodes":'
+    yield from _iter_json_array(
+        _iter_nodes(
+            ir,
+            beliefs=beliefs,
+            priors=priors,
+            exported=exported,
+            kid_module=kid_module,
+        )
+    )
+    yield ',"edges":'
+    yield from _iter_json_array(_iter_edges(ir))
+    yield "}"
+
+
+def write_graph_json(
+    path: Path,
+    ir: dict[str, Any],
+    beliefs_data: dict[str, Any] | None = None,
+    param_data: dict[str, Any] | None = None,
+    exported_ids: set[str] | None = None,
+) -> None:
+    """Write graph.json directly to *path* using a bounded-memory stream."""
+    with path.open("w", encoding="utf-8") as f:
+        for chunk in iter_graph_json_chunks(
+            ir,
+            beliefs_data=beliefs_data,
+            param_data=param_data,
+            exported_ids=exported_ids,
+        ):
+            f.write(chunk)
+
+
 def generate_graph_json(
     ir: dict[str, Any],
     beliefs_data: dict[str, Any] | None = None,
@@ -182,41 +287,11 @@ def generate_graph_json(
     exported_ids: set[str] | None = None,
 ) -> str:
     """Return JSON string with nodes, edges, modules, and cross_module_edges."""
-    beliefs = _beliefs_from_payload(beliefs_data)
-    priors = _priors_from_payload(param_data)
-    exported = exported_ids or set()
-
-    kid_module = _knowledge_modules(ir)
-    module_order: list[str] = ir.get("module_order", [])
-
-    nodes = _knowledge_nodes(ir, beliefs=beliefs, priors=priors, exported=exported)
-    edges: list[dict[str, Any]] = []
-    strategy_counts, cross_module = _append_strategy_graph(
-        ir,
-        nodes=nodes,
-        edges=edges,
-        kid_module=kid_module,
-    )
-    _append_operator_graph(ir, nodes=nodes, edges=edges, kid_module=kid_module)
-
-    modules = _module_entries(
-        nodes=nodes,
-        module_order=module_order,
-        strategy_counts=strategy_counts,
-    )
-
-    cross_module_edges = [
-        {"from_module": fm, "to_module": tm, "count": cnt}
-        for (fm, tm), cnt in sorted(cross_module.items())
-    ]
-
-    return json.dumps(
-        {
-            "modules": modules,
-            "cross_module_edges": cross_module_edges,
-            "nodes": nodes,
-            "edges": edges,
-        },
-        indent=2,
-        ensure_ascii=False,
+    return "".join(
+        iter_graph_json_chunks(
+            ir,
+            beliefs_data=beliefs_data,
+            param_data=param_data,
+            exported_ids=exported_ids,
+        )
     )

--- a/tests/cli/test_github_integration.py
+++ b/tests/cli/test_github_integration.py
@@ -247,6 +247,130 @@ def test_wiki_inference_page_when_beliefs(tmp_path: Path):
     assert (output_dir / "wiki" / "Inference-Results.md").exists()
 
 
+def test_github_output_streams_graph_json_and_wiki_pages(tmp_path: Path, monkeypatch):
+    """GitHub output should avoid graph.json and all-wiki full materialization."""
+    ir = {
+        "package_name": "stream_pkg",
+        "namespace": "github",
+        "knowledges": [
+            {
+                "id": "github:stream_pkg::a",
+                "label": "a",
+                "type": "claim",
+                "content": "A.",
+                "module": "m",
+            },
+        ],
+        "strategies": [],
+        "operators": [],
+    }
+    pkg_path = tmp_path / "pkg"
+    pkg_path.mkdir()
+
+    import gaia.cli.commands._graph_json as graph_json_mod
+    import gaia.cli.commands._wiki as wiki_mod
+
+    def fail_generate_graph_json(*_args, **_kwargs):
+        raise AssertionError("generate_github_output should stream graph.json to disk")
+
+    def fail_generate_all_wiki(*_args, **_kwargs):
+        raise AssertionError("generate_github_output should write wiki pages one by one")
+
+    monkeypatch.setattr(graph_json_mod, "generate_graph_json", fail_generate_graph_json)
+    monkeypatch.setattr(wiki_mod, "generate_all_wiki", fail_generate_all_wiki)
+
+    output_dir = generate_github_output(
+        ir,
+        pkg_path,
+        beliefs_data=None,
+        param_data=None,
+        exported_ids=set(),
+    )
+
+    graph_path = output_dir / "docs" / "public" / "data" / "graph.json"
+    assert graph_path.exists()
+    assert json.loads(graph_path.read_text())["nodes"][0]["id"] == "github:stream_pkg::a"
+    assert (output_dir / "wiki" / "Home.md").exists()
+    assert (output_dir / "wiki" / "Module-m.md").exists()
+
+
+def test_github_output_skips_mi_for_high_fan_in_coarse_graph(tmp_path: Path, monkeypatch):
+    """Large coarse strategies must not trigger exponential MI tensor contraction."""
+    premise_count = 16
+    premises = [
+        {
+            "id": f"github:wide_pkg::p{i}",
+            "label": f"p{i}",
+            "type": "claim",
+            "content": f"Premise {i}.",
+            "module": "m",
+        }
+        for i in range(premise_count)
+    ]
+    conclusion = {
+        "id": "github:wide_pkg::c",
+        "label": "c",
+        "type": "claim",
+        "content": "Conclusion.",
+        "module": "m",
+        "exported": True,
+    }
+    ir = {
+        "package_name": "wide_pkg",
+        "namespace": "github",
+        "knowledges": [*premises, conclusion],
+        "strategies": [
+            {
+                "type": "deduction",
+                "premises": [premise["id"]],
+                "background": [],
+                "conclusion": conclusion["id"],
+                "reason": "",
+            }
+            for premise in premises
+        ],
+        "operators": [],
+    }
+    beliefs_data = {
+        "beliefs": [
+            *[
+                {"knowledge_id": premise["id"], "belief": 0.6, "label": premise["label"]}
+                for premise in premises
+            ],
+            {"knowledge_id": conclusion["id"], "belief": 0.8, "label": "c"},
+        ],
+        "diagnostics": {"converged": True, "iterations_run": 1},
+    }
+    param_data = {
+        "priors": [
+            *[{"knowledge_id": premise["id"], "value": 0.5} for premise in premises],
+            {"knowledge_id": conclusion["id"], "value": 0.5},
+        ]
+    }
+    pkg_path = tmp_path / "pkg"
+    pkg_path.mkdir()
+
+    calls = {"count": 0}
+
+    def fake_compute_coarse_cpts(*_args, **_kwargs):
+        calls["count"] += 1
+        return {}
+
+    import gaia.engine.ir.coarsen as coarsen_mod
+
+    monkeypatch.setattr(coarsen_mod, "compute_coarse_cpts", fake_compute_coarse_cpts)
+
+    generate_github_output(
+        ir,
+        pkg_path,
+        beliefs_data=beliefs_data,
+        param_data=param_data,
+        exported_ids={conclusion["id"]},
+    )
+
+    assert calls["count"] == 0
+
+
 # ── CLI --github flag integration ──
 
 

--- a/tests/cli/test_graph_json.py
+++ b/tests/cli/test_graph_json.py
@@ -286,6 +286,13 @@ def test_helper_nodes_filtered():
                 "content": "Helper.",
                 "module": "m1",
             },
+            {
+                "id": "github:test_pkg::_anon_001",
+                "label": "_anon_001",
+                "type": "claim",
+                "content": "Anonymous helper.",
+                "module": "m1",
+            },
         ],
         module_order=["m1"],
     )


### PR DESCRIPTION
## Summary
- Port PR #678's GitHub render memory reduction onto current `main` after the engine namespace move.
- Stream `graph.json` to disk and write wiki/section pages one at a time instead of materializing the full output in memory.
- Bound optional coarse-graph MI annotations by graph size and fan-in, while preserving current `gaia.engine.*` imports, `format_belief`, and shared helper-prefix filtering.

## Validation
- `uv run --project /private/tmp/gaia_pr678_review_20260520 --extra dev ruff check gaia/cli/commands/_github.py gaia/cli/commands/_graph_json.py tests/cli/test_github_integration.py tests/cli/test_graph_json.py`
- `uv run --project /private/tmp/gaia_pr678_review_20260520 --extra dev ruff format --check gaia/cli/commands/_github.py gaia/cli/commands/_graph_json.py tests/cli/test_github_integration.py tests/cli/test_graph_json.py`
- `uv run --project /private/tmp/gaia_pr678_review_20260520 --extra dev python -m pytest tests/cli/test_graph_json.py tests/cli/test_github_integration.py -q`
- `uv run --project /private/tmp/gaia_pr678_review_20260520 --extra dev python -m pytest tests/cli/test_wiki.py tests/cli/test_render.py tests/cli/test_starmap.py tests/cli/test_starmap_replay.py -q`

## Relation to #678
This is a current-main port of #678's intended fix. It avoids force-pushing over the contributor branch while preserving the fixes needed after #679-#682 landed on `main`.
