### PR TITLE
[codex] Add refs diagnostics to build check

### DIFF
--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -188,7 +188,9 @@ but compiled provenance records them under `artifact_refs`, separate from
 `referenced_claims`.
 
 Run `gaia build check --refs` to see a focused citation/local-reference/artifact
-diagnostic report for a package.
+diagnostic report for a package. In CI, use `gaia build check --refs --gate`
+to fail on hard reference findings such as unresolved bare refs, missing
+artifact files, invalid artifact refs, or legacy reference metadata.
 
 Do not use `observe(source_refs=...)` for new code; put citation markers in
 `rationale`. Also do not put bibliographic citations in

--- a/docs/for-users/language-reference.md
+++ b/docs/for-users/language-reference.md
@@ -187,6 +187,9 @@ Artifact labels resolve through the same local-label syntax as notes and claims,
 but compiled provenance records them under `artifact_refs`, separate from
 `referenced_claims`.
 
+Run `gaia build check --refs` to see a focused citation/local-reference/artifact
+diagnostic report for a package.
+
 Do not use `observe(source_refs=...)` for new code; put citation markers in
 `rationale`. Also do not put bibliographic citations in
 `claim(provenance=[...])`; that field is for Gaia package/version provenance,

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -90,13 +90,13 @@ them using the mapping above.
 > stubs were removed in v0.5.x; the typer-default `No such command`
 > response shown above is the current behavior.
 
-### `check` option flags are unchanged
+### `check` option flags
 
 `gaia build check` keeps the full historical option surface from
-`gaia check`:
+`gaia check` and adds the current refs diagnostic surface:
 
 ```
---brief / --show / --hole / --warrants / --blind / --inquiry / --gate
+--brief / --show / --hole / --warrants / --blind / --inquiry / --gate / --refs
 ```
 
 All flags accept the same values, in the same order, with the same defaults.

--- a/docs/specs/2026-05-23-references-system-consolidation.md
+++ b/docs/specs/2026-05-23-references-system-consolidation.md
@@ -381,7 +381,9 @@ The compiler must never treat these legacy fields as canonical citation data.
 older proposed `gaia lint --refs` shape without adding a new top-level `lint` group. The report
 should summarize `cited_refs`, `referenced_claims`, and `artifact_refs`; list unused
 `references.json` entries; surface unresolved bare `@key` misses; and flag legacy reference
-metadata plus missing package-local artifact files.
+metadata plus missing package-local artifact files. `gaia build check --refs --gate` should fail
+the quality gate on hard reference findings: unresolved bare refs, missing artifact files, invalid
+artifact refs, and legacy reference metadata. Unused bibliography entries remain a diagnostic.
 
 ### 7.2 Renderer
 

--- a/docs/specs/2026-05-23-references-system-consolidation.md
+++ b/docs/specs/2026-05-23-references-system-consolidation.md
@@ -377,6 +377,12 @@ Deprecated legacy fields should be handled explicitly:
 
 The compiler must never treat these legacy fields as canonical citation data.
 
+`gaia build check --refs` is the grouped-CLI home for active refs linting. It supersedes the
+older proposed `gaia lint --refs` shape without adding a new top-level `lint` group. The report
+should summarize `cited_refs`, `referenced_claims`, and `artifact_refs`; list unused
+`references.json` entries; surface unresolved bare `@key` misses; and flag legacy reference
+metadata plus missing package-local artifact files.
+
 ### 7.2 Renderer
 
 Renderer behavior should follow the same three-layer split:
@@ -436,6 +442,7 @@ Skill and docs migration must update repo-bundled sources, not only local user m
 - [x] Update repo-bundled Gaia skills and user docs.
 - [x] Add tests for helper output, schema validation, source resolution, unsafe paths, CLI emission,
       provenance bucket splitting, and local `[@artifact_label]` resolution.
+- [x] Add `gaia build check --refs` as the refs-lint surface for grouped CLI users.
 
 ### PR 2: Renderer consumption
 

