### PR TITLE
feat(skills): migrate LKM skills into bundled registry; rename formalization→formalize-fine

### DIFF
--- a/gaia/_skills/_shared/bp-interpretation.md
+++ b/gaia/_skills/_shared/bp-interpretation.md
@@ -1,6 +1,6 @@
 # Interpreting `.gaia/beliefs.json`
 
-Shared reference for interpreting `.gaia/beliefs.json` output from `gaia run infer`. Pointed at by `gaia-formalization`, `gaia-publish`, `gaia-obsidian-wiki`, and `gaia-review` — those skills invoke `gaia run infer` at the end of their workflow and need a single canonical place to read off "is this belief reasonable, or is something miswired?"
+Shared reference for interpreting `.gaia/beliefs.json` output from `gaia run infer`. Pointed at by `gaia-formalize-fine`, `gaia-formalize-coarse`, `gaia-publish`, `gaia-obsidian-wiki`, and `gaia-review` — those skills invoke `gaia run infer` at the end of their workflow and need a single canonical place to read off "is this belief reasonable, or is something miswired?"
 
 This doc is reference, not procedure. It is not itself a skill; it has no frontmatter.
 

--- a/gaia/_skills/gaia-evidence-subgraph/SKILL.md
+++ b/gaia/_skills/gaia-evidence-subgraph/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: gaia-evidence-subgraph
+description: |
+  Use to build, audit, and render a methodological-decomposition evidence
+  graph rooted on a chain-backed quantitative claim of the form "<system or
+  setting> has <quantity> = <value>" or "<computation / measurement> yields
+  <observable>". The graph is the anatomy of how that single result is closed
+  inside one paper's reasoning — observational / experimental constraints,
+  theoretical or computational inputs, intermediate computed quantities,
+  derivation / inversion / fitting steps, parameter and approximation choices,
+  and external-paper / setting context. Multiple labelled joint-support factor
+  diamonds, three-class edge taxonomy (chain support / background /
+  verification support — render in the user's locale, e.g. 链式支撑 / 背景 /
+  核验支撑 in Chinese), auto-layout (Graphviz neato/sfdp or Mermaid flowchart
+  with linkStyle for per-edge classes — Mermaid mindmap is NOT acceptable),
+  CJK-safe fonts and labels. Domain-agnostic: physics, chemistry, materials,
+  biology, ML, climate, astrophysics, etc. Input is an LKM chain payload,
+  fetched via `gaia search lkm knowledge "<root>"` to surface the root and
+  `gaia search lkm reasoning --claim-id <id> --format raw-json` for the
+  chains + the `data.papers` metadata block (use `--format raw-json` — the
+  verbatim envelope is the audit substrate under `raw/`). The graph is
+  strictly chain-bounded — only LKM-returned premises and their explicit
+  content are admitted as nodes; no synthetic bridging from external sources.
+  Reach for this skill when the user explicitly asks for a closure-chain /
+  evidence graph (not Gaia formalization — that is `gaia-lkm-explorer`); it
+  pairs with `gaia-scholarly-synthesis`, which consumes the audited graph it
+  produces.
+---
+
+# Evidence Subgraph
+
+## Principle
+
+The graph shows the **anatomy of one quantitative result**, not a literature genealogy. The root is a specific result — typically `<system> has <quantity> = <value>` or `<computation / measurement> yields <observable>`. The graph traces the reasoning pipeline that produces that result inside the root paper:
+
+`(observational / experimental anchors) + (theoretical / computational inputs) + (parameter / approximation choices) → (intermediate quantities) → (derivation / inversion / fitting) → (root result)`.
+
+External papers do **not** become "tier-1 upstream conclusions" — they appear as named **context** nodes (named by the formula, dataset, method, or theorem they contributed *as named in the LKM premise content*; *not* by paper id) attached to whichever reasoning step uses them. The backbone is the root paper's own reasoning chain returned by LKM `evidence`. The graph is strictly chain-bounded: every node and edge must trace to content that LKM returned. Do not mint synthetic intermediate nodes to bridge gaps in the chain payload — gaps are recorded as audit-table observations, not papered over.
+
+The same paradigm applies across domains:
+
+- **Computational science** — `(electronic structure / force field / simulation inputs) → (intermediate observables) → (derivation) → (parameter value or predicted observable)`.
+- **Experimental science** — `(measurement protocol + calibration + sample preparation) → (raw signal) → (analysis / inversion) → (extracted parameter)`.
+- **ML / AI** — `(architecture + dataset + hyperparameters) → (training curves / intermediate metrics) → (eval protocol) → (benchmark score / scaling exponent)`.
+- **Modeling-driven fields** (climate, astrophysics, epidemiology) — `(forcings / initial conditions + model resolution + parameterizations) → (simulated observables) → (comparison / inversion) → (sensitivity parameter)`.
+
+The skill text below is domain-agnostic. Every domain-specific term in the produced graph comes from the LKM chain payload (premise / factor / step content and `data.papers` metadata), not from the skill.
+
+## Input
+
+The skill is invoked with a single root claim id and the corresponding LKM chain payload — the `gaia search lkm reasoning --claim-id <id> --format raw-json` output (and, if available, the `gaia search lkm knowledge "<root>" --format raw-json` output that surfaced the root). The root's conclusion text names a system / setting and a quantitative result. The skill does not perform discovery; it does not select among candidates. Callers (or the user directly) supply the chosen root id.
+
+If invoked with a chain-less claim id (`total_chains == 0`), stop and report the gate failure. Do not invent premises.
+
+## Output
+
+Every successful invocation leaves on disk:
+
+- a structured graph artifact (`evidence_graph.json`) capturing nodes, edges, and per-element source pointers into the LKM payload (RFC 6901 JSON Pointer convention against the verbatim raw payload);
+- the canonical re-renderable graph source (`evidence_graph.dot`, or `evidence_graph.mmd` when Mermaid is the chosen renderer);
+- a human-readable raster (`evidence_graph.png`, plus optionally SVG/PDF);
+- the verbatim LKM raw payloads under `raw/` (at minimum `evidence_<root-gcn-id>.json` — the `gaia search lkm reasoning --claim-id … --format raw-json` envelope; if a `gaia search lkm knowledge … --format raw-json` recall was consulted to surface the root, also `match_NN.json`); raw payloads are never modified, pretty-printed, or stripped — they are the audit substrate the source pointers resolve against;
+- an audit table (rows per non-trivial edge — see §6) co-located with the graph artifacts.
+
+The audit table and every node/edge in `evidence_graph.json` carry a chain-payload anchor (premise `gcn_*`, factor `gfac_*`, `factors[i].steps[j].reasoning`, or claim content) so a reader can trace any element back to the LKM JSON. Anchor discipline is canonical in `references/source-ground-truth.md` — read it before producing output.
+
+## Workflow
+
+### 0. Gate: chain-backed root
+
+The evidence payload for the root must have `total_chains > 0`. Synthetic premises only with explicit user waiver. If the root id does not satisfy the gate, stop and report — do not proceed.
+
+The chain payload itself is the **single source of truth** for every node and audit anchor in this skill: claim `content`, factor `subtype`, premise `id` and `content`, optional `steps[].reasoning`, and the `data.papers` metadata block. No external paper text is admitted as a node.
+
+### 1. Factor diamonds (one per `gfac_*`)
+
+Each `gfac_*` factor in the root's evidence chains becomes a labelled diamond (`shape=diamond` in DOT, or analogous in Mermaid). The label is two short lines:
+
+- top line: the factor operator name in the user's locale (`共同支撑` for Chinese / `joint support` for English / etc.). If the LKM payload exposes a `subtype` (e.g. `noisy_and`, `noisy_or`), include it parenthetically: `共同支撑 (noisy_and)` / `joint support (noisy_and)`.
+- bottom line: a concrete tag derived from the factor's premises — e.g. *"inversion step"*, *"first-principles input"*, *"dataset + protocol"*, *"thermodynamic coverage"*. The exact wording comes from reading the premise contents and naming the cluster they form.
+
+If the chain has **multiple** `gfac_*` nodes, render multiple factor diamonds — **do not collapse them into one**. Multiple factors carve the reasoning into distinguishable clusters (e.g. one for the input computation, another for the inversion step, another for cross-observable coverage).
+
+If the chain has **exactly one** `gfac_*` node, render exactly one diamond. Use the bottom-line tag to summarise the cumulative semantic of all premises (e.g. *"inversion-step closure"*, *"computation + fitting"*) — do not leave the bottom line empty or generic.
+
+### 2. Native premises → typed reasoning nodes
+
+The primary text source for each premise is `factors[].premises[].content` in the parent chain payload. Some chain payloads also expose `steps[].reasoning` — that field is **optional**. Do not require `steps`; do not fail when it is absent.
+
+For each native premise (chain-internal id; `total_chains == 0` standalone but full content recoverable from the parent chain), classify the premise content into one of four reasoning-node types:
+
+- **method-setting** — *what* method / protocol / model is used and *how* it is configured. Examples: "simulation method + convergence parameters", "fit model + assumed prior", "measurement protocol + calibration".
+- **intermediate result** — a computed, simulated, or measured quantity that becomes input to the next step. Examples: "computed coupling = 1.33", "fitted gap ratio = 5.0", "training loss at step N", "measured rate constant = …".
+- **parameter choice** — an explicitly chosen scalar / categorical setting, with its value. Examples: "isotropy assumption true", "cutoff ω_c = 3 Ω_max", "mini-batch size = 64", "fixed prior σ = 0.1".
+- **derivation step** — an equation, inversion, or fitting procedure that determines a downstream quantity. Examples: "Δ_{m=1}(μ*, T_c) = 0 ⇒ μ* fixed", "argmax over θ", "linear regression on log-log axes".
+
+Render each as a labelled box (filled, locale-safe font). Label is two short lines: first line = tag (the role this node plays in the chain), second line = numerical / equation / symbol anchor lifted verbatim from the premise `content` (or, when present, `steps[].reasoning`).
+
+**Empty-content premises (temporary).** Some premises currently come back from the LKM with only an `id` populated and an empty `content` — this is a temporary corpus state and the LKM is being progressively populated. Render as gray dashed nodes with the placeholder label "未展开前提 / unexpanded premise" only when the user explicitly asks for full premise coverage; the default is to omit. The audit table must mark them `content unavailable (temporary)` so a future run (when content is populated) can revisit them.
+
+**No synthetic bridging.** The graph is strictly chain-bounded. If an intermediate quantity is implied but not present in any premise / step / claim content returned by LKM, do **not** mint a node for it — record the gap in the audit table as `gap: <description>` and move on. Inventing nodes silently switches the graph from chain-backed to synthetic.
+
+**No duplicate nodes for equivalent premises.** When two premises (or a premise and a verification-support claim) assert the **same proposition** — same equation, same numerical value, same formal statement, just from different parts of the chain or different source packages — render them as a **single node**. List the two source packages in parentheses on a second label line, or as a side note in the audit table; do not draw two near-identical boxes. The merge decision is a judgement call on the premise text; when in doubt, keep the two as distinct verification-support nodes — the independent confirmation is informative for the closure-chain reader and erasing it loses information. Obvious same-paper / same-version restatements (e.g. arXiv preprint and journal version of one paper saying the same thing) should still be merged.
+
+### 3. Background / context nodes
+
+Add a panel-style node (visually distinct from reasoning nodes — different fill colour, `shape=note` in DOT) for each of:
+
+- **external paper / formula / dataset / theorem named inside an LKM premise's `content`** — name it by the formula, dataset, theorem, or method it contributed (e.g. *"AD formula"*, *"Morel–Anderson renormalization"*, *"ImageNet-1k"*, *"GPCR-Bench"*, *"Anderson's theorem"*) — **never** by paper id, and **never** drawn from outside the chain payload. The actual paper bibliography lives in the `data.papers` block of the chain payload and travels with the run-folder for downstream consumers; this skill does not emit a references list.
+- **parameter-setting / approximation / regularization choice** — e.g. *"real-axis solution, weak damping"*, *"hybrid functional"*, *"early stopping"*.
+- **scope-bounding empirical fact** — a fact that bounds where the analysis applies (e.g. *"linear-T resistivity"*, *"validation set held out"*, *"Migdal small parameter ω_ph/E_F ≪ 1"*).
+
+Connect to the reasoning node(s) they justify, scope, or limit using **background** edges. Background nodes never participate in the conjunction structure; they annotate it. Background nodes have **no incoming chain edges**.
+
+### 4. Edge taxonomy (exactly three classes)
+
+| class | render style | when to use |
+|-------|--------------|-------------|
+| **chain support** (`链式支撑` / `chain support`) | solid line, thick (penwidth 1.8–2.2), neutral colour (e.g. black) | chain conjunction edges: premises → factor diamond, factor diamond → root, and any internal step-to-step backbone explicitly carried by the LKM chain |
+| **background** (`背景` / `background`) | dashed line, thin, distinctive colour (e.g. purple) | context: parameter setting, external-paper input, regularization choice, scope-bounding fact |
+| **verification support** (`核验支撑` / `verification support`) | dashed line, thin, distinctive colour (e.g. green) | independent calculation, source-of-record number, or cross-method check that confirms (or partially disconfirms) a specific numerical anchor inside a reasoning node — for partial-disconfirm polarity append a parenthetical to the edge label, e.g. `核验支撑（部分不符）` / `verification support (partial disconfirm)` |
+
+The label rendered on the edge is in the user's locale. The taxonomy itself is fixed.
+
+**Do not introduce other classes.** No "literature support", no "tier-2 support", no `upstream_conclusion_support`. External-paper inputs are background; cross-method comparisons (confirming or partially disconfirming) are verification support — note polarity in the audit table's bridge sentence rather than inventing a fourth class.
+
+### 5. Layout, fonts, and labels (CJK-safe)
+
+- **Auto-layout renderer**: Graphviz `neato` / `sfdp` for DOT (preferred for archival), or Mermaid `flowchart` with `linkStyle` for per-edge classes (preferred when no Graphviz install). Do **not** use Mermaid `mindmap` — it has no per-edge styling and cannot encode the three-class taxonomy.
+- **Title format**: `<root system / topic> <quantity or theme>: closure-chain map (auto-layout)`. Localize to the user's prompt language (e.g. `<topic>：闭合链图（自动布局）` for Chinese). The "(auto-layout)" tag tells the reader spatial arrangement is non-semantic. The phrasing "closure chain" / "闭合链" is intentional — it names what the graph actually is (the closed reasoning that produces the root result) without overloading more general terms.
+- **Locale**: labels in the user's prompt language.
+- **CJK fonts (avoid Graphviz tofu pit).** Default Graphviz fonts (Helvetica, Times) **omit Chinese / Japanese / Korean glyphs**, producing tofu (`□`) blocks in the rendered PNG/SVG. Set fonts explicitly on `graph`, `node`, and `edge` for any non-Latin script:
+
+  ```dot
+  graph [fontname="Noto Sans CJK SC", labelloc="t", label=<...>];
+  node  [fontname="Noto Sans CJK SC", style="rounded,filled"];
+  edge  [fontname="Noto Sans CJK SC"];
+  ```
+
+  - **Linux / CI**: `Noto Sans CJK SC` (Simplified Chinese), `Noto Sans CJK TC` (Traditional Chinese), `Noto Sans CJK JP` (Japanese), `Noto Sans CJK KR` (Korean). For Latin scripts: `Noto Sans` or system default.
+  - **macOS local**: `PingFang SC` is acceptable.
+  - **Windows local**: `Microsoft YaHei` is acceptable.
+  - **Always re-open the rendered PNG/SVG and visually check** — if you see `□` boxes, the font fallback failed silently. Switch to a font you know is installed.
+  - For Mermaid `flowchart`, set `themeVariables.fontFamily` and verify in the output that CJK characters are intact.
+- **Math and symbols**: inline Unicode (μ*, λ, ∫, ⊗) when the renderer supports it; LaTeX-style `\mu^*` only where the renderer supports it. When using DOT HTML-like labels (`<...>`), prefer Unicode for cross-renderer safety.
+- **Brevity**: every node label ≤ 2 lines. First line = tag (role of node). Second line = numerical / equation / symbol anchor.
+
+### 6. Audit table
+
+One row per non-trivial edge. **Background and verification-support edges must always be documented in full** (downstream / upstream / class / bridge sentence / chain-payload anchor). For chain-support edges through a `gfac_*` factor (premises → diamond → root), full rows are *recommended but optional*: at minimum, document them once with the factor label as the bridge sentence; preferably, log each premise with its own anchor so the reader can verify the premise text is faithful to the chain payload.
+
+| downstream | upstream | edge class | bridge sentence | chain-payload anchor |
+|------------|----------|------------|-----------------|----------------------|
+
+The chain-payload anchor points back into the LKM JSON: a premise id (`gcn_…`), factor id (`gfac_…`), `factors[i].steps[j].reasoning`, or claim content quoted verbatim. For verification-support edges that **partially disconfirm** the downstream node, state the polarity explicitly ("confirms within 5%", "partially disconfirms: independent value differs by 30%"). Without a chain-payload anchor, the row is just paraphrase.
+
+### 7. Cycle check
+
+Run `node scripts/check_dot_cycles.mjs <path-to-graph.dot>` (the script bundled with this skill) for DOT graphs. The decomposition is a DAG; cycles usually indicate a misclassified background edge — for example, a verification-style fact mis-rendered as background creates a cycle through the inversion step.
+
+### 8. Best-effort numerical-anchor check
+
+Before declaring the run complete, walk every numerical anchor in every reasoning node and try to locate it inside the chain payload — premise `content`, claim content, or `factors[i].steps[j].reasoning`. The check is **soft**: chain payloads are sometimes incomplete, and an anchor may legitimately not be locatable inside the JSON. When you can confirm an anchor, log the chain-payload location in the audit row. When you cannot, mark the row `anchor not locatable in chain payload` and leave the node in place — do not delete the node, do not invent a substitute, and do not fail the run on this alone. A node whose value is contradicted by some other piece of the chain payload, however, is a real error and must be fixed. This "contradicted anchor" case is source-consistency checking, not the contradiction-admission rule used by LKM-to-Gaia packages.
+
+## Return value
+
+On success, return the run-folder path. The folder contains the structured graph (`evidence_graph.json`), the canonical re-renderable source (`evidence_graph.dot` and/or `evidence_graph.mmd`), the rendered raster (`evidence_graph.png`, plus optional SVG/PDF), the audit table, and the verbatim raw payloads under `raw/`. The relevant `data.papers` block from the chain payload is preserved verbatim under `raw/` so any downstream consumer (or the user directly) can map background-node mentions back to bibliographic records.
+
+On failure (chain-less root, contradicted anchors that cannot be reconciled, cycle detected after re-classification, CJK glyphs rendering as tofu and no installed font usable), report the failure reason and the run-folder state — do not declare partial success.
+
+## What this skill is NOT
+
+- Not a literature-genealogy graph. External papers are background nodes, not tier-1 upstream conclusions.
+- Not a thematic survey. Single root, single result, single paper's reasoning anatomy.
+- Not a renderer-of-record for purely qualitative conclusions. Qualitative claims (e.g. "X exhibits property Y") without a numeric or formula-level anchor do not have a closure step to decompose; this skill does not apply.

--- a/gaia/_skills/gaia-evidence-subgraph/references/graph-output.md
+++ b/gaia/_skills/gaia-evidence-subgraph/references/graph-output.md
@@ -1,0 +1,104 @@
+# Graph Output Reference (palette, fonts, render)
+
+This file complements `SKILL.md`. It contains the visual style and rendering details that don't belong in the workflow text but do affect whether the produced graph reads as a publication-quality figure.
+
+## Minimum artifacts
+
+The on-disk artifacts the skill emits are listed in `SKILL.md` (Output section): `evidence_graph.json`, `evidence_graph.dot` (and/or `evidence_graph.mmd`), `evidence_graph.png`, the audit table, and the verbatim raw payloads under `raw/`. Additional rendered formats (SVG / PDF) and any companion `.md` summaries are extras — write them if useful.
+
+## Human-readable node labels (mandatory)
+
+Figures are read by **scientists and reviewers**, not only by agents.
+
+1. **Primary label text:** short natural-language phrase in the user's working language (e.g. Chinese 中文短句 for Chinese-speaking users), stating *what the proposition says* (method, parameter, intermediate quantity, derivation), not the database role alone.
+2. **Technical id:** `gcn_*` / `gfac_*` ids belong **either** in the audit table **or** once in parentheses on the node — **never** as the only readable text on the node.
+3. **Root node:** use the real claim id as the Graphviz node name (e.g. `"gcn_f6058142144e4e00"`), with a `label=` carrying a domain-language tag plus the result (e.g. *"目标结论 / target result"* + content summary).
+4. **Optional empty-content premises:** if rendered (only when the user explicitly asks for full premise coverage — they are temporary corpus state), label them as *"未展开前提 / unexpanded premise"* and mark them in the audit as `content unavailable (temporary)`.
+5. **Graph `label`:** add a short **legend** matching the three edge classes — e.g. `黑实线 = 链式支撑； 紫虚线 = 背景； 绿虚线 = 核验支撑`.
+
+## CJK / Unicode rendering (Graphviz tofu pit)
+
+Default fonts (Helvetica, Times) **omit Chinese / Japanese / Korean glyphs**, producing tofu (`□`) blocks in the rendered output. Set fonts explicitly:
+
+```dot
+graph [fontname="Noto Sans CJK SC"];
+node  [fontname="Noto Sans CJK SC"];
+edge  [fontname="Noto Sans CJK SC"];
+```
+
+Font choice by environment:
+
+- **Linux / CI:** `Noto Sans CJK SC` (Simplified Chinese), `Noto Sans CJK TC` (Traditional Chinese), `Noto Sans CJK JP` (Japanese), `Noto Sans CJK KR` (Korean). For Latin-only graphs: `Noto Sans` or system default.
+- **macOS local:** `PingFang SC` is acceptable.
+- **Windows local:** `Microsoft YaHei` is acceptable.
+
+**Always re-open the rendered PNG/SVG and visually check.** If you see any `□` boxes, the font fallback failed silently — switch to a font you know is installed. For Mermaid `flowchart`, set `themeVariables.fontFamily` and verify in the output.
+
+## Edge taxonomy → render style
+
+The skill specifies exactly three edge classes. Render mapping:
+
+| class (any locale) | `color` | `style` | `penwidth` | typical edge label |
+|--------------------|---------|---------|------------|--------------------|
+| chain support / 链式支撑 | `#0f172a` (near-black) | solid | `1.8`–`2.2` | `链式支撑` / `chain support` |
+| background / 背景 | `#6a3da4` (purple) | dashed | `1.2`–`1.5` | `背景` / `background` |
+| verification support / 核验支撑 | `#137333` (green) | dashed | `1.2`–`1.5` | `核验支撑` / `verification support` (append `（部分不符）` / `(partial disconfirm)` for partial-disconfirm polarity) |
+
+No fourth class. External-paper inputs render as background nodes (purple panels) with background edges; cross-method comparisons render as verification-support hexagons with green dashed edges.
+
+## Node palette (publication-style)
+
+Default rainbow primaries look **cheap** on slides and posters. Prefer a muted, publication-style palette:
+
+| Role | `fillcolor` | `color` (stroke) | `fontcolor` | typical shape |
+|------|-------------|------------------|-------------|---------------|
+| Graph canvas | `bgcolor="#eef2f6"` | — | `#475569` (graph label) | — |
+| Cluster panel | `#ffffff` | `#cbd5e1` | — | rounded box |
+| **Root result** | `#1e293b` (dark slate) | `#0f172a` | `#f1f5f9` (light) | `octagon` or `oval` |
+| **Factor diamond** (one per `gfac_*`) | `#ede9fe` (light lilac) | `#6d28d9` | `#4c1d95` | `diamond` |
+| **Reasoning node — method-setting** | `#fff2cc` (warm parchment) | `#7f6000` | `#000000` | `box` |
+| **Reasoning node — intermediate result** | `#cfe2f3` (cool blue) | `#0b5394` | `#000000` | `box` |
+| **Reasoning node — parameter choice** | `#ead1dc` (rose) | `#741b47` | `#000000` | `box` |
+| **Reasoning node — derivation step** | `#d9ead3` (sage) | `#274e13` | `#000000` | `box` |
+| **Background node** | `#e6d3ff` (lavender panel) | `#6a3da4` | `#000000` | `note` |
+| **Verification-support node** | `#d9f9d9` (mint) | `#137333` | `#064e3b` | `hexagon` |
+| **Empty-content premise (temporary, optional)** | `#f1f5f9` (light slate, dashed border) | `#94a3b8` (gray) | `#475569` | `box` with `style="dashed,filled"` |
+
+Keep WCAG-ish contrast: light fills use dark text; only the root may use inverted (light text on dark fill).
+
+## Layout polish
+
+```dot
+graph [
+  bgcolor="#eef2f6",
+  splines=true,
+  nodesep=0.32,
+  ranksep=0.48,
+  pad=0.22,
+  fontname="Noto Sans CJK SC"
+];
+```
+
+Use `style="rounded,filled"` on clusters with a white or very light `fillcolor` so grouped nodes read as panels, not floating shapes.
+
+## Render commands
+
+```bash
+# Graphviz (DOT)
+neato -Tpdf graph.dot -o graph.pdf
+sfdp  -Tpng graph.dot -o graph.png  # better for large graphs
+dot   -Tsvg graph.dot -o graph.svg  # if you want hierarchical layout instead of force-directed
+
+# Mermaid (flowchart .mmd) — install @mermaid-js/mermaid-cli first
+mmdc -i graph.mmd -o graph.svg
+```
+
+Auto-layout (`neato` / `sfdp`) is the default. Use `dot` (hierarchical) only when the user explicitly wants a top-down layered look.
+
+## Verification before finalizing
+
+1. **Count** nodes and edges; record in the audit header.
+2. **Cycle check** — `node scripts/check_dot_cycles.mjs <path>` (the script bundled with this skill) returns `cycles: []`.
+3. **Three-class taxonomy** — every edge label ∈ {chain support, background, verification support} (any locale). No `文献支撑`, no `upstream_conclusion_support`, no `tier-2 *`.
+4. **Read every node label aloud** — would a non-implementer know what each box is? If a node label is just an id or a generic word ("step", "premise"), rewrite it.
+5. **CJK legibility** — open the rendered PNG/SVG and confirm no tofu boxes.

