### PR TITLE
feat(exploration): formalize pulled-paper reasoning into BP at the explorer checkpoint

### DIFF
--- a/gaia/engine/exploration/promote.py
+++ b/gaia/engine/exploration/promote.py
@@ -1,0 +1,280 @@
+"""Explorer-only promotion of pulled-paper ``depends_on`` scaffolds to ``derive``.
+
+When the explorer expands a node it pulls a whole paper via
+``gaia pkg add --lkm-paper <id>`` (``cli/commands/pkg/lkm_materialize.py``). That
+materialization emits every paper factor as an INERT ``depends_on(...)`` scaffold
+(recorded in the dependency sub-package's formalization manifest, never lowered
+into the factor graph). ``depends_on`` is "the authoring-scaffold counterpart of
+``derive(...)``" — it preserves premise→conclusion structure but does **not**
+enter belief propagation (BP).
+
+For *graph exploration* (the explorer's purpose), a pulled paper's internal
+reasoning should be live: each ``depends_on(conclusion, given=[...])`` should
+behave like ``derive(conclusion, given=[...])`` so the paper's factors enter BP
+and show up on the map. This module performs that promotion **at the explorer
+checkpoint only** — ``gaia pkg add`` / ``lkm_materialize`` stay neutral (they keep
+emitting the scaffold for general use).
+
+Mechanism (the cleanest seam, per the action graph):
+
+* Each pulled paper lands as an editable ``-gaia`` **dependency sub-package**
+  under ``<root>/.gaia/lkm_packages/<dist>/``. Its ``depends_on`` scaffolds live in
+  that sub-package's source ``__init__.py`` (and, after compile, its manifest) —
+  NOT in the root.
+* :func:`promote_dependency_graphs` resolves every such dependency **by path**
+  (reusing the frontier's path-based resolver — no ``import_module``), loads each
+  from source, and rewrites its in-memory action list: every :class:`DependsOn`
+  action is replaced with an equivalent :class:`Derive` (same conclusion / given /
+  rationale / label, with the scaffold's provenance ``metadata`` folded into the
+  derive ``rationale`` since ``derive`` has no ``metadata=`` kwarg). The promoted
+  package is then compiled — the derives lower into the dependency's IR as
+  strategies that enter BP.
+* The orchestrator's checkpoint lowers each promoted dependency graph + the root
+  and merges them (``merge_factor_graphs``, exactly like ``gaia run infer
+  --depth -1``) so BP runs over the **joint** graph and the promoted derives move
+  belief.
+
+A factor that cannot form a valid ``derive`` (no conclusion, or no given Claims —
+the same conditions ``lkm_materialize`` already skips) is skipped and counted,
+never crashed on. A dependency that cannot be loaded/compiled degrades to a
+warning, never breaks the checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from gaia.engine.ir.graphs import LocalCanonicalGraph
+
+
+@dataclass
+class PromotedDependency:
+    """One promoted dependency sub-package, ready for joint inference.
+
+    Attributes:
+        import_name: The dependency's import name (used as the merge prefix's
+            disambiguator and in ``merge_factor_graphs`` factor-id prefixing).
+        root: The dependency package directory on disk.
+        graph: The recompiled :class:`LocalCanonicalGraph` with the paper's
+            ``depends_on`` scaffolds promoted to live ``derive`` strategies.
+        promoted: Number of ``depends_on`` scaffolds promoted to ``derive``.
+        skipped: Number of scaffolds skipped (no conclusion / no given Claims).
+    """
+
+    import_name: str
+    root: Path
+    graph: LocalCanonicalGraph
+    promoted: int
+    skipped: int
+
+
+@dataclass
+class PromotionResult:
+    """The outcome of promoting every pulled-paper dependency (checkpoint use).
+
+    Attributes:
+        dependencies: One :class:`PromotedDependency` per loadable ``-gaia`` dep.
+        warnings: Human-readable notes about anything skipped or degraded (a dep
+            that could not be loaded/compiled, etc.) — never fatal.
+    """
+
+    dependencies: list[PromotedDependency] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def total_promoted(self) -> int:
+        """Total ``depends_on`` scaffolds promoted to ``derive`` across all deps."""
+        return sum(d.promoted for d in self.dependencies)
+
+    @property
+    def total_skipped(self) -> int:
+        """Total scaffolds skipped (unpromotable) across all deps."""
+        return sum(d.skipped for d in self.dependencies)
+
+
+def _fold_provenance_into_rationale(rationale: str, metadata: dict[str, Any]) -> str:
+    """Preserve the scaffold's provenance ``metadata`` on the promoted derive.
+
+    ``derive(...)`` has no ``metadata=`` kwarg (unlike ``depends_on``), so the
+    scaffold's provider/index/paper/doi/factor provenance cannot move onto the
+    derive as ``metadata=``. We fold the non-empty provenance keys into the
+    derive's ``rationale`` (appended as a compact ``provenance: {...}`` tail) so
+    the audit trail is not dropped. The conclusion/given Claims keep their own
+    ``metadata`` (which ``lkm_materialize`` already stamps with the same
+    provenance), so this is belt-and-suspenders, not the sole carrier.
+    """
+    clean = {k: v for k, v in metadata.items() if v is not None}
+    if not clean:
+        return rationale
+    tail = "provenance: " + json.dumps(clean, ensure_ascii=False, sort_keys=True)
+    return f"{rationale}\n\n{tail}" if rationale else tail
+
+
+def promote_actions_in_place(pkg: Any) -> tuple[int, int]:
+    """Rewrite a loaded package's actions: ``DependsOn`` → ``Derive`` (in place).
+
+    Walks ``pkg.actions`` and replaces every :class:`DependsOn` with an equivalent
+    :class:`Derive` carrying the same ``conclusion`` / ``given`` / ``label``, the
+    scaffold's ``rationale`` (with provenance folded in), and a freshly built
+    implication warrant attached to the conclusion (the step that makes a
+    conclusion enter BP). The replacement preserves action order so QID/label
+    minting stays stable.
+
+    A scaffold with no ``conclusion`` or no ``given`` Claims cannot form a valid
+    derive (the same condition ``lkm_materialize`` skips at authoring time) and is
+    dropped from the action list and counted as skipped.
+
+    Args:
+        pkg: A ``CollectedPackage`` (``loaded.package``) whose ``actions`` are
+            rewritten in place.
+
+    Returns:
+        ``(promoted, skipped)`` counts.
+    """
+    # Build the warrant the same way the `derive(...)` DSL helper does, so a
+    # promoted derive is byte-for-byte the derive an author would have written.
+    from gaia.engine.lang.dsl.support import _implication_warrant
+    from gaia.engine.lang.runtime.action import (
+        DependsOn,
+        Derive,
+        attach_reasoning,
+        validate_no_self_warrant,
+    )
+    from gaia.engine.lang.runtime.knowledge import Claim
+
+    promoted = 0
+    skipped = 0
+    new_actions: list[Any] = []
+    for action in pkg.actions:
+        if not isinstance(action, DependsOn):
+            new_actions.append(action)
+            continue
+        conclusion = action.conclusion
+        given = tuple(g for g in action.given if isinstance(g, Claim))
+        if not isinstance(conclusion, Claim) or not given:
+            # Cannot form a valid derive — skip (do not re-emit the scaffold:
+            # explorer wants live reasoning, and a lone scaffold here would just
+            # re-appear as an inert manifest record).
+            skipped += 1
+            continue
+        rationale = _fold_provenance_into_rationale(action.rationale, dict(action.metadata or {}))
+        warrant = _implication_warrant(
+            "derive",
+            given=given,
+            conclusion=conclusion,
+            rationale=rationale,
+        )
+        derive = Derive(
+            label=action.label,
+            rationale=rationale,
+            background=list(action.background or []),
+            warrants=[warrant],
+            conclusion=conclusion,
+            given=given,
+        )
+        validate_no_self_warrant(derive, conclusion)
+        attach_reasoning(conclusion, derive)
+        new_actions.append(derive)
+        promoted += 1
+
+    pkg.actions = new_actions
+    return promoted, skipped
+
+
+def _promote_one_dependency(dep_root: Path) -> PromotedDependency | None:
+    """Load a dependency from source, promote its scaffolds, recompile its IR.
+
+    Returns ``None`` (caller warns) if the dependency cannot be loaded/compiled.
+    """
+    from gaia.engine.ir import LocalCanonicalGraph
+    from gaia.engine.ir.validator import validate_local_graph
+    from gaia.engine.packaging import (
+        GaiaPackagingError,
+        apply_package_priors,
+        compile_loaded_package_artifact,
+        load_gaia_package,
+    )
+
+    loaded = load_gaia_package(str(dep_root))
+    promoted, skipped = promote_actions_in_place(loaded.package)
+    apply_package_priors(loaded)
+    compiled = compile_loaded_package_artifact(loaded)
+    ir = compiled.to_json()
+    validation = validate_local_graph(LocalCanonicalGraph(**ir))
+    if validation.errors:
+        raise GaiaPackagingError(
+            "promoted dependency did not compile cleanly: " + "; ".join(validation.errors)
+        )
+    return PromotedDependency(
+        import_name=loaded.import_name,
+        root=dep_root,
+        graph=compiled.graph,
+        promoted=promoted,
+        skipped=skipped,
+    )
+
+
+def promote_dependency_graphs(root_path: str | Path) -> PromotionResult:
+    """Promote every pulled-paper dependency's ``depends_on`` to live ``derive``.
+
+    Resolves the root package's ``-gaia`` dependencies **by path** (reusing the
+    frontier's path resolver, so no ``import_module`` is needed for an editable
+    ``pkg add --lkm-paper`` dep), and for each one loads it from source, rewrites
+    its ``depends_on`` scaffolds into ``derive`` actions, and recompiles it. The
+    returned promoted graphs are merged with the root in joint BP by the caller.
+
+    Robustness: a dependency that cannot be resolved on disk, loaded, or compiled
+    degrades to a :attr:`PromotionResult.warnings` entry — it is simply absent
+    from the joint inference rather than crashing the checkpoint.
+
+    Args:
+        root_path: The root exploration package directory.
+
+    Returns:
+        A :class:`PromotionResult` with one entry per promoted dependency.
+    """
+    from gaia.engine.exploration.frontier import _load_deps_by_path
+
+    result = PromotionResult()
+    root = Path(root_path).resolve()
+    resolution = _load_deps_by_path(root)
+
+    # Resolve dep roots for everything the by-path scan located with a compiled
+    # IR (``loaded``) — those are the deps we recompile from source with
+    # promotion. ``uncompiled`` / ``unresolved`` deps simply do not participate
+    # (they would not have been in the joint frontier view either).
+    seen: set[Path] = set()
+    for dep_root, _dep_graph in resolution.loaded:
+        dep_root = dep_root.resolve()
+        if dep_root in seen:
+            continue
+        seen.add(dep_root)
+        try:
+            promoted = _promote_one_dependency(dep_root)
+        except Exception as exc:  # degrade, never crash the checkpoint
+            result.warnings.append(
+                f"could not promote dependency at {dep_root} "
+                f"({type(exc).__name__}: {exc}); its reasoning will not enter BP this turn"
+            )
+            continue
+        if promoted is not None:
+            result.dependencies.append(promoted)
+
+    for dist_name in resolution.uncompiled:
+        result.warnings.append(
+            f"dependency {dist_name!r} is present but not compiled; "
+            "its reasoning will not enter BP (run `gaia build compile` on it)"
+        )
+    return result
+
+
+__all__ = [
+    "PromotedDependency",
+    "PromotionResult",
+    "promote_actions_in_place",
+    "promote_dependency_graphs",
+]

--- a/gaia/explore_client/instructions.py
+++ b/gaia/explore_client/instructions.py
@@ -52,6 +52,14 @@ target), rather than restating them locally. ``lkm_no_chain`` source claims are
 demoted to the explicit fallback for evidence you could not pull or that is
 genuinely chain-less. Pairs with the frontier now surfacing a pulled paper's
 not-yet-formalized claims as ``depends_on`` contacts (the formalize worklist).
+
+Build 17 (checkpoint-formalize): the v1-limits now state that a pulled paper's
+OWN internal reasoning enters BP automatically at the checkpoint — the
+orchestrator promotes each pulled-paper ``depends_on`` factor to live ``derive``
+and infers over the joint (root + pulled-paper) graph
+(:mod:`gaia.engine.exploration.promote`). Step 3b (connecting a pulled paper UP to
+the ROOT reasoning) is unchanged and stays the agent's manual job; the auto-promo
+covers only the paper's intra-paper factors.
 """
 
 from __future__ import annotations
