### PR TITLE
fix(lang/compiler): assign lco_ operator_id to formula-emitted top-level operators

### DIFF
--- a/gaia/engine/lang/compiler/lower_formula.py
+++ b/gaia/engine/lang/compiler/lower_formula.py
@@ -51,6 +51,25 @@ from gaia.engine.lang.runtime.variable import Variable
 _BindingMap = dict[int, dict[str, Any]]
 
 
+# Mirror of ``gaia.engine.lang.compiler.compile._SYMMETRIC_OPS`` / ``_operator_id_from_values``,
+# inlined here to avoid a circular import from ``compile``. Formula lowering emits
+# top-level operators (they land in ``LocalCanonicalGraph.operators``) so they must
+# carry an ``operator_id`` with the ``lco_`` prefix the validator demands.
+_SYMMETRIC_OPS = frozenset(
+    {"equivalence", "contradiction", "complement", "disjunction", "conjunction"}
+)
+
+
+def _formula_operator_id(operator: OperatorType, variables: list[str], conclusion: str) -> str:
+    """Compute a deterministic ``lco_`` operator id for a formula-emitted IR operator."""
+    op_str = operator.value
+    var_ids = list(variables)
+    if op_str in _SYMMETRIC_OPS:
+        var_ids = sorted(var_ids)
+    raw = f"{op_str}|{'|'.join(var_ids)}|{conclusion}"
+    return f"lco_{hashlib.sha256(raw.encode()).hexdigest()[:16]}"
+
+
 @dataclass(frozen=True)
 class FormulaLoweringResult:
     """IR records and source-claim updates emitted by formula lowering."""