--- a/docs/superpowers/plans/2026-05-23-build-check-refs.md
+++ b/docs/superpowers/plans/2026-05-23-build-check-refs.md
@@ -1,0 +1,26 @@
+# Build Check Refs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `gaia build check --refs` as the current grouped-CLI replacement for the old proposed `gaia lint --refs`.
+
+**Architecture:** Keep refs diagnostics inside the existing package check command. Reuse `references.json` loading, the current reference extractor/resolver, and compiled IR provenance instead of creating a new top-level CLI group.
+
+**Tech Stack:** Python 3.12, Typer, Gaia package loader/compiler, pytest.
+
+---
+
+## File Structure
+
+- Modify `gaia/cli/commands/check.py`: add the `--refs` option and refs report helpers.
+- Modify `tests/cli/test_check_refs.py`: cover the CLI-facing report for citation, knowledge, artifact, unresolved-bare, unused, missing-file, and legacy metadata cases.
+- Modify `docs/specs/2026-05-23-references-system-consolidation.md`: record `gaia build check --refs` as the current CLI location for refs linting.
+
+## Task 1: Refs Check CLI Report
+
+- [x] Write a failing test for `gaia build check --refs`.
+- [x] Verify the test fails because `--refs` does not exist.
+- [x] Implement minimal refs diagnostics in `gaia/cli/commands/check.py`.
+- [x] Verify focused tests pass.
+- [x] Update the references consolidation spec.
+- [x] Run lint/format and focused check tests.

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -32,6 +32,8 @@ from gaia.engine.ir.coarsen import ANON_HELPER_PREFIX
 from gaia.engine.ir.logic.propositional import to_sympy_proposition
 from gaia.engine.ir.operator import OperatorType
 from gaia.engine.ir.validator import validate_local_graph
