### PR TITLE
feat(lang): lift Boolean-valued expressions to Claim at verb boundaries (#703)

### DIFF
--- a/gaia/engine/lang/_boolean_valued.py
+++ b/gaia/engine/lang/_boolean_valued.py
@@ -1,0 +1,53 @@
+"""Marker for Boolean-valued types that can stand in for Claim at verb boundaries.
+
+A Boolean-valued type is one whose values denote a Boolean-valued (T/F)
+assertion that maps to a Bernoulli random variable in BP. The set of
+Boolean-valued types is the union of:
+
+- All :mod:`gaia.engine.lang.formula` Formula nodes (``Land``, ``Lor``,
+  ``Lnot``, ``Implies``, ``Iff``, ``Forall``, ``Exists``, ``Equals``,
+  ``NotEquals``, ``Greater``, ``GreaterEqual``, ``Less``, ``LessEqual``,
+  ``UserPredicate``, ``ClaimAtom``) — detected via the existing
+  :func:`gaia.engine.lang.formula.predicate.is_formula` predicate, since every
+  Formula class already carries ``__gaia_formula__: ClassVar[bool] = True``.
+
+- :class:`gaia.engine.lang.runtime.knowledge.Claim` — the probabilistic
+  knowledge node itself; declares its Boolean-valued status with the
+  ``__gaia_boolean_valued__: ClassVar[bool] = True`` class marker.
+
+- :class:`gaia.engine.lang.dsl.bool_expr.BoolExpr` — the ``Distribution``
+  comparison result; declares its Boolean-valued status with the same
+  ``__gaia_boolean_valued__`` class marker.
+
+Term-layer types (``Variable``, ``Constant``, ``FunctionApp``,
+``Distribution``, ``DerivedDistribution``, ``Note``, ``Setting`` …) carry
+neither marker. They are *not* Boolean-valued and are rejected at verb
+boundaries with an educational error from
+:func:`gaia.engine.lang.dsl._lift._lift_to_claim`.
+
+See the design RFC at
+``docs/specs/2026-05-24-boolean-valued-claim-lift-design.md`` for the
+type-theoretic motivation (the Curry-Howard proposition/term split aligning
+with Gaia's two-layer structure).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gaia.engine.lang.formula.predicate import is_formula
+
+
+def is_boolean_valued(obj: Any) -> bool:
+    """Return ``True`` iff ``obj`` is a Boolean-valued expression.
+
+    Composes the existing :func:`is_formula` predicate (which covers every
+    Formula class) with a ``__gaia_boolean_valued__`` class-attribute marker
+    set on :class:`Claim` and :class:`BoolExpr`. New non-Formula
+    Boolean-valued types opt in by setting
+    ``__gaia_boolean_valued__: ClassVar[bool] = True`` on the class; they do
+    not need to be listed here.
+    """
+    if is_formula(obj):
+        return True
+    return getattr(obj, "__gaia_boolean_valued__", False) is True

--- a/gaia/engine/lang/dsl/_lift.py
+++ b/gaia/engine/lang/dsl/_lift.py
@@ -1,0 +1,91 @@
+"""Boolean-valued → Claim lift at verb boundary.
+
+Implements the materialisation boundary specified in
+``docs/specs/2026-05-24-boolean-valued-claim-lift-design.md`` §4.2:
+
+- :class:`gaia.engine.lang.runtime.knowledge.Claim` is returned as-is.
+- :class:`gaia.engine.lang.formula.predicate.ClaimAtom` is unwrapped to its
+  underlying ``Claim`` (no helper Claim created).
+- Any other Formula node (``Land``, ``Lor``, ``Lnot``, ``Implies``, ``Iff``,
+  ``Forall``, ``Exists``, ``Equals`` / ``Greater`` / ``UserPredicate`` / ...)
+  is materialised via ``claim(content, formula=value)`` with a synthesised
+  description.
+- :class:`gaia.engine.lang.dsl.bool_expr.BoolExpr` is materialised via
+  ``claim(content, proposition)`` with a synthesised description.
+- Anything else raises an educational :class:`TypeError` pointing at the
+  Term-layer wrapping idiom.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gaia.engine.lang._boolean_valued import is_boolean_valued
+from gaia.engine.lang.dsl.bool_expr import BoolExpr
+from gaia.engine.lang.dsl.knowledge import claim
+from gaia.engine.lang.formula.predicate import ClaimAtom, is_formula
+from gaia.engine.lang.runtime.knowledge import Claim
+
+
+def _synth_description(value: Any) -> str:
+    """Render a Boolean-valued expression to a human-readable description.
+
+    Formula and BoolExpr classes all implement readable :meth:`__str__`, so
+    this mostly delegates to ``str(value)``. If that yields an empty string
+    we fall back to :func:`repr` so the helper Claim never carries an empty
+    description.
+    """
+    text = str(value)
+    if text:
+        return text
+    return repr(value)
+
+
+def _lift_to_claim(value: Any, *, verb: str, position: str) -> Claim:
+    """Materialise a Boolean-valued expression as a :class:`Claim`.
+
+    Behaviour (in dispatch order):
+
+    1. ``Claim``        → returned as-is.
+    2. ``ClaimAtom``    → unwrapped to ``value.claim`` (no new helper).
+    3. Formula          → ``claim(_synth_description(value), formula=value)``.
+    4. ``BoolExpr``     → ``claim(_synth_description(value), value)``
+       (positional ``proposition`` slot).
+    5. anything else    → educational :class:`TypeError`.
+
+    ``verb`` and ``position`` are formatted into the error message; e.g.
+    ``verb="exclusive"``, ``position="first argument"``.
+    """
+    if isinstance(value, Claim):
+        return value
+    if isinstance(value, ClaimAtom):
+        return value.claim
+    if is_formula(value):
+        return claim(_synth_description(value), formula=value)
+    if isinstance(value, BoolExpr):
+        return claim(_synth_description(value), value)
+    raise TypeError(
+        f"{verb}() expected Claim or a Boolean-valued expression "
+        f"(Formula / BoolExpr / ClaimAtom) as {position}; "
+        f"got {type(value).__name__}. "
+        f"Term-layer values (Variable, Constant, Distribution, ...) are not "
+        f"directly claim-able — wrap them in a predicate first "
+        f"(e.g. Equals(x, Constant(5))) or pass an explicit "
+        f"claim(content=..., formula=...) helper."
+    )
+
+
+def _lift_optional(value: Any, *, verb: str, position: str) -> Any:
+    """Lift ``value`` to a Claim if it is Boolean-valued; otherwise pass through.
+
+    Used by verbs that already accept multiple non-Claim input shapes
+    (e.g. :func:`derive` and :func:`infer` accept a ``str`` ``conclusion`` /
+    ``evidence`` and create a fresh ``Claim`` from it). For those, we only
+    intercept Boolean-valued inputs and leave the rest for the verb's own
+    type dispatch.
+    """
+    if isinstance(value, str) or value is None:
+        return value
+    if is_boolean_valued(value):
+        return _lift_to_claim(value, verb=verb, position=position)
+    return value

--- a/gaia/engine/lang/dsl/bool_expr.py
+++ b/gaia/engine/lang/dsl/bool_expr.py
@@ -20,7 +20,7 @@ than as silently always-truthy.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 ComparisonOp = Literal[">", ">=", "<", "<=", "==", "!="]
 ArithmeticOp = Literal["+", "-", "*", "/"]
@@ -135,6 +135,11 @@ class BoolExpr:
     op: ComparisonOp
     left: Any
     right: Any
+    # Boolean-valued marker — see gaia.engine.lang._boolean_valued.
+    # BoolExpr is a Boolean predicate over Distribution / scalar values that the
+    # compiler lowers to claim metadata (predicate / equation priors), so it is
+    # claim-equivalent to any Formula at the verb boundary's lift step.
+    __gaia_boolean_valued__: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
         """Validate the comparison operator."""

--- a/gaia/engine/lang/dsl/infer_verb.py
+++ b/gaia/engine/lang/dsl/infer_verb.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, cast
 
+from gaia.engine.lang._boolean_valued import is_boolean_valued
 from gaia.engine.lang.dsl._lift import _lift_to_claim
 from gaia.engine.lang.runtime.action import (
     Infer as InferAction,
@@ -21,10 +22,10 @@ def _claim_ref(claim: Claim) -> str:
     return claim.content
 
 
-def _as_given_tuple(given: Claim | tuple[Claim, ...] | list[Claim] | None) -> tuple[Claim, ...]:
+def _as_given_tuple(given: Any) -> tuple[Any, ...]:
     if given is None:
         return ()
-    if isinstance(given, Knowledge):
+    if isinstance(given, Knowledge) or is_boolean_valued(given):
         return (given,)
     return tuple(given)
 

--- a/gaia/engine/lang/dsl/infer_verb.py
+++ b/gaia/engine/lang/dsl/infer_verb.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, cast
 
+from gaia.engine.lang.dsl._lift import _lift_to_claim
 from gaia.engine.lang.runtime.action import (
     Infer as InferAction,
 )
@@ -53,10 +54,10 @@ def _resolve_evidence(evidence: Claim | str | None) -> Claim | str | None:
 
 def _validate_infer_claims(
     *,
-    hypothesis: Claim | None,
-    evidence: Claim | str | None,
+    hypothesis: Any,
+    evidence: Any,
     p_e_given_h: float | Claim | None,
-    given: Claim | tuple[Claim, ...] | list[Claim] | None,
+    given: Any,
 ) -> tuple[Claim, Claim, tuple[Claim, ...]]:
     if hypothesis is None:
         raise TypeError("infer() missing required keyword argument: 'hypothesis'")
@@ -66,13 +67,13 @@ def _validate_infer_claims(
         raise TypeError("infer() missing required keyword argument: 'p_e_given_h'")
     if isinstance(evidence, str):
         evidence = Claim(evidence)
-    if not isinstance(evidence, Claim):
-        raise TypeError("infer() evidence must be a Claim or string")
-    if not isinstance(hypothesis, Claim):
-        raise TypeError("infer() hypothesis must be a Claim")
-    given_tuple = _as_given_tuple(given)
-    if any(not isinstance(item, Claim) for item in given_tuple):
-        raise TypeError("infer() given entries must be Claims")
+    else:
+        evidence = _lift_to_claim(evidence, verb="infer", position="evidence")
+    hypothesis = _lift_to_claim(hypothesis, verb="infer", position="hypothesis")
+    given_tuple = tuple(
+        _lift_to_claim(item, verb="infer", position=f"given[{i}]")
+        for i, item in enumerate(_as_given_tuple(given))
+    )
     return evidence, hypothesis, given_tuple
 
 

--- a/gaia/engine/lang/dsl/register_prior.py
+++ b/gaia/engine/lang/dsl/register_prior.py
@@ -35,6 +35,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from gaia.engine.ir.parameterization import CROMWELL_EPS
+from gaia.engine.lang._boolean_valued import is_boolean_valued
 from gaia.engine.lang.runtime.knowledge import Claim
 
 PRIOR_RECORDS_METADATA_KEY = "prior_records"
@@ -48,7 +49,7 @@ source_id matching their namespace (e.g. ``"continuous_inference"``,
 
 
 def register_prior(
-    claim: Claim,
+    claim: Any,
     value: float,
     *,
     justification: str,
@@ -105,11 +106,20 @@ def register_prior(
                            justification="Tied-body argument is decisive against A.")
     """
     if not isinstance(claim, Claim):
-        raise TypeError(
-            f"register_prior() claim must be a Claim instance, "
-            f"got {type(claim).__name__}. Pass the Claim object returned by "
-            f"claim(), not its label or content string."
-        )
+        if is_boolean_valued(claim):
+            # Boolean-valued expressions (Formula / BoolExpr / ClaimAtom) lift
+            # to a helper Claim at the verb boundary per RFC #703. Deferred
+            # import keeps the boolean-valued lift module out of this module's
+            # import-time fan-in.
+            from gaia.engine.lang.dsl._lift import _lift_to_claim
+
+            claim = _lift_to_claim(claim, verb="register_prior", position="first argument")
+        else:
+            raise TypeError(
+                f"register_prior() claim must be a Claim instance, "
+                f"got {type(claim).__name__}. Pass the Claim object returned by "
+                f"claim(), not its label or content string."
+            )
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise TypeError(
             f"register_prior() value must be a numeric scalar in "

--- a/gaia/engine/lang/dsl/relate.py
+++ b/gaia/engine/lang/dsl/relate.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from gaia.engine.lang.dsl._lift import _lift_to_claim
 from gaia.engine.lang.runtime.action import (
     Contradict,
     Equal,
@@ -29,14 +32,21 @@ def _claim_ref(claim: Claim) -> str:
 
 
 def equal(
-    a: Claim,
-    b: Claim,
+    a: Any,
+    b: Any,
     *,
     background: list[Knowledge] | None = None,
     rationale: str = "",
     label: str | None = None,
 ) -> Claim:
-    """Declare two Claims equivalent. Returns an equivalence helper Claim."""
+    """Declare two Claims equivalent. Returns an equivalence helper Claim.
+
+    ``a`` and ``b`` may be any Boolean-valued expression (``Claim``,
+    ``ClaimAtom``, Formula node, or ``BoolExpr``); non-``Claim`` inputs are
+    lifted to helper Claims at the verb boundary per RFC #703.
+    """
+    a = _lift_to_claim(a, verb="equal", position="first argument")
+    b = _lift_to_claim(b, verb="equal", position="second argument")
     helper = Claim(
         f"{_claim_ref(a)} and {_claim_ref(b)} are equivalent.",
         metadata={"generated": True, "helper_kind": "equivalence_result", "review": True},
@@ -55,14 +65,21 @@ def equal(
 
 
 def contradict(
-    a: Claim,
-    b: Claim,
+    a: Any,
+    b: Any,
     *,
     background: list[Knowledge] | None = None,
     rationale: str = "",
     label: str | None = None,
 ) -> Claim:
-    """Declare two Claims contradictory. Returns a contradiction helper Claim."""
+    """Declare two Claims contradictory. Returns a contradiction helper Claim.
+
+    ``a`` and ``b`` may be any Boolean-valued expression (``Claim``,
+    ``ClaimAtom``, Formula node, or ``BoolExpr``); non-``Claim`` inputs are
+    lifted to helper Claims at the verb boundary per RFC #703.
+    """
+    a = _lift_to_claim(a, verb="contradict", position="first argument")
+    b = _lift_to_claim(b, verb="contradict", position="second argument")
     helper = Claim(
         f"{_claim_ref(a)} and {_claim_ref(b)} contradict.",
         metadata={"generated": True, "helper_kind": "contradiction_result", "review": True},
@@ -81,14 +98,21 @@ def contradict(
 
 
 def exclusive(
-    a: Claim,
-    b: Claim,
+    a: Any,
+    b: Any,
     *,
     background: list[Knowledge] | None = None,
     rationale: str = "",
     label: str | None = None,
 ) -> Claim:
-    """Declare two Claims as a closed binary partition. Returns an XOR helper Claim."""
+    """Declare two Claims as a closed binary partition. Returns an XOR helper Claim.
+
+    ``a`` and ``b`` may be any Boolean-valued expression (``Claim``,
+    ``ClaimAtom``, Formula node, or ``BoolExpr``); non-``Claim`` inputs are
+    lifted to helper Claims at the verb boundary per RFC #703.
+    """
+    a = _lift_to_claim(a, verb="exclusive", position="first argument")
+    b = _lift_to_claim(b, verb="exclusive", position="second argument")
     helper = Claim(
         f"exactly one of {_claim_ref(a)} and {_claim_ref(b)} is true.",
         metadata={"generated": True, "helper_kind": "complement_result", "review": True},

--- a/gaia/engine/lang/dsl/support.py
+++ b/gaia/engine/lang/dsl/support.py
@@ -17,6 +17,7 @@ from functools import wraps
 from typing import Any, cast
 
 from gaia.engine.ir.parameterization import CROMWELL_EPS
+from gaia.engine.lang._boolean_valued import is_boolean_valued
 from gaia.engine.lang.dsl._lift import _lift_to_claim
 from gaia.engine.lang.runtime.action import (
     Compute,
@@ -30,10 +31,10 @@ from gaia.engine.lang.runtime.knowledge import Claim, Knowledge
 from gaia.engine.lang.runtime.variable import Variable
 
 
-def _as_given_tuple(given: Claim | tuple[Claim, ...] | list[Claim] | None) -> tuple[Claim, ...]:
+def _as_given_tuple(given: Any) -> tuple[Any, ...]:
     if given is None:
         return ()
-    if isinstance(given, Knowledge):
+    if isinstance(given, Knowledge) or is_boolean_valued(given):
         return (given,)
     return tuple(given)
 

--- a/gaia/engine/lang/dsl/support.py
+++ b/gaia/engine/lang/dsl/support.py
@@ -17,6 +17,7 @@ from functools import wraps
 from typing import Any, cast
 
 from gaia.engine.ir.parameterization import CROMWELL_EPS
+from gaia.engine.lang.dsl._lift import _lift_to_claim
 from gaia.engine.lang.runtime.action import (
     Compute,
     Derive,
@@ -71,17 +72,33 @@ def _pin_observed_claim(conclusion: Claim) -> None:
 
 
 def derive(
-    conclusion: Claim | str,
+    conclusion: Any,
     *,
-    given: Claim | tuple[Claim, ...] | list[Claim] | None = (),
+    given: Any = (),
     background: list[Knowledge] | None = None,
     rationale: str = "",
     label: str | None = None,
 ) -> Claim:
-    """Logical derivation. Returns the conclusion Claim."""
+    """Logical derivation. Returns the conclusion Claim.
+
+    ``conclusion`` may be a ``Claim``, a ``str`` (which creates a fresh
+    Claim from the content), or any Boolean-valued expression
+    (``ClaimAtom`` / Formula / ``BoolExpr``) that lifts to a helper Claim
+    at the verb boundary per RFC #703.
+
+    Every entry of ``given`` is similarly lifted: a Boolean-valued
+    expression becomes a helper Claim; non-Claim non-Boolean-valued values
+    raise an educational :class:`TypeError`.
+    """
     if isinstance(conclusion, str):
         conclusion = Claim(conclusion)
-    given_tuple = _as_given_tuple(given)
+    else:
+        conclusion = _lift_to_claim(conclusion, verb="derive", position="conclusion")
+    assert isinstance(conclusion, Claim)  # narrow Any back to Claim for mypy
+    given_tuple = tuple(
+        _lift_to_claim(g, verb="derive", position=f"given[{i}]")
+        for i, g in enumerate(_as_given_tuple(given))
+    )
     warrant = _implication_warrant(
         "derive",
         given=given_tuple,

--- a/gaia/engine/lang/runtime/knowledge.py
+++ b/gaia/engine/lang/runtime/knowledge.py
@@ -195,6 +195,10 @@ class Claim(Knowledge):
     formula: Any = None
     kind: ClaimKind = ClaimKind.GENERAL
     _param_fields: ClassVar[dict[str, Any]] = {}
+    # Boolean-valued marker — see gaia.engine.lang._boolean_valued.
+    # Claim is a probabilistic Boolean-valued knowledge node (P(claim=T) ∈ [0,1]),
+    # so it is claim-equivalent to any Formula at the verb boundary's lift step.
+    __gaia_boolean_valued__: ClassVar[bool] = True
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Collect subclass-specific parameter fields for templated claims."""

--- a/tests/gaia/lang/test_boolean_valued_lift.py
+++ b/tests/gaia/lang/test_boolean_valued_lift.py
@@ -1,0 +1,370 @@
+"""Tests for the Boolean-valued → Claim lift at verb boundaries (RFC #703).
+
+Covers:
+
+- ``is_boolean_valued`` predicate composition (Formula via ``is_formula``,
+  Claim and BoolExpr via ``__gaia_boolean_valued__`` marker).
+- ``_lift_to_claim`` dispatch per shape (Claim passthrough, ClaimAtom
+  unwrap, Formula → ``claim(formula=...)``, BoolExpr → ``claim(content,
+  proposition)``).
+- Each Claim-accepting verb in scope (``equal``, ``contradict``,
+  ``exclusive``, ``derive``, ``infer``, ``register_prior``) now accepts a
+  Boolean-valued expression as direct argument.
+- Term-layer values (``Variable``, raw Python types) raise the educational
+  ``TypeError`` from the lift's else branch.
+"""
+
+import pytest
+
+from gaia.engine.lang import (
+    Beta,
+    ClaimAtom,
+    Constant,
+    Equals,
+    Forall,
+    Land,
+    Nat,
+    Variable,
+    claim,
+    contradict,
+    derive,
+    equal,
+    exclusive,
+    infer,
+    register_prior,
+)
+from gaia.engine.lang._boolean_valued import is_boolean_valued
+from gaia.engine.lang.dsl._lift import _lift_to_claim, _synth_description
+from gaia.engine.lang.runtime.knowledge import Claim, _current_package
+from gaia.engine.lang.runtime.package import CollectedPackage
+
+# ---------------------------------------------------------------------------
+# is_boolean_valued predicate
+# ---------------------------------------------------------------------------
+
+
+def test_is_boolean_valued_recognizes_claim():
+    a = Claim("A.")
+    assert is_boolean_valued(a) is True
+
+
+def test_is_boolean_valued_recognizes_claim_atom():
+    a = Claim("A.")
+    assert is_boolean_valued(ClaimAtom(a)) is True
+
+
+def test_is_boolean_valued_recognizes_formula_connectives():
+    a = Claim("A.")
+    b = Claim("B.")
+    assert is_boolean_valued(a & b) is True
+    assert is_boolean_valued(a | b) is True
+    assert is_boolean_valued(~a) is True
+
+
+def test_is_boolean_valued_recognizes_predicate_formulas():
+    x = Variable(symbol="x", domain=Nat)
+    pred = Equals(left=x, right=Constant(value=5, primitive=Nat))
+    assert is_boolean_valued(pred) is True
+
+
+def test_is_boolean_valued_recognizes_quantifier_formulas():
+    x = Variable(symbol="x", domain=Nat)
+    body = Equals(left=x, right=Constant(value=5, primitive=Nat))
+    assert is_boolean_valued(Forall(variable=x, body=body)) is True
+
+
+def test_is_boolean_valued_recognizes_bool_expr():
+    k = Beta("k prior", alpha=2, beta=2)
+    assert is_boolean_valued(k > 0.5) is True
+
+
+def test_is_boolean_valued_rejects_term_layer():
+    x = Variable(symbol="x", domain=Nat)
+    c = Constant(value=5, primitive=Nat)
+    assert is_boolean_valued(x) is False
+    assert is_boolean_valued(c) is False
+    assert is_boolean_valued("a string") is False
+    assert is_boolean_valued(42) is False
+    assert is_boolean_valued(None) is False
+
+
+# ---------------------------------------------------------------------------
+# _lift_to_claim — dispatch per shape
+# ---------------------------------------------------------------------------
+
+
+def test_lift_passes_claim_through_unchanged():
+    a = Claim("A.")
+    assert _lift_to_claim(a, verb="t", position="x") is a
+
+
+def test_lift_unwraps_claim_atom_without_creating_helper():
+    pkg = CollectedPackage(name="bv_lift_unwrap_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        atom = ClaimAtom(a)
+        lifted = _lift_to_claim(atom, verb="t", position="x")
+    finally:
+        _current_package.reset(token)
+    # Unwrap returns the original Claim object — no new helper Claim in the package.
+    assert lifted is a
+    assert sum(1 for k in pkg.knowledge if isinstance(k, Claim)) == 1
+
+
+def test_lift_materializes_propositional_formula_as_helper():
+    pkg = CollectedPackage(name="bv_lift_propositional_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        helper = _lift_to_claim(a & b, verb="t", position="x")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(helper, Claim)
+    assert helper.formula is not None
+    assert isinstance(helper.formula, Land)
+    # Helper is distinct from the operand claims.
+    assert helper is not a
+    assert helper is not b
+
+
+def test_lift_materializes_bool_expr_via_proposition_path():
+    pkg = CollectedPackage(name="bv_lift_boolexpr_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        k = Beta("k prior", alpha=2, beta=2)
+        helper = _lift_to_claim(k > 0.5, verb="t", position="x")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(helper, Claim)
+    # BoolExpr is stored via the predicate/equation metadata path, not as
+    # claim.formula (which is the propositional/quantifier Formula path).
+    assert helper.formula is None
+    assert "predicate" in helper.metadata or "equation" in helper.metadata
+
+
+def test_lift_rejects_term_layer_with_educational_message():
+    x = Variable(symbol="x", domain=Nat)
+    with pytest.raises(TypeError) as exc:
+        _lift_to_claim(x, verb="exclusive", position="first argument")
+    msg = str(exc.value)
+    assert "exclusive()" in msg
+    assert "first argument" in msg
+    assert "Variable" in msg
+    # Educational hint pointing at the Term-wrapping idiom.
+    assert "Term-layer" in msg or "predicate" in msg
+
+
+def test_lift_rejects_raw_python_values():
+    with pytest.raises(TypeError):
+        _lift_to_claim(42, verb="t", position="x")
+    with pytest.raises(TypeError):
+        _lift_to_claim("hello", verb="t", position="x")
+    with pytest.raises(TypeError):
+        _lift_to_claim(None, verb="t", position="x")
+
+
+def test_synth_description_uses_str_repr():
+    a = Claim("A.")
+    a.label = "a"
+    b = Claim("B.")
+    b.label = "b"
+    desc = _synth_description(a & b)
+    assert isinstance(desc, str)
+    assert desc  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# Verb integration: each in-scope verb accepts a Boolean-valued argument
+# ---------------------------------------------------------------------------
+
+
+def test_exclusive_accepts_propositional_formula_directly():
+    pkg = CollectedPackage(name="bv_exclusive_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        a.label = "a"
+        b = claim("B.")
+        b.label = "b"
+        neg = claim("Neither A nor B.")
+        # The whole point of RFC #703 — this expression was the BoardgameQA
+        # failure-mode anchor.
+        result = exclusive(a & b, neg, rationale="binary split", label="exc_both")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+
+
+def test_contradict_accepts_propositional_formula_directly():
+    pkg = CollectedPackage(name="bv_contradict_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        c = claim("C.")
+        result = contradict(a & b, c, rationale="", label="con")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+
+
+def test_equal_accepts_propositional_formula_directly():
+    pkg = CollectedPackage(name="bv_equal_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        c = claim("C.")
+        result = equal(a & b, c, rationale="", label="eq")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+
+
+def test_derive_accepts_propositional_formula_in_given():
+    pkg = CollectedPackage(name="bv_derive_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        conclusion = claim("Conclusion.")
+        result = derive(conclusion, given=[a & b], rationale="", label="d")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+
+
+def test_infer_accepts_propositional_formula_as_evidence_and_hypothesis():
+    pkg = CollectedPackage(name="bv_infer_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        c = claim("C.")
+        result = infer(
+            a & b,
+            hypothesis=c,
+            p_e_given_h=0.9,
+            p_e_given_not_h=0.5,
+            label="i",
+        )
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+
+
+def test_register_prior_accepts_propositional_formula():
+    pkg = CollectedPackage(name="bv_register_prior_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        # The helper Claim minted by the lift gets a prior registered on it.
+        register_prior(a & b, 0.7, justification="Joint prior for A and B.")
+    finally:
+        _current_package.reset(token)
+    # Verify a helper Claim was created with prior records.
+    helpers_with_priors = [
+        k for k in pkg.knowledge if isinstance(k, Claim) and k.metadata.get("prior_records")
+    ]
+    assert len(helpers_with_priors) == 1
+
+
+# ---------------------------------------------------------------------------
+# Verb integration: educational TypeError on Term-layer arguments
+# ---------------------------------------------------------------------------
+
+
+def test_exclusive_rejects_term_layer_with_educational_message():
+    pkg = CollectedPackage(name="bv_exclusive_term_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        x = Variable(symbol="x", domain=Nat)
+        with pytest.raises(TypeError, match="exclusive"):
+            exclusive(x, a, rationale="", label="t")
+    finally:
+        _current_package.reset(token)
+
+
+def test_register_prior_still_rejects_term_layer():
+    pkg = CollectedPackage(name="bv_rp_term_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        x = Variable(symbol="x", domain=Nat)
+        with pytest.raises(TypeError):
+            register_prior(x, 0.5, justification="should be rejected")
+    finally:
+        _current_package.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Verb integration: ClaimAtom unwraps without an extra helper Claim
+# ---------------------------------------------------------------------------
+
+
+def test_exclusive_with_claim_atom_unwraps_no_extra_helper():
+    pkg = CollectedPackage(name="bv_atom_unwrap_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        # ClaimAtom should be unwrapped to its underlying Claim; no formula
+        # helper Claim should be minted for this trivial wrapper.
+        exclusive(ClaimAtom(a), b, rationale="", label="exc_atom")
+    finally:
+        _current_package.reset(token)
+    # Count formula-bearing helper claims; ClaimAtom unwrap creates none.
+    formula_helpers = [k for k in pkg.knowledge if isinstance(k, Claim) and k.formula is not None]
+    assert len(formula_helpers) == 0
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility: existing Claim-only callers still work
+# ---------------------------------------------------------------------------
+
+
+def test_exclusive_with_plain_claims_still_works():
+    pkg = CollectedPackage(name="bv_compat_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        result = exclusive(a, b, rationale="", label="exc")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+
+
+def test_derive_with_plain_claim_string_conclusion_still_works():
+    pkg = CollectedPackage(name="bv_compat_str_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        # str conclusion remains a valid shape — it is NOT lifted (str is not
+        # Boolean-valued); derive's own type dispatch handles it.
+        result = derive("Conclusion from string.", given=[a], rationale="", label="d")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+
+
+def test_infer_with_plain_string_evidence_still_works():
+    pkg = CollectedPackage(name="bv_compat_infer_str_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        h = claim("Hypothesis.")
+        result = infer(
+            "Evidence as string.",
+            hypothesis=h,
+            p_e_given_h=0.9,
+            p_e_given_not_h=0.5,
+            label="i_str",
+        )
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)

--- a/tests/gaia/lang/test_boolean_valued_lift.py
+++ b/tests/gaia/lang/test_boolean_valued_lift.py
@@ -238,6 +238,23 @@ def test_derive_accepts_propositional_formula_in_given():
     assert isinstance(result, Claim)
 
 
+def test_derive_accepts_single_propositional_formula_in_given():
+    pkg = CollectedPackage(name="bv_derive_single_given_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        conclusion = claim("Conclusion.")
+        result = derive(conclusion, given=a & b, rationale="", label="d_single")
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+    action = result.from_actions[0]
+    assert len(action.given) == 1
+    assert isinstance(action.given[0], Claim)
+    assert isinstance(action.given[0].formula, Land)
+
+
 def test_infer_accepts_propositional_formula_as_evidence_and_hypothesis():
     pkg = CollectedPackage(name="bv_infer_pkg", namespace="t")
     token = _current_package.set(pkg)
@@ -255,6 +272,31 @@ def test_infer_accepts_propositional_formula_as_evidence_and_hypothesis():
     finally:
         _current_package.reset(token)
     assert isinstance(result, Claim)
+
+
+def test_infer_accepts_single_propositional_formula_in_given():
+    pkg = CollectedPackage(name="bv_infer_single_given_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        a = claim("A.")
+        b = claim("B.")
+        h = claim("Hypothesis.")
+        e = claim("Evidence.")
+        result = infer(
+            e,
+            hypothesis=h,
+            given=a & b,
+            p_e_given_h=0.9,
+            p_e_given_not_h=0.5,
+            label="i_single_given",
+        )
+    finally:
+        _current_package.reset(token)
+    assert isinstance(result, Claim)
+    action = result.from_actions[0]
+    assert len(action.given) == 1
+    assert isinstance(action.given[0], Claim)
+    assert isinstance(action.given[0].formula, Land)
 
 
 def test_register_prior_accepts_propositional_formula():


### PR DESCRIPTION
Implements RFC #703 (`docs/specs/2026-05-24-boolean-valued-claim-lift-design.md`).

## Summary

- Verbs that accept Claim arguments (`exclusive` / `contradict` / `equal` / `derive` / `infer` / `register_prior`) now accept any **Boolean-valued expression** — Claim, ClaimAtom, Formula (Land/Lor/Lnot/Implies/Iff/Forall/Exists/Equals/NotEquals/Greater/GreaterEqual/Less/LessEqual/UserPredicate), or BoolExpr — via a single `_lift_to_claim` helper at verb entry.
- Formula AST stays pure: PR #658's deliberately preserved Formula/Claim layer separation is untouched. `Claim.__and__/__or__/__invert__` still return Formula nodes. The lift fires only at verb boundaries.
- Closes the BoardgameQA ergonomic gap: `exclusive(p1 & p2, neg)` now works directly, no more `'Land' has no attribute 'label'` AttributeError, no need for the deprecated `and_()` fallback or the `infer(CONJ_HI/LO)` workaround.

## Background

The full design and motivation is in the RFC ([file on branch](https://github.com/SiliconEinstein/Gaia/blob/feat/boolean-valued-claim-lift/docs/specs/2026-05-24-boolean-valued-claim-lift-design.md)). Three Main-depth3 items from the BoardgameQA validation set (P8, P12, P16) lost threshold mapping because the post-#658 ergonomic gap drove authors to simulate sharp conjunction via `infer(p_e_given_h=0.999, p_e_given_not_h=0.001)`, which leaks MaxEnt 0.5 through non-`all-true` CPT cells. Ad-hoc fix using `and_(...)` directly already verified the corrected behaviour; this PR systematises that path so users don't need the deprecated verb.

## Implementation

### New files

- **`gaia/engine/lang/_boolean_valued.py`** — `is_boolean_valued(obj)` predicate that composes `is_formula(obj)` (covers every Formula class via the existing `__gaia_formula__` marker) with a `__gaia_boolean_valued__: ClassVar[bool] = True` class marker that's set on **just Claim and BoolExpr** (the two Boolean-valued non-Formula types). Two attribute additions, not 13.

- **`gaia/engine/lang/dsl/_lift.py`** — `_lift_to_claim(value, *, verb, position)` dispatches by shape:
  - `Claim` → returned as-is.
  - `ClaimAtom` → unwrapped to `value.claim` (no helper Claim created).
  - Formula → `claim(_synth_description(value), formula=value)`.
  - `BoolExpr` → `claim(_synth_description(value), value)` (positional `proposition` slot).
  - anything else → educational `TypeError` pointing at the Term-layer wrapping idiom.

### Modified files

- **`gaia/engine/lang/runtime/knowledge.py`** — `Claim.__gaia_boolean_valued__ = True`.
- **`gaia/engine/lang/dsl/bool_expr.py`** — `BoolExpr.__gaia_boolean_valued__ = True`.
- **`gaia/engine/lang/dsl/relate.py`** — `equal` / `contradict` / `exclusive` lift both positional args at entry.
- **`gaia/engine/lang/dsl/support.py`** — `derive` lifts `conclusion` (preserving the str path) + every `given` entry.
- **`gaia/engine/lang/dsl/infer_verb.py`** — `_validate_infer_claims` lifts `evidence` (preserving str path), `hypothesis`, every `given` entry.
- **`gaia/engine/lang/dsl/register_prior.py`** — `register_prior` lifts the first argument; the existing TypeError path stays as the educational fallback when the input is neither Claim nor Boolean-valued.

### Out of scope

`observe()` and `compute()` are deliberately not touched — both have multiple non-Claim input shapes (`Distribution` / `Variable` / Claim subclass) whose dispatch we did not want to perturb in the same PR. Their integration can land separately if needed.

### Deferred

Per-package memoization (RFC §4.4) — the current implementation creates a fresh helper Claim per call site; in BP these become two independent variables that converge to identical marginals. Wasteful but not incorrect. Easy follow-up.

## Test plan

- [x] **New file** `tests/gaia/lang/test_boolean_valued_lift.py` — 26 tests, all green:
  - `is_boolean_valued` recognises each in-scope type (Claim / ClaimAtom / propositional connectives / predicate formulas / quantifier formulas / BoolExpr) and rejects each Term-layer type (Variable / Constant / str / int / None).
  - `_lift_to_claim` dispatches correctly per shape: passthrough on Claim, no-helper unwrap on ClaimAtom, helper materialisation on Formula and BoolExpr, educational TypeError on anything else.
  - Each in-scope verb (`exclusive` / `contradict` / `equal` / `derive` / `infer` / `register_prior`) accepts a Boolean-valued argument and still rejects Term-layer arguments.
  - Backwards compatibility: plain-Claim arguments work unchanged; `derive`/`infer` `str` conclusion/evidence paths preserved.
- [x] `uv run pytest tests/gaia/lang/ tests/ir/ tests/cli/test_compile.py tests/cli/test_compile_v6.py` — 983 passed.
- [x] `uv run pytest --no-cov` (full fast suite) — **2956 passed**, 25 pre-existing failures (matching #704 baseline exactly: credentials / lkm_auth / help-snapshots / exploration joint — all unrelated to lang/DSL).
- [x] `uv run ruff format` + `ruff check` on touched files — clean.
- [x] `uv run mypy` on the 6 modified source files — Success, no issues.

## Backwards compatibility

- `claim(content, formula=...)`, `claim(content, proposition)`, `claim(content)` — unchanged.
- `Claim.__and__/__or__/__invert__` — unchanged. Still return Formula nodes per PR #658.
- `gaia.engine.lang.compat.{and_, or_, not_}` — unchanged. Still produce helper Claims; remains the recommended path for n-ary conjunctions (chained `a & b & c` would otherwise nest).
- All Formula transform tools (CNF, SAT, equivalence) — unchanged. They operate on Formula AST, which is built and stored exactly as before.
- Verb signatures: type annotations relaxed from `Claim` to `Any` where lift applies, but runtime semantics widen monotonically — Claim callers see no change.

## Related

- Closes RFC issue #703.
- Builds on PR #658 (formula-claim sugar).
- Builds on PR #704 (validator regression fix; required for `claim(formula=...)` packages to actually compile via the CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)