### PR TITLE
docs(sdk): split cheat sheet by hard/soft semantics, document infer/associate, fix v6 signatures

### DIFF
--- a/gaia/cli/commands/sdk/_cheatsheet.py
+++ b/gaia/cli/commands/sdk/_cheatsheet.py
@@ -17,6 +17,29 @@ One page, every verb/term/distribution with a copy-pasteable example.
 optional convenience; it writes the same statements into the re-exported
 `authored/` submodule.
 
+## Authoring guidelines (read first)
+
+1. **Logical structure is the foundation; computed belief is a reference.**
+   Get the relations right — which claims premise which, which observations
+   constrain which hypotheses, which assertions are mutually exclusive. The
+   posterior `gaia run infer` returns reflects the structure you wrote; if
+   the structure is wrong, the number is precisely as wrong. Treat a
+   suspicious posterior as a structural-debugging signal first, not as the
+   final answer.
+
+2. **Avoid double-counting evidence.** Each piece of evidence should enter
+   the graph at most once. If observation A is downstream of observation B
+   (or both are downstream of a common cause), independently relating both
+   to the same hypothesis inflates posterior confidence. Model the shared
+   cause as a single Claim and connect it ONCE.
+
+3. **Surface weak points as Claims, not buried assumptions.** If a reasoning
+   step depends on something you're not fully confident in (small sample,
+   indirect proxy, a plausible-but-untested mechanism), do NOT bury it in a
+   `rationale` string. Extract it to its own Claim, put it in `given=[...]`,
+   and `register_prior` it with your honest uncertainty so that uncertainty
+   propagates through inference.
+
 ## Imports
 
 ```python
@@ -26,9 +49,11 @@ from gaia.engine.lang import (
     parameter,                                              # Structured formula claims
     ClaimAtom, land, lnot, lor, implies, iff, equals,       # Propositional formula helpers
     forall, exists,                                         # First-order quantifiers
-    contradict, equal, exclusive, associate,                # Reviewable relations
+    contradict, equal, exclusive,                           # Reviewable relations — hard
+    associate,                                              # Reviewable relations — soft
     depends_on, candidate_relation, materialize,            # Scaffold annotations
-    observe, derive, compute, infer, decompose,             # Recommended actions
+    observe, derive, compute, decompose,                    # Reasoning actions — hard
+    infer,                                                  # Reasoning actions — soft
     compose, composition,                                   # Action composition
     register_prior,                                         # External prior records
     Normal, LogNormal, Beta, Gamma, StudentT,               # Distribution factories
@@ -41,28 +66,83 @@ import gaia.engine.bayes as bayes                           # Bayes hypothesis c
 
 ```python
 h = claim("Heavier bodies fall faster in air.", title="Daily observation")
+# `claim` is a proposition that participates in BP and carries an optional
+# prior probability. If unset, the claim is treated as MaxEnt (no external
+# prior). Use `register_prior(h, value=..., justification=...)` to attach one.
+
 n = note("Framing: this is a thought experiment, not an observed fact.")
+# `note` is context / framing only — no truth value, does not participate in BP.
+
 q = question("Does weight set the natural falling speed?")
+# `question` records an open question — no truth value of its own.
 ```
 
-## Reviewable relations
+## Reviewable relations — hard (no probability parameters)
+
+Deterministic logical assertions over the relata's truth values. No conditional
+probabilities; lowering uses fixed factors.
 
 ```python
-equal(prediction, observation, rationale="Prediction matches the data.")
-contradict(pred_a, pred_b, rationale="Same setup, incompatible predictions.")
-exclusive(model_a, model_b, rationale="Competing explanations of one fact.")
-associate(claim_a, claim_b, rationale="Loosely related; not entailment.")
+equal(prediction, observation, rationale="...")     # both must hold the same truth value
+contradict(pred_a, pred_b, rationale="...")         # the two cannot both be true
+exclusive(model_a, model_b, rationale="...")        # competing explanations; at most one is true
 ```
 
-## Recommended actions
+## Reviewable relations — soft (explicit conditional probabilities)
+
+You estimate both directions of the association. There is no logical entailment.
 
 ```python