+from gaia.engine.lang.refs import extract, load_references, resolve
+from gaia.engine.lang.runtime.nodes import Step
 from gaia.engine.packaging import (
     GaiaPackagingError,
     apply_package_priors,
@@ -95,6 +97,26 @@ class _InducedMaxEntSummary:
 class _BayesCheckDiagnostics:
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _RefsCheckReport:
+    cited_refs: set[str] = field(default_factory=set)
+    knowledge_refs: set[str] = field(default_factory=set)
+    artifact_refs: set[str] = field(default_factory=set)
+    artifact_source_refs: set[str] = field(default_factory=set)
+    legacy_source_refs: set[str] = field(default_factory=set)
+    unused_citations: set[str] = field(default_factory=set)
+    unresolved_bare_refs: set[str] = field(default_factory=set)
+    missing_artifact_files: list[tuple[str, str]] = field(default_factory=list)
+    invalid_artifact_refs: set[str] = field(default_factory=set)
+    legacy_metadata: list[tuple[str, tuple[str, ...]]] = field(default_factory=list)
+
+
+@dataclass
+class _TextRefsScan:
+    citation_refs: set[str] = field(default_factory=set)
+    unresolved_bare_refs: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -1453,6 +1475,214 @@ def _emit_prior_diagnostic_sections(
             typer.echo(line)
 
 
+def _metadata_gaia(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    gaia_meta = (metadata or {}).get("gaia")
+    return gaia_meta if isinstance(gaia_meta, dict) else {}
+
+
+def _provenance(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    provenance = _metadata_gaia(metadata).get("provenance")
+    return provenance if isinstance(provenance, dict) else {}
+
+
+def _artifact_metadata(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+    artifact = _metadata_gaia(metadata).get("artifact")
+    return artifact if isinstance(artifact, dict) else None
+
+
+def _knowledge_label(knowledge: dict[str, Any]) -> str:
+    return str(knowledge.get("label") or knowledge.get("id") or "<unlabeled>")
+
+
+def _action_label_display(action_label: str) -> str:
+    return action_label.rsplit("::action::", maxsplit=1)[-1]
+
+
+def _compiled_label_table(ir: dict[str, Any], compiled: Any) -> dict[str, bool]:
+    labels: dict[str, bool] = {}
+    for knowledge in ir.get("knowledges", []):
+        label = knowledge.get("label")
+        if label:
+            labels[str(label)] = True
+    for action_label in getattr(compiled, "action_label_map", {}):
+        labels[_action_label_display(str(action_label))] = True
+    return labels
+
+
+def _strategy_reason_texts(strategy: Any) -> Iterator[str]:
+    reason = getattr(strategy, "reason", "")
+    if isinstance(reason, str):
+        if reason:
+            yield reason
+    elif isinstance(reason, list):
+        for entry in reason:
+            if isinstance(entry, str) and entry:
+                yield entry
+            elif isinstance(entry, Step) and entry.reason:
+                yield entry.reason
+    for child in getattr(strategy, "sub_strategies", []):
+        yield from _strategy_reason_texts(child)
+
+
+def _reference_bearing_texts(loaded: Any) -> Iterator[str]:
+    for knowledge in loaded.package.knowledge:
+        if knowledge.content:
+            yield knowledge.content
+    for strategy in loaded.package.strategies:
+        yield from _strategy_reason_texts(strategy)
+    for operator in loaded.package.operators:
+        reason = getattr(operator, "reason", "")
+        if reason:
+            yield reason
+    for action in getattr(loaded.package, "actions", []):
+        rationale = getattr(action, "rationale", "")
+        if rationale:
+            yield rationale
+
+
+def _collect_text_refs(
+    loaded: Any,
+    *,
+    label_table: dict[str, bool],
+    references: dict[str, Any],
+) -> _TextRefsScan:
+    scan = _TextRefsScan()
+    for text in _reference_bearing_texts(loaded):
+        extracted = extract(text)
+        for marker in extracted.markers:
+            kind = resolve(marker.key, label_table, references)
+            if kind == "citation":
+                scan.citation_refs.add(marker.key)
+            elif kind == "unknown" and not marker.strict:
+                scan.unresolved_bare_refs.add(marker.key)
+    return scan
+
+
+def _source_refs(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return {value} if value else set()
+    if isinstance(value, list | tuple | set):
+        return {str(ref) for ref in value if ref}
+    return set()
+
+
+def _add_legacy_source_refs(
+    report: _RefsCheckReport,
+    legacy_keys: list[str],
+    key: str,
+    value: Any,
+) -> None:
+    source_refs = _source_refs(value)
+    if not source_refs:
+        return
+    report.legacy_source_refs.update(source_refs)
+    if key not in legacy_keys:
+        legacy_keys.append(key)
+
+
+def _collect_legacy_reference_metadata(
+    report: _RefsCheckReport,
+    *,
+    label: str,
+    metadata: dict[str, Any],
+) -> None:
+    legacy_keys = [key for key in ("refs", "figure") if key in metadata]
+    _add_legacy_source_refs(report, legacy_keys, "source_refs", metadata.get("source_refs"))
+    observation = metadata.get("observation")
+    if isinstance(observation, dict):
+        _add_legacy_source_refs(
+            report,
+            legacy_keys,
+            "observation.source_refs",
+            observation.get("source_refs"),
+        )
+    supported_by = metadata.get("supported_by")
+    if isinstance(supported_by, list):
+        for entry in supported_by:
+            if isinstance(entry, dict):
+                _add_legacy_source_refs(
+                    report,
+                    legacy_keys,
+                    "observe.source_refs",
+                    entry.get("source_refs"),
+                )
+    if legacy_keys:
+        report.legacy_metadata.append((label, tuple(legacy_keys)))
+
+
+def _collect_refs_check_report(loaded: Any, compiled: Any, ir: dict[str, Any]) -> _RefsCheckReport:
+    references = load_references(loaded.pkg_path / "references.json")
+    text_refs = _collect_text_refs(
+        loaded,
+        label_table=_compiled_label_table(ir, compiled),
+        references=references,
+    )
+    report = _RefsCheckReport()
+    artifact_labels: set[str] = set()
+    report.cited_refs.update(text_refs.citation_refs)
+
+    for knowledge in ir.get("knowledges", []):
+        metadata = knowledge.get("metadata") or {}
+        label = _knowledge_label(knowledge)
+        provenance = _provenance(metadata)
+        report.cited_refs.update(str(ref) for ref in provenance.get("cited_refs", []) if ref)
+        report.knowledge_refs.update(
+            str(ref) for ref in provenance.get("referenced_claims", []) if ref
+        )
+        report.artifact_refs.update(str(ref) for ref in provenance.get("artifact_refs", []) if ref)
+
+        artifact = _artifact_metadata(metadata)
+        if artifact is not None:
+            artifact_labels.add(label)
+            source = artifact.get("source")
+            if source:
+                report.artifact_source_refs.add(str(source))
+            path = artifact.get("path")
+            if path and not (loaded.pkg_path / str(path)).exists():
+                report.missing_artifact_files.append((label, str(path)))
+
+        _collect_legacy_reference_metadata(report, label=label, metadata=metadata)
+
+    report.invalid_artifact_refs = report.artifact_refs.difference(artifact_labels)
+    report.unused_citations = set(references).difference(
+        report.cited_refs | report.artifact_source_refs | report.legacy_source_refs
+    )
+    report.unresolved_bare_refs = text_refs.unresolved_bare_refs
+    report.missing_artifact_files.sort()
+    report.legacy_metadata.sort()
+    return report
+
+
+def _format_ref_set(values: set[str]) -> str:
+    return ", ".join(sorted(values)) if values else "none"
+
+
+def _format_ref_pairs(values: list[tuple[str, str]]) -> str:
+    return ", ".join(f"{label} -> {value}" for label, value in values) if values else "none"
+
+
+def _format_legacy_metadata(values: list[tuple[str, tuple[str, ...]]]) -> str:
+    if not values:
+        return "none"
+    return ", ".join(f"{label} -> {', '.join(keys)}" for label, keys in values)
+
+
+def _emit_refs_check_report(loaded: Any, compiled: Any, ir: dict[str, Any]) -> None:
+    report = _collect_refs_check_report(loaded, compiled, ir)
+    typer.echo("")
+    typer.echo("Reference checks:")
+    typer.echo(f"  Cited refs: {_format_ref_set(report.cited_refs)}")
+    typer.echo(f"  Artifact source refs: {_format_ref_set(report.artifact_source_refs)}")
+    typer.echo(f"  Legacy source refs: {_format_ref_set(report.legacy_source_refs)}")
+    typer.echo(f"  Knowledge refs: {_format_ref_set(report.knowledge_refs)}")
+    typer.echo(f"  Artifact refs: {_format_ref_set(report.artifact_refs)}")
+    typer.echo(f"  Unused citations: {_format_ref_set(report.unused_citations)}")
+    typer.echo(f"  Unresolved bare refs: {_format_ref_set(report.unresolved_bare_refs)}")
+    typer.echo(f"  Missing artifact files: {_format_ref_pairs(report.missing_artifact_files)}")
+    typer.echo(f"  Invalid artifact refs: {_format_ref_set(report.invalid_artifact_refs)}")
+    typer.echo(f"  Legacy reference metadata: {_format_legacy_metadata(report.legacy_metadata)}")
+
+
 def check_command(
     path: str = typer.Argument(".", help="Path to knowledge package directory"),
     brief: bool = typer.Option(
@@ -1489,6 +1719,11 @@ def check_command(
         "--gate",
         help="Run quality gate checks and exit non-zero on failure",
     ),
+    refs: bool = typer.Option(
+        False,
+        "--refs",
+        help="Show reference/citation/artifact diagnostics for this package.",
+    ),
 ) -> None:
     """Validate structure and artifact consistency for a Gaia knowledge package.
 
@@ -1510,6 +1745,7 @@ def check_command(
     * ``--inquiry`` — render goal-oriented inquiry trees
     * ``--gate`` — apply ``[tool.gaia.quality]`` thresholds, exit
       non-zero on failure (CI-friendly)
+    * ``--refs`` — show citation/local-reference/artifact diagnostics
 
     Example:
 
@@ -1517,6 +1753,7 @@ def check_command(
 
         gaia build check .
         gaia build check . --hole
+        gaia build check . --refs
         gaia build check . --gate
     """
     loaded, compiled, ir = _load_check_artifacts(path)
@@ -1528,6 +1765,8 @@ def check_command(
         f"{len(ir['strategies'])} strategies, "
         f"{len(ir['operators'])} operators"
     )
+    if refs:
+        _emit_refs_check_report(loaded, compiled, ir)
 
     review_manifest = None
     induced_summary = None

--- a/gaia/cli/commands/check.py
+++ b/gaia/cli/commands/check.py
@@ -1402,6 +1402,7 @@ def _run_check_quality_gate(
     loaded: Any,
     compiled: Any,
     review_manifest: ReviewManifest,
+    extra_failures: list[str] | None = None,
 ) -> None:
     """Run the quality gate and print its result."""
     from gaia.cli.commands._quality_gate import (
@@ -1420,6 +1421,7 @@ def _run_check_quality_gate(
             config,
             formalization_manifest=compiled.formalization_manifest,
         )
+        failures.extend(extra_failures or [])
     except GaiaPackagingError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -1667,7 +1669,31 @@ def _format_legacy_metadata(values: list[tuple[str, tuple[str, ...]]]) -> str:
     return ", ".join(f"{label} -> {', '.join(keys)}" for label, keys in values)
 
 
-def _emit_refs_check_report(loaded: Any, compiled: Any, ir: dict[str, Any]) -> None:
+def _refs_gate_failures(report: _RefsCheckReport) -> list[str]:
+    failures: list[str] = []
+    if report.unresolved_bare_refs:
+        failures.append(
+            f"Reference check: unresolved bare refs: {_format_ref_set(report.unresolved_bare_refs)}"
+        )
+    if report.missing_artifact_files:
+        failures.append(
+            f"Reference check: missing artifact files: "
+            f"{_format_ref_pairs(report.missing_artifact_files)}"
+        )
+    if report.invalid_artifact_refs:
+        failures.append(
+            f"Reference check: invalid artifact refs: "
+            f"{_format_ref_set(report.invalid_artifact_refs)}"
+        )
+    if report.legacy_metadata:
+        failures.append(
+            f"Reference check: legacy reference metadata: "
+            f"{_format_legacy_metadata(report.legacy_metadata)}"
+        )
+    return failures
+
+
+def _emit_refs_check_report(loaded: Any, compiled: Any, ir: dict[str, Any]) -> _RefsCheckReport:
     report = _collect_refs_check_report(loaded, compiled, ir)
     typer.echo("")
     typer.echo("Reference checks:")
@@ -1681,6 +1707,7 @@ def _emit_refs_check_report(loaded: Any, compiled: Any, ir: dict[str, Any]) -> N
     typer.echo(f"  Missing artifact files: {_format_ref_pairs(report.missing_artifact_files)}")
     typer.echo(f"  Invalid artifact refs: {_format_ref_set(report.invalid_artifact_refs)}")
     typer.echo(f"  Legacy reference metadata: {_format_legacy_metadata(report.legacy_metadata)}")
+    return report
 
 
 def check_command(
@@ -1765,8 +1792,9 @@ def check_command(
         f"{len(ir['strategies'])} strategies, "
         f"{len(ir['operators'])} operators"
     )
+    refs_report = None
     if refs:
-        _emit_refs_check_report(loaded, compiled, ir)
+        refs_report = _emit_refs_check_report(loaded, compiled, ir)
 
     review_manifest = None
     induced_summary = None
@@ -1799,6 +1827,7 @@ def check_command(
             loaded=loaded,
             compiled=compiled,
             review_manifest=review_manifest,
+            extra_failures=_refs_gate_failures(refs_report) if refs_report is not None else None,
         )
 
     if warrants and blind and not (brief or show or hole):

--- a/tests/cli/test_check_refs.py
+++ b/tests/cli/test_check_refs.py
@@ -1,0 +1,183 @@
+"""Tests for ``gaia build check --refs``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from gaia.cli.main import app
+
+pytestmark = pytest.mark.pr_gate
+
+runner = CliRunner()
+
+
+def _write_refs_package(pkg_dir) -> None:
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "refs-check-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    (pkg_dir / "references.json").write_text(
+        json.dumps(
+            {
+                "Bell1964": {"type": "article-journal", "title": "Bell theorem"},
+                "Unused2020": {"type": "article-journal", "title": "Unused paper"},
+            }
+        )
+    )
+    pkg_src = pkg_dir / "refs_check"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.engine.lang import claim, figure\n\n"
+        'lemma = claim("A local lemma.")\n'
+        "fig1 = figure(\n"
+        '    source="Bell1964",\n'
+        '    locator="Fig. 1",\n'
+        '    path="artifacts/figures/missing.png",\n'
+        '    caption="A missing package-local figure.",\n'
+        ")\n"
+        'main = claim("Cites [@Bell1964], uses [@lemma] and [@fig1], and has @typo.")\n'
+        'legacy = claim("Legacy reference metadata.", '
+        'refs=[{"type": "figure", "id": "Fig. 2"}], figure="Fig. 2")\n'
+        '__all__ = ["main"]\n'
+    )
+
+
+def test_check_refs_reports_reference_findings(tmp_path):
+    pkg_dir = tmp_path / "refs_check"
+    _write_refs_package(pkg_dir)
+
+    compile_result = runner.invoke(app, ["build", "compile", str(pkg_dir)])
+    assert compile_result.exit_code == 0, compile_result.output
+
+    result = runner.invoke(app, ["build", "check", "--refs", str(pkg_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "Reference checks:" in result.output
+    assert "Cited refs: Bell1964" in result.output
+    assert "Knowledge refs: lemma" in result.output
+    assert "Artifact refs: fig1" in result.output
+    assert "Unused citations: Unused2020" in result.output
+    assert "Unresolved bare refs: typo" in result.output
+    assert "Missing artifact files: fig1 -> artifacts/figures/missing.png" in result.output
+    assert "Legacy reference metadata: legacy -> refs, figure" in result.output
+
+
+def test_check_refs_counts_legacy_observe_source_refs(tmp_path):
+    pkg_dir = tmp_path / "refs_check_source_refs"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "refs-check-source-refs-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    (pkg_dir / "references.json").write_text(
+        json.dumps(
+            {
+                "Legacy2015": {
+                    "type": "article-journal",
+                    "title": "Legacy observation source",
+                }
+            }
+        )
+    )
+    pkg_src = pkg_dir / "refs_check_source_refs"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.engine.lang import claim, observe\n\n"
+        'hypothesis = claim("A measured claim.")\n'
+        'observe(hypothesis, source_refs=["Legacy2015"], label="legacy_obs")\n'
+        '__all__ = ["hypothesis"]\n'
+    )
+
+    result = runner.invoke(app, ["build", "check", "--refs", str(pkg_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "Legacy source refs: Legacy2015" in result.output
+    assert "Unused citations: none" in result.output
+    assert "Legacy reference metadata: hypothesis -> observe.source_refs" in result.output
+
+
+def test_check_refs_counts_nonlocal_strategy_reason_citations_as_used(tmp_path, monkeypatch):
+    dep_dir = tmp_path / "refs_dep_bridge_root"
+    dep_dir.mkdir()
+    (dep_dir / "pyproject.toml").write_text(
+        '[project]\nname = "refs-dep-bridge-gaia"\nversion = "0.4.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    dep_src = dep_dir / "src" / "refs_dep_bridge"
+    dep_src.mkdir(parents=True)
+    (dep_src / "__init__.py").write_text(
+        "from gaia.engine.lang import claim\nfrom gaia.engine.lang.compat import deduction\n\n"
+        'missing_lemma = claim("A missing lemma.")\n'
+        'main_theorem = claim("Main theorem.")\n'
+        "deduction(premises=[missing_lemma], conclusion=main_theorem)\n"
+        '__all__ = ["main_theorem"]\n'
+    )
+    monkeypatch.syspath_prepend(str(dep_dir / "src"))
+    dep_compile = runner.invoke(app, ["build", "compile", str(dep_dir)])
+    assert dep_compile.exit_code == 0, dep_compile.output
+
+    bridge_dir = tmp_path / "refs_bridge_pkg"
+    bridge_dir.mkdir()
+    (bridge_dir / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "refs-bridge-pkg-gaia"\n'
+        'version = "1.0.0"\n'
+        'dependencies = ["refs-dep-bridge-gaia>=0.4.0"]\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    (bridge_dir / "references.json").write_text(
+        json.dumps(
+            {
+                "Bridge2024": {
+                    "type": "article-journal",
+                    "title": "Bridge citation",
+                }
+            }
+        )
+    )
+    bridge_src = bridge_dir / "refs_bridge_pkg"
+    bridge_src.mkdir()
+    (bridge_src / "__init__.py").write_text(
+        "from gaia.engine.lang import claim\nfrom gaia.engine.lang.compat import fills\n"
+        "from refs_dep_bridge import missing_lemma\n\n"
+        'bridge_result = claim("A new theorem that proves the missing lemma.")\n'
+        "fills(\n"
+        "    source=bridge_result,\n"
+        "    target=missing_lemma,\n"
+        '    reason="Theorem 3 establishes the lemma. See [@Bridge2024].",\n'
+        ")\n"
+        '__all__ = ["bridge_result"]\n'
+    )
+
+    result = runner.invoke(app, ["build", "check", "--refs", str(bridge_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "Cited refs: Bridge2024" in result.output
+    assert "Unused citations: none" in result.output
+
+
+def test_check_refs_reports_unresolved_bare_refs_for_scaffold_action_labels(tmp_path):
+    pkg_dir = tmp_path / "refs_check_scaffold_labels"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "refs-check-scaffold-labels-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n'
+    )
+    pkg_src = pkg_dir / "refs_check_scaffold_labels"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.engine.lang import candidate_relation, claim\n\n"
+        'a = claim("This text mentions @open_relation, but it is not a Knowledge ref.")\n'
+        'b = claim("Second claim.")\n'
+        'candidate_relation(claims=[a, b], label="open_relation")\n'
+        '__all__ = ["a", "b"]\n'
+    )
+
+    result = runner.invoke(app, ["build", "check", "--refs", str(pkg_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "Unresolved bare refs: open_relation" in result.output

--- a/tests/cli/test_check_refs.py
+++ b/tests/cli/test_check_refs.py
@@ -181,3 +181,42 @@ def test_check_refs_reports_unresolved_bare_refs_for_scaffold_action_labels(tmp_
 
     assert result.exit_code == 0, result.output
     assert "Unresolved bare refs: open_relation" in result.output
+
+
+def test_check_refs_gate_fails_on_hard_reference_findings(tmp_path):
+    pkg_dir = tmp_path / "refs_check_gate"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "refs-check-gate-gaia"\nversion = "0.1.0"\n\n'
+        '[tool.gaia]\nnamespace = "github"\ntype = "knowledge-package"\n\n'
+        "[tool.gaia.quality]\nallow_holes = true\n"
+    )
+    (pkg_dir / "references.json").write_text(
+        json.dumps({"Bell1964": {"type": "article-journal", "title": "Bell theorem"}})
+    )
+    pkg_src = pkg_dir / "refs_check_gate"
+    pkg_src.mkdir()
+    (pkg_src / "__init__.py").write_text(
+        "from gaia.engine.lang import figure, note\n\n"
+        "fig1 = figure(\n"
+        '    source="Bell1964",\n'
+        '    locator="Fig. 1",\n'
+        '    path="artifacts/figures/missing.png",\n'
+        '    caption="Missing figure.",\n'
+        ")\n"
+        'main = note("A note with @typo and [@fig1].")\n'
+        'legacy = note("Legacy reference metadata.", '
+        'refs=[{"type": "figure", "id": "Fig. 2"}], figure="Fig. 2")\n'
+        '__all__ = ["main"]\n'
+    )
+
+    result = runner.invoke(app, ["build", "check", "--refs", "--gate", str(pkg_dir)])
+
+    assert result.exit_code != 0
+    assert "Quality gate failed:" in result.output
+    assert "Reference check: unresolved bare refs: typo" in result.output
+    assert (
+        "Reference check: missing artifact files: fig1 -> artifacts/figures/missing.png"
+        in result.output
+    )
+    assert "Reference check: legacy reference metadata: legacy -> refs, figure" in result.output


### PR DESCRIPTION
## Summary
- Add gaia build check --refs to report citation, local knowledge, artifact, unused citation, unresolved bare-ref, missing artifact file, invalid artifact ref, and legacy reference metadata diagnostics.
- Reuse compiled IR/action targets for reference resolution so scaffold-only action labels do not mask unresolved bare refs.
- Count legacy observe(source_refs=...), artifact sources, and non-local strategy reason citations as used references without expanding the author-facing API surface.

## Test Plan
- python -m pytest tests/cli/test_check_refs.py tests/cli/test_check.py -q
- uv run ruff check gaia/cli/commands/check.py tests/cli/test_check_refs.py
- uv run ruff format --check gaia/cli/commands/check.py tests/cli/test_check_refs.py
- git diff --check