--- a/gaia/_skills/gaia-evidence-subgraph/references/source-ground-truth.md
+++ b/gaia/_skills/gaia-evidence-subgraph/references/source-ground-truth.md
@@ -1,0 +1,68 @@
+# Chain-Payload Audit Discipline
+
+LKM chain payloads (`gaia search lkm knowledge` recall + `gaia search lkm reasoning --claim-id <id> --format raw-json` chains) are this skill's **single source of truth**. Every node in the graph and every audit row must trace back into that JSON — no external paper text, no agent paraphrase, no synthetic bridging.
+
+## Why the discipline matters
+
+The graph claims to be *chain-backed*. That claim is meaningful only if a reader or auditor can take any node or edge and follow the audit table back to a specific piece of LKM-returned content. Two failure modes silently break the contract:
+
+1. **Synthetic bridging** — minting an intermediate-result node because "the closure chain obviously needs one here", even though no premise / step / claim content in the payload mentions it. This makes the graph indistinguishable from agent paraphrase.
+2. **Floating numerical anchors** — quoting a value on a node that does not appear inside any premise content, claim content, or `steps[].reasoning` in the chain. The number then has no provenance the user can verify.
+
+The discipline below is what prevents both.
+
+## Anchor sources (in priority order)
+
+For each node and edge, pick the most specific anchor available:
+
+| Anchor | What it points to |
+| --- | --- |
+| `gcn_<premise_id>` | A native premise inside `evidence_chains[].factors[].premises[]`. Quote `content` verbatim. |
+| `gfac_<factor_id>` | A factor diamond. Quote `subtype` and the cluster semantics implied by its premises. |
+| `factors[i].steps[j].reasoning` | An optional step note inside a factor — not always populated. When present, treat as second-class evidence after premise content. |
+| Root `data.claim.content` | The root claim text itself. Use only on the root node. |
+| `data.papers[paper:<id>]` | Bibliographic metadata for a `source_package`. Use for `gaia-scholarly-synthesis` references; **never** as the source of a graph node's text. |
+
+If none of these contain what you want to assert, the assertion does not belong in the graph.
+
+## Chain-payload anchor in the audit row
+
+Every audit-table row carries a `chain-payload anchor` column (last column). Examples:
+
+| What you are anchoring | Anchor value |
+| --- | --- |
+| A premise rendered as an intermediate-result node | `gcn_a1b2c3…` |
+| A factor diamond label | `gfac_d4e5f6… (subtype=noisy_and)` |
+| A step-level numerical claim | `gfac_d4e5f6…/steps[0].reasoning` |
+| The root result | `data.claim.content` |
+| A polarity remark on a verification edge | `gcn_…/content: "…differs by 30%…"` |
+
+Where a quotation is short and load-bearing, include it inline (`gcn_…/content: "Δ/Q ≈ 0.066"`) rather than just the id.
+
+## Best-effort numerical-anchor check
+
+Walk every numerical anchor on every reasoning node and try to find it inside the chain payload. The check is **soft**:
+
+- **Located** → record the anchor cell and move on.
+- **Not located, but consistent with related premises** → mark `anchor not locatable in chain payload`. Leave the node and value in place; do not delete, do not substitute. Chain payloads are sometimes incomplete and this row simply records that fact.
+- **Located, but contradicted** by another premise / step / claim in the same payload → real error. Fix the node (re-read the contradicting premise) before publishing. This is payload-internal source consistency checking, not the Gaia contradiction-admission rule defined for LKM-to-Gaia packages.
+
+The goal is no fabrication — not exhaustive coverage. A graph with a few `anchor not locatable` rows is still chain-bounded; a graph with one undeclared synthetic node is not.
+
+## What is forbidden
+
+- Reading the original paper (PDF, HTML rendering, scanned image, or otherwise) and pulling text from it into a node, label, or audit row.
+- Paraphrasing a premise into a "tighter" form. Quote `content` verbatim or summarise it inside the audit row's bridge sentence — never both, never altered.
+- Naming background nodes by paper id (`paper:…`). Background nodes are named by the formula / dataset / theorem / method as it appears in the LKM premise content; bibliographic metadata stays in `data.papers`.
+- Adding a node whose label asserts a fact that no premise / step / claim content in the payload supports, even when the fact is "obviously true" in the field.
+
+## Multi-sub-model papers
+
+When a single paper analyses multiple sub-models / variants and LKM has split it into several claims, each chain-backed claim id is a candidate root. Pick **one** as the root for this graph and limit nodes to that claim's `evidence_chains`. If the user wants the other sub-models, that is a separate run with a different root id.
+
+If the chain you receive is missing a sub-model the user expected to see, run targeted `gaia search lkm knowledge` queries (`--retrieval-mode lexical --keywords <sub-model's distinctive terms> --scopes claim`) for that sub-model — do **not** import sub-model content from outside the chain payload.
+
+## Caching
+
+- Persist the raw `gaia search lkm reasoning --claim-id … --format raw-json` JSON (and the `gaia search lkm knowledge … --format raw-json` JSON that surfaced the candidate) under the run's working folder. The audit anchors are line-item references into that JSON; without the JSON the anchors lose meaning.
+- Re-issue `evidence` if more than a few minutes pass between discovery and graph build — the corpus may have moved, and an anchor that used to resolve may not after a re-fetch. When this happens, prefer re-pinning the anchor over editing the graph.

--- a/gaia/_skills/gaia-evidence-subgraph/scripts/check_dot_cycles.mjs
+++ b/gaia/_skills/gaia-evidence-subgraph/scripts/check_dot_cycles.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+function usage() {
+  console.log("Usage: check_dot_cycles.mjs graph.dot");
+}
+
+const path = process.argv[2];
+if (!path || process.argv.includes("--help")) {
+  usage();
+  process.exit(path ? 0 : 1);
+}
+
+const dot = await fs.readFile(path, "utf8");
+const edges = [...dot.matchAll(/"([^"]+)"\s*->\s*"([^"]+)"/g)].map((match) => [match[1], match[2]]);
+const adj = new Map();
+for (const [from, to] of edges) {
+  if (!adj.has(from)) adj.set(from, []);
+  if (!adj.has(to)) adj.set(to, []);
+  adj.get(from).push(to);
+}
+
+const seen = new Set();
+const stack = new Set();
+const cycles = [];
+
+function dfs(node, pathStack) {
+  seen.add(node);
+  stack.add(node);
+  pathStack.push(node);
+  for (const next of adj.get(node) || []) {
+    if (!seen.has(next)) {
+      dfs(next, pathStack);
+    } else if (stack.has(next)) {
+      cycles.push([...pathStack.slice(pathStack.indexOf(next)), next]);
+    }
+  }
+  stack.delete(node);
+  pathStack.pop();
+}
+
+for (const node of adj.keys()) {
+  if (!seen.has(node)) dfs(node, []);
+}
+
+console.log(JSON.stringify({ nodes: adj.size, edges: edges.length, cycles }, null, 2));
+process.exit(cycles.length ? 2 : 0);

