### PR TITLE
fix(skills): replace rejected PRIORS dict with register_prior in gaia-lkm-explorer

### DIFF
--- a/gaia/_skills/gaia-lkm-explorer/references/step-4-supports-priors-and-review.md
+++ b/gaia/_skills/gaia-lkm-explorer/references/step-4-supports-priors-and-review.md
@@ -84,13 +84,22 @@ Rules:
 ## Leaf Priors
 
 After source emission, the caller quality gate runs `gaia build check --hole .`.
-Claims reported as leaves get entries in `priors.py`:
+Each claim reported as a leaf gets a `register_prior(...)` record in
+`priors.py`, emitted in Step 5 via `gaia author register-prior --file
+priors.py` (one invocation per leaf):
 
 ```python
-PRIORS = {
-    <label>: (<float>, "<heuristic tag + LKM context + TODO:review>"),
-}
+register_prior(
+    <label>,
+    value=<float>,
+    justification="<heuristic tag + LKM context + TODO:review>",
+)
 ```
+
+Do **not** write a legacy `PRIORS = {...}` dict — `gaia build compile`
+rejects it with a migration error (`gaia/engine/packaging.py`) because the
+dict form carries no per-source provenance. `register_prior(...)` is the
+only v0.5 prior surface.
 
 The float is a direct judgment of correctness, not LKM match score. Cap source
 claim priors at 0.90. Do not lower a prior solely because the claim has


### PR DESCRIPTION
## Summary

`gaia/_skills/gaia-lkm-explorer/references/step-4-supports-priors-and-review.md`
("Leaf Priors") instructed skill users to author a legacy `PRIORS = {...}`
dict in `priors.py`. **v0.5 `gaia build compile` rejects that form.**

The package loader in `gaia/engine/packaging.py` raises a
`GaiaPackagingError`:

> Error: priors.py exports a `PRIORS = {...}` dict, which is no longer
> supported (removed in v0.5+). Set priors with register_prior() instead.

This change replaces the dict illustration with the
`register_prior(claim, value=..., justification=...)` form — matching the
migration snippet the compiler itself emits — and states explicitly that
the dict is rejected. It aligns step-4 with step-5, which already emits
leaf priors via `gaia author register-prior --file priors.py`.

## Verification

Checked against **engine/CLI source**, not docs:

- `gaia/engine/packaging.py` — the `PRIORS` rejection and its recommended
  `register_prior()` migration message.
- `gaia/engine/lang/dsl/register_prior.py` — `register_prior(claim, value,
  *, justification, source_id=...)` signature; `justification` required.
- `gaia/cli/commands/author/register_prior.py` — the `gaia author
  register-prior` flag surface (`--claim --value --justification --file
  --source-id`).

## Scope note

This is the one confirmed v0.5 drift in the `gaia-lkm-explorer` /
`gaia-formalize-coarse` skills. A separate finding worth a maintainer's
attention: `docs/reference/cli/author.md` is **stale** — it omits the
`--dsl-binding-name` flag entirely and describes `--label` as the binding
flag, whereas the actual CLI (`gaia/cli/commands/author/*.py`) exposes both
`--dsl-binding-name` (Python LHS) and `--label` (engine label), with
`claim.py` enforcing "`--label` requires `--dsl-binding-name`". The skills
themselves use the flags correctly; only the reference doc disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)