@@ -549,6 +568,9 @@ def _lower_exists(
         )
 
     exists_operator = IrOperator(
+        operator_id=_formula_operator_id(
+            OperatorType.DISJUNCTION, instance_ids, claim_id
+        ),
         scope="local",
         operator=OperatorType.DISJUNCTION,
         variables=instance_ids,
@@ -672,6 +694,7 @@ class _FormulaState:
         conclusion = target_id or self._helper_claim(operator_name, child_ids)
         self.operators.append(
             IrOperator(
+                operator_id=_formula_operator_id(operator_name, child_ids, conclusion),
                 scope="local",
                 operator=operator_name,
                 variables=child_ids,
@@ -1188,6 +1211,9 @@ def _equivalence_result(
         ],
         operators=[
             IrOperator(
+                operator_id=_formula_operator_id(
+                    OperatorType.EQUIVALENCE, [left_id, right_id], helper_id
+                ),
                 scope="local",
                 operator=OperatorType.EQUIVALENCE,
                 variables=[left_id, right_id],

--- a/gaia/engine/lang/compiler/lower_formula.py
+++ b/gaia/engine/lang/compiler/lower_formula.py
@@ -568,9 +568,7 @@ def _lower_exists(
         )
 
     exists_operator = IrOperator(
-        operator_id=_formula_operator_id(
-            OperatorType.DISJUNCTION, instance_ids, claim_id
-        ),
+        operator_id=_formula_operator_id(OperatorType.DISJUNCTION, instance_ids, claim_id),
         scope="local",
         operator=OperatorType.DISJUNCTION,
         variables=instance_ids,

--- a/tests/gaia/lang/test_formula_claim_sugar.py
+++ b/tests/gaia/lang/test_formula_claim_sugar.py
@@ -250,9 +250,7 @@ def test_formula_claim_package_passes_local_graph_validation():
 
     artifact = compile_package_artifact(pkg)
     result = validate_local_graph(artifact.graph)
-    assert not result.errors, (
-        f"Expected validation to pass, got errors: {result.errors}"
-    )
+    assert not result.errors, f"Expected validation to pass, got errors: {result.errors}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gaia/lang/test_formula_claim_sugar.py
+++ b/tests/gaia/lang/test_formula_claim_sugar.py
@@ -212,6 +212,47 @@ def test_claim_with_coerced_land_formula_compiles_to_conjunction_operator():
     assert op.operator == "conjunction"
     assert op.variables == ["t:sugar_a_compile_pkg::a", "t:sugar_a_compile_pkg::b"]
     assert op.conclusion == "t:sugar_a_compile_pkg::both"
+    # Formula-emitted operators are top-level in graph.operators (not embedded
+    # inside a FormalExpr), so they must carry an lco_ operator_id per the
+    # validator contract (validator.py:199-203). Regression for issue #702.
+    assert op.operator_id is not None
+    assert op.operator_id.startswith("lco_")
+    assert op.scope == "local"
+
+
+def test_formula_claim_package_passes_local_graph_validation():
+    """Regression for issue #702.
+
+    `gaia build compile` calls `validate_local_graph` on the artifact.graph;
+    `compile_package_artifact` alone does not. Before the fix, formula
+    lowering emitted top-level operators without `operator_id`, so the
+    validator rejected any package that used `claim(formula=...)`. This
+    test exercises the exact validate-after-compile path the CLI uses.
+    """
+    from gaia.engine.ir.validator import validate_local_graph
+
+    pkg = CollectedPackage(name="validator_regression_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        # The exact shape that triggered the bug — implicit Sugar B path
+        # (`a & b` returns Land via Claim.__and__) plus explicit Sugar A
+        # path (claim(formula=land(...))) — both must validate.
+        both_implicit = claim("A and B (implicit).", formula=a & b)
+        both_implicit.label = "both_implicit"
+        both_explicit = claim("A and B (explicit).", formula=land(a, b))
+        both_explicit.label = "both_explicit"
+    finally:
+        _current_package.reset(token)
+
+    artifact = compile_package_artifact(pkg)
+    result = validate_local_graph(artifact.graph)
+    assert not result.errors, (
+        f"Expected validation to pass, got errors: {result.errors}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Three `IrOperator` constructions in `lower_formula.py` (connective lowering, `Exists` grounding, `Equals` equivalence helper) emit top-level operators without `operator_id`, causing `validate_local_graph` to reject any package containing a `claim(formula=...)` at `gaia build compile` time
- Assigns deterministic `lco_` operator_id at each site, mirroring `compile._operator_id_from_values` (variables sorted only for symmetric operators; SHA-256 over `operator|vars|conclusion`); helper inlined locally to avoid circular import from `compile.py`
- Regression test in `test_formula_claim_sugar.py` exercises the validate-after-compile path the CLI uses

Closes #702.

## Root cause

`validate_local_graph` (called only on the CLI compile path, not by pytest's `compile_package_artifact`) demands `operator_id` and `scope` on every top-level Operator (`validator.py:199-203`):

```python
if top_level and (op.operator_id is None or op.scope is None):
    result.error(
        "Top-level Operator must set both operator_id and scope "
        "(embedded FormalExpr operators may omit them)"
    )
```

Before this PR, formula lowering set `scope="local"` on emitted operators but never set `operator_id`. Those operators were spliced into top-level `LocalCanonicalGraph.operators` (compile.py:2030-2034 — `*formula_generated.operators`), so they tripped the validator.

The asymmetry vs the test suite was that pytest reaches `compile_package_artifact(pkg).graph` directly and never calls `validate_local_graph`. The CLI does. So PR #658's sugar tests all pass, but any real package using `claim(formula=...)` blew up on `gaia build compile`.

## Fix

Add a local `_formula_operator_id(operator, variables, conclusion)` helper in `lower_formula.py` that mirrors `compile._operator_id_from_values` byte-for-byte (same sort/hash logic). Call it at each of the 3 `IrOperator(...)` sites:

1. **Line 551** — `Exists` quantifier grounding (`OperatorType.DISJUNCTION`)
2. **Line 674** — connective lowering (`Land/Lor/Lnot/Implies/Iff`, dynamic operator)
3. **Line 1190** — `Equals` equivalence helper (`OperatorType.EQUIVALENCE`)

Helper is inlined (not imported from `compile`) to avoid the circular import `compile → lower_formula`. The two definitions of `_SYMMETRIC_OPS` are now duplicated across `compile.py` and `lower_formula.py`; future cleanup could lift them to a shared module under `gaia/engine/ir/`, but that's out of scope here.

## Test plan

- [x] `uv run pytest tests/gaia/lang/test_formula_claim_sugar.py` — 20 passed (1 new test)
- [x] `uv run pytest tests/gaia/lang/ tests/ir/ tests/cli/test_compile.py tests/cli/test_compile_v6.py` — 956 passed
- [x] `uv run pytest --no-cov` (full fast suite) — 2930 passed, 25 pre-existing failures (verified pre-existing on clean main; all in unrelated areas: credentials, lkm_auth, help snapshots, exploration joint view)
- [x] `uv run ruff check` on touched files — clean
- [x] `uv run mypy gaia/engine/lang/compiler/lower_formula.py` — Success, no issues
- [x] Minimal CLI reproducer from #702 now compiles + checks + infers cleanly (`P(both) = 0.25 ≈ P(a)·P(b)`, deterministic AND lowering verified end-to-end)

## Regression test

`tests/gaia/lang/test_formula_claim_sugar.py::test_formula_claim_package_passes_local_graph_validation` exercises the exact path the CLI uses: build a package via Sugar A (`claim(formula=land(a, b))`) **and** Sugar B (`claim(formula=a & b)`), compile, then explicitly call `validate_local_graph(artifact.graph)`. Before this PR, the test fails with the same error as the CLI; after, both shapes validate cleanly.

The existing `test_claim_with_coerced_land_formula_compiles_to_conjunction_operator` also gets three new assertions (`op.operator_id is not None`, `startswith("lco_")`, `op.scope == "local"`) so it catches any future drift on the operator_id contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)