--- a/gaia/_skills/gaia-formalize-coarse/SKILL.md
+++ b/gaia/_skills/gaia-formalize-coarse/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: gaia-formalize-coarse
+description: |
+  Use for a quick, single-paper formalization into a Gaia knowledge package:
+  read one academic paper (Markdown preferred; plain-text or other readable
+  formats also accepted) and emit a standalone `<name>-gaia/` package. Runs a
+  four-phase analytical workflow (Phase 1 extract conclusions / motivation /
+  open questions / cross-conclusion logic graph; Phase 2 reconstruct each
+  conclusion's reasoning chain; Phase 3 audit weak points and highlights,
+  calibrate leaf priors; Phase 4 emit Gaia DSL package files), gated by an
+  upfront suitability check (skip review/survey/perspective papers and
+  corrupted paper text). Surfaces 9 argument-pattern weak-point types
+  (`measurement`, `causal`, `model`, `statistical`, `generalization`,
+  `comparative`, `formal`, `computational`, `external`). Cross-grounds the
+  paper against LKM's existing knowledge graph in Phase 1b via
+  `gaia search lkm knowledge`, filtering on `provenance.source_packages` and
+  verifying reasoning-chain closure via `gaia search lkm reasoning --claim-id`.
+  This is the **Paper → package** entry point when speed matters — the quick
+  four-phase single-pass sibling of `gaia-formalize-fine` (the thorough
+  six-pass treatment). Reach for `gaia-formalize-coarse` for a fast first cut
+  of one paper; reach for `gaia-formalize-fine` when the source is
+  load-bearing, multi-section, or destined for publication. For the
+  LKM-driven (not paper-driven) route that grows a multi-paper graph, use
+  `gaia-lkm-explorer` instead. Use whenever the user asks to "formalize a
+  paper into Gaia", "produce a Gaia package from this paper", "turn this
+  paper into a knowledge package", or any variant where the upstream is a
+  single paper text and the requested output is Gaia DSL — even if the user
+  does not explicitly mention Gaia DSL syntax.
+---
+
+# Formalize
+
+## Mission
+
+Read a single academic paper (Markdown preferred; plain-text or other
+readable text formats also accepted), audit it as a scientific reasoning
+reviewer would, and emit a standalone Gaia knowledge package that
+compiles via `gaia build compile` and propagates beliefs via `gaia run infer`. The
+agent running this skill does the analytical work itself; it does not
+orchestrate a separate extraction pipeline and does not produce intermediate
+XML artifacts.
+
+Gaia knowledge-package shape is the canonical Gaia spec — see
+`docs/for-users/language-reference.md` and `docs/for-users/quick-start.md` in
+this repo. This skill defines the paper-driven workflow that produces packages
+conforming to that spec.
+
+```
+paper.{md,txt,...}
+  |
+  v
+gaia-formalize-coarse
+  (standalone Gaia package source for that paper)
+```
+
+`gaia-formalize-coarse` is the **quick paper-driven** sibling of
+[`../gaia-formalize-fine/SKILL.md`](../gaia-formalize-fine/SKILL.md) (the
+thorough six-pass treatment of the same paper-driven route) and of
+[`../gaia-lkm-explorer/SKILL.md`](../gaia-lkm-explorer/SKILL.md) — the
+**LKM-driven** workflow that grows a Gaia package from LKM evidence chains.
+All three produce package outputs of identical shape, but enter the graph
+from different directions: the two `gaia-formalize-*` skills start from one
+paper and audit its derivations (coarse = fast single-pass, fine = exhaustive
+six-pass); `gaia-lkm-explorer` starts from LKM search and grows a frontier
+across many papers.
+
+## Output Mode
+
+This skill operates in **single-paper batch mode** only:
+
+- Input: one paper text file (`.md` preferred; plain-text and other readable
+  formats also accepted) plus a desired package name (or one inferred from
+  the paper's first author + year).
+- Output: a fresh standalone `<name>-gaia/` package directory.
+
+Refresh / multi-paper batches are out of scope; if the user wants to merge a
+paper into an existing multi-paper package, the workflow is to produce the
+single-paper package here and then hand it off to a downstream merge step.
+
+## Progressive Workflow
+
+At the start of each `gaia-formalize-coarse` run, create a session todo list
+with the four items below. Mark only Phase 1 as in progress. Do not load later
+phase documents until the current phase is complete; each later phase depends
+on the working notes produced by the earlier phases.
+
+1. **Extract conclusions, motivation, open questions, and the
+   cross-conclusion logic graph** — load
+   [`references/phase-1-extract-conclusions.md`](references/phase-1-extract-conclusions.md).
+2. **Reconstruct each conclusion's reasoning chain** — load
+   [`references/phase-2-build-reasoning-chain.md`](references/phase-2-build-reasoning-chain.md).
+3. **Audit weak points and highlights, calibrate probabilities** — load
+   [`references/phase-3-review-weak-points.md`](references/phase-3-review-weak-points.md).
+   Phase 3 also contains the **Phase 1b LKM reverse-provenance trace** —
+   a best-effort cross-grounding pass against LKM's existing graph via
+   `gaia search lkm knowledge`. Skipped silently when the paper is
+   not yet in the LKM corpus.
+4. **Emit the Gaia package and audit log** — load
+   [`references/phase-4-emit-package.md`](references/phase-4-emit-package.md).
+
+After each phase, immediately mark the corresponding todo complete, mark the
+next one in progress, and only then load the next phase document. Phases 1–3
+produce structured working notes (held in the agent's scratch, not on disk).
+Phase 4 is the only phase that writes files.
+
+The four-phase split is mental scaffolding, not a contract with the user.
+The agent must treat the phases as cumulative — the package emitted in Phase
+4 must reflect the conclusions, reasoning chains, weak points, and
+highlights surfaced in Phases 1–3 as a single coherent body of work, not as
+independent passes.
+
+## Suitability Gate
+
+Before Phase 1 begins, decide whether the paper is amenable to formalization.
+Skip with a short note if:
+
+- The paper is a review, survey, or perspective without original results.
+- The paper has no identifiable structured contributions (no derivations, no
+  measurements, no method introductions).
+- The paper text is corrupted, truncated, or contains only abstract/metadata.
+
+In any of these cases, do not emit a Gaia package. Write a single
+`<package_name>.skip.md` next to the input that records the reason in one
+paragraph. Do not invent contributions to fill the gap.
+
+## Non-Negotiable Invariants
+
+- **Self-contained `claim(...)` text.** The string body of every `claim(...)`
+  must read as a first-class scientific proposition independent of the paper.
+  This is the same rule the legacy step 4 prompt enforced — here it is
+  enforced at the moment the claim is written, not as a post-hoc rewrite.
+  Setup, symbols, regimes, and inlined figure/table content live inside the
+  claim string itself; structural pointers ("Eq. (3)", "Fig. 4",
+  "Section II") are forbidden inside the claim body.
+- **Paper text is the only source of truth.** Do not introduce external
+  knowledge, repair missing arguments, or upgrade speculative claims. If a
+  symbol is undefined in the paper, leave it undefined and surface the gap
+  in the hand-off report. (Phase 1b LKM cross-grounding is the one
+  exception — it queries LKM purely to *audit* what the paper said, never
+  to augment paper content.)
+- **Two claim kinds only.** A `claim(...)` is either a step-1 root
+  conclusion or a step-3 weak point used as a leaf premise (the leaf gets
+  a paired `register_prior(...)`). A reasoning step is not a claim; it is
+  text that lives inside a `derive(...)` `rationale=` field.
+- **One epistemic question per conclusion.** Each conclusion `claim(...)`
+  body answers exactly one citable question — "what is the new bound /
+  relation / procedure / value / agreement?" — not several. A paragraph
+  that bundles a procedure, the value it produced, and the benchmark it
+  passed is three conclusions, not one. See
+  `phase-1-extract-conclusions.md` for the split test and common
+  under-splitting traps.
+- **One deduction per derived conclusion.** Each conclusion that has at
+  least one upstream conclusion or one weak point becomes the conclusion
+  of exactly one
+  `derive(conclusion, given=[premises], rationale=..., label=...)`.
+  Premises are the union of the conclusion's upstream conclusions (from
+  the cross-conclusion logic graph) and its weak-point claims. The
+  engine `derive(...)` signature accepts only
+  `{given, background, rationale, label}` — no `metadata=` kwarg, so
+  warrant-strength intent lives in `--rationale` prose.
+- **Highlights are working-notes only.** Step-3 highlights characterize
+  *why* a conclusion is unusually solid, but they do not enter the
+  executable DSL — Gaia's BP semantics already handle credit through
+  priors and the `derive(...)` warrant. Highlights inform the qualitative
+  warrant-strength prose Phase 4 writes into each deduction's
+  `--rationale`.
+- **Probability calibration via `register_prior(...)`.** Leaf-claim priors
+  come from step-3 calibrations (`prior_probability` for the weak point,
+  capped at 0.9). Each justification ends with `TODO:review`. Do not
+  invent priors that contradict the reviewer's calibration in working
+  notes.
+
+## Responsibility Boundaries
+
+- This skill owns the four analytical passes (plus the Phase 1b LKM
+  reverse-trace audit) and the Gaia package emission.
+- It does not own package-shape — that is the canonical Gaia spec (see
+  `docs/for-users/`). This skill consumes those rules where they apply and
+  adds paper-decomposition workflow on top.
+- It does not run `gaia build compile` / `gaia run infer` itself; the caller runs
+  those quality gates after emission. Surfaced compile errors come back as
+  Phase 4 follow-up obligations, not as a built-in step.
+- It does not orchestrate the existing `paper-extract` Python pipeline.
+  The Python pipeline is a parallel route from paper to XML; this skill
+  is the direct route from paper to Gaia.
+- It does not own the LKM API surface — Phase 1b shells out to the
+  `gaia search lkm` CLI (`knowledge` / `reasoning --claim-id`). Flags, auth,
+  and known quirks live behind `gaia search lkm <verb> --help`.
+- Multi-paper merges, cross-paper contradictions, and downstream rendering
+  are separate concerns handled by other tools.
+
+## Reference Files
+
+### Local (this skill)
+
+- [`references/phase-1-extract-conclusions.md`](references/phase-1-extract-conclusions.md)
+  — conclusions, motivation, open questions, cross-conclusion logic graph.
+- [`references/phase-2-build-reasoning-chain.md`](references/phase-2-build-reasoning-chain.md)
+  — per-conclusion reasoning reconstruction.
+- [`references/phase-3-review-weak-points.md`](references/phase-3-review-weak-points.md)
+  — weak-point and highlight audit, probability calibration, and the
+  Phase 1b LKM reverse-provenance trace.
+- [`references/phase-4-emit-package.md`](references/phase-4-emit-package.md)
+  — composing Phase 1–3 working notes into Gaia DSL package files.
+
+### Gaia knowledge-package contract (this repo's docs)
+
+- `docs/for-users/quick-start.md` — end-to-end Gaia knowledge-package
+  workflow, including single-paper package layout and file templates.
+- `docs/for-users/language-reference.md` — `claim` / `derive` /
+  `question` emission rules, generic `lkm_id` / `provenance_source`
+  metadata semantics, deduction warrant calibration, label rules, and
+  `references.json` (CSL-JSON) conventions.
+- `docs/for-users/cli-commands.md` — full CLI reference (`gaia build compile`
+  / `build check` / `run infer` / `run render`).
+- `docs/for-users/hole-bridge-tutorial.md` — prior calibration tutorial.
+
+For runtime help, prefer `gaia <group> <cmd> --help`.
+
+Sibling skills (this registry):
+
+- LKM search is the native `gaia search lkm` CLI (`knowledge` /
+  `reasoning [--claim-id]` / `nodes` / `package` / `auth`), used by the
+  Phase 1b reverse-provenance trace. Verify flags with
+  `gaia search lkm <verb> --help`.
+- [`../gaia-lkm-explorer/SKILL.md`](../gaia-lkm-explorer/SKILL.md) — sibling
+  LKM-driven exploration workflow producing the same Gaia
+  knowledge-package output shape from a different upstream.

--- a/gaia/_skills/gaia-formalize-coarse/references/phase-1-extract-conclusions.md
+++ b/gaia/_skills/gaia-formalize-coarse/references/phase-1-extract-conclusions.md
@@ -1,0 +1,279 @@
+# Phase 1 — Extract Conclusions, Motivation, Open Questions, Logic Graph
+
+Load this file when `gaia-formalize-coarse` starts. Do not load later phase
+files until this phase is complete.
+
+## Goal
+
+Read the paper end-to-end and identify, in working notes:
+
+1. **Motivation** — the unresolved scientific problem-state that necessitated
+   the paper's work (paper-level, single block).
+2. **Conclusions** — the genuinely new contributions established by the paper,
+   each as an atomic scientific proposition.
+3. **Open questions** — scientifically meaningful issues the paper explicitly
+   leaves unresolved (paper-level, single block).
+4. **Logic graph** — directed dependency edges among conclusions: an edge
+   `A → B` means the paper's own reasoning uses A in deriving B.
+
+These four objects are held in working notes only. Phase 4 is the only phase
+that writes files.
+
+## Suitability Gate
+
+Before extraction, decide whether the paper is amenable to formalization:
+
+- A review article, survey, or perspective without original results.
+- A paper without identifiable structured contributions (no derivations, no
+  new measurements, no new methods).
+- A corrupted / abstract-only paper text.
+
+If any holds, **stop here**. Do not invent contributions. Record the reason in
+working notes; Phase 4 will write a `<package_name>.skip.md` file instead of
+the package.
+
+## Extraction Rules
+
+### What is a conclusion
+
+A conclusion is **new author-asserted knowledge** that would not exist if this
+paper had not been written:
+
+- a newly derived formula, theoretical relation, or analytical result;
+- a quantitatively new numerical or experimental value, scaling law, phase
+  boundary, or benchmark;
+- a newly proposed algorithm, computational scheme, or experimental method.
+
+It is **not**:
+
+- a restatement of prior work;
+- a trivial corollary of the paper's own assumptions;
+- a rhetorical claim of importance, motivation, or future work;
+- a reformulation that adds no information.
+
+### Atomicity
+
+Each conclusion must answer **exactly one** citable epistemic question
+about the paper — one new bound, one new relation, one new procedure, one
+new measured value, one new comparison outcome, one new causal attribution,
+one new generalization result, etc. If a candidate body answers two,
+split it into two conclusions.
+
+This rule is **field-agnostic**: the same one-question-per-conclusion
+discipline applies whether the paper is a theorem in pure math, a
+clinical-trial endpoint in medicine, a benchmark result in ML, a causal
+estimate in social science, or a measurement in experimental physics.
+
+Do **not** pre-classify a conclusion by "type" (analytical / empirical /
+methodological / etc.) here, and do **not** pre-assign it a Phase 3
+`weak_types` pattern. The nine `weak_types` keys describe *threats to a
+conclusion's derivation*, not *what kind of conclusion it is*; a single
+conclusion typically rests on several patterns simultaneously, and the
+pattern assignment happens per weak point in Phase 3, not per conclusion
+here. Phase 1's only job for atomicity is to enforce the
+one-question-per-conclusion split.
+
+**Common under-splitting traps to avoid:**
+
+Each trap is illustrated with examples from different fields to make
+clear that the trap is structural, not domain-specific.
+
+- **Definition + headline result.** A new bound (e.g., "the scheme is
+  parametrically valid when $\omega_D \ll E_F$, $\omega_c^2 \ll \omega_p^2$,
+  $T \ll \omega_c$") and the downstream result that uses it are *two*
+  conclusions, not one — the bound is a citable regime claim on its own.
+  Outside physics, the same trap appears in a clinical RCT that introduces
+  a new operational criterion alongside its prevalence: "the protocol's
+  prespecified no-disease-activity criterion at week 24 (combining OCT
+  central-subfield thickness, BCVA, hemorrhage status, and investigator
+  judgment) is met by 65% of treated participants" is two conclusions —
+  the criterion is a methodological contribution citable by anyone
+  designing a similar extended-dosing regimen, separate from the
+  empirical prevalence it yielded in this particular cohort.
+- **Procedure + the value it produced.** "Cluster-DiagMC achieves
+  γ~$10^5$ at $n=6$ and reproduces $P(0,0)=0.0504(3)$" is two
+  conclusions: the algorithm's measured speedup, and the agreement with
+  the polarization baseline. Each has different evidence and different
+  weak points. Outside physics, the same trap appears in a clinical RCT
+  conclusion that bundles regimen with outcome: "faricimab dosed every
+  16 weeks after a four-monthly loading phase produces +11.4 ETDRS
+  letters at week 52 with a mean of 6.2 injections" is two — the dosing
+  regimen is a methodological contribution that downstream trials could
+  reuse for a different outcome, and the measured BCVA change is an
+  empirical efficacy result that a different regimen could equally have
+  produced.
+- **Theorem + worked example.** A general formal claim and the explicit
+  worked-example calculation that motivates it (e.g., "the third-order
+  four-diagram cancellation drops by $\sim 3.48 \times 10^{-3}$") are two
+  conclusions when the worked example is a separate quantitative finding.
+  Outside physics, the same trap appears in causal-inference methodology
+  papers that bundle theory with demonstration: a new identifiability
+  theorem for an estimand under stated assumptions, and a worked example
+  applying the resulting estimator to a specific competing-events dataset
+  to produce a numerical estimate, are two conclusions — the theorem is
+  a formal contribution citable by anyone working with that estimand
+  class, and the worked example is an empirical instantiation citable
+  only by people analyzing that specific data.
+- **Mechanism + benchmark.** "The downfolded Migdal–Eliashberg equation
+  reproduces the toy-model $T_c$ to within $0.2\%$" — the mechanism (the
+  equation) is one conclusion (analytical); the benchmark agreement is
+  another (comparative). Outside physics, the same trap appears in
+  algorithmic system papers that bundle a method with its benchmark:
+  "DVL pre-integration is linearized in the rotation update, avoiding
+  full re-integration inside the nonlinear solver, and AQUA-SLAM
+  achieves lower translation RMSE than five baselines on the WaveTank
+  dataset" is two — the linearization mechanism is a methodological
+  contribution that downstream SLAM systems could adopt with a different
+  baseline set, and the WaveTank RMSE comparison is an empirical
+  benchmark result that could come from a different underlying
+  algorithmic choice.
+
+**Split test.** After writing a candidate body, ask: *if I deleted any one
+clause, would I lose an answer to a distinct citable question?* If yes,
+split that clause off. If the body merely loses an aside that does not
+answer its own citable question, it is one conclusion.
+
+**Standalone-citation test.** Would each candidate stand on its own as a
+sentence the paper could have published as a stand-alone bullet in the
+abstract? If yes, it is an atomic conclusion. If two candidates can only
+be cited together (because one is an aside of the other), they are one.
+
+### Self-containment as you write
+
+Every conclusion's working-note text must already meet the
+self-containment criterion that Phase 4 will demand:
+
+- All symbols and acronyms defined in-text on first use.
+- The system / model / dataset / regime described inside the proposition.
+- Inline numerical values, equation forms, or experimental setups instead of
+  pointers like "Eq. (3)" or "Fig. 4".
+- Concrete subject in every sentence (the model, the estimator, the
+  measurement) — not "the paper" or "this work".
+
+This is the rule the legacy step-4 prompt enforced; here it is enforced at
+the moment the conclusion is written, not as a post-hoc rewrite.
+
+### Fidelity
+
+- Do not strengthen heuristic claims into established facts.
+- Do not supply missing derivations.
+- Do not import outside knowledge.
+- Preserve the authors' epistemic hedging exactly (regimes, error bars,
+  speculative qualifiers).
+
+### Evidence localization
+
+For each conclusion, note the figures / tables / equations / external
+citations that primarily evidence it. These notes become the `refs`
+metadata on the `claim(...)` in Phase 4 (the `refs` metadata field is
+documented in `docs/for-users/language-reference.md`).
+
+Allowed pointer kinds — these are the **only three** that may end up in
+`refs`:
+
+- **`figure`** — a figure or table in the paper (e.g. `Fig. 2`, `Table I`).
+- **`equation`** — an equation referenced by number (e.g. `Eq. (5)`).
+- **`citation`** — an external bibliographic reference. Convert numeric
+  citations from the paper (e.g. `[33]`, `Ref. 5`) to a key matching the
+  paper's first-author surname plus year (e.g. `Smith2020`); the same key
+  goes into `references.json` in Phase 4.
+
+Section, appendix, paragraph, theorem, lemma, and footnote pointers are
+**not** legitimate `refs` entries and must not be retained. If a conclusion
+is rooted in "Section IV" of the paper, the relevant content has to be
+inlined into the conclusion's body itself; do not preserve the section
+pointer.
+
+## Motivation Block
+
+Write a single paragraph (3–6 sentences) capturing:
+
+- The physical / scientific context — research area, phenomenon under study,
+  broader scientific goal.
+- The prior state of knowledge — methods, approximations, or phenomenological
+  treatments that existed and their specific shortcomings.
+- The scientific consequences of those gaps — what could not be predicted,
+  understood, or measured before this paper.
+
+Style: narrative, like an Introduction-section paragraph. Not a checklist of
+"lack of X". Do **not** include the paper's solutions — motivation is the
+pre-paper state.
+
+## Open Questions Block
+
+Write a single paragraph capturing what the paper itself leaves unresolved:
+explicit future work, acknowledged limitations, conjectures, unresolved
+regimes. Do not invent new open problems and do not weaken accepted
+conclusions into open questions.
+
+## Logic Graph
+
+For each ordered pair `(A, B)` of conclusions, decide whether the paper's
+own argumentation **uses** A in deriving B. Add an edge `A → B` if and only if:
+
+- The reasoning that establishes B explicitly or implicitly relies on A's
+  result as a premise or intermediate step, **and**
+- The reliance is traceable to the paper text, not to your own reasoning
+  about the subject matter.
+
+Rules:
+
+- The graph must be acyclic.
+- Independent conclusions have no edges; that is expected.
+- Edges must be **direct**: if A → B and B → C, do not also add A → C unless
+  the paper uses A directly in deriving C without going through B.
+- Topical similarity ≠ derivation dependency.
+- Two conclusions appearing in the same downstream application ≠ derivation
+  dependency.
+
+## Working Notes Schema
+
+Hold Phase 1 output in scratch as something like:
+
+```yaml
+suitability: ok | skip
+skip_reason: <if skipping>
+
+motivation: |
+  <single paragraph>
+
+conclusions:
+  - id: 1
+    title: <≤ 25-word descriptor>
+    body: <self-contained scientific proposition>
+    refs:
+      - {type: figure, id: "Fig. 2"}
+      - {type: figure, id: "Table I"}
+      - {type: equation, id: "Eq. (5)"}
+      - {type: citation, key: "Smith2020"}
+  - id: 2
+    title: ...
+    body: ...
+    refs: ...
+
+logic_graph:
+  - from: 1
+    to: 2
+  - from: 1
+    to: 3
+
+open_questions: |
+  <single paragraph>
+```
+
+The `id` integers are local to this paper and are referenced by Phases 2 and
+3. They will not appear in the emitted Gaia DSL — the final claim labels are
+minted in Phase 4 from the paper key plus a semantic suffix.
+
+## Phase-Completion Gate
+
+Before moving to Phase 2:
+
+- Suitability decision is made; if skipping, stop here and note for Phase 4.
+- Every retained conclusion passes atomicity, fidelity, and self-containment
+  checks.
+- The logic graph is acyclic and minimal.
+- Motivation and open-question paragraphs are present (or recorded as
+  "no motivation block" / "no open questions" if genuinely absent).
+- The next todo is marked in progress before loading
+  `phase-2-build-reasoning-chain.md`.

--- a/gaia/_skills/gaia-formalize-coarse/references/phase-2-build-reasoning-chain.md
+++ b/gaia/_skills/gaia-formalize-coarse/references/phase-2-build-reasoning-chain.md
@@ -1,0 +1,186 @@
+# Phase 2 — Reconstruct the Reasoning Chain
+
+Load this file after Phase 1 is complete. Phase 2 produces the per-conclusion
+reasoning chains that will populate the `rationale=` field of each
+`derive(...)` in Phase 4.
+
+## Goal
+
+For every Phase 1 conclusion, reconstruct the paper's own reasoning trace
+from foundational material (definitions, assumptions, experimental setups,
+upstream conclusions, prior cited results) to the conclusion itself.
+
+The trace is held in working notes as an ordered list of step strings per
+conclusion. Each step is one logical move. Steps are not claims; they are
+prose that becomes part of `derive(...)`'s `rationale=`.
+
+## Topological Ordering
+
+Process conclusions in topological order on the Phase 1 logic graph:
+
+1. If `A → B` is an edge, A is reconstructed before B.
+2. Tie-break by id (smaller first).
+3. Every conclusion appears exactly once, including isolated ones.
+
+Topological order matters for two reasons:
+
+- When reconstructing B, A's result is already established and can be
+  referenced by name in B's chain instead of re-derived.
+- The output of Phase 2 will line up with the deduction-emission order in
+  Phase 4 so that downstream readers can read the package linearly.
+
+## Per-Conclusion Reconstruction
+
+### Root and isolated conclusions
+
+For a conclusion with no upstream conclusions, reconstruct the full chain
+from the paper's foundations:
+
+- Definitions, assumptions, model setups.
+- Experimental protocol, dataset construction, sample preparation.
+- Theoretical framework or governing equations.
+- Cited results explicitly invoked.
+
+Capture every logical move from those foundations to the conclusion. Do not
+skip mechanical algebra "for brevity"; redundancy is acceptable, omission is
+not.
+
+### Derived conclusions
+
+For a conclusion B with upstream `A_1, A_2, ...`:
+
+- The first one or two steps state what each upstream conclusion's result is
+  (treating it as established) and which aspects of it B will use.
+- The remaining steps are the **incremental** reasoning that bridges from
+  those upstream results to B.
+- If the derivation also uses additional definitions, assumptions, or cited
+  results outside the upstream conclusions, include those — but only the
+  ones the paper itself invokes.
+
+Do not re-derive an upstream conclusion. Do not invent a dependency that the
+paper does not use.
+
+## Step-Writing Rules
+
+### 1. Maximize detail and completeness
+
+- One logical move per step.
+- Every symbol introduced gets defined inside the same step or an earlier
+  step in the same conclusion's chain.
+- If the authors rely on a result implicitly, surface that reliance as its
+  own step.
+
+### 2. Textualize figures and tables
+
+The paper Markdown does not carry figure pixels. When the paper's argument
+relies on what a figure or table shows, **inline that information as prose**:
+the specific quantity, the curve shape, the trend, the comparison value.
+
+Avoid: "Fig. 3 shows a direct gap."
+Write: "The computed band structure has a direct gap of 1.2 eV at the
+$\Gamma$ point, decreasing to 0.8 eV under 5% biaxial strain."
+
+After writing, no step should rely on a reader being able to *see* the
+figure to follow the argument.
+
+### 3. Use formalism where the paper uses formalism
+
+- Reproduce equations explicitly with LaTeX in `$...$` or `$$...$$`.
+- Do not paraphrase mathematics into prose if the paper itself states the
+  formula.
+- Define every quantity at first appearance.
+
+### 4. Record logical gaps and heuristic moves explicitly
+
+If the authors skip a derivation, appeal to intuition, or assert without
+proof, record the move as such — do not silently repair it:
+
+- "The authors assert without derivation that ..."
+- "At this point the argument relies on a heuristic that ..."
+
+These flagged steps inform the deduction warrant intent Phase 4 writes
+into the `--rationale` prose; persistent gaps surface as explicit "the
+authors assert without derivation" / "the argument relies on a heuristic"
+sentences in the rationale (the engine `derive(...)` signature has no
+`metadata=` / `warrant_prior` kwarg, so the calibration cannot live as
+a number on the deduction itself).
+
+### 5. No paper-internal pointers in step prose
+
+Do not write "Eq. (16)", "Sec. II", "Theorem 2", "Appendix A", or "as derived
+above in the paper" inside step text. Resolve every such pointer inline:
+
+- "Using Eq. (16)" → reproduce the equation, with symbols defined.
+- "The Hamiltonian defined in Sec. II" → write the explicit Hamiltonian.
+- "By the argument in Appendix A" → summarize the relevant argument inline.
+
+Paper-internal structural pointers are not preserved at all. **External
+citations** are preserved (the cited work is still credited) but they are
+rewritten into the `[@key]` form prescribed in rule 6a — never left in the
+paper's original numeric form (`[33]`, `Ref. 5`).
+
+### 6. No external knowledge
+
+Do not invoke "well-known facts", standard theorems, or textbook results
+unless the paper explicitly does. If the paper cites such results without
+proof, record the citation as the paper presents it — but in the citation
+form prescribed in rule 8 below.
+
+### 6a. Citation form in step prose
+
+External citations appearing in step prose use the `[@key]` form, where
+`key` matches an entry in `references.json` (`<FirstAuthorSurname><Year>`,
+e.g. `[@Smith2020]`). Do **not** leave numeric paper-style citations like
+`[33]`, `Ref. 5`, or `Smith et al., 2020` in step prose; convert at write
+time. If a key cannot be derived from the paper's bibliography, use
+`@unknown_<n>` (bare `@key`, **no brackets** — `gaia build compile` rejects
+bracketed `[@unknown_n]` as an unresolvable strict reference; bare `@key`
+is opportunistic) and note the gap in the hand-off report. The full
+citation contract (allowed prose forms, `refs` whitelist, CSL-JSON /
+`references.json` conventions) is documented in
+`docs/for-users/language-reference.md`.
+
+### 7. Authorial voice
+
+Use impersonal scientific voice without changing modal force.
+"We assume X" → "X is assumed". "The authors observe Y" → "Y is observed".
+Do not strengthen ("show" / "prove") or weaken ("suggest" / "indicate")
+beyond the paper's own modality.
+
+## Working Notes Schema
+
+```yaml
+reasoning_chains:
+  - conclusion_id: 1
+    title: <repeats Phase 1 title>
+    upstreams: []
+    steps:
+      - "1. <full prose for step 1>."
+      - "2. <full prose for step 2>."
+      - ...
+  - conclusion_id: 2
+    title: ...
+    upstreams: [1]
+    steps:
+      - "1. From conclusion 1's result, ... is treated as known: <inlined statement>."
+      - "2. <bridging step>."
+      - ...
+```
+
+Step ids are **local** to each conclusion's chain (1, 2, 3, ... per chain).
+The numbered Markdown formatting carries through to the final `derive(...)`
+`rationale=` field in Phase 4.
+
+## Phase-Completion Gate
+
+Before moving to Phase 3:
+
+- Every Phase 1 conclusion has a reasoning chain in working notes.
+- Each chain processes the conclusion in topological order on the logic
+  graph.
+- No step contains a paper-internal pointer (Eq./Fig./Table/Sec./Appendix)
+  whose content has not been inlined.
+- Every flagged logical gap or heuristic move is recorded as such, not
+  silently repaired.
+- The next todo is marked in progress before loading
+  `phase-3-review-weak-points.md`.

--- a/gaia/_skills/gaia-formalize-coarse/references/phase-3-review-weak-points.md
+++ b/gaia/_skills/gaia-formalize-coarse/references/phase-3-review-weak-points.md
@@ -1,0 +1,614 @@
+# Phase 3 — Audit Weak Points and Highlights, Calibrate Probabilities
+
+Load this file after Phase 2 is complete. Phase 3 is the analytical heart of
+the skill: it produces the load-bearing uncertainties (weak points) and
+load-bearing strengths (highlights) for each conclusion, and the leaf-claim
+prior calibrations that drive `priors.py`.
+
+## Goal
+
+For every Phase 1 conclusion, audit the reasoning chain reconstructed in
+Phase 2 and produce in working notes:
+
+1. **Weak points** — load-bearing uncertainties between the paper's evidence
+   and the conclusion. Each weak point will become a leaf `claim(...)` plus a
+   `register_prior(...)` entry in Phase 4.
+2. **Highlights** — load-bearing strengths whose presence is a substantive
+   reason to credit the conclusion. Highlights are working-notes only; they
+   inform the qualitative warrant-strength prose Phase 4 writes into each
+   `derive(...)` `--rationale`, but do not enter the executable DSL.
+3. **Per-conclusion synthesis** — an integrated `prior_probability` and a
+   short narrative explaining how the weak points and highlights interact for
+   that conclusion.
+
+## What Counts as a Weak Point
+
+A weak point is a **load-bearing uncertainty** in the path from evidence to
+conclusion. It is **not** a generic limitation, a caveat about future work,
+or a boilerplate hedge. A claim is a weak point only if **weakening or
+negating it would materially weaken, invalidate, or narrow the conclusion**.
+
+### Classify by Argument Pattern, Not by Field
+
+For each conclusion, identify which of the following nine reasoning patterns
+its derivation rests on, then surface weak points specific to those
+patterns. Do not classify by academic field (physics, ML, biology).
+
+1. **`measurement`** — does the observed/measured/computed quantity really
+   capture the stated object? Cues: proxies, instrument assumptions, label
+   noise, construct validity, simulation fidelity.
+2. **`causal`** — does the evidence support a causal mechanism rather than
+   mere association? Cues: confounders, reverse causality, missing
+   interventional controls.
+3. **`model`** — is the model / idealization / simplification / asymptotic
+   regime adequate? Cues: validity regime, neglected terms, linearization,
+   mean-field assumptions.
+4. **`statistical`** — is the treatment of uncertainty / sample size /
+   significance strong enough? Cues: sample size, posterior choices, error
+   bars, ignored correlations.
+5. **`generalization`** — does extrapolation from tested cases to the
+   broader target scope hold? Cues: dataset-specific artifacts, regime
+   extrapolation, benchmark-vs-deployment gap.
+6. **`comparative`** — is the comparison fair and the baseline appropriate?
+   Cues: baseline strength, hyperparameter asymmetry, metric choice, leakage.
+7. **`formal`** — is the mathematical / logical / algorithmic transition
+   fully established? Cues: skipped proofs, regularity assumptions,
+   convergence, limit exchange.
+8. **`computational`** — is the code / solver / numerical method reliable?
+   Cues: tolerance, stability, code correctness, seed dependence.
+9. **`external`** — is a cited result / dataset / pretrained component
+   applicable here? Cues: results used outside their stated regime,
+   pretrained components not re-validated.
+
+A single conclusion typically rests on several patterns simultaneously. Tag
+each weak point with 1–3 of these patterns (`weak_types`), in dominance
+order — first key is the dominant pattern.
+
+### Gating Questions for Each Candidate Weak Point
+
+Before committing to a weak point, it must pass all five:
+
+- **Which conclusion does it threaten?** — Name **one** conclusion by
+  Phase 1 id. Every weak point is bound to a single conclusion — the one
+  whose derivation it directly undermines. If the underlying scientific
+  uncertainty seems to threaten several conclusions, apply the
+  weak-point ↔ one-conclusion (strict) discipline: pick the conclusion
+  with the most catastrophic failure mode (tie-break by smaller id), and
+  let cross-conclusion influence propagate through the logic graph
+  (`W → C2 → C4` if C2 is upstream of C4) rather than re-binding W to C4.
+  For independent conclusions that share a foundational assumption with no
+  logic-graph link, the BP-invisible effect on the other conclusion(s) is
+  noted in working notes as `also_threatens` (working-notes only — not
+  emitted into the executable DSL).
+- **Which part of that conclusion's derivation depends on it?** — Point to
+  the specific argumentative move (a Phase 2 step, an experimental design
+  choice, an assumption, a comparison).
+- **If false or weaker, what specifically would fail?** — Describe the
+  concrete failure: which part of the conclusion collapses, narrows, or
+  becomes unsupported.
+- **Is the failure specific and load-bearing?** — If the same objection
+  could be pasted against almost any paper in the field, it is not specific.
+- **Is the claim already directly established by the paper?** — If the paper
+  proves it, validates it with independent evidence, or it is a universally
+  accepted fact, it is not a weak point.
+
+### Do Not Extract
+
+- Definitions ("let $H$ denote the Hamiltonian").
+- Direct reported observations (what a figure or table shows).
+- Mechanical algebra or identities.
+- Generic limitations ("no model is perfect", "more data would be better").
+- Background facts not in question here.
+- Caveats that do not affect the conclusion.
+
+### Shared-factor weak points
+
+If two weak points on the same conclusion share an underlying factor — same
+approximation, same dataset, same lemma, same external assumption — extract
+the shared factor as a separate weak-point claim and let both supports
+threaten that one factor. This is the same logic as the `gaia-lkm-explorer`
+shared-factor extraction rule on the `derive(...)` warrant surface (legacy
+`support()`); see
+[`../../gaia-lkm-explorer/references/mapping-contract.md`](../../gaia-lkm-explorer/references/mapping-contract.md)
+§3a "Shared-factor extraction" for the canonical statement.
+
+## What Counts as a Highlight
+
+A highlight is a **load-bearing strength**: a specific element of the
+derivation that gives the conclusion substantively more credit than a
+default well-written paper would have, and whose absence would leave the
+conclusion materially less credible. Use the same nine patterns
+(`strength_types`) to classify.
+
+### Common Forms of Highlight
+
+- **Independent validation / cross-check** — the same claim reached by two
+  independent methods (analytical vs. simulation, two non-overlapping
+  datasets, etc.).
+- **Formal proof or rigorous derivation** — a step typically assumed in the
+  field is here actually proved or bounded.
+- **Quantitative agreement with prior independent results** — the paper's
+  number reproduces a previously reported, independently obtained value
+  within stated error bars.
+- **Strong baseline / ablation design** — credible, well-tuned baseline plus
+  ablations that isolate the contribution.
+- **Statistical robustness** — large sample, multiple seeds, sensitivity
+  sweeps, calibrated intervals beyond the field's default.
+- **Computational reproducibility / numerical control** — explicit
+  convergence tests, solver-tolerance sweeps, code/data release sufficient
+  for re-execution.
+- **Direct mechanistic evidence** — interventional controls, ablation
+  experiments, do-style interventions when the conclusion is mechanistic.
+- **Tight scope discipline** — the conclusion is explicitly bounded to the
+  regime where evidence is strong; out-of-scope claims declared as conjecture.
+
+### Gating Questions for Each Candidate Highlight
+
+- **Which conclusion does it underwrite?** — Name by id.
+- **Which part of the derivation gains credit?** — Point to the specific
+  move whose strength is materially elevated.
+- **What concretely would the conclusion lose without it?** — Describe the
+  loss: which quantitative figure, qualitative regime, comparative ranking,
+  or interpretive attribution would no longer be credibly supported.
+- **Is the strength specific and load-bearing?** — If the same praise could
+  be pasted onto any competently written paper, it is not specific.
+- **Is the strength actually supplied?** — If the paper merely declares the
+  property without evidence (claims robustness without showing the sweep),
+  it is not a highlight.
+
+### Do Not Extract
+
+- Restatement of the conclusion (the conclusion is not its own highlight).
+- Generic compliments about clarity, importance, writing.
+- Standard-practice elements (routine train/test split, ordinary baseline,
+  ordinary statistical reporting).
+- Strengths with no specific conclusion-level credibility effect.
+- Mere absence of weakness.
+
+## Body-Writing Rule (Same for Weak Points and Highlights)
+
+Each weak point and each highlight gets a **body** — a self-standing
+scientific proposition that, in Phase 4, will become the string body of a
+`claim(...)` (for weak points) or a working-notes line (for highlights;
+highlights do not enter the executable DSL — see formalize/SKILL.md).
+The writing rules are identical:
+
+- **Self-standing setup**: every model / system / procedure / dataset /
+  regime / variable named inside the body must be **introduced inside the
+  same body**. If the claim concerns "a model", first characterize that
+  model; do not appeal to "the model" as if the reader knows.
+- **Paper-specific specifics**: concrete quantities, parameter values,
+  regimes, equation forms, dataset identifiers — not abstract placeholders.
+- **Inlined content, not pointers**: any equation, value, protocol,
+  figure/table finding, or cited result the body relies on must appear,
+  translated into prose, inside the body itself. No "Eq. (5)" or "Fig. 3"
+  inside the body.
+- **Atomic**: one claim per body. Two independent claims become two findings.
+- **LaTeX math** inside `$...$`; no Unicode math symbols.
+- **No cross-finding references**: "see P2" / "as in H1" not allowed inside
+  the body.
+- **Concrete subject**: the procedure, the estimator, the model, the
+  measurement — not "the paper" or "this work".
+
+The reviewer fields (`weakness_reason`, `failure_mode` for weak points;
+`credit` for highlights) are reviewer commentary written **about** the body
+and live in Phase 3 working notes only — they do not enter the executable
+DSL and do not get emitted as audit artifacts in the post-purge SOP. They
+inform the qualitative warrant-strength prose Phase 4 writes into each
+deduction's `--rationale` and the agent's own hand-off narrative.
+
+## Reviewer-Field Writing Rules (`weakness_reason` / `failure_mode` / `credit`)
+
+These three fields are where Phase 3's analytical value materializes for the
+reviewing agent. Gaia's BP propagation only consumes the numeric
+`prior_probability` on leaf claims (via `register_prior`); the textual
+reasoning behind those numbers — what makes a weak point worth surfacing,
+what would break if it failed, why a highlight underwrites the conclusion —
+lives only in working notes and informs the warrant-strength prose Phase 4
+writes into each deduction's `--rationale`. Sloppy writing here means
+Phase 4's rationale and the agent's own hand-off narrative are unjustified.
+
+All three are read alongside the `body` they annotate and may freely refer
+to its contents — they do **not** need to restate the body's setup, and
+they are **not** self-standing on their own.
+
+### `weakness_reason` — critique, not description
+
+`weakness_reason` is the reviewer's **critical judgment of why the claim
+in `body` is uncertain on its own merits**. It is a critique, not a
+description of what the paper does.
+
+Substantive critique draws on (any of):
+
+- the alternative formulations the body's claim rules out;
+- known counter-cases or competing conventions in the field;
+- evidence that the choice was made for tractability or convention rather
+  than empirical grounding;
+- the specific kind of derivation or evidence that would be needed to
+  establish the claim, which the paper does not provide.
+
+Paper-structure references (Section / Eq / Fig / footnote) are permitted
+only as supplementary citations attached to the critique; they must not
+carry the reasoning. A `weakness_reason` whose content reduces to
+describing where in the paper the claim is made, or how the paper sets it
+up, is paper-description, not critique, and must be rewritten.
+
+**Judgment test (self-check).** Strip every paper-structure reference out
+of the field and read what remains. If what remains is substantive
+reasoning about why the claim is dubious on its own merits, the field is
+correctly written. If what remains is empty or vacuous, the field must be
+rewritten.
+
+### `failure_mode` — concrete counterfactual, not hedging
+
+`failure_mode` is the reviewer's **counterfactual reasoning about what
+breaks in the threatened conclusion if the claim in `body` turns out to
+be false or weaker**.
+
+It must contain all four of:
+
+1. **An explicit counterfactual premise** — "If [body claim] fails in
+   way W, ...", stating the specific form of failure (not just negation
+   of the claim).
+2. **An identifiable downstream consequence in the conclusion** — a
+   specific quantitative figure, a qualitative regime, a comparative
+   ranking, or an interpretive attribution that breaks, narrows, flips,
+   or becomes unsupported.
+3. **The mechanism** — the intermediate step in the derivation that
+   stops working, linking "body false" to "conclusion damaged".
+4. **The scope of damage** — full invalidation / narrowing of valid
+   regime / quantitative shift / alternative-mechanism substitution.
+
+**What is not a `failure_mode`:**
+
+- restating the `body` claim in the future tense;
+- generic hedges ("the conclusion would be weakened", "results may be
+  affected");
+- re-describing the paper's conclusion without saying what fails in it;
+- re-iterating why the claim is dubious (that is `weakness_reason`, not
+  here).
+
+**Diagnostic.** If you cannot write a concrete, specific consequence
+under all four requirements above, the candidate is probably not
+load-bearing — go back and remove it from the weak-point list rather
+than fill `failure_mode` with hedging to get past this phase.
+
+### `credit` — integrated underwriting argument, not praise
+
+`credit` is the reviewer's **integrated argument for the role this
+strength plays in the conclusion's derivation**. A single coherent piece
+of reasoning (not a multi-field decomposition) that conveys three things
+together:
+
+1. **Which specific failure mode in the derivation it guards against** —
+   what concrete failure (a particular alternative explanation, a
+   particular extrapolation, a particular numerical artifact, a
+   particular confounder, etc.) the conclusion would have been
+   vulnerable to without this element.
+2. **Which layer of the conclusion's credibility it underwrites** —
+   qualitative direction, quantitative magnitude, mechanism /
+   attribution, generalization / extrapolation scope, or error /
+   uncertainty quantification.
+3. **The scope of credit** — full underwriting of the conclusion /
+   quantitative tightening / regime-bounded support / ruling out of a
+   specific alternative explanation / extension of the conclusion's
+   regime of validity.
+
+State these as one integrated argument, not as labelled sub-fields.
+
+**What is not a `credit`:**
+
+- generic praise ("the conclusion is well supported", "this is good
+  practice", "the paper is rigorous");
+- a `credit` whose content reduces to "the paper does X" without
+  naming a concrete failure preempted or a specific layer
+  underwritten — that is description, not reasoning, and must be
+  rewritten.
+
+Paper-structure references (Section / Eq / Fig) are permitted only as
+supplementary citations attached to the reasoning; they must not carry
+the reasoning.
+
+## Probability Calibration
+
+Each weak point carries three numbers in `[0, 1]`. Use the full range; do
+not default everything to 0.7–0.8.
+
+- **`prior_probability`** — the weak-point claim's intrinsic credibility on
+  its own merits.
+  - **0.80–0.90** — standard approximation used within its **known valid
+    regime**, or an empirical fact the field treats as settled. The claim
+    is defensible by appeal to established practice; the only residual
+    doubt is theoretical purity.
+  - **0.60–0.80** — plausible but debatable in *this* setting: a reasonable
+    assumption that has not been rigorously verified for the specific
+    system, dataset, regime, or parameter range under study.
+  - **0.40–0.60** — heuristic / extrapolative / single-anchor: assertions
+    of asymptotic / functional form fit to a small number of anchor
+    points, validations performed at a single parameter setting / dataset
+    / subgroup / regime being generalized to other settings, cited
+    results applied outside their stated regime, qualitative arguments
+    substituting for a derivation, mechanistic interpretation of a single
+    observed correlation. **The single biggest calibration mistake is to
+    put these at 0.80** because the claim "feels reasonable" — they are
+    exactly the load-bearing uncertainties this phase is meant to surface.
+  - **0.20–0.40** — actively doubtful: contradicted by available evidence,
+    internally inconsistent, or relying on a step the field has flagged
+    elsewhere.
+  - **0.001–0.20** — almost certainly wrong (rare; reserved for clear
+    refutations).
+  - Cap at 0.9 (no claim is absolutely certain). Lower bound 0.001
+    (Cromwell).
+- **`p1`** — sufficiency: if the weak-point claim is true, how strongly does
+  the conclusion follow? `p1 ≈ P(conclusion | weak point true)`.
+- **`p2`** — necessity: if the weak-point claim is false, how strongly does
+  the conclusion fail? `p2 ≈ P(conclusion false | weak point false)`.
+
+`prior_probability` is consumed by Phase 4's `register_prior(...)` emission
+for this weak point. `p1` and `p2` are reviewer working-notes only — they
+inform the qualitative warrant-strength prose Phase 4 writes into the
+`derive(...)` `--rationale` but are not emitted into the package; BP does
+not consume them.
+
+## Per-Conclusion Synthesis
+
+After all weak points and highlights for a conclusion are recorded, write a
+synthesis for that conclusion:
+
+- **`prior_probability`** (a number in `[0.001, 0.9]`) — the reviewer's
+  overall credibility judgment (posterior) for the conclusion, integrating
+  its weak points and highlights. This is **not** a mechanical function of
+  the weak points' probabilities; it is informed by both findings. In
+  Phase 4 this number is consumed in two ways: (1) for isolated
+  conclusions (no upstream, no weak points → no `derive(...)`) it becomes
+  the conclusion's `register_prior(...)` value because the conclusion is a
+  leaf in that case; (2) for derived conclusions it informs the qualitative
+  warrant-strength prose Phase 4 writes into the `derive(...)` `--rationale`
+  (alongside per-highlight and per-gap commentary — see Phase 4 Step 4a).
+  The engine `derive(...)` signature has no `metadata=` / `warrant_prior`
+  kwarg, so warrant-strength intent does not live as a number on the
+  deduction itself; numerical priors live only on leaf claims via
+  `register_prior`. Calibration:
+  - A conclusion with several high-`p2` weak points cannot have a high
+    prior, even with highlights.
+  - A conclusion with no load-bearing weak points and at least one
+    substantive highlight should be close to 1.
+  - A conclusion with neither weak points nor highlights (a routine
+    derivation) sits in the upper-middle range, not at the ceiling.
+- **`narrative`** (2–4 sentences in reviewer voice) — articulates how the
+  attached weak points and highlights interact for this conclusion. Cover
+  at least 2–3 of:
+  - **Layer of unreliability** — which layer(s) are weak: qualitative
+    direction, quantitative magnitude, mechanism / attribution,
+    generalization scope, error / uncertainty.
+  - **Dominant risks vs refinements** — among the weak points, which would
+    materially collapse the conclusion (show-stoppers) versus which only
+    shift magnitude (refinements). Reference by working-note id.
+  - **Composition of risks and supports** — how weak points and highlights
+    interact: compounding, cumulative, partially redundant, offsetting (a
+    highlight specifically preempts a failure mode named in a weak point's
+    `failure_mode`), or unprotected.
+  - **Layers underwritten by highlights** — which layer(s) are positively
+    supported by the highlights.
+  - **Importance among highlights** — which highlights are doing the
+    substantive underwriting versus confirming-but-not-essential.
+
+The narrative is not an index. Naming weak-point and highlight ids is fine,
+but a narrative that only lists ids and restates one-line content is not
+doing its job.
+
+If a conclusion has zero weak points and zero highlights, the narrative is a
+single sentence stating that no load-bearing risks or distinguishing
+strengths were identified.
+
+## Working Notes Schema
+
+```yaml
+weak_points:
+  - id: P1                       # ephemeral id local to working notes
+    conclusion_id: 1             # the single conclusion this weak point threatens
+    also_threatens: []           # audit-only: independent conclusions this assumption also affects
+                                 # (BP cannot see this; do NOT add the weak point to those conclusions' deductions)
+    title: <≤ 25-word descriptor>
+    body: <self-standing scientific proposition>
+    weak_types: [model]
+    prior_probability: 0.65
+    p1: 0.7
+    p2: 0.85
+    weakness_reason: <reviewer critique of why the body claim is uncertain>
+    failure_mode: <reviewer counterfactual: what breaks in the threatened conclusion if body fails>
+    refs: [{type: figure, id: "Fig. 4"}, {type: equation, id: "Eq. (12)"}]   # only figure/equation/citation; section/appendix forbidden
+
+highlights:
+  - id: H1
+    conclusion_id: 1
+    title: <descriptor>
+    body: <self-standing scientific proposition>
+    strength_types: [computational, statistical]
+    credit: <reviewer integrated argument: failure preempted, layer underwritten, scope of credit>
+    refs: [{type: figure, id: "Fig. 4"}, {type: equation, id: "Eq. (12)"}]   # only figure/equation/citation; section/appendix forbidden
+
+conclusion_synthesis:
+  - conclusion_id: 1
+    prior_probability: 0.78
+    narrative: |
+      <2–4 sentences>
+```
+
+P-ids and H-ids are ephemeral and used only for cross-references in the
+narrative; the final claim labels for weak points are minted in Phase 4 from
+the paper key plus a semantic suffix.
+
+## Calibration Sanity Check
+
+After all weak points have been assigned `prior_probability`, run this
+quick distributional sanity check **before** the phase-completion gate:
+
+- If **every** weak point has `prior_probability ≥ 0.80`, the calibration
+  is almost certainly miscalibrated. Load-bearing uncertainties in any
+  non-trivial paper are not all "plausible standard approximations" — at
+  least one is normally heuristic, extrapolative, or single-anchor and
+  belongs in the 0.40–0.60 band. Re-read each weak point against the
+  bands above; specifically check whether you are giving 0.80+ to a
+  claim that the paper itself only supports by extrapolation, asymptotic
+  fit, validation at a single parameter setting / dataset / subgroup,
+  or qualitative argument.
+- The opposite failure (every weak point ≤ 0.40) is also miscalibration:
+  if the derivation really had that many actively doubtful steps, the
+  conclusion would not be defensible at all. Re-read for whether each
+  is genuinely a refutation rather than a heuristic gap.
+- A healthy distribution typically spans at least two bands across the
+  weak points of a paper. Aim for that, not for a uniform default.
+
+This check guards against a known failure mode: agents tend to cluster
+priors at 0.80 because the bodies "look reasonable", losing the signal
+the weak-point analysis is supposed to produce.
+
+## Phase 1b — LKM Reverse-Provenance Trace (cross-grounding)
+
+This section is named "Phase 1b" because the *analytical role* it plays
+is paper-level cross-grounding — adjacent to Phase 1's conclusion
+extraction. It runs late (here, in Phase 3) only because the audit weights
+it produces are consumed by the same pass that calibrates weak-point
+priors. Phase 4 emit time is when the resulting `lkm_id=` metadata
+actually lands on `claim(...)` calls.
+
+### Goal
+
+Cross-ground the paper's claims by checking whether they appear in LKM's
+existing knowledge graph as evidence chains rooted in this paper's
+`paper:<id>`. The pass surfaces:
+
+- Which Phase 1 conclusions have been independently formalized by LKM
+  with provenance back to *this* paper (their `gcn_*` ids become the
+  `lkm_id=` metadata on the paper-extract `claim(...)`).
+- Which Phase 3 weak points threaten conclusions that LKM treats as
+  load-bearing for downstream multi-paper reasoning (cross-paper evidence
+  fan-out). The reviewer should weight those weak points heavier in the
+  per-conclusion synthesis prior: their failure doesn't just collapse one
+  paper's claim, it perturbs an inter-paper reasoning chain.
+
+This is **best-effort cross-grounding**, not a gate. Papers not yet
+ingested by LKM yield no trace; that is a no-op, not a failure. The
+underlying `claim(...)` bodies and conclusion list are not changed by
+Phase 1b — only `lkm_id=` metadata is added in Phase 4, and the reviewer's
+per-conclusion synthesis judgment may shift.
+
+### Procedure
+
+Use the native `gaia search lkm` CLI. Make sure an LKM access key is set —
+run `gaia search lkm auth login` (or set `GAIA_LKM_ACCESS_KEY` /
+`LKM_ACCESS_KEY`); check with `gaia search lkm auth status`. Verify any flag
+with `gaia search lkm <verb> --help`.
+
+1. **Identify the input paper's `paper:<id>`.** From the paper Markdown's
+   bibliographic metadata (DOI, first-author surname + year). If the
+   paper id cannot be derived (corrupted bibliography, unindexed
+   preprint), skip Phase 1b entirely and note it in the hand-off report's
+   metadata-gaps section.
+2. **Query LKM by title or anchor phrase.** Use the paper title; if it is
+   too generic, supplement with one or two distinctive anchor phrases
+   from the paper's contribution sentences (Phase 1 working notes are a
+   good source). Filter to claim-typed nodes with reasoning backing so
+   the next step has something to trace. Use `--format raw-json` so the
+   verbatim LKM envelope (`data.variables[]` with `provenance`, plus
+   `data.papers`) is preserved for the provenance filter in step 3.
+
+   ```bash
+   gaia search lkm knowledge "<paper title or anchor phrase>" \
+     --scopes claim --reasoning-only \
+     --limit 50 --format raw-json --out search.json
+   ```
+
+3. **Filter `data.variables[]`** for entries whose
+   `provenance.source_packages` list contains the input paper's
+   `paper:<id>`. Those are LKM claims whose provenance traces back to
+   this paper. Collect the matching `gcn_*` ids (each will be
+   `type=claim` because of `--reasoning-only`) and their `data.papers`
+   metadata into working notes.
+4. **Fetch reasoning chains for each match.** For every matching
+   `gcn_id`:
+
+   ```bash
+   gaia search lkm reasoning --claim-id <gcn_id> \
+     --max-chains 10 --format raw-json --out reasoning_<gcn_id>.json
+   ```
+
+   Some claims may come back with no reasoning chains
+   (`total_chains == 0`); treat those as `unmatched` for verdict purposes
+   and move on.
+
+5. **Verify chain closure.** For each `reasoning_chains[]` entry, examine
+   the chain's `paper_id` (resolves into `data.papers`). A chain whose
+   `paper_id` matches the input paper's id represents reasoning fully
+   internal to this paper — expected for a typical paper-extract claim.
+   A chain whose `paper_id` is a *different* paper indicates LKM has
+   rooted this claim in inter-paper reasoning; this paper is feeding
+   into a cross-paper provenance chain. Count the cross-paper chains per
+   `gcn_id`; these are the "LKM treats as load-bearing for downstream
+   reasoning" signal.
+
+### Outputs
+
+- **Phase 1b LKM-trace table in working notes.** Columns:
+  `gcn_id | matched_paper_claim_label | chain_total | cross_paper_chains | LKM_provenance_verdict`.
+  The verdict is one of `single-paper-internal`, `cross-paper-fanout`,
+  or `unmatched`. Surface a summary count in the hand-off report.
+- **`lkm_id=` metadata on Phase 1 conclusion claims.** Whenever a
+  matched `gcn_id` corresponds to a Phase 1 conclusion (mapped by content
+  similarity in working notes), record the join so Phase 4 can emit
+  `lkm_id="gcn_..."` on that conclusion's `claim(...)`. Paper-extract
+  emitters reuse `lkm_id` purely as a provenance join.
+- **Reviewer-signal bump on cross-paper-fanout weak points.** When a
+  Phase 3 weak point threatens a conclusion whose matched `gcn_id` has
+  `cross_paper_chains > 0`, note the cross-paper exposure in working
+  notes; the reviewer may use it to nudge the per-conclusion synthesis
+  prior or the deduction warrant downward. Phase 1b does **not**
+  automatically lower or raise the weak point's numeric
+  `prior_probability` / `p1` / `p2` — those reflect the paper's own
+  evidence, not LKM downstream consumption.
+
+### When to skip
+
+- **Paper not in LKM corpus.** Step 3 yields no `data.variables[]` whose
+  `provenance.source_packages` includes the paper's `paper:<id>`. Note
+  the skip in the hand-off report; Phase 4 emit proceeds without
+  cross-grounding.
+- **Network or API failure.** Best-effort. Note the failure mode (e.g.
+  `code=290001` retry exhausted, network timeout) in the hand-off report
+  and continue. Phase 4 emit proceeds.
+- **Paper too recent for LKM ingestion cutoff.** Same handling as
+  not-found.
+- **`LKM_ACCESS_KEY` unavailable** (and the user declines to provide
+  one). Same handling as not-found.
+
+In every skip path, the rest of Phase 3 (weak points, highlights,
+synthesis priors) is unaffected. Phase 1b is an additive audit; its
+absence does not block emission.
+
+## Phase-Completion Gate
+
+Before moving to Phase 4:
+
+- Every conclusion has gone through both weak-point and highlight gating.
+- Every retained weak point and highlight passes its five gating questions
+  and is not on its do-not-extract list.
+- Every body satisfies the self-standing rule.
+- Each weak point has `prior_probability`, `p1`, `p2`, `weakness_reason`,
+  `failure_mode`.
+- Each highlight has `credit`.
+- Every `weakness_reason` passes its judgment test (strip paper-structure
+  references; substantive critique remains).
+- Every `failure_mode` carries all four components (counterfactual
+  premise, downstream consequence, mechanism, scope of damage) and is not
+  one of the listed non-`failure_mode` shapes. Weak points whose
+  `failure_mode` cannot be made concrete are removed, not hedged.
+- Every `credit` integrates the three aspects (failure preempted, layer
+  underwritten, scope of credit) and is not generic praise or
+  paper-description.
+- Each conclusion has a synthesis (`prior_probability` + `narrative`).
+- Phase 1b LKM reverse-trace has either run (results captured in working
+  notes; `lkm_id` joins recorded for Phase 4) or been skipped with the
+  skip reason noted for the hand-off report.
+- The next todo is marked in progress before loading
+  `phase-4-emit-package.md`.

--- a/gaia/_skills/gaia-formalize-coarse/references/phase-4-emit-package.md
+++ b/gaia/_skills/gaia-formalize-coarse/references/phase-4-emit-package.md
@@ -1,0 +1,354 @@
+# Phase 4 — Emit the Gaia Package
+
+Load this file after Phase 3 is complete. This is the only phase that writes
+files. It composes the working notes from Phases 1–3 into a standalone Gaia
+knowledge package on disk.
+
+## Goal
+
+Produce a `<name>-gaia/` package on disk per the Gaia
+knowledge-package spec (file layout: `docs/for-users/quick-start.md`;
+`claim` / `derive` / `question` body discipline, label rules, `__all__`
+rules: `docs/for-users/language-reference.md`). After emission, the package
+must be ready for `gaia build compile` and `gaia build check --hole .` (see
+`docs/for-users/cli-commands.md`).
+
+## Authoring surface — `gaia author` (cli-as-client)
+
+Phase 4 emits the package through the **agent-first authoring CLI**
+(`docs/reference/cli/author.md`), not by writing raw
+Python DSL by hand. The CLI:
+
+- pre-validates each statement (identifier collision, reference resolution,
+  syntactic well-formedness) before writing,
+- appends the rendered Python to the target source file,
+- runs `gaia build check` automatically after each successful write
+  (default `--check` on),
+- emits a uniform JSON envelope on stdout — `json.loads(stdout)` once and
+  dispatch on `verb` / `status` / `code`.
+
+Every Phase 4 sub-step below names the specific `gaia author <verb>`
+invocations to use. The DSL primitives this skill emits map to author verbs
+as follows (canonical v0.5 names; legacy aliases in
+`gaia.engine.lang.compat` emit `DeprecationWarning` and must not be used in
+fresh packages):
+
+| Phase 4 emission | DSL primitive | Author verb |
+|---|---|---|
+| Motivation question | `question(...)` | `gaia author question` |
+| Conclusion / weak-point claim | `claim(...)` | `gaia author claim` |
+| Deduction (1+ premises → conclusion) | `derive(...)` | `gaia author derive` |
+| Leaf prior record | `register_prior(...)` | `gaia author register-prior` |
+
+Errors surface in the envelope's `diagnostics` array with a `kind`
+dispatch key (`prewrite.collision`, `prewrite.reference_unresolved`,
+`prewrite.syntax`, `prewrite.self_loop`, `postwrite.check_fail`, ...).
+Treat non-zero `code` as a fix-and-retry obligation before moving on; the
+CLI guarantees no partial writes on pre-write failure.
+
+## Step 0 — Decide the package name and import name
+
+- Extract the paper's reference key from its bibliographic metadata
+  (`<FirstAuthorSurname><Year>`, e.g., `Liu2015`). If multiple papers shared
+  a key in this run, append `a`, `b`, ...
+- Derive a short topic slug (1–4 lowercase tokens) from the paper title or
+  the dominant conclusion's title.
+- Package directory: `<author-lowercase><year>-<topic-slug>-gaia` (kebab
+  case), e.g., `liu2015-fibonacci-anyons-gaia`.
+- Python import name: derived **by the CLI** from `--name` by stripping the
+  trailing `-gaia` and converting hyphens to underscores
+  (`liu2015-fibonacci-anyons-gaia` → `liu2015_fibonacci_anyons`). Per
+  `docs/reference/cli/author.md` `gaia pkg scaffold` section, the cli does
+  not accept an `--import-name` override.
+
+If the paper Markdown is missing author / year, fall back to
+`<topic-slug>-gaia` and note the metadata gap in the hand-off report.
+
+## Step 1 — Mint claim labels
+
+For every Phase 1 conclusion, mint a label of the form
+`<key>_c<id>_<semantic_suffix>`, where the suffix is 1–4 tokens drawn from
+the conclusion's title (lowercase, ASCII, underscores only).
+
+For every Phase 3 weak point, mint a label of the form
+`<key>_c<id>_wp_<semantic_suffix>`, where the suffix is 1–4 tokens drawn
+from the weak point's title.
+
+Label rules (recap; canonical rules in
+`docs/for-users/language-reference.md` "label rules"):
+
+- Valid Gaia QID: `[a-z_][a-z0-9_]*`. Lowercase letters, digits, underscores.
+- No hyphens, no dots, no uppercase, no diacritics.
+- 1–4 token semantic suffixes; do not pack the entire body into the label.
+
+## Step 2 — Scaffold the package
+
+Bootstrap the package directory with the CLI:
+
+```bash
+gaia pkg scaffold \
+    --target <name>-gaia \
+    --name <name>-gaia \
+    --namespace <namespace> \
+    --with-uuid \
+    --description "<one-line description from Phase 1 motivation>"
+```
+
+This writes `pyproject.toml` (with `[tool.gaia] type = "knowledge-package"`
+and a freshly-minted `uuid`), `src/<import_name>/__init__.py` seeded with
+`from gaia.engine.lang import claim`, and `.gaia/.gitkeep`. The cli refuses
+to write into a non-empty target. `--namespace` sets the Gaia package
+namespace (matches the upstream `gaia example mendel` / `gaia example
+galileo` walkthroughs, which pass `--namespace example`); use whatever
+namespace the calling SOP has chosen for this run.
+
+All Phase 4 DSL emissions for this paper — motivation question, conclusions,
+weak-point claims, deductions — go in the scaffolded `__init__.py` (the
+default target when `gaia author <verb>` is invoked without `--file`). The
+only sibling module Phase 4 creates is `priors.py`, scaffolded with the
+upstream pattern:
+
+```bash
+gaia pkg add-module \
+    --name priors \
+    --imports register_prior \
+    --target <name>-gaia
+```
+
+`--imports register_prior` pre-seeds the import so `priors.py` can call
+`register_prior(...)` directly. This matches the canonical
+`gaia example mendel` / `gaia example galileo` walkthroughs and the
+upstream knowledge-package convention; this skill does not prescribe
+per-paper sibling modules.
+
+## Step 3 — Write `references.json`
+
+Emit a CSL-JSON record for the paper using its reference key. Fields:
+
+- `type`: `article-journal` (default; switch to `paper-conference`,
+  `book-chapter`, etc. only if the paper Markdown clearly indicates so).
+- `title`, `DOI`, `container-title`, `issued`, `author`.
+- Use the paper's own metadata; do not invent fields. Missing fields are
+  omitted, not stubbed.
+
+`references.json` is a JSON object keyed by citation key, CSL-JSON entry
+shape; each entry must include `type` (drawn from the CSL allowlist). The
+full schema is in
+`docs/specs/2026-04-09-references-and-at-syntax.md`.
+
+`references.json` is SOP-owned — the CLI does not manage it. Write the file
+directly with the file-write tooling of choice.
+
+## Step 4 — Emit the DSL statements via `gaia author`
+
+Emit one CLI invocation per DSL statement, in the order below. Each
+invocation auto-runs `gaia build check` post-write (default), so a failure
+in any statement halts the chain at that statement.
+
+### 4a. `__init__.py` — motivation, conclusions, weak-point claims, deductions
+
+All Phase 4 DSL emissions for this paper go into the scaffolded
+`__init__.py`. Omit `--file` and the default is `__init__.py`, matching the
+upstream Mendel/Galileo walkthroughs.
+
+1. **Motivation as `question(...)`** — one invocation for Phase 1's
+   motivation block:
+
+   ```bash
+   gaia author question "<motivation prose>" \
+       --dsl-binding-name <key>_problem \
+       --target <name>-gaia
+   ```
+
+   `gaia author question` has no `--label` flag because the underlying
+   `question(...)` constructor does not accept an engine `label=` kwarg;
+   `--dsl-binding-name` is the only label-like flag the verb exposes and
+   sets the Python LHS binding. Aligns `gaia-formalize-coarse` with pipeline B
+   (XML→LKM), where `<problem>` from `select_conclusion.xml` becomes a
+   `LocalVariableNode(type="question")`.
+
+2. **Conclusions section** — one `gaia author claim` per Phase 1 conclusion,
+   in topological order:
+
+   ```bash
+   gaia author claim "<self-contained conclusion body>" \
+       --dsl-binding-name <key>_c<id>_<suffix> \
+       --label <key>_c<id>_<suffix> \
+       --target <name>-gaia
+   ```
+
+   The CLI requires `--dsl-binding-name` whenever `--label` is set, so
+   pair them with the same identifier: `--dsl-binding-name` mints the
+   Python LHS the rest of the package references by name; `--label` sets
+   the engine `Claim.label` used by `[@label]` prose references and by
+   `gaia inquiry review`.
+
+   Phase 3's per-conclusion synthesis posterior is consumed as the
+   conclusion's leaf prior in Step 4b only when the conclusion is isolated
+   (no upstream conclusions, no weak points → no `derive(...)`). For
+   derived conclusions, Phase 3's synthesis informs the qualitative
+   warrant-strength prose written into the deduction's `--rationale`
+   (Phase 4 does not emit a numerical warrant prior; see Step 4a step 4
+   below).
+
+3. **Weak-point leaf claims section** — one `gaia author claim` per Phase 3
+   weak point, into the same `__init__.py`:
+
+   ```bash
+   gaia author claim "<self-contained weak-point body>" \
+       --dsl-binding-name <key>_c<id>_wp_<suffix> \
+       --label <key>_c<id>_wp_<suffix> \
+       --target <name>-gaia
+   ```
+
+   Each weak-point claim is defined exactly once and appears as a premise
+   in exactly one deduction (its target conclusion's). It is NOT shared
+   across deductions; cross-conclusion uncertainty propagates through the
+   logic graph instead (weak point ↔ one conclusion (strict) discipline).
+
+4. **Deductions section** — one `gaia author derive` per derived conclusion,
+   into `__init__.py`. The premises list is the union of upstream
+   conclusion labels and weak-point labels:
+
+   ```bash
+   gaia author derive \
+       --conclusion <key>_c<id>_<suffix> \
+       --given <upstream_label_1>,<upstream_label_2>,<wp_label_1>,... \
+       --label <key>_c<id>_chain \
+       --rationale "<Phase 2 numbered chain prose, with warrant-strength intent inline>" \
+       --target <name>-gaia
+   ```
+
+   Use the `--conclusion <ident>` shape (NOT `--conclusion-content` /
+   `--conclusion-prose`) because the conclusion Claim has already been
+   minted with a named label in Step 4a step 2.
+
+   **Do not pass `--metadata`.** The engine `derive(...)` signature accepts
+   only `{given, background, rationale, label}` — no `metadata=` kwarg.
+   The CLI's `--metadata` flag on `derive` is silently broken: it renders
+   `derive(..., metadata={...})` and the post-write `gaia build check`
+   rejects. The same constraint applies to `contradict` / `equal` /
+   `exclusive` / `observe`. Warrant-strength intent therefore lives in
+   `--rationale` prose, not in a metadata kwarg.
+
+5. **Open questions section (optional, opt-in)** — only when the user asks,
+   emit `gaia author question` calls into `__init__.py` with binding names
+   `<key>_open_question_<n>` (via `--dsl-binding-name`). Pipeline B does
+   not extract open questions; this is a `gaia-formalize-coarse` extension.
+
+The string body of every `claim(...)` / `question(...)` is the
+self-contained body from working notes — no further rewriting in Phase 4.
+The Phase 1 self-containment discipline and the Phase 3 body-writing rule
+already satisfy what the legacy step-4 prompt enforced; this phase only
+relabels and emits.
+
+Warrant-strength intent (formerly the `warrant_prior` numerical
+calibration) is encoded in `--rationale` prose: when Phase 2 surfaced an
+explicit logical gap, say so; when Phase 3 surfaced a highlight that
+specifically underwrites a step in this chain, say so. The reviewer's
+calibration shows up as qualitative prose in the deduction rationale; the
+numerical prior surface lives only on leaf claims via `register_prior` in
+`priors.py` (Step 4b).
+
+### 4b. Leaf priors in `priors.py`
+
+For every leaf claim in the package, emit a `gaia author register-prior`
+invocation routed to the scaffolded `priors.py`:
+
+- Every Phase 3 weak point is a leaf — its `prior_probability` from working
+  notes goes here, capped at 0.9.
+- A Phase 1 conclusion that ended up with **no** upstream conclusions and
+  **no** weak points is also a leaf — its prior comes from Phase 3's
+  per-conclusion `prior_probability`, capped at 0.9.
+
+`register-prior` writes a bare `register_prior(...)` expression (no LHS
+binding):
+
+```bash
+gaia author register-prior \
+    --claim <key>_c<id>_wp_<suffix> \
+    --value <float> \
+    --justification "<terse rationale ending in TODO:review>" \
+    --target <name>-gaia \
+    --file priors.py
+```
+
+The CLI auto-inserts `from <import_name> import <claim>` into `priors.py`
+when the referenced claim is not already imported.
+
+Justification text format: one line, terse rationale (model assumption /
+empirical pattern / cited result / etc.) ending with `TODO:review`. Pull the
+rationale from the weak point's `weakness_reason` (compressed to one
+sentence) or from the conclusion's `narrative`. The `TODO:review` convention
+survives the CLI's `--justification` round-trip verbatim.
+
+## Step 5 — Self-Check Before Reporting Complete
+
+`gaia author --check` runs `gaia build check` automatically after each
+statement write, so pre-write reference resolution, label collision, and
+syntactic well-formedness are already enforced statement-by-statement.
+Treat any non-zero envelope `code` from Step 4 as a fix-and-retry
+obligation. The remaining self-check is the SOP-owned semantic content:
+
+1. (manual) Every leaf claim (every weak point + any isolated conclusions)
+   has a `register_prior(...)` entry; no entry's prior exceeds 0.9 or falls
+   below 0.001.
+2. (manual) Every justification in a `register_prior(...)` call ends with
+   `TODO:review`.
+3. (manual) Every `claim(...)` body passes the self-standing test:
+   stripped of all surrounding context, can a reader unfamiliar with the
+   paper identify the model / system / regime, the symbols, and the
+   claim? If any body fails, rewrite it before reporting completion.
+4. (manual) **Pointer and citation hygiene** (two-part check, must both
+   pass):
+   - **4a.** No paper-internal pointer (`Eq. (X)` / `Fig. Y` / `Table Z` /
+     `Sec. W` / `Appendix A` / `Theorem N` / `Lemma M`) appears inside a
+     `claim(...)` body, inside a `derive(...)` `--rationale`, or inside
+     a `register_prior(...)` justification. External bibliographic
+     citations in `[@key]` form are allowed in any prose.
+   - **4b.** Every prose citation uses the `[@key]` form, where `key`
+     matches an entry in `references.json`. Numeric paper-style
+     citations (`[33]`, `Ref. 5`, `Smith et al., 2020`) must not survive
+     in any prose; convert at write time. Unresolvable citations are
+     emitted as `@unknown_<n>` (bare, **no brackets** — bracketed
+     `[@unknown_n]` fails `gaia build compile`'s strict-reference check;
+     bare `@key` is treated as opportunistic).
+5. (manual) `references.json` contains an entry whose key matches every
+   `[@key]` cited in any prose.
+
+The final invocation's envelope `payload.check.knowledge_count` /
+`check.strategy_count` / `check.operator_count` give a sanity-report count
+of the package's IR contents — surface these in the hand-off report.
+
+If any check fails, fix it before reporting completion. Surface remaining
+issues to the user in the final report (e.g., conclusions you could not
+derive a self-contained body for, or metadata gaps that prevented a clean
+references.json).
+
+## Step 6 — Hand Off
+
+Report to the user:
+
+- The path of the emitted `<name>-gaia/` directory.
+- The counts: conclusions, weak points, deductions, priors (plus the
+  final `gaia author` envelope's `check.knowledge_count` /
+  `check.strategy_count` / `check.operator_count` as IR-side sanity).
+- The three follow-up commands the user is expected to run as quality
+  gates (this skill produces production-quality knowledge packages, so
+  the gate goes beyond the minimum demo `gaia build compile + gaia build
+  check` of the upstream Mendel/Galileo walkthroughs):
+  - `gaia build compile <name>-gaia/` — full-package compile catches
+    cross-statement issues the per-write `gaia build check` cannot
+    (cyclic imports, IR-hash drift, manifest emission).
+  - `gaia run infer <name>-gaia/` — belief propagation; emits
+    `.gaia/beliefs.json` so the user can inspect downstream posteriors.
+  - `gaia inquiry review --strict <name>-gaia/` — strict warrant /
+    obligation / duplicate-control review.
+
+Per-write `gaia build check` already ran after every Step 4 statement; the
+end-of-package full compile is implicit in `gaia build compile` (and surfaces
+issues that only fire when the full module graph loads together).
+
+This skill does not run the quality gates itself; surfaced compile errors or
+inquiry-review findings come back as a follow-up obligation, not a built-in
+step.

--- a/gaia/_skills/gaia-formalize-fine/SKILL.md
+++ b/gaia/_skills/gaia-formalize-fine/SKILL.md
@@ -1,12 +1,17 @@
 ---
-name: gaia-formalization
+name: gaia-formalize-fine
 description: |
   Use when formalising a knowledge source (scientific paper, textbook chapter,
-  technical report) into a Gaia knowledge package. Walks a six-pass pipeline —
-  extract → connect → check completeness → refine strategy types → verify
-  structural integrity → polish for standalone readability — with a compile +
-  check loop after every pass and a prior-assignment + inference tail. Emits
-  the package source, `priors.py`, and `ANALYSIS.md`.
+  technical report) into a Gaia knowledge package and you want the thorough,
+  audit-grade treatment. Walks a six-pass pipeline — extract → connect → check
+  completeness → refine strategy types → verify structural integrity → polish
+  for standalone readability — with a compile + check loop after every pass and
+  a prior-assignment + inference tail. Emits the package source, `priors.py`,
+  and `ANALYSIS.md`. This is the **Paper → package** entry point when depth
+  matters: the slow, exhaustive sibling of `gaia-formalize-coarse` (which is a
+  quick four-phase single-pass for one paper). Reach for `gaia-formalize-fine`
+  when the source is load-bearing, multi-section, or destined for publication;
+  reach for `gaia-formalize-coarse` for a fast first cut of a single paper.
 ---
 
 # Knowledge-package formalization