@@ -84,10 +92,17 @@ materialize them into the Gaia package. The engine then adjudicates the
 - The frontier grows primarily from `lkm_related` contacts. Each survey's
   `gaia search lkm` returns related papers you haven't pulled; feeding that JSON
   to `gaia-lkm-explore observe` records them as `lkm_related` paper-contacts — the
-  primary expansion signal. `depends_on` contacts (from a pulled paper's
-  formalization manifest) are a secondary, intra-survey signal. If you neither
-  observe related papers nor pull a paper, the frontier can go empty — expected,
-  not a bug. So observe every search, and pull at least one paper per turn.
+  primary expansion signal. `depends_on` contacts (a pulled paper's claims not yet
+  wired into YOUR root reasoning) are a secondary, intra-survey signal. If you
+  neither observe related papers nor pull a paper, the frontier can go empty —
+  expected, not a bug. So observe every search, and pull at least one paper per turn.
+- A pulled paper's OWN internal reasoning goes live automatically. When you
+  re-invoke `gaia-lkm-explore turn`, the checkpoint promotes each pulled paper's
+  intra-paper `depends_on` factors to live `derive` and infers over the joint
+  (root + pulled-paper) graph — so a pulled paper's internal premise→conclusion
+  structure enters belief propagation and moves belief on the map without any
+  manual step. What still needs YOUR hand (step 3b) is connecting the pulled
+  paper UP to your root reasoning — the `depends_on` contacts are that worklist.
 - Survey-facing contact signals: `closeness_to_seed` (relevance),
   `new_territory` (coverage; live for lkm contacts only), `obligation_pressure`
   (1.0 iff the contact discharges an open obligation you marked — see "Mark

--- a/gaia/explore_client/orchestrator.py
+++ b/gaia/explore_client/orchestrator.py
@@ -239,20 +239,34 @@ def _resolve_seeds(exploration_map: ExplorationMap, graph: Any, view: JointView)
     return changed
 
 
-def _compile_and_infer(pkg: str | Path) -> None:
-    """Compile the package then run BP inference, writing artifacts (SDK).
+def _compile_and_infer(pkg: str | Path) -> list[str]:
+    """Compile the package then run JOINT BP inference, writing artifacts (SDK).
 
-    Mirrors what ``gaia build compile`` + ``gaia run infer`` do, but called
-    programmatically through the engine packaging / BP SDK rather than by
+    Mirrors what ``gaia build compile`` + ``gaia run infer --depth -1`` do, but
+    called programmatically through the engine packaging / BP SDK rather than by
     shelling out to the ``gaia`` CLI (CLIENT.md "Resolved: compile/infer via the
     SDK"). Writes ``.gaia/ir.json`` (+ manifests) and ``.gaia/beliefs.json`` — the
     artifacts the subsequent round step diffs.
+
+    **Explorer promotion (this build).** Before inference, every pulled-paper
+    ``-gaia`` dependency is recompiled from source with its inert ``depends_on``
+    scaffolds promoted to live ``derive`` reasoning (see
+    :mod:`gaia.engine.exploration.promote`), and the promoted dependency factor
+    graphs are merged into the root's (``merge_factor_graphs``, exactly like
+    ``infer --depth -1``). This is what makes a pulled paper's internal reasoning
+    enter BP and move belief on the map — root-only / depth-0 inference would
+    leave the paper's factors out of the graph entirely, making promotion a no-op.
+
+    Returns the list of human-readable promotion/joint-view notes (counts of
+    promoted derives, skipped factors, and any degraded dependency) for the
+    checkpoint to surface.
     """
     import json
     from dataclasses import asdict as _asdict
 
-    from gaia.engine.bp import lower_local_graph
+    from gaia.engine.bp import lower_local_graph, merge_factor_graphs
     from gaia.engine.bp.engine import InferenceEngine
+    from gaia.engine.exploration.promote import promote_dependency_graphs
     from gaia.engine.ir import LocalCanonicalGraph
     from gaia.engine.ir.validator import validate_local_graph
     from gaia.engine.packaging import (
@@ -288,14 +302,58 @@ def _compile_and_infer(pkg: str | Path) -> None:
         formalization_manifest=compiled.formalization_manifest,
     )
 
-    # Inference (flat priors — depth 0; the round diffs root beliefs).
-    factor_graph = lower_local_graph(compiled.graph)
+    notes: list[str] = []
+
+    # (explorer promotion) Recompile each pulled-paper dependency from source with
+    # its `depends_on` scaffolds promoted to live `derive`, so the paper's
+    # internal reasoning is in the factor graph. Degrades to warnings; never
+    # crashes the checkpoint.
+    try:
+        promotion = promote_dependency_graphs(pkg_path)
+    except Exception as exc:  # promotion must never break a checkpoint
+        promotion = None
+        notes.append(f"dependency promotion skipped ({type(exc).__name__}: {exc})")
+    dep_factor_graphs: list[tuple[str, Any, str]] = []
+    if promotion is not None:
+        notes.extend(promotion.warnings)
+        for dep in promotion.dependencies:
+            dep_fg = lower_local_graph(dep.graph)
+            dep_prefix = f"{dep.graph.namespace}:{dep.graph.package_name}::"
+            dep_factor_graphs.append((dep.import_name, dep_fg, dep_prefix))
+        if promotion.dependencies:
+            notes.append(
+                f"promoted {promotion.total_promoted} pulled-paper depends_on edge(s) "
+                f"to live derive across {len(promotion.dependencies)} dependency package(s)"
+                + (
+                    f" (skipped {promotion.total_skipped} unpromotable factor(s))"
+                    if promotion.total_skipped
+                    else ""
+                )
+            )
+
+    # Joint inference: merge the promoted dependency factor graphs into the root's
+    # (like `gaia run infer --depth -1`). With no deps this is the root graph alone
+    # (flat priors — the round diffs root beliefs).
+    local_fg = lower_local_graph(compiled.graph)
+    if dep_factor_graphs:
+        local_prefix = f"{compiled.graph.namespace}:{compiled.graph.package_name}::"
+        factor_graph = merge_factor_graphs(local_fg, dep_factor_graphs, local_prefix=local_prefix)
+    else:
+        factor_graph = local_fg
     fg_errors = factor_graph.validate()
     if fg_errors:
         raise OrchestratorError("inference failed: " + "; ".join(fg_errors))
     result = InferenceEngine().run(factor_graph).result
 
+    # Beliefs span the JOINT graph: root knowledges + every promoted dependency's
+    # knowledges, so a pulled paper's now-live claims surface their belief on the
+    # map (not just the root's). Each QID is globally unique (namespace:pkg::label
+    # prefixed), so the union is collision-free.
     knowledge_by_id = {k.id: k for k in compiled.graph.knowledges}
+    if promotion is not None:
+        for dep in promotion.dependencies:
+            for k in dep.graph.knowledges:
+                knowledge_by_id.setdefault(k.id, k)
     beliefs_payload = {
         "ir_hash": compiled.graph.ir_hash,
         "gaia_lang_version": gaia_lang_version(),
@@ -316,6 +374,7 @@ def _compile_and_infer(pkg: str | Path) -> None:
         json.dumps(beliefs_payload, ensure_ascii=False, indent=2, sort_keys=True),
         encoding="utf-8",
     )
+    return notes
 
 
 def _rank_open_contacts(exploration_map: ExplorationMap) -> list[Contact]:
@@ -604,8 +663,10 @@ def _checkpoint(
     messages: list[str] = []
     current_round = exploration_map.round
 
-    # Recompute belief through the SDK (never shelling out to gaia).
-    _compile_and_infer(pkg)
+    # Recompute belief through the SDK (never shelling out to gaia). This also
+    # promotes each pulled-paper dependency's depends_on scaffolds to live derive
+    # and infers over the joint graph, so the paper's reasoning enters BP.
+    messages.extend(_compile_and_infer(pkg) or [])
 
     graph = _resolve_graph(pkg)
     if graph is None:

--- a/tests/exploration/test_promote.py
+++ b/tests/exploration/test_promote.py
@@ -1,0 +1,321 @@
+"""Tests for explorer-only depends_on → derive promotion at the checkpoint.
+
+The supervisor's gap: a paper pulled via ``gaia pkg add --lkm-paper`` lands as a
+dependency sub-package whose factors are emitted as INERT ``depends_on`` scaffolds
+(recorded in the manifest, never lowered into BP). For *graph exploration* the
+paper's internal reasoning should be live. These tests cover the two layers of the
+fix:
+
+* :func:`promote_actions_in_place` — the in-memory action-graph rewrite
+  (``DependsOn`` → ``Derive``), including skipping a scaffold that cannot form a
+  valid derive and folding provenance metadata into the derive rationale; and
+* the **RISK proof + the fix**: that the orchestrator checkpoint
+  (``_compile_and_infer``) (a) without promotion would leave a pulled dependency's
+  factors out of BP entirely (root-only inference), and (b) WITH promotion +
+  joint inference, the dependency's promoted derive moves its conclusion belief
+  and the conclusion QID surfaces in the joint ``beliefs.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.pr_gate
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — promote_actions_in_place (pure action-graph rewrite)              #
+# --------------------------------------------------------------------------- #
+
+
+def test_promote_actions_rewrites_depends_on_to_derive():
+    """A ``depends_on`` action becomes a ``Derive`` that enters BP (attaches reasoning)."""
+    from gaia.engine.exploration.promote import promote_actions_in_place
+    from gaia.engine.lang.dsl.scaffold import depends_on
+    from gaia.engine.lang.runtime.action import DependsOn, Derive
+    from gaia.engine.lang.runtime.knowledge import Claim
+    from gaia.engine.lang.runtime.package import CollectedPackage
+
+    with CollectedPackage("pkg", namespace="lkm") as pkg:
+        premise = Claim("the premise", label="p1")
+        conclusion = Claim("the conclusion", label="c1")
+        depends_on(
+            conclusion,
+            given=[premise],
+            rationale="because reasons",
+            label="lkm_factor_0",
+            metadata={"provider": "lkm", "paper_id": "42", "doi": None},
+        )
+
+    assert any(isinstance(a, DependsOn) for a in pkg.actions)
+    promoted, skipped = promote_actions_in_place(pkg)
+
+    assert (promoted, skipped) == (1, 0)
+    # The scaffold is gone; a Derive took its place, preserving label + given.
+    assert not any(isinstance(a, DependsOn) for a in pkg.actions)
+    derives = [a for a in pkg.actions if isinstance(a, Derive)]
+    assert len(derives) == 1
+    d = derives[0]
+    assert d.label == "lkm_factor_0"
+    assert d.conclusion is conclusion
+    assert d.given == (premise,)
+    # provenance metadata is folded into the rationale (derive has no metadata=).
+    assert "provenance:" in d.rationale and "paper_id" in d.rationale
+    assert "because reasons" in d.rationale
+    # A None metadata value is dropped from the folded provenance.
+    assert "doi" not in d.rationale
+    # The conclusion now carries the derive as reasoning — the BP-entry hook.
+    assert any(r is d for r in conclusion.from_actions)
+
+
+def test_promote_actions_skips_unpromotable_scaffold():
+    """A scaffold with no given Claims cannot derive — it is skipped + counted."""
+    from gaia.engine.exploration.promote import promote_actions_in_place
+    from gaia.engine.lang.runtime.action import DependsOn, Derive
+    from gaia.engine.lang.runtime.knowledge import Claim
+    from gaia.engine.lang.runtime.package import CollectedPackage
+
+    with CollectedPackage("pkg", namespace="lkm") as pkg:
+        conclusion = Claim("the conclusion", label="c1")
+        # Construct a malformed scaffold directly (no given) — the kind the
+        # materializer would never emit, but promotion must tolerate.
+        DependsOn(label="bad", conclusion=conclusion, given=())
+
+    promoted, skipped = promote_actions_in_place(pkg)
+    assert (promoted, skipped) == (0, 1)
+    assert not any(isinstance(a, (DependsOn, Derive)) for a in pkg.actions)
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — checkpoint joint inference proof (RISK + fix)                      #
+# --------------------------------------------------------------------------- #
+
+
+def _write_dep_package(dep_root: Path) -> None:
+    """A dependency package with a high-prior premise → depends_on conclusion.
+
+    Mirrors the shape ``lkm_materialize`` produces: claims + a ``depends_on``
+    scaffold. The premise carries a strong prior so a *live* derive would pull the
+    conclusion's belief well above the flat 0.5 — making the BP effect observable.
+    """
+    src = dep_root / "src" / "deppkg"
+    src.mkdir(parents=True, exist_ok=True)
+    (dep_root / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "deppkg-gaia"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+            dependencies = []
+
+            [build-system]
+            requires = ["hatchling"]
+            build-backend = "hatchling.build"
+
+            [tool.hatch.build.targets.wheel]
+            packages = ["src/deppkg"]
+
+            [tool.gaia]
+            type = "knowledge-package"
+            namespace = "lkm"
+
+            [tool.gaia.source]
+            provider = "lkm"
+            kind = "paper"
+            paper_id = "999"
+            """
+        ),
+        encoding="utf-8",
+    )
+    (src / "__init__.py").write_text(
+        textwrap.dedent(
+            """\
+            from gaia.engine.lang import claim, depends_on, register_prior
+
+            premise = claim("strong premise", title="premise")
+            conclusion = claim("dependent conclusion", title="conclusion")
+
+            register_prior(premise, value=0.95, justification="test")
+
+            lkm_factor_0 = depends_on(
+                conclusion,
+                given=[premise],
+                rationale="paper factor",
+                label="lkm_factor_0",
+                metadata={"provider": "lkm", "paper_id": "999"},
+            )
+
+            __all__ = ["premise", "conclusion"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_root_package(root: Path, dep_rel_path: str) -> None:
+    """A minimal root exploration package depending on the dep BY PATH."""
+    src = root / "src" / "rootpkg"
+    src.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [project]
+            name = "rootpkg-gaia"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+            dependencies = ["deppkg-gaia"]
+
+            [build-system]
+            requires = ["hatchling"]
+            build-backend = "hatchling.build"
+
+            [tool.hatch.build.targets.wheel]
+            packages = ["src/rootpkg"]
+
+            [tool.gaia]
+            type = "knowledge-package"
+            namespace = "example"
+
+            [tool.uv.sources]
+            deppkg-gaia = {{ path = "{dep_rel_path}", editable = true }}
+            """
+        ),
+        encoding="utf-8",
+    )
+    (src / "__init__.py").write_text(
+        textwrap.dedent(
+            """\
+            from gaia.engine.lang import claim
+
+            root_seed = claim("the root seed claim", title="seed")
+
+            __all__ = ["root_seed"]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _compile_dep(dep_root: Path) -> None:
+    """Compile the dependency to disk as the NEUTRAL (depends_on) artifact.
+
+    This is the state ``pkg add --lkm-paper`` leaves: the dep's ``.gaia/ir.json``
+    has NO strategy for the factor (it is in the manifest). The checkpoint must
+    recompile-with-promotion to make it live.
+    """
+    from gaia.engine.ir import LocalCanonicalGraph
+    from gaia.engine.packaging import (
+        apply_package_priors,
+        build_package_manifests,
+        compile_loaded_package_artifact,
+        load_gaia_package,
+        write_compiled_artifacts,
+    )
+
+    loaded = load_gaia_package(str(dep_root))
+    apply_package_priors(loaded)
+    compiled = compile_loaded_package_artifact(loaded)
+    ir = compiled.to_json()
+    manifests = build_package_manifests(loaded, compiled)
+    write_compiled_artifacts(
+        loaded.pkg_path,
+        ir,
+        manifests=manifests,
+        formalization_manifest=compiled.formalization_manifest,
+    )
+    # Sanity: the neutral compile records the factor as an inert depends_on
+    # manifest record and NOT a strategy.
+    graph = LocalCanonicalGraph(**ir)
+    assert not graph.strategies, "neutral dep compile should have no strategy"
+    deps = compiled.formalization_manifest["dependencies"]
+    assert any(r.get("kind") == "depends_on" for r in deps)
+
+
+def test_checkpoint_promotes_dependency_reasoning_into_bp(tmp_path: Path):
+    """RISK proof + fix: a pulled dep's depends_on enters BP only via promotion.
+
+    Builds a root package depending (by path) on a dep package carrying a
+    high-prior premise → ``depends_on`` conclusion (the ``pkg add --lkm-paper``
+    shape). Runs the orchestrator's ``_compile_and_infer``:
+
+    * the dep's conclusion QID appears in the JOINT ``beliefs.json`` (root-only
+      inference would never include a dependency node), and
+    * its belief is pulled WELL above the flat 0.5 prior by the now-live derive
+      from the strong premise — proving the promoted derive entered BP and moved
+      belief.
+    """
+    from gaia.explore_client.orchestrator import _compile_and_infer
+
+    dep_root = tmp_path / "deppkg"
+    root = tmp_path / "rootpkg"
+    _write_dep_package(dep_root)
+    _write_root_package(root, dep_rel_path="../deppkg")
+    _compile_dep(dep_root)
+
+    notes = _compile_and_infer(root)
+
+    # The checkpoint reported the promotion.
+    assert any("promoted" in n and "derive" in n for n in notes), notes
+
+    beliefs_path = root / ".gaia" / "beliefs.json"
+    assert beliefs_path.exists()
+    payload = json.loads(beliefs_path.read_text(encoding="utf-8"))
+    by_id = {b["knowledge_id"]: b["belief"] for b in payload["beliefs"]}
+
+    concl_qid = "lkm:deppkg::conclusion"
+    premise_qid = "lkm:deppkg::premise"
+    # The dep nodes are in the JOINT beliefs (root-only inference would omit them).
+    assert concl_qid in by_id, f"dep conclusion missing from joint beliefs: {sorted(by_id)}"
+    assert premise_qid in by_id
+    # The strong premise (prior ~0.95) pulled the conclusion's belief up via the
+    # promoted derive — well above the flat 0.5 a non-live (depends_on) factor or
+    # an unconnected node would sit at.
+    assert by_id[premise_qid] > 0.9
+    assert by_id[concl_qid] > 0.6, by_id[concl_qid]
+
+
+def test_compile_and_infer_no_deps_is_root_only(tmp_path: Path):
+    """With no -gaia deps, the checkpoint is plain root inference (no promotion)."""
+    from gaia.explore_client.orchestrator import _compile_and_infer
+
+    root = tmp_path / "solo"
+    src = root / "src" / "solo"
+    src.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "solo-gaia"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+            dependencies = []
+
+            [build-system]
+            requires = ["hatchling"]
+            build-backend = "hatchling.build"
+
+            [tool.hatch.build.targets.wheel]
+            packages = ["src/solo"]
+
+            [tool.gaia]
+            type = "knowledge-package"
+            namespace = "example"
+            """
+        ),
+        encoding="utf-8",
+    )
+    (src / "__init__.py").write_text(
+        "from gaia.engine.lang import claim\n\nseed = claim('a seed', title='seed')\n\n"
+        "__all__ = ['seed']\n",
+        encoding="utf-8",
+    )
+
+    notes = _compile_and_infer(root)
+    # No deps -> no promotion note.
+    assert not any("promoted" in n for n in notes)
+    assert (root / ".gaia" / "beliefs.json").exists()


### PR DESCRIPTION
## What & why

When the explorer expands a node it pulls a **whole paper** (`gaia pkg add --lkm-paper` — the only granularity). Those pulls auto-emit `depends_on` scaffolds, which are **inert**: they record premise→conclusion structure but never enter belief propagation. So a pulled paper's internal reasoning stayed dark on the map until hand-formalized.

This makes a pulled paper's internal reasoning **live automatically**, at the exploration turn **checkpoint** — without changing `gaia pkg add` / `lkm_materialize` (those stay neutral; the scaffold remains the general-purpose default). The "make it live reasoning" decision lives where the exploration intent is: the orchestrator.

## Key realization

Promotion alone was a **no-op**: the checkpoint inferred **root-only / depth-0**, so a pulled dependency's factors were never in the inferred graph regardless of `depends_on` vs `derive`. The fix had to be **paired with joint inference**.

## Changes

- **`gaia/engine/exploration/promote.py`** (new) — promotes each pulled `-gaia` dependency's `DependsOn` → `Derive` on the loaded action graph (resolved **by path**, no `import_module`), building the warrant + `attach_reasoning` exactly as the `derive()` DSL helper does, then recompiles. Unpromotable factors (no conclusion / no given) are skipped + counted, never crash the checkpoint. `depends_on` provenance metadata is folded into the derive `rationale` (derive takes no `metadata=`).
- **`gaia/explore_client/orchestrator.py`** — `_compile_and_infer` now lowers + **merges dependency factor graphs** into the root's (joint inference, like `infer --depth -1`) and infers over the joint graph; `beliefs.json` now spans root + promoted-dependency nodes. Promotion notes surface in the turn outcome.
- **`gaia/explore_client/instructions.py`** — reconciled the frontier "formalize worklist": two senses of *formalize* kept distinct — **(i)** a pulled paper's *internal* factors now auto-enter BP at checkpoint (this change); **(ii)** wiring pulled claims *up to the root* graph stays the agent's manual `derive --given <pulled_qid>` step.
- **`tests/exploration/test_promote.py`** (new, 4 pr_gate tests) — action-rewrite, skip-unpromotable, the joint-inference BP proof (promoted conclusion 0.5 → >0.6), and the no-deps root-only case.

## Validation

- pr_gate slice: **1144 passed, 3 skipped**; `ruff` + `mypy --strict` clean. Pre-push gate green.
- BP movement proven at integration level (a promoted dependency conclusion's belief rises, pulled by its strong premise).

> Note: pre-existing nightly failure `tests/exploration/test_joint.py::test_joint_view_surfaces_cross_package_unmaterialized_contact` exists on base `main` (orthogonal to this PR).
