### PR TITLE
fix(cli): extend run-from-parent guidance to build/run verbs

### DIFF
--- a/gaia/cli/commands/init.py
+++ b/gaia/cli/commands/init.py
@@ -192,8 +192,10 @@ def init_command(
         f"  cd <parent of {name}>\n"
         f'  gaia author claim "..." --target ./{name}\n'
         "\n"
-        "Author verbs run from the parent directory, with --target pointing\n"
-        f"at ./{name}. Running them from inside {name} will not find gaia-lang.\n"
+        "Run gaia from the parent directory: author verbs with --target\n"
+        f"pointing at ./{name}, and build/run with ./{name} as the path\n"
+        "argument (shown below). Running any of them from inside the package\n"
+        "will not find gaia-lang.\n"
         f"\n  gaia build compile ./{name}\n"
         f"  gaia run infer ./{name}"
     )

--- a/gaia/cli/commands/pkg/scaffold.py
+++ b/gaia/cli/commands/pkg/scaffold.py
@@ -302,9 +302,10 @@ def _next_steps_text(plan: _ScaffoldPlan) -> str:
         f"  cd {parent}\n"
         f'  gaia author claim "..." --target ./{pkg_rel}\n'
         f"\n"
-        f"Author verbs run from the parent directory, with --target pointing\n"
-        f"at ./{pkg_rel}. Running them from inside the package will not find\n"
-        f"gaia-lang.\n"
+        f"Run gaia from the parent directory: author verbs with --target\n"
+        f"pointing at ./{pkg_rel}, and build/run with ./{pkg_rel} as the path\n"
+        f"argument (shown below). Running any of them from inside the package\n"
+        f"will not find gaia-lang.\n"
         f"\n"
         f"  gaia build compile ./{pkg_rel}\n"
         f"  gaia run infer ./{pkg_rel}"


### PR DESCRIPTION
The "Next steps" block printed after scaffolding a package (`gaia pkg` and `gaia init`) warned that author verbs must run from the package's parent directory — but listed `gaia build compile` / `gaia run infer` right below without the same caveat. Running those from inside the package surfaces a bare `error: Failed to spawn: gaia` from uv, which doesn't point at the cause.

**CLI / UX**
- Broaden the scaffolded "Next steps" guidance so the "run from the parent directory; running from inside won't find gaia-lang" caveat covers `build`/`run` as well as author verbs. Applied consistently to `gaia pkg` and `gaia init`.

Text-only; no behavior change.