--- a/gaia/_skills/gaia-lkm-explorer/SKILL.md
+++ b/gaia/_skills/gaia-lkm-explorer/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: gaia-lkm-explorer
+description: |
+  Use for the **LKM → Gaia package** route: grow a Gaia knowledge package
+  from LKM evidence chains across many papers, contradiction-first. This is
+  the agent methodology that builds a real `derive` / `contradict` graph over
+  a multi-paper frontier — distinct from the mechanical single-paper
+  materialization that `gaia pkg add --lkm-paper` (`gaia/cli/commands/pkg/
+  lkm_materialize.py`) performs by scaffolding `depends_on`. Maps LKM
+  evidence/source payloads into Gaia DSL via a progressive five-step workflow
+  with contradiction-driven graph expansion. Modes are `batch` (create a
+  fresh `<name>-gaia/` package) and `refresh` (extend or repair an existing
+  package in place). All LKM retrieval is the native `gaia search lkm` CLI
+  (`knowledge` / `reasoning [--claim-id]` / `nodes` / `package` / `auth`).
+  Generic claim / derive / contradict emission rules and package layout are
+  the canonical Gaia spec (see `docs/for-users/`). Reach for this skill on
+  prompts like "build a Gaia package from LKM", "formalize this LKM claim
+  into Gaia", "extend / keep growing this package", or "clean duplicate
+  claims". For the **Paper → package** route (one paper text in), use
+  `gaia-formalize-coarse` (quick) or `gaia-formalize-fine` (thorough)
+  instead. Domain-agnostic.
+---
+
+# LKM-Explorer
+
+## Mission
+
+Use LKM as the source of truth to explore evidence and build or update a
+standalone Gaia knowledge package. This skill turns raw LKM payloads,
+exploration state, and package requirements into executable and iteratively
+extensible Gaia DSL through contradiction-driven frontier expansion.
+
+It is not only a one-shot converter. During mapping it may continue focused
+LKM-grounded checks for claim-driven supports, open questions, contradictions,
+equivalences, provenance, and obligations. Every newly retrieved LKM payload
+must be classified through the local mapping contract before it enters
+executable DSL.
+
+A Gaia package produced here compiles via `gaia build compile`, propagates beliefs
+via `gaia run infer`, and carries LKM provenance into `**metadata` kwargs of every
+claim.
+
+> **Contract ownership.** Gaia knowledge-package shape (`<name>-gaia/` layout,
+> file templates), `claim` / `derive` / `contradict` body discipline, label
+> rules, and module placement are the canonical Gaia spec — see
+> `docs/for-users/language-reference.md` and `docs/for-users/quick-start.md`
+> in this repo. This skill adds the LKM-specific exploration workflow and the
+> LKM-side `lkm_id` / `provenance_source` metadata kwargs on emitted
+> statements.
+
+> **Where this sits vs. `gaia pkg add --lkm-paper`.** The CLI's
+> `gaia pkg add --lkm-paper` (implemented in
+> `gaia/cli/commands/pkg/lkm_materialize.py`) does the *mechanical*
+> single-paper materialization — it pulls one LKM paper package and scaffolds
+> `depends_on`. This skill is the *agent methodology* that grows a real
+> `derive` / `contradict` reasoning graph across many papers via
+> contradiction-driven frontier expansion. Use the CLI verb for a quick
+> single-paper scaffold; use this skill to build the multi-paper graph.
+
+```
+gaia search lkm  (knowledge / reasoning / nodes / package, --format raw-json)
+        |
+        v
+  gaia-lkm-explorer
+  (Gaia package source per the Gaia spec)
+```
+
+Reach for this skill when the user asks for a "Gaia package", "Gaia DSL",
+"knowledge package", or "formalized into Gaia" from LKM evidence.
+
+## Output Modes
+
+- **Batch** creates a fresh standalone `<name>-gaia/` package.
+- **Refresh** extends an existing standalone package while preserving prior
+  emitted statements (`gaia author` pre-write collision check enforces
+  append-only at the DSL boundary).
+
+Broad topic discovery, root candidate ranking, user-selection checkpoints, and
+claim-driven frontier iteration are driven by this skill directly: use
+`gaia search lkm knowledge` for topic/candidate recall and
+`gaia search lkm reasoning` (by query, or `--claim-id` for one claim's chains)
+for the support and open-question/conflict channels, checkpointing root
+selection with the user. Once a mapping run starts, this skill may request
+further focused `gaia search lkm` retrievals needed to complete its five-step
+workflow.
+
+Raw LKM payloads consumed during the run live in the agent's scratch.
+
+## Progressive Workflow
+
+At the start of each `gaia-lkm-explorer` run, create a session todo/checklist
+with these five items. Mark only Step 1 as in progress. Do not load later step
+documents until the current step is complete.
+
+1. **Inputs, scope, and evidence status** — load
+   `references/step-1-inputs-and-scope.md`.
+2. **Bootstrap, refine, decompose, and map DSL** — load
+   `references/step-2-bootstrap-and-map.md`.
+3. **Screen contradictions and open questions** — load
+   `references/step-3-contradictions-and-open-questions.md`.
+4. **Add supports, priors, obligations, and duplicate controls** — load
+   `references/step-4-supports-priors-and-review.md`.
+5. **Emit package and hand off to quality gates** — load
+   `references/step-5-emit-and-handoff.md`.
+
+After each step, immediately mark that todo complete, mark the next todo in
+progress, and only then load the next step document. If quality gates reveal new
+obligations, start a new five-step iteration with the new target.
+
+## Non-Negotiable Invariants
+
+- Raw LKM JSON and `data.papers` are the source of truth for science-facing
+  claims, factors, steps, provenance, and references.
+- Chain-backed claims (`total_chains > 0`) may produce factor-derived
+  `derive(...)`; no-chain LKM source claims may enter after cold start only
+  as leaf/source `claim(...)` nodes.
+- Search leads outside accepted chain-backed factors or accepted post-cold-start
+  source claims do not enter executable DSL.
+- Claims must be self-contained and preserve `lkm_id` when available.
+- No `prior` kwarg on `claim(...)`; leaf priors live in
+  `register_prior(...)` calls (see `docs/for-users/language-reference.md`
+  for package layout and DSL discipline).
+- Post-cold-start expansion follows the cold-start root frontier selected by the
+  user. For every frontier science claim, run both the support channel
+  (`gaia search lkm reasoning --claim-id <id>`) and the
+  open-question/conflict channel (`gaia search lkm reasoning "<query>"` /
+  `gaia search lkm knowledge "<query>"`); this skill maps accepted candidates.
+- Support handling follows `mapping-contract.md` §3: real Gaia
+  `derive(target, given=[premises], rationale=..., label=...)`
+  syntax (canonical replacement for the legacy named-strategy
+  `support(...)`), LKM-grounded endpoints, no synthetic bridge facts, and
+  duplicate/shared-factor controls. The engine `derive(...)` signature
+  accepts only `{given, background, rationale, label}` — warrant-strength
+  intent lives in `--rationale` prose, not in a metadata kwarg.
+- Contradiction handling follows `mapping-contract.md` §4: prioritize open
+  questions, then final-scan accepted scientific contradictions into direct
+  `contradict(a, b)` operators with `xx_vs_yy` labels; other useful tensions
+  remain optional inquiry hypotheses.
+- Refresh runs must not silently overwrite previously emitted statements;
+  `gaia author`'s pre-write collision check enforces this at the CLI boundary.
+- Package-level quality gates (`gaia build compile` / `gaia build check` /
+  `gaia run infer`) are run after source emission — see Step 5.
+
+## Responsibility Boundaries
+
+- This skill owns turn shape, broad root discovery, user checkpoints, the
+  five-step mapping workflow, and running the Gaia quality gates after
+  emission.
+- LKM retrieval is the `gaia search lkm` CLI; flag/endpoint mechanics live
+  behind `gaia search lkm <verb> --help` (use `--format raw-json` when the
+  verbatim LKM envelope — `data.papers`, `provenance`, factor/premise ids —
+  is needed downstream).
+- The canonical Gaia knowledge-package shape and generic DSL body discipline
+  are documented in `docs/for-users/language-reference.md` and
+  `docs/for-users/quick-start.md`.
+- This skill owns LKM-driven exploration and LKM-specific mapping rules
+  (evidence-status vocabulary, no-chain source claims, frontier supports,
+  open-question-first contradiction handling).
+- Evidence-graph rendering (`gaia-evidence-subgraph`), scholarly prose
+  synthesis (`gaia-scholarly-synthesis`), external host integration, and
+  final scientific review are separate responsibilities.
+
+## Reference files
+
+LKM-explorer-specific (in this skill):
+
+- [`references/mapping-contract.md`](references/mapping-contract.md) —
+  LKM-specific mapping rules: evidence-status vocabulary, no-chain source
+  claims, root-claim frontier supports, open-question-first contradiction
+  handling.
+- [`references/package-skeleton.md`](references/package-skeleton.md) —
+  LKM-explorer module-routing convention (DSL emissions in `__init__.py`,
+  leaf priors in `priors.py`).
+- [`references/step-1-inputs-and-scope.md`](references/step-1-inputs-and-scope.md)
+  — progressive workflow Step 1.
+- [`references/step-2-bootstrap-and-map.md`](references/step-2-bootstrap-and-map.md)
+  — progressive workflow Step 2.
+- [`references/step-3-contradictions-and-open-questions.md`](references/step-3-contradictions-and-open-questions.md)
+  — progressive workflow Step 3.
+- [`references/step-4-supports-priors-and-review.md`](references/step-4-supports-priors-and-review.md)
+  — progressive workflow Step 4.
+- [`references/step-5-emit-and-handoff.md`](references/step-5-emit-and-handoff.md)
+  — progressive workflow Step 5.
+
+Gaia knowledge-package contract (this repo's docs):
+
+- `docs/for-users/quick-start.md` — end-to-end Gaia knowledge-package
+  workflow (directory layout, file templates, package initialization).
+- `docs/for-users/language-reference.md` — DSL primitives
+  (`claim` / `derive` / `contradict` / `equal` / `exclusive`),
+  label discipline, module placement.
+- `docs/for-users/cli-commands.md` — full CLI reference
+  (`gaia build compile` / `build check` / `run infer` / `run render` / etc.).
+- `docs/for-users/hole-bridge-tutorial.md` — prior calibration tutorial.
+
+LKM retrieval is the native `gaia search lkm` CLI (`knowledge` /
+`reasoning [--claim-id]` / `nodes` / `package` / `auth`). For runtime help,
+prefer `gaia <group> <cmd> --help` and `gaia search lkm <verb> --help`.

--- a/gaia/_skills/gaia-lkm-explorer/references/mapping-contract.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/mapping-contract.md
@@ -1,0 +1,254 @@
+# LKM-Explorer-Specific Contract
+
+> Generic Gaia knowledge package emission rules — `claim` / `derive` /
+> `contradict` / `equal` / `exclusive` body discipline and package
+> layout — are the canonical Gaia spec (see
+> `docs/for-users/language-reference.md` and
+> `docs/for-users/quick-start.md`). This file covers ONLY rules specific
+> to contradiction-driven LKM exploration: the LKM evidence-status vocabulary,
+> no-chain source-claim handling, root-claim frontier supports, the
+> open-question-first contradiction policy, and the timeline emission
+> requirement for LKM-driven package work.
+
+## 0. Evidence-status vocabulary
+
+- **Chain-backed claim**: LKM returned claim content and
+  `gaia search lkm reasoning --claim-id <id>` reports `total_chains > 0`. Emit
+  `claim(...)` plus factor-derived `derive(...)` when factors are present.
+- **LKM source claim**: LKM returned claim content and provenance, but `total_chains = 0`. After cold start, emit it as a leaf/source `claim(...)`; do not invent premises or deductions.
+- **Search lead**: insufficient content or provenance for a self-contained claim outside an accepted chain-backed factor. Keep only in audit/search notes.
+
+`total_chains > 0` is required for cold-start root selection. It is not a global admissibility rule for post-cold-start frontier expansion or conflict-channel candidates.
+
+## 1. LKM-specific claim handling
+
+Generic `claim(...)` body rules — label discipline, self-contained check, no
+`prior` kwarg — are the canonical Gaia spec (see
+`docs/for-users/language-reference.md`). The rules below are LKM-specific.
+
+- **No-chain LKM source claims.** If `total_chains = 0`, use
+  `provenance_source="lkm_no_chain"` and preserve `lkm_id` when available.
+  Do not create `derive(...)` without factors.
+- **Prior policy for no-chain candidates.** Do not lower a prior solely because
+  `total_chains=0`. Set priors from claim content, provenance clarity,
+  method/scope specificity, and scientific judgment.
+- **Chain-internal empty-content premises.** When an LKM evidence chain
+  references a premise whose `content` is empty, a placeholder string plus
+  `todo="revisit when LKM corpus populates this premise"` in metadata may be
+  used to preserve a factor-derived `derive(...)`. Do not invent content.
+- **Empty or under-provenanced match/search results outside an accepted
+  chain** are **search leads**, not placeholder claims. Do not emit them.
+
+## 3. Root-claim frontier supports
+
+During root-claim frontier expansion, the agent searches LKM for content that
+can directly support each frontier claim. A single target claim may have
+**multiple** accepted upstream supports. Use the canonical v0.5 deterministic
+warrant primitive (the legacy named-strategy `support(...)` is replaced by
+`derive(...)` — see `docs/for-users/language-reference.md`):
+
+```python
+derive(target, given=[U_1], rationale="<what U_1 says and why it supports target>",
+       label="<u1_supports_target>")
+derive(target, given=[U_2], rationale="<what U_2 says and why it supports target>",
+       label="<u2_supports_target>")
+```
+
+When several upstream claims only support the target jointly, use one joint
+derivation:
+
+```python
+derive(target, given=[U_1, U_2], rationale="<joint support rationale>",
+       label="<u1_u2_supports_target>")
+```
+
+`derive(target, given=[a], rationale=...)` is directional: `a` supports
+`target`. In Gaia v0.5 the engine `derive(...)` signature accepts only
+`{given, background, rationale, label}` — there is no `metadata=` /
+`warrant_prior` kwarg. Warrant-strength intent (legacy strong/moderate/weak
+bands) lives in the `rationale=` prose so the reviewer's intent is
+preserved in the source without breaking `gaia build check`.
+
+Search effort for each frontier target:
+- Run at least 2 distinct support-channel LKM queries
+  (`gaia search lkm knowledge` / `gaia search lkm reasoning`).
+- Use `--limit 10` for each query.
+- Preserve raw match/evidence payloads.
+- If no candidate satisfies the support standard, record the queries and
+  rejection rationales as `support_not_found`; do not invent support.
+
+Warrant-strength intent (encode qualitatively in `rationale=` prose; the
+engine has no numerical warrant-prior surface on `derive`):
+- Strong (same topic, directly implies) — say so in the rationale.
+- Moderate (related, partially overlaps) — say so in the rationale.
+- Weak/lateral — say so in the rationale, and explicitly note the gap.
+
+The support relation itself may be a reviewer/agent scientific judgment rather
+than an LKM `gfac_*` factor, but both endpoints must already be LKM-grounded
+Gaia claims.
+
+> Warrant rationale discipline (no smuggling; on-the-fly premise claims are
+> normal): see `docs/for-users/language-reference.md` (`derive` semantics; the
+> legacy `support` strategy semantics on the compat surface inform the same
+> discipline).
+
+For cross-scope supports (different geometry, material, temperature, extraction
+method, approximation, or mass definition), explicitly downgrade the warrant
+intent in the `rationale=` text (e.g. "lateral support: scope differs in
+<axis>, treat as weak evidence") unless the LKM-grounded claim text directly
+implies the target. Reflect the scope difference in the rationale so the
+reviewer reading the source can see the gap; the engine `derive` surface has
+no numerical knob to lower.
+
+Support candidates may be chain-backed or no-chain LKM source claims after cold
+start. Chain-backed candidates may add their own `claim(...)` nodes and
+factor-derived `derive(...)` strategies. No-chain candidates may enter only
+as leaf/source `claim(...)` nodes with clear content and provenance.
+
+### 3a. Shared-factor extraction (>=2 supports converging on same target)
+
+When >=2 upstream supports converge on the same target claim P, check whether the upstream claims share a common factor (same method, model assumption, dataset, physical approximation). If they do, BP would incorrectly treat them as independent evidence. Extract the shared factor as a new claim and route supports through it:
+
+```
+Before:  U1 --support-->  P
+         U2 --support-->  P      <- double counting
+
+After:   U1 --support-->  shared_factor  <--support-- U2
+                                 |
+                              support
+                                 |
+                                 v
+                                 P
+```
+
+Judge the shared factor's prior normally (cap 0.9).
+
+## 4. Open-question-first contradiction handling
+
+This section is the canonical policy for contradiction handling in the local
+LKM-explorer workflow.
+
+The workflow prioritizes open questions during discovery and mapping. When two
+source claims `A` and `B` appear to be in tension, first name the scientific
+open problem they raise. When the problem may drive later work, register it
+under `.gaia/inquiry/` as a hypothesis via `gaia inquiry hypothesis add`.
+
+During root-claim frontier expansion, run an open-question/conflict channel for every
+frontier claim. Minimum effort is 5 distinct LKM queries with `--limit 10`.
+Prioritize theory-vs-experiment or experiment-vs-theory candidates first: if the
+frontier claim is theoretical/computational, look first for experimental
+observations or measurements that disagree with or qualify it; if the frontier
+claim is experimental, look first for theoretical/computational results that
+disagree with or reinterpret it. Then search same-system different-method,
+boundary-condition, approximation/regime, and adjacent hypothesis candidates.
+If no candidate satisfies the hypothesis or contradiction standard, record the
+queries and rejection rationales as `conflict_not_found`.
+
+At the final contradiction scan, promote a candidate to executable Gaia DSL when
+it is a scientifically meaningful, adjudicable conflict: the pair concerns the
+same scientific object/question closely enough that resolving the open problem
+would confirm, falsify, or materially qualify at least one side of `A`/`B`.
+This admission standard is intentionally broader than strict logical identity
+of scope. Differences in method, finite-size treatment, extrapolation protocol,
+approximation domain, or benchmark regime do not by themselves block promotion
+when the field-facing question is genuinely the same.
+
+Accepted scientific contradictions use the direct operator. Name the operator
+after the two sides so graph views and review output make the conflict visible
+without opening metadata:
+
+```python
+<side_a>_vs_<side_b>[_<quantity_or_regime>] = contradict(
+    A,
+    B,
+    rationale="<why these claims are adjudicably conflicting> | open_problem: <specific discriminating question>",
+    label="<side_a>_vs_<side_b>[_<quantity_or_regime>]",
+)
+```
+
+The engine `contradict(...)` signature accepts only
+`{background, rationale, label}` — no `metadata=` / `warrant_prior` /
+`prior=` kwarg. Warrant-strength intent (legacy "clear / less crisp"
+bands) lives in the `rationale=` prose alongside the `open_problem:`
+clause.
+
+Label rules:
+- Prefer `<side_a>_vs_<side_b>` with short semantic side names, e.g.
+  `dmc_vs_gw_mass_enhancement`.
+- Add a quantity/regime suffix when needed to disambiguate, e.g.
+  `low_density_dmc_vs_gw_mass_enhancement`.
+- Keep the label a valid Gaia/Python identifier: lowercase letters, digits, and
+  underscores only.
+- Do not name the node `scientific_inconsistency_*`, `paradox_*`, or a generic
+  `contradict_*`; the operator kind already supplies the relation semantics,
+  while the label should identify the two conflicting sides.
+
+Warrant-strength intent on a `contradict(...)` is the conviction that this
+pair should be treated as an adjudicable scientific contradiction, not a
+prior on either claim being true. Encode in the rationale: say "clear
+accepted contradiction" for the strongest cases; say "accepted but scope
+match / discriminating question is less crisp" when the candidate is
+borderline. Do not weaken the rationale merely because the candidate came
+from different methods; method/method conflicts are often the point of the
+contradiction.
+
+Avoid the word `paradox` in operator labels; it may be used only in synthesis
+prose when appropriate for the field.
+
+### Promotion signals
+
+Promote a candidate to `contradict(A, B)` when one or more of these apply:
+
+- The claims assert opposite values, signs, orderings, trends, or qualitative
+  conclusions about the same system/material, quantity/effect, or scientific
+  mechanism.
+- The claims use different methods or approximations but are commonly read as
+  answering the same field-facing question.
+- The disagreement can be tested by a concrete calculation, measurement,
+  benchmark, extrapolation, or reanalysis.
+- Resolving that test would make at least one claim, interpretation, or
+  unqualified conclusion untenable or materially qualified.
+
+For example, the low-density 2D homogeneous-electron-gas effective-mass tension
+where treatments can put `m*/m` on opposite sides of unity is admissible as an
+accepted contradiction: the open problem is whether the sign and magnitude of
+the mass renormalization survive matched treatment of correlation,
+finite-size/extrapolation, and approximation regime.
+
+### Hypothesis-only tensions
+
+Keep a candidate as audit/hypothesis-only when the pair is interesting but not
+yet promotable:
+
+- the open problem is still vague or not discriminating,
+- the scope relation is unknown because content/provenance is insufficient,
+- the claims address adjacent but not adjudicably conflicting questions,
+- the candidate is a model-applicability gap, coverage gap, or benchmark
+  omission without a concrete test,
+- the candidate is a false alarm, duplicate wording, or unsupported search lead.
+
+For hypothesis-only rows, record why the pair is scientifically interesting,
+the best current open problem, why no `contradict(...)` operator was emitted,
+and what query or evidence would be needed to promote it later. In the
+post-purge SOP these notes live in the agent's scratch and the
+`gaia inquiry hypothesis add` text, not in a dedicated audit file.
+
+## 9. What this contract does NOT cover
+
+- Generic claim/derive/contradict/equal/exclusive emission rules,
+  label discipline, and module placement — the canonical Gaia spec
+  (`docs/for-users/language-reference.md`).
+- Package layout and templates (`pyproject.toml`, `__init__.py`,
+  `paper_<key>.py`, `references.json`) — the canonical Gaia spec
+  (`docs/for-users/quick-start.md`).
+- Generic `lkm_id` / `provenance_source` metadata semantics on Gaia
+  statements — the canonical Gaia spec.
+- The shape of `pyproject.toml` — follow current package examples and verify
+  with `gaia build compile`.
+- BP interpretation and weakness analysis — handled by caller/user review after
+  `gaia run infer` (see `../_shared/bp-interpretation.md`).
+- Render-time choices — use `gaia run render` or package-specific
+  render commands after compilation/inference (see
+  `docs/for-users/cli-commands.md`).
+- The Gaia DSL grammar — governed by the installed Gaia library; see
+  `docs/for-users/language-reference.md`.

--- a/gaia/_skills/gaia-lkm-explorer/references/package-skeleton.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/package-skeleton.md
@@ -1,0 +1,60 @@
+# LKM-Explorer Package Layout
+
+> Generic Gaia knowledge-package layout, naming conventions, and file
+> templates (`pyproject.toml`, `__init__.py`, `priors.py`,
+> `references.json`) are the canonical Gaia spec — see
+> `docs/for-users/quick-start.md` and `docs/for-users/language-reference.md`,
+> and the shipping walkthroughs `gaia example mendel` /
+> `gaia example galileo`. This file documents only the LKM-explorer
+> module-routing convention.
+
+## Module routing
+
+`gaia-lkm-explorer` follows the Mendel/Galileo two-module layout:
+
+- All DSL emissions for every source paper — `claim` / `derive` / `equal`
+  / `contradict` / `exclusive` / `observe` / `note` / `question` — go in
+  the scaffolded `__init__.py` (the default `--file` target when
+  `gaia author <verb>` is invoked without `--file`).
+- Leaf-prior records (`register_prior(...)`) go in a sibling `priors.py`,
+  scaffolded explicitly with `--imports register_prior` so the import is
+  pre-seeded.
+
+There is no per-paper `paper_<key>.py` sibling — that pattern is not in
+the shipping walkthroughs and is not prescribed here.
+
+```text
+<name>-gaia/
+├── pyproject.toml
+├── references.json
+└── src/<import>/
+    ├── __init__.py
+    └── priors.py
+```
+
+`references.json` is a JSON object keyed by citation key, CSL-JSON entry
+shape; each entry must include `type` (drawn from the CSL allowlist). See
+`docs/specs/2026-04-09-references-and-at-syntax.md` for the full schema.
+
+Scaffold with:
+
+```bash
+gaia pkg scaffold \
+    --target <name>-gaia \
+    --name <name>-gaia \
+    --namespace <namespace> \
+    --with-uuid \
+    --description "<one-line description>"
+
+gaia pkg add-module \
+    --name priors \
+    --imports register_prior \
+    --target <name>-gaia
+```
+
+`--namespace` matches the walkthroughs (Mendel/Galileo pass
+`--namespace example`); set it to whatever namespace you have
+chosen for this run. `--imports register_prior` pre-seeds the
+`register_prior` import into `priors.py` so subsequent `gaia author
+register-prior --file priors.py` invocations compile without adding the
+import by hand.

--- a/gaia/_skills/gaia-lkm-explorer/references/step-1-inputs-and-scope.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/step-1-inputs-and-scope.md
@@ -1,0 +1,99 @@
+# Step 1 — Inputs, Scope, And Checklist
+
+Load this file first when `gaia-lkm-explorer` starts a batch or refresh mapping
+task. Do not load later step files until this step is complete.
+
+## Goal
+
+Establish the mapping mode, accepted inputs, evidence status for every selected
+claim, and output target before writing Gaia DSL.
+
+## Required Session Todos
+
+The agent running `gaia-lkm-explorer` must create a session todo/checklist with these
+five steps, mark Step 1 in progress, and update statuses as each step completes:
+
+1. Step 1 — Inputs, scope, and evidence status.
+2. Step 2 — Bootstrap, refine, decompose, and map DSL.
+3. Step 3 — Screen contradictions and open questions.
+4. Step 4 — Add supports, priors, obligations, and duplicate controls.
+5. Step 5 — Emit package and hand off to quality gates.
+
+The checklist is ephemeral and is not written to the package.
+
+## Inputs
+
+- Raw LKM reasoning JSON for each selected chain-backed claim, from
+  `gaia search lkm reasoning --claim-id <id> --format raw-json`, with
+  `data.reasoning_chains[]` (each containing
+  `premises / conclusion / steps / motivating_questions`),
+  `data.total_chains`, and `data.papers`.
+- Raw LKM source JSON for no-chain source claims when accepted after
+  cold start (`gaia search lkm nodes <ids…>` for node detail).
+- Raw LKM search JSON from `gaia search lkm knowledge "<query>" --format
+  raw-json`, with `data.variables` (typed nodes — `claim` / `question` /
+  `setting` / `action`) and `data.papers`.
+- Root-claim frontier expansion records (kept by this skill) when in refresh
+  mode: frontier claim labels, support-channel query payloads,
+  open-question/conflict-channel query payloads, and candidate classifications.
+- Existing package path for refresh work, including `.gaia/inquiry/` and prior
+  source files.
+
+These are loose files. `gaia-lkm-explorer` reads raw LKM payloads directly
+(via the `gaia search lkm` CLI with `--format raw-json`) and does not use an
+intermediate graph artifact.
+
+## Modes
+
+### Batch
+
+Input: one or more selected LKM roots/leads plus desired package name.
+
+Output: a standalone `<name>-gaia/` package:
+
+- `pyproject.toml`
+- `references.json`
+- `src/<import>/__init__.py`
+- `src/<import>/priors.py`
+
+Read `package-skeleton.md` before creating or substantially reshaping a package.
+
+### Refresh
+
+Input: batch inputs plus an existing standalone package directory.
+
+Output: edits to the existing package source. Preserve existing
+labels and prior decisions unless the user explicitly asks to revise a prior
+decision.
+
+Read `package-skeleton.md` before substantially reshaping package files.
+
+## Evidence-Status Vocabulary
+
+Use the canonical terms from `mapping-contract.md`:
+
+- **Chain-backed claim**: LKM returned claim content and evidence has
+  `total_chains > 0`. It can produce claims plus factor-derived
+  `derive(...)`.
+- **LKM source claim**: LKM returned claim content and provenance, but
+  `total_chains = 0`. After cold start, it may enter Gaia as a leaf/source
+  `claim(...)`; do not invent premises or deductions.
+- **Search lead**: insufficient content or provenance for a self-contained
+  claim outside an accepted chain-backed factor. Keep it in audit/search notes
+  only.
+
+`total_chains > 0` is a cold-start root-selection gate, not a global
+admissibility rule after a package already has a chain-backed root.
+
+## Step-Completion Gate
+
+Before moving to Step 2:
+
+- Mode is known: batch or refresh.
+- The SOP Environment Preflight has passed before any package file is edited.
+- Every selected item is classified as chain-backed claim, LKM source claim, or
+  search lead.
+- Raw LKM payload paths are known (kept in the agent's scratch for the run, not
+  emitted into the package).
+- The next todo is marked in progress before loading
+  `step-2-bootstrap-and-map.md`.

--- a/gaia/_skills/gaia-lkm-explorer/references/step-2-bootstrap-and-map.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/step-2-bootstrap-and-map.md
@@ -1,0 +1,134 @@
+# Step 2 — Bootstrap, Refine, Decompose, And Map DSL
+
+Load this file only after Step 1 is complete. This step turns accepted LKM
+payload content into Gaia DSL source.
+
+## Required References
+
+- `mapping-contract.md` §§0–2, 5–7 for claim, derive, references, exports,
+  and module placement rules.
+- `package-skeleton.md` when creating or reshaping package files.
+
+## Bootstrap
+
+For each chain-backed root claim, load the LKM evidence payload. Write:
+
+- one `claim(...)` for the root conclusion,
+- one `claim(...)` for every distinct premise with usable content,
+- one placeholder `claim(...)` for a chain-internal empty-content premise only
+  when needed to preserve a factor-derived `derive(...)`,
+- one `derive(conclusion, given=[premises], rationale="<numbered LKM steps>",
+  label="<gfac_id>")` for every `gfac_*` factor (the engine `derive(...)`
+  has no `metadata=` / `warrant_prior` kwarg; warrant-strength intent
+  lives in the `rationale=` prose).
+
+When `factors[].steps[]` contains usable `reasoning`, the deduction rationale
+is the full LKM evidence formatted as a numbered markdown list, preserving
+step order and figure/table references.
+
+When `factors[].steps[]` is missing or empty, still emit the factor-derived
+`derive(...)`, but use an explicit fallback rationale:
+`LKM factor <gfac_id> links premises <ids> to conclusion <id>; step-level
+reasoning was not returned by the API.`
+
+For an accepted no-chain LKM source claim (`total_chains=0`), write only a
+leaf/source `claim(...)` with:
+
+- `provenance_source="lkm_no_chain"`,
+- preserved `lkm_id`.
+
+Do not fabricate premises, factors, steps, or `derive(...)` for no-chain
+source claims.
+
+## Empty-Content Premises Vs Search Leads
+
+If a premise is inside an accepted chain-backed factor but has an empty
+`content`, it may enter Gaia as a placeholder only to preserve that factor's
+deduction structure. Use a content string such as
+`"<unexpanded LKM premise gcn_xxx>"`, preserve the LKM id, and add
+`todo="revisit when LKM corpus populates this premise"`.
+
+If an empty or under-provenanced item came from match/search output outside an
+accepted chain-backed factor, classify it as a search lead. Do not emit a
+placeholder claim.
+
+## Claim Self-Containment
+
+Every executable claim must be judgeable true/false without reading the LKM
+payload. If raw LKM text omits context, rewrite the claim using only context
+available in the LKM claim, factor steps/premises, and `data.papers`.
+
+Include the missing scientific scope when available:
+
+- system/material,
+- method/model/measurement protocol,
+- quantity and value,
+- temperature, pressure, field, sample regime, approximation domain, and
+  boundary conditions.
+
+Do not add a `prior` kwarg on `claim(...)`; leaf priors are added via
+`gaia author register-prior --file priors.py` after
+`gaia build check --hole` reports remaining holes.
+
+## Decompose Compound Claims
+
+Decompose only when both sides can be made self-contained and source-grounded.
+
+Detect compound claims such as:
+
+- "method A predicts X, method B measures Y, they disagree",
+- "M1 and M2 agree",
+- "theory vs experiment differs by N%".
+
+For each side, write an atomic claim with explicit system, method, quantity,
+value, and conditions. If the evidence does not support two self-contained
+atomic claims, keep the original compound claim and log the limitation.
+
+Connect decomposed claims through `mapping-contract.md` §4:
+
+- Accepted scientific contradiction -> emit direct `contradict(A, B)` with
+  an `xx_vs_yy` label and the associated `open_problem:` rationale.
+  Warrant-strength intent (clear vs. less crisp) lives in the rationale
+  prose; the engine `contradict(...)` has no `metadata=` /
+  `warrant_prior` kwarg.
+- Same proposition -> `equal(A, B, rationale="...", label="...")`. The
+  engine `equal(...)` likewise has no `metadata=` / `warrant_prior` kwarg.
+- Useful but not-yet-promoted tension -> no Gaia operator; register an inquiry
+  hypothesis instead (see Step 4).
+
+Preserve the original LKM meta-claim as a `claim(C, ...)` with its `lkm_id`
+metadata. When an accepted contradiction represents the meta-claim, follow
+the operator rules in `mapping-contract.md` §4. If the result is
+hypothesis-only, keep C and register an inquiry hypothesis instead.
+
+## References And Modules
+
+Build `references.json` from the union of `data.papers` across raw evidence and
+match/source files. Key records as `<FirstAuthorSurname><Year>`, deduped with
+suffixes when needed. Cite via `[@<key>]`.
+
+Place source:
+
+- canonical claims, `gfac_*` deductions, and cross-paper operators
+  (`equal` / `contradict` / `exclusive`) in `__init__.py` — the upstream
+  Mendel/Galileo two-module pattern,
+- leaf-prior `register_prior(...)` records in `priors.py` (scaffolded via
+  `gaia pkg add-module --name priors --imports register_prior`).
+
+See `package-skeleton.md` for the canonical layout.
+
+## Step-Completion Gate
+
+Before moving to Step 3:
+
+- All accepted claims are self-contained or explicitly retained as placeholders.
+- Chain-backed factors have corresponding `derive(...)` calls.
+- Factors without step-level reasoning have explicit fallback rationales.
+- Chain-internal empty premises are placeholders only when needed for a factor.
+- Search leads outside accepted chains do not enter executable DSL.
+- No-chain source claims are leaf/source claims only.
+- Compound claims have been decomposed according to `mapping-contract.md` §4 or
+  explicitly retained with reason.
+- References and module placement decisions are ready.
+- Mark Step 2 complete, mark Step 3 in progress, then load
+  `step-3-contradictions-and-open-questions.md`.

--- a/gaia/_skills/gaia-lkm-explorer/references/step-3-contradictions-and-open-questions.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/step-3-contradictions-and-open-questions.md
@@ -1,0 +1,144 @@
+# Step 3 — Screen Contradictions And Open Questions
+
+Load this file only after Step 2 is complete. This step is mandatory for every
+new claim. In root-claim frontier expansion it is also the mapping-time
+open-question/conflict channel for each frontier claim being expanded.
+
+## Canonical Policy
+
+Read `mapping-contract.md` §4 before making any contradiction decision. If this
+file and the mapping contract disagree, the mapping contract wins.
+
+`mapping-contract.md` §4 is the sole authority for contradiction semantics. In
+this step, prioritize open-question discovery, then run a final scan that either
+emits direct `contradict(A, B)` for accepted scientific contradictions or
+keeps the item as hypothesis/audit-only.
+
+## Baseline Sources To Check
+
+Check every new claim against:
+
+- other new claims in the current batch,
+- existing package claims,
+- upstream/support claims found while resolving obligations,
+- `.gaia/ir.json` when available for internal tensions.
+
+Do not skip a claim because it looks obvious, narrow, or already accepted.
+
+Focused LKM retrieval is allowed when needed to classify a current candidate
+pair, verify scope/provenance for a claim already being mapped, or run the
+claim-driven conflict channel. Do not use external PDFs or web
+summaries as evidence unless the user explicitly changes the rule.
+
+For root-claim frontier expansion, each frontier claim must run at least 5
+distinct LKM conflict queries (`gaia search lkm knowledge "<query>" --limit 10`,
+or `gaia search lkm reasoning "<query>" --limit 10` for reasoning-chain
+recall) for this conflict channel.
+
+Priority order for conflict queries:
+
+1. Theory-vs-experiment or experiment-vs-theory. For a theoretical/computational
+   frontier claim, first search for experimental observations or measurements
+   that disagree with, qualify, or fail to confirm it. For an experimental
+   frontier claim, first search for theoretical/computational results that
+   disagree with or reinterpret it.
+2. Computation-vs-experiment or measurement-vs-model comparisons not covered by
+   the first category.
+3. Same-system different-method conflicts.
+4. Approximation, boundary-condition, regime, dimensionality, temperature,
+   disorder, sample-quality, or protocol conflicts.
+5. Broader adjacent tensions that may become useful hypotheses but are not yet
+   promotable.
+
+## Baseline Candidate Tracking
+
+Track every candidate pair in the agent's scratch only — frontier-claim and
+candidate identifiers, scope-tuple comparison across system/material,
+quantity, method/model, conditions, and regime, the open problem or
+discriminating question raised by the pair, the verdict
+(`accepted_contradiction`, `hypothesis_only`, `dismissed`, or
+`needs_more_evidence`), the rationale, and the next action. Verdicts that
+produce a Gaia operator manifest in the emitted source; hypothesis-only
+verdicts manifest as `gaia inquiry hypothesis add` calls (see below);
+dismissed and needs-more-evidence verdicts produce no on-disk artifact in the
+post-purge SOP.
+
+## Open-Question-First Review
+
+For every plausible tension, ask the model to name the best field-facing open
+problem before deciding whether to emit an operator. Register useful open
+problems even when the pair is not yet a Gaia contradiction:
+
+```bash
+gaia inquiry hypothesis add "<open problem>" --scope <namespace>::<label>
+```
+
+Do not wait for perfect contradiction certainty before recording the hypothesis;
+the hypothesis is how later refreshes remember what to test.
+
+## Accepted Contradiction Output
+
+For each final-scan `accepted_contradiction`, emit direct
+`contradict(A, B)` using the `xx_vs_yy` label policy in
+`mapping-contract.md` §4:
+
+```python
+<side_a>_vs_<side_b>[_<quantity_or_regime>] = contradict(
+    A,
+    B,
+    rationale="<why A and B are an adjudicable scientific conflict> | open_problem: <specific discriminating question>",
+    label="<side_a>_vs_<side_b>[_<quantity_or_regime>]",
+)
+```
+
+The engine `contradict(...)` signature accepts only
+`{background, rationale, label}` — no `metadata=` / `warrant_prior` /
+`prior=` kwarg. Warrant-strength intent lives in the `rationale=` prose
+alongside the `open_problem:` clause.
+
+The `rationale` field must include `open_problem:`. If no specific open
+problem can be written, the candidate is not ready for
+`accepted_contradiction`; keep it as `hypothesis_only`.
+
+Register the same open problem:
+
+```bash
+gaia inquiry hypothesis add "<open problem>" --scope <namespace>::<op_label>
+```
+
+Warrant-strength intent for accepted contradiction operators (encode
+qualitatively in `rationale=` prose; the engine has no numerical warrant
+surface on `contradict`):
+
+- Clear accepted contradiction: say "clear accepted contradiction".
+- Accepted but less crisp scope/test relation: say so explicitly.
+- Do not downgrade the rationale solely because the pair is method/method,
+  theory/computation, or finite-size/extrapolation mediated.
+
+## Hypothesis-Only Output
+
+For tensions that raise useful open problems but do not yet satisfy
+`mapping-contract.md` §4's final promotion standard:
+
+- write no Gaia `contradict(...)` operator,
+- add an inquiry hypothesis scoped to the most relevant claim — the
+  hypothesis text is how the package remembers the open problem.
+
+Dismiss false alarms, duplicate wording, and unsupported search leads silently
+within the run.
+
+## Step-Completion Gate
+
+Before moving to Step 4:
+
+- Every new claim has completed baseline screening against available package
+  context.
+- Root-claim frontier claims have completed the required conflict-channel
+  search or surfaced a `conflict_not_found` note in the hand-off report.
+- Accepted contradictions have direct `contradict(A, B)` operators whose
+  labels identify both sides with the `xx_vs_yy` convention, with an
+  `open_problem:` rationale and warrant-strength intent encoded in the
+  rationale prose (no `metadata=` kwarg on `contradict`).
+- Non-promoted but useful tensions are registered as inquiry hypotheses.
+- Mark Step 3 complete, mark Step 4 in progress, then load
+  `step-4-supports-priors-and-review.md`.

--- a/gaia/_skills/gaia-lkm-explorer/references/step-4-supports-priors-and-review.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/step-4-supports-priors-and-review.md
@@ -1,0 +1,148 @@
+# Step 4 — Supports, Priors, Obligations, And Duplicate Controls
+
+Load this file only after Step 3 is complete. This step prevents unsupported
+leaves, double counting, and untracked weak premises.
+
+## Upstream Support
+
+For root-claim frontier expansion, every frontier claim receives a
+support-channel LKM search. Search for upstream LKM-grounded conclusions
+relevant to the target claim. A single target may have multiple upstream
+supports; each can get its own directional `derive(...)` (canonical v0.5
+replacement for the legacy `support(...)` strategy — see
+`docs/for-users/language-reference.md`):
+
+```python
+derive(P, given=[U_1], rationale="<what U_1 says and why it supports P>",
+       label="<u1_supports_p>")
+derive(P, given=[U_2], rationale="<what U_2 says and why it supports P>",
+       label="<u2_supports_p>")
+```
+
+When several upstream claims only support the target jointly, use a joint
+derivation:
+
+```python
+derive(P, given=[U_1, U_2], rationale="<joint support rationale>",
+       label="<u1_u2_supports_p>")
+```
+
+`derive(P, given=[a], rationale=...)` means `a` supports `P`. The engine
+`derive(...)` signature accepts only `{given, background, rationale, label}` —
+warrant-strength intent (strong / moderate / weak / lateral) lives in the
+`rationale=` prose, not in a `metadata=` / `warrant_prior` kwarg (the CLI
+flag exists but the post-write `gaia build check` rejects).
+
+Minimum support-channel effort per frontier claim:
+
+- run at least 2 distinct LKM queries (`gaia search lkm knowledge` /
+  `gaia search lkm reasoning`),
+- use `--limit 10` for each query,
+- if no candidate satisfies the support standard, surface `support_not_found`
+  in the hand-off report with query and rejection rationales.
+
+Warrant-strength intent (encode qualitatively in `rationale=` prose; the
+engine has no numerical warrant surface on `derive`):
+
+- Strong, same topic and directly implies — say so in the rationale.
+- Moderate, related and partially overlaps — say so in the rationale.
+- Weak or lateral — say so in the rationale and name the gap (scope,
+  method, regime).
+
+The `derive(...)` warrant edge may be a scientific-review judgment rather
+than an LKM factor, but both endpoint claims must already be LKM-grounded.
+
+> Warrant rationale discipline (no smuggling; on-the-fly premise claims are
+> normal): see `docs/for-users/language-reference.md` (`derive` semantics; the
+> legacy `support` strategy semantics on the compat surface inform the same
+> discipline).
+
+For cross-scope supports involving different geometry, material, temperature,
+experimental extraction method, approximation, or mass definition, explicitly
+flag the support as weak/lateral in the `rationale=` text (e.g. "lateral
+support: scope differs in <axis>; treat as weak evidence") unless the
+LKM-grounded source claim directly implies the target.
+
+If no relevant upstream conclusion is found, do not invent one.
+
+## Shared-Factor Extraction
+
+Run shared-premise extraction before operator emission and again whenever two or
+more supports converge on the same premise.
+
+Rules:
+
+1. Auto-merge identical normalized claim text.
+2. Auto-merge same paper / different version when DOI, title, or author-year
+   metadata show they are the same result.
+3. When multiple upstream supports share a common method, model assumption,
+   dataset, physical approximation, or other non-independent factor, extract
+   that factor as a new claim and route supports through it.
+4. Keep distinct supports that are genuinely independent.
+5. For ambiguous cases, default to keep distinct.
+
+## Leaf Priors
+
+After source emission, the caller quality gate runs `gaia build check --hole .`.
+Claims reported as leaves get entries in `priors.py`:
+
+```python
+PRIORS = {
+    <label>: (<float>, "<heuristic tag + LKM context + TODO:review>"),
+}
+```
+
+The float is a direct judgment of correctness, not LKM match score. Cap source
+claim priors at 0.90. Do not lower a prior solely because the claim has
+`total_chains=0`; judge content, provenance clarity, method/scope specificity,
+and scientific plausibility.
+
+Accepted `contradict(...)` operators from Step 3 carry their warrant-strength
+intent in the `rationale=` prose (the engine has no `metadata=` /
+`warrant_prior` kwarg on `contradict`); that intent is not a leaf-claim
+prior and is not mirrored into `priors.py`.
+
+## Inquiry Obligations
+
+Mark unreliable reasoning chains or weak premises:
+
+```bash
+gaia inquiry obligation add <claim_or_strategy_qid> -c "<concern>"
+```
+
+Use `gaia inquiry obligation list` as the exploration TODO list. Do not
+mechanically pick the lowest-belief claim; obligations carry intentional
+exploration choices, while beliefs are diagnostics.
+
+Register open-question hypotheses from Step 3 with:
+
+```bash
+gaia inquiry hypothesis add "<open question>" --scope <namespace>::<label>
+```
+
+## Duplicate Controls
+
+For duplicate cleanup or refreshes, classify suspicious pairs:
+
+- exact duplicate -> merge,
+- same-paper helper restatement -> merge into canonical claim when safe,
+- independent same proposition -> keep both and add `equal(...)`,
+- different scope/material/method/condition -> keep distinct,
+- ambiguous -> default to keep distinct.
+
+Preserve merged-out labels' `lkm_id` provenance in the canonical claim via
+`lkm_ids=[...]` when possible.
+
+## Step-Completion Gate
+
+Before moving to Step 5:
+
+- Relevant upstream supports have been searched and mapped or explicitly not
+  found.
+- Root-claim frontier claims have completed the required support-channel
+  search or surfaced `support_not_found` in the hand-off report.
+- Shared-factor and duplicate decisions are resolved.
+- Leaf-prior candidates are ready for `priors.py`.
+- Inquiry obligations/hypotheses are registered.
+- Mark Step 4 complete, mark Step 5 in progress, then load
+  `step-5-emit-and-handoff.md`.

--- a/gaia/_skills/gaia-lkm-explorer/references/step-5-emit-and-handoff.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/step-5-emit-and-handoff.md
@@ -1,0 +1,284 @@
+# Step 5 — Emit And Hand Off
+
+Load this file only after Step 4 is complete. This step finalizes the source
+artifact and runs the Gaia quality gates.
+
+## Authoring surface — `gaia author` (cli-as-client)
+
+Step 5 emits the package through the **agent-first authoring CLI**
+(`docs/reference/cli/author.md`), not by writing raw
+Python DSL by hand. The CLI:
+
+- pre-validates each statement (identifier collision, reference resolution,
+  syntactic well-formedness, structural self-loop) before writing,
+- appends the rendered Python to the target source file,
+- runs `gaia build check` automatically after each successful write
+  (default `--check` on),
+- emits a uniform JSON envelope on stdout — `json.loads(stdout)` once and
+  dispatch on `verb` / `status` / `code`.
+
+Per Step 4's mapping outputs, the DSL primitives this skill emits map to
+author verbs as follows (canonical v0.5 names; legacy aliases in
+`gaia.engine.lang.compat` emit `DeprecationWarning` and must not be used in
+fresh packages):
+
+| Step 4/5 emission | DSL primitive | Author verb |
+|---|---|---|
+| LKM source / no-chain claim | `claim(...)` | `gaia author claim` |
+| Background context | `note(...)` | `gaia author note` |
+| Open inquiry | `question(...)` | `gaia author question` |
+| Factor-derived deduction | `derive(...)` | `gaia author derive` |
+| Frontier support warrant (`support([U], target)`) | `derive(target, given=[U])` | `gaia author derive` |
+| Accepted scientific contradiction (`contradiction(A, B)`) | `contradict(a, b)` | `gaia author contradict` |
+| Cross-paper equivalence (`equivalence(A, B)`) | `equal(a, b)` | `gaia author equal` |
+| Mutually-exclusive hypothesis pair | `exclusive(a, b)` | `gaia author exclusive` |
+| Leaf prior record | `register_prior(...)` | `gaia author register-prior` |
+
+The legacy `support([U], target, reason=..., prior=...)` strategy is
+replaced by `derive(target, given=[U], rationale=...)` per
+`docs/for-users/language-reference.md`.
+The engine `derive(...)` signature accepts only `{given, background,
+rationale, label}` — there is no `metadata=` / `warrant_prior` kwarg on
+`derive` / `equal` / `contradict` / `exclusive` / `observe`. The CLI
+exposes `--metadata` on these verbs but the post-write `gaia build check`
+rejects, so warrant-strength intent (legacy `prior=` on the strategy)
+moves into the `--rationale` prose instead.
+
+`--metadata` remains valid on `gaia author claim` / `note` / `question`
+(those underlying engine constructors accept `**metadata`), so
+LKM provenance kwargs (`provenance_source`, `lkm_id`) continue to flow
+through `claim --metadata`.
+
+Errors surface in the envelope's `diagnostics` array with a `kind`
+dispatch key (`prewrite.collision`, `prewrite.reference_unresolved`,
+`prewrite.syntax`, `prewrite.self_loop`, `postwrite.check_fail`, ...).
+Treat non-zero `code` as a fix-and-retry obligation before moving on; the
+CLI guarantees no partial writes on pre-write failure.
+
+## Batch Output
+
+For batch mode, emit a new standalone `<name>-gaia/` package. Bootstrap the
+package and its `priors.py` sibling with the CLI (matches the upstream
+Mendel/Galileo two-module layout):
+
+```bash
+gaia pkg scaffold \
+    --target <name>-gaia \
+    --name <name>-gaia \
+    --namespace <namespace> \
+    --with-uuid \
+    --description "<one-line description of this LKM-rooted package>"
+
+gaia pkg add-module \
+    --name priors \
+    --imports register_prior \
+    --target <name>-gaia
+```
+
+`gaia pkg scaffold` writes `pyproject.toml` (with `[tool.gaia] type =
+"knowledge-package"` and a freshly-minted `uuid`),
+`src/<import_name>/__init__.py` seeded with a minimal DSL import, and
+`.gaia/.gitkeep`. `--namespace` matches `gaia example mendel` / `gaia
+example galileo` (both pass `--namespace example`); set it to whatever
+namespace you have chosen for this run. `add-module --name
+priors --imports register_prior` creates `src/<import_name>/priors.py`
+with the `register_prior` import pre-seeded.
+
+All DSL emissions for this package — claims, deductions, cross-paper
+operators (`equal` / `contradict` / `exclusive`) — go in `__init__.py`
+(the default `--file` target). Leaf-prior `register_prior(...)` records
+go in `priors.py` via `gaia author register-prior --file priors.py`.
+
+Resulting layout after Step 4 + Step 5 emissions complete:
+
+```text
+<name>-gaia/
+├── pyproject.toml
+├── references.json
+└── src/<import>/
+    ├── __init__.py
+    └── priors.py
+```
+
+`references.json` is a JSON object keyed by citation key, CSL-JSON entry
+shape; each entry must include `type` (drawn from the CSL allowlist). See
+`docs/specs/2026-04-09-references-and-at-syntax.md` for the full schema.
+
+For refreshes, extend `__init__.py` and `priors.py` rather than replacing
+prior emitted statements. Reuse existing labels where possible.
+
+### Example invocations
+
+Source claim with LKM provenance (no-chain) — `--metadata` is valid on
+`claim` because the engine `claim(...)` accepts `**metadata`:
+
+```bash
+gaia author claim "<self-contained claim body>" \
+    --dsl-binding-name <key>_<suffix> \
+    --target <name>-gaia \
+    --metadata '{"provenance_source": "lkm_no_chain", "lkm_id": "<lkm_id>"}'
+```
+
+Factor-derived deduction (chain-backed). Provenance kwargs that used to
+ride `--metadata` are dropped here — the engine `derive(...)` has no
+`metadata=` kwarg. LKM provenance for chain-backed deductions lives on
+the conclusion / premise `claim --metadata` records and in the
+`--rationale` prose for the deduction itself:
+
+```bash
+gaia author derive \
+    --conclusion <key>_c<id>_<suffix> \
+    --given <premise_label_1>,<premise_label_2> \
+    --label <key>_c<id>_chain \
+    --rationale "<factor-chain rationale>. LKM provenance: factor=<chain_id>, source=lkm:factor_chain. Warrant intent: strong (directly implies via factor chain)." \
+    --target <name>-gaia
+```
+
+Frontier support warrant (legacy `support([U], target, prior=p)` → canonical
+`derive(target, given=[U], rationale=...)`):
+
+```bash
+gaia author derive \
+    --conclusion <target_label> \
+    --given <upstream_label> \
+    --label <upstream>_supports_<target> \
+    --rationale "<what U says and why it supports target>. Provenance: lkm:frontier_support. Warrant intent: moderate (related, partial overlap)." \
+    --target <name>-gaia
+```
+
+Cross-paper equivalence:
+
+```bash
+gaia author equal --a <claim_label_from_paper_A> --b <claim_label_from_paper_B> \
+    --label <key_a>_<key_b>_<short_suffix>_equiv \
+    --rationale "<why these refer to the same scientific assertion>. Provenance: lkm:factor_chain.equivalence, lkm_id=<lkm_equiv_id>." \
+    --target <name>-gaia
+```
+
+Accepted scientific contradiction (per `mapping-contract.md` §4):
+
+```bash
+gaia author contradict --a <side_a_label> --b <side_b_label> \
+    --label <side_a>_vs_<side_b>[_<quantity_or_regime>] \
+    --rationale "<why these claims are adjudicably conflicting> | open_problem: <specific discriminating question>. Provenance: lkm:contradiction_scan. Warrant intent: clear accepted contradiction." \
+    --target <name>-gaia
+```
+
+Per author.md "the contradiction operator binds the helper Claim to
+`--label`; do not mint fresh claims by design" — `<side_a>_vs_<side_b>` is
+the contradiction's helper-Claim label, not a synthesized side claim. The
+`open_problem:` convention lives inside `--rationale`.
+
+Leaf prior record (in `priors.py`):
+
+```bash
+gaia author register-prior \
+    --claim <claim_label> \
+    --value <float> \
+    --justification "<terse rationale ending in TODO:review>" \
+    --target <name>-gaia \
+    --file priors.py
+```
+
+The CLI auto-inserts `from <import_name> import <claim>` into `priors.py`
+when the referenced claim is not already imported.
+
+## Refresh Output
+
+For an existing standalone package, extend the existing package in place.
+`gaia author` writes are append-only by design (pre-write collision check
+refuses to overwrite a binding):
+
+- extend `__init__.py` with new `gaia author` invocations carrying
+  `--target <existing-pkg>` (the default `--file` is `__init__.py`),
+- extend `priors.py` with `gaia author register-prior --file priors.py`
+  invocations,
+- reuse existing labels in `--given` / `--a` / `--b` / `--claim` to weave
+  new statements into the prior graph; the CLI's pre-write reference
+  resolution catches typos at write time,
+- preserve existing labels and priors where possible — `gaia author
+  register-prior` is additive (a Claim can carry multiple prior records
+  from distinct `--source-id`s; Gaia's `ResolutionPolicy` picks the
+  winning value at compile time and keeps the losing records for audit).
+
+## Local Source Checks
+
+Pre-write CLI validation handles the syntactic / structural slice — every
+`gaia author <verb>` invocation runs identifier-collision, reference-
+resolution, and `ast.parse`-equivalent checks before writing, and aborts
+with a `prewrite.*` diagnostic on failure (see `docs/reference/cli/author.md`
+"Pre-write invariants"). So legacy items "Python source parses with
+`ast.parse`", "Gaia labels are lowercase identifiers", and "no claim has a
+`prior` kwarg" (the CLI renders `--prior` as a `register_prior(...)` call
+attached to the claim, never as a `prior=` claim kwarg) are enforced at the
+verb boundary.
+
+The remaining checks before handoff are SOP-owned semantic content:
+
+- Every claim preserves LKM provenance metadata where available
+  (`provenance_source` and `lkm_id` flow through `claim --metadata`).
+- Every `derive(...)` is factor-derived; no-chain source claims have no
+  fabricated deductions (no `gaia author derive` invocation against a
+  no-chain source claim's label unless a real factor chain backs it).
+  Factor / chain ids and warrant-strength intent live in the
+  `--rationale` prose (the engine `derive` has no `metadata=` kwarg).
+- Accepted contradictions use direct `contradict(A, B)` per
+  `mapping-contract.md` §4, with an `xx_vs_yy` label and `open_problem:`
+  + warrant-strength intent in the `--rationale` prose.
+
+## Caller Quality Gate
+
+`gaia author --check` (default on) runs `gaia build check` automatically
+after each statement write, so per-statement structural / IR-hash drift is
+already caught at the verb boundary. The end-of-batch quality gates this
+skill runs collapse to three commands:
+
+```bash
+gaia build compile .
+gaia run infer .
+gaia inquiry review --strict .
+```
+
+- `gaia build compile .` — full-package compile catches cross-statement
+  issues the per-write check cannot (cyclic imports, IR-hash regeneration,
+  manifest emission for `exports` / `premises` / `holes` / `bridges`).
+- `gaia run infer .` — belief propagation; emits `.gaia/beliefs.json`.
+- `gaia inquiry review --strict .` — strict warrant / obligation /
+  duplicate-control review (unchanged subapp).
+
+If inquiry review reports unreviewed warrants or duplicates, resolve them
+according to Step 4 and rerun the gate.
+
+## Hand-Off Report
+
+Return:
+
+- files created or changed (aggregated from each `gaia author` envelope's
+  `payload.written_to`),
+- high-level counts: claims (chain-backed vs no-chain), deductions, supports
+  (emitted as `derive(...)` with `provenance_source="lkm:frontier_support"`),
+  equivalences, accepted contradictions, hypothesis-only open problems,
+  priors added,
+- inquiry obligations/hypotheses opened or closed,
+- the three quality-gate commands run and pass/fail status
+  (`gaia build compile .`, `gaia run infer .`, `gaia inquiry review
+  --strict .`),
+- the final `gaia author` envelope's `check.knowledge_count` /
+  `check.strategy_count` / `check.operator_count` as IR-side sanity counts,
+- deviations from the mapping contract, if any.
+
+## What This Skill Is Not
+
+- Not graph rendering: use `gaia run render` (or `gaia-evidence-subgraph`
+  for closure-chain graphs) outside this skill.
+- Not scholarly prose: that is `gaia-scholarly-synthesis`.
+- Not a Gaia DSL language guide: syntax details belong to the installed Gaia
+  package (`docs/reference/cli/author.md` for the authoring surface;
+  `docs/for-users/language-reference.md` for the DSL primitives) and must be
+  verified through Gaia CLI quality gates.
+
+## Step-Completion Gate
+
+When handoff is complete, mark Step 5 complete. If quality gates surface new
+obligations, create a new iteration checklist and return to Step 1 with the new
+target or obligation.

--- a/gaia/_skills/gaia-obsidian-wiki/SKILL.md
+++ b/gaia/_skills/gaia-obsidian-wiki/SKILL.md
@@ -336,7 +336,7 @@ Before declaring the vault done, run a sweep:
 - [`../_shared/bp-interpretation.md`](../_shared/bp-interpretation.md) —
   How to read the Review section's `Prior → Belief` shift on each claim
   page.
-- [`../gaia-formalization/SKILL.md`](../gaia-formalization/SKILL.md) —
+- [`../gaia-formalize-fine/SKILL.md`](../gaia-formalize-fine/SKILL.md) —
   Upstream skill: produces the DSL source, `priors.py`, and the
   `ANALYSIS.md` that this vault visualises.
 - [`../gaia-publish/SKILL.md`](../gaia-publish/SKILL.md) — Alternate

--- a/gaia/_skills/gaia-publish/SKILL.md
+++ b/gaia/_skills/gaia-publish/SKILL.md
@@ -89,7 +89,7 @@ Shape:
 > See [ANALYSIS.md](ANALYSIS.md) for detailed verification results.
 ```
 
-Replace the `<!-- badges:start --><!-- badges:end -->` pair with links to CI, docs, the wiki output, and GitHub Pages if any of those exist for the repo. Keep the AI-generated-analysis disclaimer verbatim — it sets the right expectation for readers and is the canonical pointer to `ANALYSIS.md` (produced upstream by `gaia-formalization`).
+Replace the `<!-- badges:start --><!-- badges:end -->` pair with links to CI, docs, the wiki output, and GitHub Pages if any of those exist for the repo. Keep the AI-generated-analysis disclaimer verbatim — it sets the right expectation for readers and is the canonical pointer to `ANALYSIS.md` (produced upstream by `gaia-formalize-fine`).
 
 The bibliographic header is also the canonical attribution source for figure captions later in the document. Pin author + year here so every figure embed can refer back to it consistently.
 
@@ -232,7 +232,7 @@ Some gaps cross themes (a missing measurement that motivates a tighter derivatio
 
 ### Link to ANALYSIS.md
 
-If the package has an `ANALYSIS.md` (produced upstream by `gaia-formalization`'s Pass 5/6 + prior-assignment tail), close the README with:
+If the package has an `ANALYSIS.md` (produced upstream by `gaia-formalize-fine`'s Pass 5/6 + prior-assignment tail), close the README with:
 
 ```markdown
 ## Detailed Analysis
@@ -293,5 +293,5 @@ When writing verdict sentences in Reasoning Structure and the root-cause sentenc
 ## Cross-refs
 
 - `../_shared/bp-interpretation.md` — belief-result interpretation reference; consult when phrasing verdicts and root-cause sentences.
-- `../gaia-formalization/SKILL.md` — upstream skill that produces the knowledge package and `ANALYSIS.md`; the README's Detailed Analysis section links into it.
+- `../gaia-formalize-fine/SKILL.md` — upstream skill that produces the knowledge package and `ANALYSIS.md`; the README's Detailed Analysis section links into it.
 - `../gaia-obsidian-wiki/SKILL.md` — alternate output channel; richer browsable vault for the same package, when README polish is not the goal.

--- a/gaia/_skills/gaia-review/SKILL.md
+++ b/gaia/_skills/gaia-review/SKILL.md
@@ -327,7 +327,7 @@ observation" is a placeholder, not a discrimination story.
 After `gaia run infer`, the package writes per-claim beliefs and
 per-strategy posteriors to `.gaia/beliefs.json`. Interpretation — what
 counts as normal vs abnormal, which problems map to which fixes — lives
-in `../_shared/bp-interpretation.md` so this skill and `gaia-formalization`
+in `../_shared/bp-interpretation.md` so this skill and `gaia-formalize-fine`
 share one canonical copy. Read it after the first `gaia run infer` of an
 iteration cycle; don't infer-then-tweak without it.
 
@@ -474,6 +474,6 @@ supported pattern.
 - `../_shared/bp-interpretation.md` — interpretation of `gaia run infer`
   results; the iteration loop's step 5 defers to this single canonical
   table.
-- `../gaia-formalization/SKILL.md` — upstream context; this skill is
+- `../gaia-formalize-fine/SKILL.md` — upstream context; this skill is
   invoked from formalization Pass 5/6 once structural integrity is
   settled.

--- a/gaia/_skills/gaia-scholarly-synthesis/SKILL.md
+++ b/gaia/_skills/gaia-scholarly-synthesis/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: gaia-scholarly-synthesis
+description: |
+  Use to write a domain-vocabulary scholarly synthesis centered on one
+  chain-backed quantitative claim about a system or setting (any field —
+  physics, chemistry, materials, biology, ML, climate, astrophysics, etc.).
+  Section structure traces the closure chain from observational / experimental
+  anchors → theoretical or computational inputs → derivation / inversion /
+  fitting → cross-method comparison → open problems. Heavy on equations,
+  units, and named author–year references resolved via a supplied
+  `data.papers` bibliographic metadata block. When source-paper figures or
+  data tables are appropriate to quote, the agent does so on a best-effort
+  basis with `Adapted from <author–year>` attribution; when such material is
+  not recoverable from the input payload, the agent surfaces the
+  missing-material list to the user instead of fabricating. Banned-phrase
+  audit (no system / pipeline vocabulary in main narrative). **Mandatory
+  inputs:** an audited evidence graph (source + rendered raster), an audit
+  table with payload anchors, and the `data.papers` bibliographic metadata —
+  exactly the artifacts `gaia-evidence-subgraph` produces, so this skill is
+  its downstream pair. If the graph is not provided, stop and instruct the
+  user to supply one. Distinct from `gaia-publish` (which renders a Gaia
+  package's belief-annotated README); this skill writes a field-vocabulary
+  scholarly article from an audited evidence graph. Note: this skill is
+  self-marked **future work** — accurate as a writing primitive, expect
+  refinement later.
+---
+
+# Scholarly Synthesis
+
+> **Status: future work.** This skill currently exposes only an atomic surface — synthesis primitive that turns an audited evidence graph plus bibliographic metadata into a domain-vocabulary scholarly article. Full polish (including discovery-flag integration for cross-method comparison and open-problem narration) is deferred to after the LKM→gaia priority workflow lands. The body below is accurate-for-purpose as a writing primitive; expect substantive refinement later.
+
+## Principle
+
+The synthesis answers exactly one question: **how is this result closed?**
+
+Not "is this system / model / phenomenon X conventional?", not "what is the general theory of the field?" — only: given the observational / experimental anchors and the theoretical / computational inputs, what derivation produces the target result, what assumptions does that derivation hide, what theory–theory or method–method tensions does it surface, and where do open theory–experiment / model–observation gaps remain?
+
+The supplied evidence graph and audit table are **mandatory scaffolding**. The synthesis's subject is the **scientific / scholarly claim itself**, in the field's normal vocabulary — not the graph, not whatever pipeline produced it.
+
+## Mandatory inputs
+
+This skill **requires** the following inputs to be supplied by the caller:
+
+1. **Audited evidence graph** — DOT or Mermaid `flowchart` source plus a rendered raster (PNG / PDF / SVG). The rendered raster is what gets embedded as Figure 1 of the body.
+2. **Audit table** — per-edge bridge sentences with payload anchors (premise / factor / step references into the underlying source data).
+3. **`data.papers` metadata** — the authoritative paper-id → bibliographic-metadata map; the references list is built from this.
+
+If the **graph is not provided**, stop and instruct the user to supply one (graph + raster + audit table). Do not attempt to write a synthesis from raw source JSON without the audited graph — the graph is what disciplines the synthesis's structure and prevents drift into ungrounded prose.
+
+## Source-paper figures and tables (best-effort)
+
+A literature synthesis benefits from reproducing or adapting figures and data tables from the source papers — that is convention in the field. This skill follows the convention on a **best-effort** basis, bounded by what the supplied source payload actually carries.
+
+**When the source payload describes a figure / table.** When premise `content`, claim content, or `factors[i].steps[j].reasoning` quotes or paraphrases a specific figure caption, table row, or numerical breakdown from a source paper, the synthesis may quote that text verbatim with attribution `Adapted from <author–year>`. The "adapted from" tag is mandatory whenever the wording originates from a paper that is not the user-selected root.
+
+**When the source payload does not carry the figure / table itself.** The supplied payload is propositional content — it does not include rendered figure images, image-format tables, or non-textual artifacts. The skill must **not fabricate** a figure or invented numerical table. Instead, the skill records the gap in a **`missing-material.md`** file in the run folder, one row per gap:
+
+```
+| section | citation in synthesis | what was referenced | source paper (DOI) | why not reproduced |
+```
+
+`missing-material.md` is surfaced to the user in the final hand-off so the user can manually fetch the figure / table from the DOI for camera-ready preparation.
+
+**Citation discipline for adapted material.** Every "Adapted from" attribution names a paper that already appears in the references list (built from `data.papers`). Do not introduce a new paper in an "Adapted from" line that is not in the references — that bypasses the citation-completeness check.
+
+## Topic-agnosticism
+
+This skill is installed by users across many fields. Domain-specific terms in the produced synthesis come from the supplied source payload (premise / factor / step / claim content) and the user-selected claim, plus bibliographic context from `data.papers` — **not** from the skill text. The closure-chain abstraction generalizes:
+
+- **Computational / first-principles fields** — `(electronic structure / force field / simulation inputs) → (intermediate computed quantities) → (derivation / inversion) → (parameter or predicted observable)`.
+- **Experimental / observational fields** — `(measurement protocol + calibration + sample / observation conditions) → (raw signal / dataset) → (analysis / inversion) → (extracted parameter or property)`.
+- **ML / AI** — `(architecture + dataset + hyperparameters) → (training and intermediate metrics) → (eval protocol) → (benchmark or scaling result)`.
+- **Modeling-driven fields** (climate, astrophysics, epidemiology) — `(forcings / initial conditions + model resolution + parameterizations) → (simulated observables) → (comparison / inversion) → (sensitivity or response parameter)`.
+
+Wherever the section structure below says "theoretical / computational inputs" or "cross-method comparison", read the corresponding noun in your own field.
+
+## Hard style bans (main narrative — title, abstract, body, conclusion, references)
+
+The following are forbidden in the main narrative; allowed only in an explicit "methodology / provenance" appendix.
+
+**English ban list:**
+
+- "evidence graph", "subgraph", "dependency graph", "evidence chain", "chain-internal", "chain-backed"
+- "premise", "factor", "claim id", "upstream support", "upstream conclusion", "upstream claim"
+- "tier 0 / tier 1 / tier 2" (when referring to graph layers)
+- "first layer / second layer" (when referring to graph layers, not physical or model layers)
+- "audit table", "audit trail", "retrieval bundle", "retrieval system"
+- "LKM", "Large Knowledge Model", "gcn_*", "gfac_*", "paper:<id>", "source package id"
+- The graph's own section titles (e.g. "evidence chain and context") — never quoted as a section heading
+
+**Locale-mirrored ban list.** When the synthesis is written in a language other than English, mirror the ban list to that language before running the banned-phrase grep. Canonical mirrors:
+
+- *Simplified Chinese:* `证据图`, `子图`, `依赖图`, `证据链`, `链内`, `链支持`, `前提`, `因子`, `声明 id`, `上游支撑`, `上游结论`, `上游声明`, `第 0 层 / 第 1 层 / 第 2 层` (in graph-tier sense), `审计表` / `核查表`, `审计轨迹`, `检索包`, `检索系统`, `LKM`, `大知识模型`, `gcn_*`, `gfac_*`, `paper:<id>`, `来源包 id`, and the graph's own section titles such as `证据链与上下文`.
+- *Other locales:* mirror each English term to the equivalent native term before grepping. Document the locale-specific list once in the synthesis's `notes.md` so future runs in the same locale can re-use it.
+
+**Word allow-list.** The English word "chain" is acceptable in physics / domain phrases such as "closure chain", "reaction chain", "supply chain", "Markov chain" — these refer to the substantive scientific concept, not to the graph data structure. The corresponding allow-list in Chinese: `闭合链`, `推理链`, `反应链`, `供应链`, `马尔可夫链` — explicitly permitted in the main narrative. Same logic for "tier" when it refers to a real-world hierarchy in the domain (e.g. "tier-1 evidence" in clinical research) and not to the graph's tier-0/1/2 vocabulary. Use judgement; the test is whether a domain reader who has never heard of the graph would parse the word in its physical / scholarly sense.
+
+External papers are cited by **author–year**, resolved through the `data.papers` metadata block (`en_title`, `authors`, `publication_date`, `publication_name`, `doi`). System identifiers (`gcn_*`, `gfac_*`, `paper:<id>`) may appear only in the optional provenance appendix.
+
+**The rendered evidence graph itself is exempt from the ban,** because its node labels are domain-language phrases (the graph skill mandates human-readable labels). The graph is **Figure 1 of the body**, with a domain-language caption that does not contain banned phrases (no "evidence graph", no "subgraph", no "证据图", etc. in the caption text — call it "closure-chain map of <topic>" or similar). The audit table, by contrast, still belongs only in the optional provenance appendix or in `notes.md` — it carries chain-payload anchors and would trip the banned-phrase grep if placed in the body.
+
+## Default section structure
+
+Generalizable to any chain-backed quantitative root. Adapt the closure-chain expression in section 1 to the domain.
+
+1. **Title.** Names the system / setting, the quantitative result, and the framing question. Localize to the user's prompt language.
+
+2. **Abstract.** ≤ 250 English-word equivalents. For CJK-language syntheses, the analogous bound is ≈ 350 Chinese / Japanese characters; for other languages, scale by typical word density. Cover: the system / setting, the observational signals or experimental anchors that motivate the question, the theoretical / computational task (the chain to close), the central inversion / fitting result, what it resolves, and what it leaves open. End with keywords.
+
+3. **Figure 1 — the closure-chain map.** Embed the rendered evidence graph immediately after the abstract, **before** Section 1. Caption in domain language. Two well-formed examples:
+
+   - English: *"Figure 1. Closure-chain map of <topic>: how the experimental anchors and the theoretical / computational inputs combine to fix <target quantity>. Edge legend on the figure."*
+   - 中文: *「图 1. 〈课题〉闭合链图：实验锚点与理论/计算输入如何共同确定〈目标量〉。边的图例见图内。」*
+
+   Do **not** caption it as "evidence graph" / "subgraph" / "证据图" / etc. — those are banned in the main narrative. Do **not** restate the three edge classes ("chain support", "background", "verification support" / "链式支撑", "背景", "核验支撑") inside the body caption — the rendered graph already carries that legend, and repeating those names in body prose risks tripping the banned-phrase grep. Section 1 references the figure (e.g. *"as summarised in Figure 1"*) when introducing the closure chain.
+
+4. **Section 1 — Introduction: the closure chain.**
+   State the problem in domain language. Write the closure chain as an explicit schematic — for example:
+
+   `(theoretical / computational inputs) → (intermediate quantities) → (observables or benchmarks) ↔ (target parameter)`
+
+   In a specific domain, instantiate the schematic with the actual symbols, e.g. for a strong-coupling Eliashberg-style problem `α²F(ω) → λ, ω_log → Tc, Δ(0) ↔ μ*`; for a binding-affinity problem `(force field + sampling protocol) → (free-energy estimator output) → (assay K_d) ↔ (binding pose conformation)`; etc. Explain why the framing question is *not* "is this case conventional / typical" but "given these inputs, does this number close the chain consistently".
+
+5. **Section 2 — Observational / experimental constraints.**
+   Quote the anchoring measurements with units and uncertainties. State explicitly which observation disciplines which theoretical / computational input. This is the section that prevents the rest of the synthesis from drifting into pure model-talk.
+
+6. **Section 3 — Theoretical / computational inputs.**
+   Method (computational technique, fit family, simulation protocol); what was computed or simulated (intermediate quantities); model prunings (which symmetries assumed, which sub-effects dropped); validity conditions (where the chosen method is expected to be reliable). Quote computed numbers from the calculation / simulation paper(s) by author–year. State which simplifications matter for the rest of the chain.
+
+7. **Section 4 — Inversion / fitting.**
+   The equation, optimization, or procedure that fixes the target result. Quote it explicitly. Derive or describe the resulting value. Make a clean separation between *measured* / *computed* / *fitted* / *assumed* — a reader should be able to colour each input by category and see what the conclusion really rests on.
+
+8. **Section 5 — Cross-method or cross-formalism comparison.**
+   Where applicable: analytical formulas vs numerical solvers, mean-field vs many-body, perturbative vs non-perturbative, model-A vs model-B, in-distribution vs out-of-distribution, simulation-with-X vs simulation-without-X. Quote the discrepancy with units. Explain its origin (truncation conventions, neglected sub-effects, dataset shifts). When verification edges in the graph **partially disconfirm** the root, narrate that tension explicitly here. For accepted contradictions, describe the direct scientific conflict and the associated discriminating open problem. Cite both sides by author–year.
+
+9. **Section 6 — Open problems and what would discriminate.**
+   Assumptions that carry the conclusion (symmetry assumptions, single-channel reductions, harmonic / linearity assumptions, fixed priors, etc.); theory–experiment / model–observation gaps still uncovered; theory–theory or method–method tensions; **specific** experiments / measurements / calculations that would discriminate the surviving alternatives. Avoid generic gestures — name the measurement and the threshold. For each accepted contradiction, state the source claims, why they form an adjudicable conflict, and what open problem would discriminate them. Cite both sides by author–year.
+
+10. **References.** Author–year, fully bibliographic. **Build entries from the supplied `data.papers` metadata block:** `en_title` for English titles (or `zh_title` if the synthesis is Chinese and a Chinese title is preferred); `authors` (split on `|` and reformat); `publication_date`; `publication_name`; `doi`. The references list is part of the **main narrative** for ban-list purposes — no `paper:<id>` strings, no system identifiers, no internal claim ids. Append a short closing line such as: *"For further information about each cited result, refer to the original paper via the DOI listed above."*
+
+11. **Optional methodology / provenance appendix.** The only place where the audit table or system identifiers (`gcn_*`, `gfac_*`, `paper:<id>`) may appear. The rendered graph itself is **not** appendix material — it has been promoted to Figure 1 of the body. Caption any appendix tables plainly: this material summarises how the literature was organised during preparation; it is **not** the scientific content of the synthesis.
+
+## Style
+
+- **Equations numbered.** `(1)`, `(2)`, … with `\eqref{...}` cross-references in LaTeX, or `(eq. 3)` inline in markdown.
+- **Units everywhere.** Don't write "8.4 K" once and "8.4" later. Keep units on every numeric quantity that has them.
+- **Significant figures.** Preserve from source; do not round unless the source does so.
+- **Voice.** Impersonal or "we"; never refer to the agent, the graph, or the retrieval pipeline.
+- **Tone.** A domain researcher who has never heard of the underlying knowledge-base / retrieval system should be able to read the article cover to cover without losing the argument.
+
+## LaTeX defaults
+
+If LaTeX is requested:
+
+- `article` class, 11–12 pt, A4 or letter.
+- For Chinese: `xeCJK` package, e.g. `Noto Serif CJK SC`. For other non-Latin scripts: select an analogous fallback font.
+- `amsmath`, `amssymb`, `mathtools` for equations; `hyperref` for cross-refs; `graphicx` for figures. Field-specific packages (e.g. `physics`, `chemfig`, `siunitx`) only when the domain calls for them.
+- Compile with `latexmk -xelatex -interaction=nonstopmode` (or `pdflatex` if no CJK).
+- Inspect the log for missing-glyph warnings, overfull hboxes, undefined references — fix before declaring done.
+
+## Verification before hand-off
+
+Before declaring the synthesis complete:
+
+1. **Mandatory-inputs check.** Confirm graph (source + rendered raster) + audit table + `data.papers` were all supplied. If any is missing, STOP and request it.
+2. **Figure 1 placement.** The rendered evidence graph appears as Figure 1 of the body, immediately after the abstract and before Section 1. Caption is in domain language and contains zero banned phrases.
+3. **Banned-phrase grep.** Run a regex grep for the ban list (English + locale mirror) against the main-narrative source (excluding the appendix and the embedded graph file itself, which is binary). Zero hits required. The allow-list above clarifies legitimate uses of words like "chain" / "tier" in the domain sense.
+4. **Best-effort numerical-anchor check.** For every number in the synthesis, try to locate it in the supplied source payload (premise `content`, factor steps, claim content) or — for numbers attributed to a different paper — in that paper's `data.papers` entry plus the source payload of the root. The check is **soft**: payloads are sometimes incomplete, and a number may legitimately not be locatable inside the JSON we have. When a number cannot be confirmed, do not delete it — note `anchor not locatable in payload` next to the audit-table row that supplied it. A number that the payload **contradicts**, however, is a source-consistency error and must be fixed; this is separate from Gaia package contradiction admission.
+5. **Citation completeness.** Every author–year mention in the body has a matching reference entry built from `data.papers`, and vice versa. Every "Adapted from <author–year>" attribution names a paper already in the references list.
+6. **Missing-material list.** `missing-material.md` is up-to-date: every "Adapted from" reference whose figure / table could not be reproduced has a row pointing to the source paper's DOI.
+7. **Equation-number consistency.** No undefined `\eqref{...}`, no duplicated labels.
+
+## What this skill is NOT
+
+- Not a broad literature-survey writer. This skill writes one closure-chain article at a time, anchored on a single chain-backed root.
+- Not a graph-renderer. The audited graph and rendered raster are caller-supplied inputs; this skill embeds the raster as Figure 1 and consumes the audit table for verification.
+- Not a figure-generator. Figures and data tables adapted from source papers may be quoted with attribution when the supplied payload carries the text; image-format figures cannot be reproduced and are surfaced as missing-material gaps for the user to fill in.
+- Not for purely qualitative claims. A claim with no numeric or formula-level anchor has no closure step to write about; this skill does not apply.

--- a/gaia/_skills/gaia-scholarly-synthesis/references/synthesis-structure.md
+++ b/gaia/_skills/gaia-scholarly-synthesis/references/synthesis-structure.md
@@ -1,0 +1,93 @@
+# Synthesis Structure Reference (closure chain)
+
+This file complements `SKILL.md`. It contains the reusable section outline plus the banned-phrase checklist.
+
+## Standard outline (any domain)
+
+The synthesis answers exactly one question: **how is this result closed?** All sections serve that question. Adapt the closure-chain expression in §1 to the domain.
+
+| § | section | what goes here |
+|---|---------|----------------|
+| — | **Title** | system / setting + quantitative result + framing question. Localize to user's prompt language. |
+| — | **Abstract** | ≤ 250 English-word equivalents (~ 350 CJK characters). System, observational signals, theoretical task, central inversion result, what it resolves, what it leaves open. End with keywords. |
+| — | **Figure 1** | The rendered closure-chain map (caller-supplied), embedded immediately after the abstract and before §1. Caption in domain language — e.g. *"Closure-chain map of <topic>: how the inputs combine to fix <target>."* — with zero banned phrases. §1 references it. |
+| 1 | Introduction: the closure chain | State the closure-chain schematic explicitly: `(theoretical / computational inputs) → (intermediate quantities) → (observables / benchmarks) ↔ (target parameter)`. Instantiate with domain symbols. Frame the question as "does this number close the chain consistently", not "is this case typical". Reference Figure 1. |
+| 2 | Observational / experimental constraints | Anchoring measurements with units and uncertainties. Which observation disciplines which input. |
+| 3 | Theoretical / computational inputs | Method (computational / fit / simulation); intermediate quantities computed; model prunings; validity conditions. Quote computed numbers by author–year. |
+| 4 | Inversion / fitting | The equation, optimization, or procedure that fixes the target result. Quote it explicitly. Resulting value. Clean separation of measured / computed / fitted / assumed. |
+| 5 | Cross-method or cross-formalism comparison | Analytical vs numerical, mean-field vs many-body, model-A vs model-B, in-distribution vs out-of-distribution, etc. Quote discrepancies with units. Explain origin. Narrate any partial-disconfirm verification edges from the graph. For accepted contradictions, explain the direct scientific conflict and its associated open problem. Cite both sides by author–year. |
+| 6 | Open problems and what would discriminate | Assumptions carrying the conclusion; theory-experiment gaps; theory-theory tensions; *specific* experiments / calculations to discriminate. Name measurements and thresholds. For each accepted contradiction, state the source claims, why they are adjudicably conflicting, and what open problem would discriminate them. Cite both sides by author–year. |
+| 9 | References | Author–year, fully bibliographic. Build entries from the `data.papers` metadata block (`en_title` or `zh_title`, `authors` split on `\|`, `publication_date`, `publication_name`, `doi`). End with: *"For further information about each cited result, refer to the original paper via the DOI listed above."* |
+| 10 | (Optional) methodology / provenance appendix | Only place where the audit table or system identifiers (`gcn_*`, `gfac_*`, `paper:<id>`) may appear. The rendered graph itself is **not** appendix material — it has been promoted to Figure 1. |
+
+## Banned-phrase checklist (run before declaring done)
+
+### English ban list
+
+```
+\b(evidence graph|subgraph|dependency graph|evidence chain|chain-internal|chain-backed)\b
+\b(premise|factor|claim id|upstream support|upstream conclusion|upstream claim)\b
+\b(tier ?[012]|first layer|second layer)\b   # graph-tier sense only
+\b(audit table|audit trail|retrieval bundle|retrieval system)\b
+\b(LKM|Large Knowledge Model)\b
+\b(gcn_|gfac_|paper:|source package id)\b
+```
+
+### Simplified Chinese ban list
+
+```
+证据图|子图|依赖图|证据链|链内|链支持
+前提|因子|声明 ?id|上游支撑|上游结论|上游声明
+第 ?[012] ?层|第一层|第二层      # graph-tier sense only
+审计表|核查表|审计轨迹|检索包|检索系统
+LKM|大知识模型
+gcn_|gfac_|paper:|来源包 ?id
+证据链与上下文                    # graph's own section title
+```
+
+### Word allow-list (legitimate domain uses)
+
+These are *not* bans, even though they share roots with banned terms — the test is whether a domain reader (who has never heard of the graph) parses them in the physical / scholarly sense:
+
+- English: "closure chain", "reaction chain", "supply chain", "Markov chain", "tier-1 evidence" (clinical research sense).
+- Chinese: `闭合链`, `推理链`, `反应链`, `供应链`, `马尔可夫链`, `一级证据` (clinical sense).
+
+When grepping, exclude those phrases from the match (e.g. two-step grep, or `grep -v` post-filter).
+
+### Locale-mirror rule
+
+For any language other than English or Simplified Chinese, mirror each banned term to the equivalent native term before grepping. Document the locale-specific list in the run's `notes.md` so future runs in the same locale can re-use it.
+
+## Mandatory inputs reminder
+
+The skill **requires** the following from the caller:
+
+1. Audited evidence graph source (DOT or Mermaid `flowchart`) **plus a rendered raster** (PNG / PDF / SVG) — the raster becomes Figure 1 of the body.
+2. Audit table with payload anchors (premise / factor / step references into the underlying source data).
+3. `data.papers` subset (paper-id → bibliographic-metadata) for the references list.
+
+If any input is missing, **stop** and request it. Do not write a synthesis from raw source JSON without the audited graph — the graph is what disciplines the synthesis's structure and prevents drift.
+
+## Citation rendering from `data.papers`
+
+Each entry in `data.papers` looks like:
+
+```json
+"paper:812085204238729217": {
+  "id": "812085204238729217",
+  "doi": "10.1088/...",
+  "publication_name": "Plasma Sources Sci. Technol.",
+  "zh_title": "...",
+  "en_title": "...",
+  "authors": "A A Belevtsev | V F Chinnov | E Kh Isakaev",
+  "publication_date": "2006-8-1"
+}
+```
+
+Render as a typical journal-style reference; example output:
+
+```
+[1] A. A. Belevtsev, V. F. Chinnov, E. Kh. Isakaev. <Title>. Plasma Sources Sci. Technol., 2006. https://doi.org/10.1088/...
+```
+
+Match the rendering convention to the journal / venue the user is targeting (numbered vs author-year). Always include the DOI when present, so the user can navigate to the original paper.

--- a/tests/cli/test_skill.py
+++ b/tests/cli/test_skill.py
@@ -293,9 +293,13 @@ class TestRegisterIntegration:
 
         registry = tmp_path / ".gaia-skills"
         assert registry.is_dir()
-        # All four shipped skills materialised, plus _shared.
+        # All shipped skills materialised, plus _shared.
         for skill in (
-            "gaia-formalization",
+            "gaia-formalize-fine",
+            "gaia-formalize-coarse",
+            "gaia-lkm-explorer",
+            "gaia-evidence-subgraph",
+            "gaia-scholarly-synthesis",
             "gaia-obsidian-wiki",
             "gaia-publish",
             "gaia-review",
@@ -316,7 +320,11 @@ class TestRegisterIntegration:
         assert list_result.exit_code == 0, list_result.output
         # Every shipped skill row should carry an OK status.
         for skill in (
-            "gaia-formalization",
+            "gaia-formalize-fine",
+            "gaia-formalize-coarse",
+            "gaia-lkm-explorer",
+            "gaia-evidence-subgraph",
+            "gaia-scholarly-synthesis",
             "gaia-obsidian-wiki",
             "gaia-publish",
             "gaia-review",
@@ -335,8 +343,8 @@ class TestRegisterIntegration:
         assert result.exit_code == 0, result.output
 
         # Registry created; claude links present; .agent/ not created.
-        assert (tmp_path / ".gaia-skills" / "gaia-formalization").is_dir()
-        assert (tmp_path / ".claude" / "skills" / "gaia-formalization").is_symlink()
+        assert (tmp_path / ".gaia-skills" / "gaia-formalize-fine").is_dir()
+        assert (tmp_path / ".claude" / "skills" / "gaia-formalize-fine").is_symlink()
         assert not (tmp_path / ".agent").exists()
 
     def test_fresh_cwd_neither_surface_present(
@@ -348,7 +356,7 @@ class TestRegisterIntegration:
         result = runner.invoke(app, ["skill", "register"])
         assert result.exit_code == 0, result.output
 
-        assert (tmp_path / ".gaia-skills" / "gaia-formalization" / "SKILL.md").is_file()
+        assert (tmp_path / ".gaia-skills" / "gaia-formalize-fine" / "SKILL.md").is_file()
         # No agent-surface dirs should have been created in auto mode.
         assert not (tmp_path / ".claude").exists()
         assert not (tmp_path / ".agent").exists()
@@ -363,8 +371,8 @@ class TestRegisterIntegration:
         result = runner.invoke(app, ["skill", "register", "--target", "claude"])
         assert result.exit_code == 0, result.output
 
-        assert (tmp_path / ".gaia-skills" / "gaia-formalization").is_dir()
-        link = tmp_path / ".claude" / "skills" / "gaia-formalization"
+        assert (tmp_path / ".gaia-skills" / "gaia-formalize-fine").is_dir()
+        link = tmp_path / ".claude" / "skills" / "gaia-formalize-fine"
         assert link.is_symlink()
         # And .agent/ remains untouched.
         assert not (tmp_path / ".agent").exists()
@@ -395,9 +403,9 @@ class TestRegisterIntegration:
         assert first.exit_code == 0, first.output
 
         registry = tmp_path / ".gaia-skills"
-        link = tmp_path / ".claude" / "skills" / "gaia-formalization"
+        link = tmp_path / ".claude" / "skills" / "gaia-formalize-fine"
         before_link_target = os.readlink(link)
-        before_skill_mtime = (registry / "gaia-formalization" / "SKILL.md").stat().st_mtime_ns
+        before_skill_mtime = (registry / "gaia-formalize-fine" / "SKILL.md").stat().st_mtime_ns
 
         second = runner.invoke(app, ["skill", "register"])
         assert second.exit_code == 0, second.output
@@ -405,7 +413,7 @@ class TestRegisterIntegration:
 
         # Symlink unchanged, registry file unchanged.
         assert os.readlink(link) == before_link_target
-        after_skill_mtime = (registry / "gaia-formalization" / "SKILL.md").stat().st_mtime_ns
+        after_skill_mtime = (registry / "gaia-formalize-fine" / "SKILL.md").stat().st_mtime_ns
         assert after_skill_mtime == before_skill_mtime
 
     def test_stale_entry_removed_from_registry_and_surfaces(
@@ -449,7 +457,7 @@ class TestRegisterIntegration:
         """Real dir at our entry path → COLLISION, exit 1, dir preserved."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".claude").mkdir()
-        colliding = tmp_path / ".claude" / "skills" / "gaia-formalization"
+        colliding = tmp_path / ".claude" / "skills" / "gaia-formalize-fine"
         colliding.mkdir(parents=True)
         sentinel = colliding / "user-content.md"
         sentinel.write_text("user data\n")
@@ -457,7 +465,7 @@ class TestRegisterIntegration:
         result = runner.invoke(app, ["skill", "register"])
         assert result.exit_code == 1, result.output
         assert "COLLISION" in result.output
-        assert "gaia-formalization" in result.output
+        assert "gaia-formalize-fine" in result.output
 
         # The colliding real dir + its contents are preserved.
         assert colliding.is_dir()
@@ -474,7 +482,7 @@ class TestRegisterIntegration:
         """Real file at our entry path → COLLISION, exit 1, file preserved."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".claude" / "skills").mkdir(parents=True)
-        colliding = tmp_path / ".claude" / "skills" / "gaia-formalization"
+        colliding = tmp_path / ".claude" / "skills" / "gaia-formalize-fine"
         colliding.write_text("user notes\n")
 
         result = runner.invoke(app, ["skill", "register"])
@@ -491,10 +499,10 @@ class TestRegisterIntegration:
         """Foreign-target symlink at our entry path → COLLISION, link preserved."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".claude" / "skills").mkdir(parents=True)
-        elsewhere = tmp_path / "elsewhere" / "gaia-formalization"
+        elsewhere = tmp_path / "elsewhere" / "gaia-formalize-fine"
         elsewhere.mkdir(parents=True)
         (elsewhere / "marker.txt").write_text("foreign\n")
-        colliding = tmp_path / ".claude" / "skills" / "gaia-formalization"
+        colliding = tmp_path / ".claude" / "skills" / "gaia-formalize-fine"
         os.symlink(elsewhere, colliding)
 
         result = runner.invoke(app, ["skill", "register"])
@@ -517,7 +525,7 @@ class TestListIntegration:
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".claude" / "skills").mkdir(parents=True)
         # Real dir collision at one of the shipped skill names.
-        (tmp_path / ".claude" / "skills" / "gaia-formalization").mkdir()
+        (tmp_path / ".claude" / "skills" / "gaia-formalize-fine").mkdir()
 
         result = runner.invoke(app, ["skill", "list"])
         assert result.exit_code == 1, result.output


### PR DESCRIPTION
Migrates the maintained skills from `gaia-lkm-skills` into Gaia's bundled `gaia/_skills/` registry (shipped with `gaia-lang`, materialized by `gaia skill register`). PR 1 of 2 — the companion change deprecates `gaia-lkm-skills` to a stub pointing at this CLI.

## Registry changes (`gaia/_skills/`)
- **Renamed** `gaia-formalization` → `gaia-formalize-fine` (thorough six-pass); description now contrasts it with the coarse path.
- **Added** `gaia-formalize-coarse` (quick four-phase single-paper), `gaia-lkm-explorer` (multi-paper contradiction-driven exploration), `gaia-evidence-subgraph` (closure-chain graph; keeps `check_dot_cycles.mjs`), `gaia-scholarly-synthesis` (future-work).
- **Not migrated:** `lkm-search` / `lkm-search-internal` (superseded by the native `gaia search lkm` CLI), `orchestrator` (Gaia routes by skill `description`; its routing hints were folded into the migrated skills).

## Rewrites applied to every migrated skill
- API mechanics → `gaia search lkm` CLI: `/search`→`knowledge`, `/claims/{id}/reasoning`→`reasoning --claim-id`, `/reasoning/search`→`reasoning <q>`, `/variables/batch`→`nodes`, `/papers/graph`→`package`; `--format raw-json` where the verbatim envelope is the audit substrate. Bundled `lkm_search.py`/`lkm_internal.py` dropped.
- `$skill` cross-refs → plain names; stale `docs/for-users/...` pointers repointed to in-repo docs; `gaia-` prefix + `description:|` frontmatter style.

## Notes
- Renaming a skill is remove+add in the registry diff, so existing `.gaia-skills/` consumers will see `gaia-formalization` as STALE and `gaia-formalize-fine` as ADD on their next `gaia skill register`.
- `test_skill.py` integration assertions were repointed to the new shipped set; pr_gate slice green (1041 passed / 3 skipped).