-derive("Composite should fall faster.", given=[model_a], rationale="...")
-observe("F1 offspring are uniformly dominant.", rationale="Qualitative F1 result.")
-compute(result, fn=my_fn, given=[x, y], rationale="Deterministic computation.")
-infer(hypothesis, given=[evidence], rationale="Probabilistic support.")
-decompose(whole, parts=[part_a, part_b], rationale="Whole = sum of parts.")
+associate(claim_a, claim_b,
+          p_a_given_b=0.85,   # P(claim_a is true | claim_b is true)
+          p_b_given_a=0.40,   # P(claim_b is true | claim_a is true)
+          rationale="...")
 ```
+
+## Reasoning actions — hard (no probability parameters)
+
+No probability arguments; relate claims by deterministic logic, or, for `observe`,
+by pinning the observed claim's prior to ~1 − ε.
+
+If a derivation depends on an uncertain intermediate step (small n, indirect
+proxy, contested mechanism), do **NOT** bury it in `rationale`. Extract it as a
+separate Claim, put it in `given=[...]`, and `register_prior` it so the
+uncertainty enters the inference. This makes weak points explicit and reviewable.
+
+```python
+derive("Composite should fall faster.",
+       given=[model_a, weak_step_premise],   # premises (extract uncertain steps to their own Claims)
+       rationale="...")
+
+observe("F1 offspring are uniformly dominant.", rationale="...")
+# Pins the observed claim's prior to ~1 − ε.
+
+compute(result, fn=my_fn, given=[x, y], rationale="...")
+# Deterministic functional computation: result = fn(x, y).
+
+decompose(whole, parts=[part_a, part_b], formula=..., rationale="...")
+# whole ≡ formula(parts) — equivalence by decomposition.
+```
+
+## Reasoning actions — soft (explicit conditional probabilities)
+
+The single soft reasoning action. Bayesian update: how strongly does the
+evidence shift belief in the hypothesis? YOU estimate the two conditionals.
+
+```python
+infer(evidence,
+      hypothesis=H,
+      given=[scope_assumption_1, scope_assumption_2],   # assumptions under which the likelihoods hold
+      p_e_given_h=0.90,        # P(observing this evidence | H is true)
+      p_e_given_not_h=0.10,    # P(observing this evidence | H is false)
+      rationale="...")
+```
+
+The likelihood ratio `p_e_given_h / p_e_given_not_h` controls update strength.
+A ratio of 1 produces no update; the larger the ratio, the more the evidence
+pushes posterior(H) above prior(H). If any claim in `given=` is uncertain
+(carries a prior < 1), that uncertainty attenuates the update — surface the
+scope assumptions honestly rather than asserting them silently.
 
 ## Scaffold annotations
 

--- a/gaia/cli/commands/sdk/_cheatsheet.py
+++ b/gaia/cli/commands/sdk/_cheatsheet.py
@@ -44,7 +44,7 @@ optional convenience; it writes the same statements into the re-exported
 
 ```python
 from gaia.engine.lang import (
-    claim, note, question,                                  # Knowledge
+    Claim, claim, note, question,                           # Knowledge
     Variable, Nat, Real, Probability, Bool, Constant,       # Formula terms
     parameter,                                              # Structured formula claims
     ClaimAtom, land, lnot, lor, implies, iff, equals,       # Propositional formula helpers
@@ -111,13 +111,17 @@ uncertainty enters the inference. This makes weak points explicit and reviewable
 
 ```python
 derive("Composite should fall faster.",
-       given=[model_a, weak_step_premise],   # premises (extract uncertain steps to their own Claims)
+       given=[model_a, weak_step_premise],   # extract uncertain steps to Claims
        rationale="...")
 
 observe("F1 offspring are uniformly dominant.", rationale="...")
 # Pins the observed claim's prior to ~1 − ε.
 
-compute(result, fn=my_fn, given=[x, y], rationale="...")
+class ResultClaim(Claim):
+    '''Computed result is {value}.'''
+    value: float
+
+compute(ResultClaim, fn=my_fn, given=[x, y], rationale="...")
 # Deterministic functional computation: result = fn(x, y).
 
 decompose(whole, parts=[part_a, part_b], formula=..., rationale="...")
@@ -132,7 +136,7 @@ evidence shift belief in the hypothesis? YOU estimate the two conditionals.
 ```python
 infer(evidence,
       hypothesis=H,
-      given=[scope_assumption_1, scope_assumption_2],   # assumptions under which the likelihoods hold
+      given=[scope_assumption_1, scope_assumption_2],  # likelihood scope
       p_e_given_h=0.90,        # P(observing this evidence | H is true)
       p_e_given_not_h=0.10,    # P(observing this evidence | H is false)
       rationale="...")


### PR DESCRIPTION
## Motivation

Practical use of the cheat sheet exposed several ambiguities that led DSL authors (human + agent) to misuse the surface:

1. The **"Recommended actions"** block listed deterministic-logic verbs (`derive`, `observe`, `compute`, `decompose`) alongside `infer` — the only soft Bayesian update — with no hint that they are different semantic kinds. Authors regularly conflate hard entailment with Bayesian likelihood update.
2. `infer` was documented with its **v5 legacy signature** (`infer(hypothesis, given=[evidence], rationale="…")`), missing the v6 canonical `(evidence, *, hypothesis, p_e_given_h, p_e_given_not_h)` form and the conditioning `given=` scope claims.
3. `associate` appeared with no probability parameters, hiding that it requires `p_a_given_b` + `p_b_given_a`.
4. `claim` did not document its optional `prior` — the one feature that makes it participate in BP.
5. There was no top-of-file guidance against double-counting evidence, and weak intermediate steps were quietly buried in `rationale` strings.

## Changes

- New **Authoring guidelines (read first)** section at the top — 3 short principles:
  1. Logical structure is the foundation; computed belief is a reference.
  2. Avoid double-counting evidence (downstream observations / common cause).
  3. Surface weak points as Claims into `given=`, not buried in `rationale`.
- Imports block + verb sections split by **hard** vs **soft** axis; "Recommended actions" → **"Reasoning actions"** (more accurate).
- `claim` / `note` / `question` each get a one-line semantics comment; `claim` explicitly mentions its optional prior and how to attach one via `register_prior`.
- `associate` example shows both required conditional-probability kwargs and explains it as the symmetric soft relation.
- `infer` example replaced with the **v6 canonical** signature, including `given=` (scope assumptions under which the likelihoods hold) and an inline note on how the likelihood ratio controls update strength.
- `decompose` example gains the required `formula=` kwarg (was missing).
- Hard-action section gains the weak-point-extraction note.

## Non-changes

- Generator surface (`gaia sdk` command, `_introspect.py`, per-symbol reference) untouched.
- Other sections (Scaffold annotations, Action composition, Typed terms + formulas, Priors, Distributions, Bayes hypothesis-vs-data) unchanged.

## Test plan

- [x] `tests/cli/test_sdk.py` asserts the per-symbol reference's API surface, not the cheat-sheet prose. All 5 SDK tests pass locally.
- [x] `gaia sdk --out /tmp/check-sdk` regenerates without error; CHEATSHEET.md renders with the new structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
