### PR TITLE
feat(exploration): expand↔consolidate loop — maximize maintainable graph growth

### DIFF
--- a/gaia/engine/exploration/__init__.py
+++ b/gaia/engine/exploration/__init__.py
@@ -42,6 +42,7 @@ from gaia.engine.exploration.render import (
     exploration_header_fields,
     frontier_graph_elements,
     inject_exploration_header,
+    ratified_node_classes,
     wrap_self_contained_html,
 )
 from gaia.engine.exploration.scorer import (
@@ -115,6 +116,7 @@ __all__ = [
     "mint_contact_id",
     "observe_lkm_results",
     "promote_materialized_lkm_contacts",
+    "ratified_node_classes",
     "read_rounds",
     "reconcile_frontier",
     "result_path",

--- a/gaia/engine/exploration/__init__.py
+++ b/gaia/engine/exploration/__init__.py
@@ -25,6 +25,12 @@ from gaia.engine.exploration.handoff import (
     result_path,
     task_path,
 )
+from gaia.engine.exploration.health import (
+    Component,
+    MapHealth,
+    RatifiedSeparation,
+    compute_map_health,
+)
 from gaia.engine.exploration.observe import (
     ObserveResult,
     observe_lkm_results,
@@ -79,10 +85,13 @@ __all__ = [
     "VALID_REF_KINDS",
     "VALID_SEED_KINDS",
     "VALID_TURN_PHASES",
+    "Component",
     "Contact",
     "ExplorationMap",
+    "MapHealth",
     "ObserveResult",
     "Policy",
+    "RatifiedSeparation",
     "SurveyRecord",
     "SurveyResult",
     "SurveyTask",
@@ -90,6 +99,7 @@ __all__ = [
     "append_round",
     "binary_entropy",
     "build_joint_view",
+    "compute_map_health",
     "doctrine_policy",
     "exploration_dir",
     "exploration_header_fields",

--- a/gaia/engine/exploration/__init__.py
+++ b/gaia/engine/exploration/__init__.py
@@ -19,6 +19,8 @@ from gaia.engine.exploration.frontier import (
     reconcile_frontier,
 )
 from gaia.engine.exploration.handoff import (
+    IslandBrief,
+    RatifiedSeparationResult,
     SurveyResult,
     SurveyTask,
     TaskContact,
@@ -88,10 +90,12 @@ __all__ = [
     "Component",
     "Contact",
     "ExplorationMap",
+    "IslandBrief",
     "MapHealth",
     "ObserveResult",
     "Policy",
     "RatifiedSeparation",
+    "RatifiedSeparationResult",
     "SurveyRecord",
     "SurveyResult",
     "SurveyTask",

--- a/gaia/engine/exploration/discoveries.py
+++ b/gaia/engine/exploration/discoveries.py
@@ -14,11 +14,14 @@ kind              meaning                                                    sou
 ``contradiction``  an authored ``contradict`` fired / a belief conflict       v1
 ``keystone``       a high in-degree node many others depend on                v1
 ``settled_core``   a high-belief, low-entropy stable region                   v1
+``bridge``         an edge that merged two previously-disjoint components      Phase 3
+``fault_line``     a surveyed region disconnected from the seed core           Phase 3
 ================  =========================================================  ======
 
-``bridge`` / ``fault_line`` are deferred (DESIGN §8 topology / §2a half-b). The
-``discoveries[].kind`` field is an open string, so deferred kinds slot in later
-without a schema migration.
+``bridge`` / ``fault_line`` land now that MapHealth (EXPANSION.md §3) supplies the
+component partition; they are computed from the MapHealth-derived partitions the
+caller passes, not from the graph alone. The ``discoveries[].kind`` field is an
+open string, so these slotted in without a schema migration.
 
 Contradiction wiring (documented decision)
 ------------------------------------------
@@ -59,6 +62,12 @@ if TYPE_CHECKING:
 KIND_CONTRADICTION = "contradiction"
 KIND_KEYSTONE = "keystone"
 KIND_SETTLED_CORE = "settled_core"
+# EXPANSION.md §3 / Phase 3 — connectivity discovery kinds, now that MapHealth
+# exists. ``bridge`` = an edge that connected two previously-disjoint components
+# this round (fragmentation healed); ``fault_line`` = a surveyed region that
+# became (or remains) a disconnected orphan island (fragmentation surfaced).
+KIND_BRIDGE = "bridge"
+KIND_FAULT_LINE = "fault_line"
 
 # A belief that moved down by more than this between rounds is a contradiction
 # signal (mirrors inquiry diagnostics' conservative default).
@@ -282,6 +291,109 @@ def detect_settled_core(
     return out
 
 
+def _component_of(components: list[frozenset[str]]) -> dict[str, int]:
+    """Map each node to its component index in a partition."""
+    out: dict[str, int] = {}
+    for i, comp in enumerate(components):
+        for q in comp:
+            out[q] = i
+    return out
+
+
+def detect_bridges(
+    prev_components: list[frozenset[str]],
+    curr_components: list[frozenset[str]],
+    *,
+    labels: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Find ``bridge`` discoveries: components merged since the prior round.
+
+    A bridge fired when two nodes that sat in **different** components last round
+    are in the **same** component now — the connecting edge authored/pulled this
+    round healed that fragmentation (EXPANSION.md §3). We report one ``bridge``
+    discovery per pair of previously-separate prior components now unified, naming
+    a representative node from each side. No prior partition (round 0) ⇒ no
+    bridges. Pure.
+
+    Args:
+        prev_components: the surveyed-node partition at the prior round.
+        curr_components: the surveyed-node partition now.
+        labels: optional ``qid -> author label`` for the human-facing note.
+
+    Returns:
+        ``{kind, ids, note}`` records, one per newly-merged prior-component pair.
+    """
+    if not prev_components:
+        return []
+    prev_of = _component_of(prev_components)
+    out: list[dict[str, Any]] = []
+    seen_pairs: set[tuple[int, int]] = set()
+    for comp in curr_components:
+        # Which prior components do this current component's nodes come from?
+        prior_ids = sorted({prev_of[q] for q in comp if q in prev_of})
+        if len(prior_ids) < 2:
+            continue
+        # Each pair of distinct prior components now unified = one bridge.
+        for i in range(len(prior_ids)):
+            for j in range(i + 1, len(prior_ids)):
+                pair = (prior_ids[i], prior_ids[j])
+                if pair in seen_pairs:
+                    continue
+                seen_pairs.add(pair)
+                left = sorted(prev_components[prior_ids[i]])
+                right = sorted(prev_components[prior_ids[j]])
+                a = _display(left[0], labels) if left else "?"
+                b = _display(right[0], labels) if right else "?"
+                out.append(
+                    {
+                        "kind": KIND_BRIDGE,
+                        "ids": [left[0], right[0]] if left and right else [],
+                        "note": (
+                            f"bridged previously-disjoint regions ({a} ↔ {b}); "
+                            "a connecting edge unified them this round"
+                        ),
+                    }
+                )
+    return out
+
+
+def detect_fault_lines(
+    orphan_components: list[frozenset[str]],
+    *,
+    labels: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Find ``fault_line`` discoveries: surveyed regions disconnected from the core.
+
+    A fault line is a surveyed orphan island — a cluster of materialized nodes not
+    wired to the seed core (EXPANSION.md §1/§3). We report one ``fault_line`` per
+    orphan component, naming a representative member. Pure; the caller supplies the
+    orphan partition (from ``MapHealth.orphans``) so this stays I/O-free.
+
+    Args:
+        orphan_components: the orphan (non-core) surveyed components.
+        labels: optional ``qid -> author label`` for the human-facing note.
+
+    Returns:
+        ``{kind, ids, note}`` records, one per orphan island.
+    """
+    out: list[dict[str, Any]] = []
+    for comp in sorted(orphan_components, key=lambda c: (-len(c), sorted(c))):
+        members = sorted(comp)
+        if not members:
+            continue
+        out.append(
+            {
+                "kind": KIND_FAULT_LINE,
+                "ids": members,
+                "note": (
+                    f"disconnected region of {len(members)} surveyed node(s) "
+                    f"(e.g. {_display(members[0], labels)}) not wired to the seed core"
+                ),
+            }
+        )
+    return out
+
+
 def compute_discoveries(
     ir: LocalCanonicalGraph,
     beliefs: dict[str, float],
@@ -291,6 +403,9 @@ def compute_discoveries(
     drop_threshold: float = BELIEF_DROP_THRESHOLD,
     settled_epsilon: float = SETTLED_ENTROPY_EPSILON,
     keystone_min_indegree: int = KEYSTONE_MIN_INDEGREE,
+    prev_components: list[frozenset[str]] | None = None,
+    curr_components: list[frozenset[str]] | None = None,
+    orphan_components: list[frozenset[str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Compute the full v1 discovery set for one round (SCHEMA.md §6 / §7c).
 
@@ -306,6 +421,14 @@ def compute_discoveries(
         drop_threshold: Belief-drop magnitude for a contradiction.
         settled_epsilon: Entropy ceiling for a settled-core node.
         keystone_min_indegree: In-degree threshold for a keystone.
+        prev_components: optional prior-round surveyed-node partition (from the
+            prior round's MapHealth) for ``bridge`` detection. Paired with
+            ``curr_components``.
+        curr_components: optional current surveyed-node partition for ``bridge``
+            detection. When both partitions are given, components merged since the
+            prior round surface as ``bridge`` discoveries.
+        orphan_components: optional current orphan (non-core) partition (from
+            ``MapHealth.orphans``) for ``fault_line`` detection.
 
     Returns:
         The concatenated list of discovery records for the round.
@@ -327,4 +450,11 @@ def compute_discoveries(
     )
     discoveries.extend(detect_keystones(ir, min_indegree=keystone_min_indegree, labels=labels))
     discoveries.extend(detect_settled_core(beliefs, epsilon=settled_epsilon, labels=labels))
+    # Connectivity discoveries (EXPANSION.md §3 / Phase 3) — only when the caller
+    # supplies the MapHealth-derived component partitions (the orchestrator does;
+    # the standalone round verb may not, in which case these are simply absent).
+    if prev_components is not None and curr_components is not None:
+        discoveries.extend(detect_bridges(prev_components, curr_components, labels=labels))
+    if orphan_components is not None:
+        discoveries.extend(detect_fault_lines(orphan_components, labels=labels))
     return discoveries

--- a/gaia/engine/exploration/handoff.py
+++ b/gaia/engine/exploration/handoff.py
@@ -73,19 +73,55 @@ class TaskContact(BaseModel):
     survey_brief: str = ""
 
 
+class IslandBrief(BaseModel):
+    """One disconnected island in a consolidate task's bridge worklist (EXPANSION.md §3.D).
+
+    A consolidate turn operates over ALREADY-surveyed nodes (no new pulls): for
+    each orphan island the agent either authors a connecting
+    ``derive``/``contradict``/``depends_on`` to wire it to the core, OR ratifies
+    it as a legitimately separate region.
+
+    Attributes:
+        member_qids: the surveyed QIDs in this island (the component members).
+        brief: a short NL description of the island (its node labels / what it is)
+            so the agent can judge whether a sound connection exists.
+        reopened: whether this island was previously ratified and is back on the
+            worklist because new evidence may now connect it (provisional reopen).
+        bridge_hint: when ``reopened`` (or otherwise bridgeable), the QID whose
+            presence may now connect this island to the core — surfaced in the
+            "reconsider" note.
+    """
+
+    member_qids: list[str] = Field(default_factory=list)
+    brief: str = ""
+    reopened: bool = False
+    bridge_hint: str | None = None
+
+
 class SurveyTask(BaseModel):
     """The task envelope (client → agent): ``turn-<n>.task.json``.
 
     Self-contained per CLIENT.md "no skill": ``instructions`` carries the full
     survey procedure absorbed from the retired ``gaia-lkm-explorer`` skill, so an
     agent reading only this file can survey correctly and re-invoke the client.
+
+    EXPANSION.md §3.D adds a ``kind`` discriminator: an ``"expand"`` task is the
+    today's-behaviour frontier shortlist (``contacts``); a ``"consolidate"`` task
+    instead carries a ``bridge_worklist`` of disconnected ``islands`` (over
+    already-surveyed nodes) for the agent to bridge-or-ratify. Default ``"expand"``
+    keeps a task written before this existed back-compat.
     """
 
     pkg: str
     round: int
     doctrine: str
     budget_k: int
+    # EXPANSION.md §3.D — task kind discriminator (default expand, back-compat).
+    kind: str = "expand"
     contacts: list[TaskContact] = Field(default_factory=list)
+    # EXPANSION.md §3.D — the consolidate bridge worklist (empty for an expand
+    # task): the disconnected islands/orphans, each with a per-island brief.
+    bridge_worklist: list[IslandBrief] = Field(default_factory=list)
     # CLIENT.md round-0 special case: a seed-survey task instead of a frontier
     # shortlist. The client sets this so the agent knows to survey the seed text.
     seed_survey: bool = False
@@ -110,6 +146,19 @@ class SurveyTask(BaseModel):
         return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
 
 
+class RatifiedSeparationResult(BaseModel):
+    """One island the agent ratified as legitimately separate (EXPANSION.md §3.E).
+
+    The agent reports the island's surveyed-node set and a one-line scientific
+    rationale; the orchestrator records it into ``map.ratified_separations`` (with
+    the round + evidence fingerprint it stamps) so MapHealth excludes the island
+    from the unhealthy count until new evidence reopens it.
+    """
+
+    member_qids: list[str] = Field(default_factory=list)
+    rationale: str = ""
+
+
 class SurveyResult(BaseModel):
     """The result envelope (agent → client): ``turn-<n>.result.json``.
 
@@ -122,9 +171,19 @@ class SurveyResult(BaseModel):
     Pydantic's default ``extra="ignore"`` means legacy result files carrying the
     retired ``observed`` / ``notes`` keys still read without error — the extra
     keys are tolerated and dropped.
+
+    EXPANSION.md §3.E adds the consolidate outcome: ``ratified`` carries the
+    islands the agent judged legitimately-separate this turn (each a
+    :class:`RatifiedSeparationResult`). It is the one consolidate signal the
+    orchestrator cannot infer from the authored DSL (a bridge authored as a
+    ``derive`` shows up in the graph; a *non-connection* — "this island is
+    legitimately apart" — has no graph footprint, so the agent must report it).
+    Default empty keeps an expand-turn result envelope just ``{surveyed_qids}``,
+    back-compat.
     """
 
     surveyed_qids: list[str] = Field(default_factory=list)
+    ratified: list[RatifiedSeparationResult] = Field(default_factory=list)
 
     def write(self, path: str | Path) -> Path:
         """Atomically write this result to ``path`` and return it."""
@@ -147,6 +206,8 @@ class SurveyResult(BaseModel):
 __all__ = [
     "RESULT_FILENAME_TEMPLATE",
     "TASK_FILENAME_TEMPLATE",
+    "IslandBrief",
+    "RatifiedSeparationResult",
     "SurveyResult",
     "SurveyTask",
     "TaskContact",

--- a/gaia/engine/exploration/health.py
+++ b/gaia/engine/exploration/health.py
@@ -1,0 +1,367 @@
+"""Map connectivity health — the ``MapHealth`` primitive (EXPANSION.md §3.A).
+
+The expand↔consolidate iteration adds one genuinely new engine primitive: a pure
+function that measures the **connectivity** of the joint exploration graph. It
+powers the activated scorer slots (``bridge_potential`` / qid ``new_territory``),
+the ``auto`` mode cadence, the maintainability readout, and the consolidate
+bridging task — all from one place.
+
+A :class:`MapHealth` answers, over the JOINT undirected adjacency (the same edge
+set the scorer / frontier already share):
+
+* which weakly-connected components the surveyed territory falls into;
+* what fraction of surveyed nodes sit in the biggest component
+  (``largest_fraction``);
+* which components are **orphans** — surveyed islands not in the seed's
+  component (the disconnected pulled papers EXPANSION.md §1 describes);
+* whether the map is *unhealthy past the fragmentation threshold* — the single
+  predicate that triggers an ``auto`` consolidate turn (EXPANSION.md §4).
+
+**Ratified-aware (EXPANSION.md §3.E).** Some islands are *legitimately* disjoint
+(genuinely different domains). The agent can ratify a whole component as
+separate; a ratified-and-still-valid island is **excluded** from the unhealthy
+count (a map of 3 components, all ratified, reads HEALTHY). A ratification is
+**provisional**: it is honored only while its premise still holds — when a later
+expansion introduces a node that bridges the ratified island to the core, the
+ratification is **REOPENED** and the island returns to the unhealthy count and
+the consolidate worklist. The reopen test reuses the same bridge adjacency check
+the scorer's ``bridge_potential`` uses — no separate machinery.
+
+Pure, deterministic, no I/O — mirrors :mod:`gaia.engine.exploration.discoveries`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from gaia.engine.exploration.scorer import _adjacency_from_edges
+
+# EXPANSION.md §4 — default fragmentation threshold. The map is "unhealthy past
+# the threshold" iff there are at least this many un-ratified orphan components
+# OR the orphan node fraction exceeds :data:`DEFAULT_ORPHAN_FRACTION`. Threshold
+# over hair-trigger (user, 2026-05-25): the map is allowed to fragment a little
+# and grow uninterrupted, then healed in a sweep once fragmentation crosses here.
+DEFAULT_MIN_ORPHAN_COMPONENTS = 2
+DEFAULT_ORPHAN_FRACTION = 0.34
+
+
+@dataclass(frozen=True)
+class RatifiedSeparation:
+    """An island the agent judged a legitimately-separate region (EXPANSION.md §3.E).
+
+    Per-component granularity (user, 2026-05-25): the agent ratifies a whole
+    island, not individual contacts. ``member_qids`` is the surveyed-node set of
+    the island at ratification time; ``rationale`` is the agent's one-line
+    scientific reason it is legitimately disjoint; ``round`` and
+    ``evidence_fingerprint`` capture the joint-graph state it was judged under so
+    the provisional-reopen test (below) can tell whether new evidence has changed
+    the premise.
+
+    This dataclass is the in-memory shape the health computation consumes;
+    :class:`~gaia.engine.exploration.state.ExplorationMap` persists the same
+    fields as plain dicts in ``ratified_separations`` (additive, back-compat).
+    """
+
+    member_qids: frozenset[str]
+    rationale: str = ""
+    round: int = 0
+    evidence_fingerprint: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, object]) -> RatifiedSeparation:
+        """Rehydrate from the persisted ``map.json`` payload (defensive on types)."""
+        members = raw.get("member_qids", [])
+        if not isinstance(members, (list, tuple, set, frozenset)):
+            members = []
+        fp = raw.get("evidence_fingerprint", {})
+        round_raw = raw.get("round", 0)
+        round_val = round_raw if isinstance(round_raw, int) else 0
+        return cls(
+            member_qids=frozenset(str(q) for q in members),
+            rationale=str(raw.get("rationale", "")),
+            round=round_val,
+            evidence_fingerprint=dict(fp) if isinstance(fp, dict) else {},
+        )
+
+
+@dataclass(frozen=True)
+class Component:
+    """One weakly-connected component of the surveyed territory.
+
+    Attributes:
+        members: the surveyed QIDs in this component (sorted, for legibility).
+        is_seed: whether this component contains a resolved seed (the core).
+        ratified: whether this component is covered by a still-valid
+            :class:`RatifiedSeparation` (excluded from the unhealthy count).
+        reopened: whether this component was ratified but its ratification is now
+            stale — a newly-surveyed node bridges it to the core, so it counts as
+            un-ratified again (EXPANSION.md §3.E provisional reopening).
+        bridge_qid: when ``reopened`` (or when a non-seed component is adjacent to
+            the core through an unmaterialized contact), the QID whose presence
+            now connects this island to the core — surfaced in the worklist note.
+    """
+
+    members: tuple[str, ...]
+    is_seed: bool = False
+    ratified: bool = False
+    reopened: bool = False
+    bridge_qid: str | None = None
+
+
+@dataclass(frozen=True)
+class MapHealth:
+    """The connectivity readout over the joint graph (EXPANSION.md §3.A / §4).
+
+    Attributes:
+        components: every surveyed component, seed component first then by size.
+        largest_fraction: share of surveyed nodes in the biggest component
+            (``1.0`` for a fully-connected map, ``0.0`` for an empty one).
+        orphans: the non-seed components (surveyed islands off the core).
+        orphan_node_fraction: share of surveyed nodes that sit in an orphan.
+        unratified_orphan_count: orphans that are neither bridged nor
+            validly-ratified (a reopened ratification counts here) — the quantity
+            the fragmentation threshold is measured against.
+        reopened: the components whose ratification went stale this compute.
+    """
+
+    components: tuple[Component, ...]
+    largest_fraction: float
+    orphans: tuple[Component, ...]
+    orphan_node_fraction: float
+    unratified_orphan_count: int
+    reopened: tuple[Component, ...]
+
+    @property
+    def component_count(self) -> int:
+        """Number of surveyed components."""
+        return len(self.components)
+
+    @property
+    def ratified_count(self) -> int:
+        """Number of still-valid (non-reopened) ratified components."""
+        return sum(1 for c in self.components if c.ratified and not c.reopened)
+
+    def is_unhealthy(
+        self,
+        *,
+        min_orphan_components: int = DEFAULT_MIN_ORPHAN_COMPONENTS,
+        orphan_fraction: float = DEFAULT_ORPHAN_FRACTION,
+    ) -> bool:
+        """Whether fragmentation is past the threshold (EXPANSION.md §4).
+
+        Unhealthy ⇔ there exist un-ratified orphan components (a reopened
+        ratification counts as un-ratified) **in a quantity past the threshold**:
+        at least ``min_orphan_components`` of them OR an orphan node fraction
+        above ``orphan_fraction``. Non-coercive by construction — fragmentation is
+        tolerated below the threshold and healed in a sweep past it.
+        """
+        if self.unratified_orphan_count <= 0:
+            return False
+        return (
+            self.unratified_orphan_count >= min_orphan_components
+            or self.orphan_node_fraction > orphan_fraction
+        )
+
+
+def _weakly_connected_components(
+    nodes: set[str],
+    adjacency: dict[str, set[str]],
+) -> list[set[str]]:
+    """Partition ``nodes`` into weakly-connected components over ``adjacency``.
+
+    Only edges *between two ``nodes``* connect (an edge to an unmaterialized
+    contact does not pull a fog node into a component). A node with no in-set
+    neighbour is its own singleton component. Deterministic: components are
+    discovered in sorted-node order via flood fill.
+    """
+    seen: set[str] = set()
+    components: list[set[str]] = []
+    for start in sorted(nodes):
+        if start in seen:
+            continue
+        comp: set[str] = set()
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            if node in comp:
+                continue
+            comp.add(node)
+            seen.add(node)
+            for neighbour in adjacency.get(node, ()):  # only in-set neighbours connect
+                if neighbour in nodes and neighbour not in comp:
+                    stack.append(neighbour)
+        components.append(comp)
+    return components
+
+
+def _bridges_to_core(
+    island: set[str],
+    core: set[str],
+    edges: list[tuple[str, list[str]]],
+    adjacency: dict[str, set[str]],
+) -> str | None:
+    """Return a QID that links ``island`` to ``core``, or ``None`` (EXPANSION.md §3.E/B).
+
+    The same adjacency notion ``bridge_potential`` uses: a *candidate connecting
+    edge now exists* iff —
+
+    * some reference edge **co-references** a member of ``island`` and a member of
+      ``core`` (a direct spanning edge — would also merge the components, so this
+      mainly fires the round the bridge first appears); OR
+    * a node ``x`` is **adjacent to both** the island and the core — typically an
+      as-yet-unmaterialized contact ``x`` that two separate edges tie to an island
+      member and to a core member respectively. The components are still disjoint
+      (``x`` is not surveyed, so it does not merge them), yet authoring ``x`` (or
+      the connecting edge) *would* wire the island to the core — the provisional
+      reopen trigger.
+
+    Returns the first such bridging QID — preferring a concrete island member the
+    spanning edge ties in (so the worklist note can name *which* new evidence
+    reopens the island), then the connecting node ``x`` — or ``None`` when the two
+    are still genuinely disjoint.
+    """
+    if not island or not core:
+        return None
+    # Direct spanning edge.
+    for _edge_kind, refs in edges:
+        present = [r for r in refs if r]
+        touches_island = any(r in island for r in present)
+        touches_core = any(r in core for r in present)
+        if touches_island and touches_core:
+            for r in present:
+                if r in island:
+                    return r
+            return present[0]
+    # A connecting node adjacent to both (e.g. an unmaterialized contact).
+    island_neighbours: set[str] = set()
+    for m in island:
+        island_neighbours |= adjacency.get(m, set())
+    for x in sorted(island_neighbours):
+        if adjacency.get(x, set()) & core:
+            # Prefer naming an island member that x ties in, for the note.
+            tied = sorted(adjacency.get(x, set()) & island)
+            return tied[0] if tied else x
+    return None
+
+
+def compute_map_health(
+    surveyed: Iterable[str],
+    seeds: Iterable[str],
+    edges: list[tuple[str, list[str]]],
+    *,
+    ratified: Iterable[RatifiedSeparation] = (),
+) -> MapHealth:
+    """Compute the connectivity health of the joint exploration graph (EXPANSION.md §3.A).
+
+    Pure and deterministic. Builds the undirected adjacency from ``edges`` (reuses
+    :func:`~gaia.engine.exploration.scorer._adjacency_from_edges`), partitions the
+    ``surveyed`` set into weakly-connected components, identifies the seed
+    component as the core, and classifies every other component as an orphan —
+    excluding components covered by a *still-valid* ratified separation.
+
+    Ratification is honored provisionally: for each ratified component, the
+    bridge test (:func:`_bridges_to_core`) is re-run against the current joint
+    edges; if a connecting edge now exists, the ratification is **reopened** and
+    the island re-enters the unhealthy count (EXPANSION.md §3.E).
+
+    Args:
+        surveyed: the surveyed-node QIDs (``map.surveyed`` keys).
+        seeds: the resolved seed QIDs (the core anchor); empty ⇒ the largest
+            component is treated as the core (best-effort, so health still reads
+            on a seedless map).
+        edges: the JOINT ``(edge_kind, [referenced_qids])`` edge set — the same
+            list :class:`~gaia.engine.exploration.frontier.JointView` exposes.
+        ratified: the in-memory ratified separations (per component); a component
+            whose member set matches one is excluded unless reopened.
+
+    Returns:
+        A :class:`MapHealth` readout.
+    """
+    surveyed_set = {q for q in surveyed if q}
+    seed_set = {q for q in seeds if q} & surveyed_set
+    adjacency = _adjacency_from_edges(edges)
+    raw_components = _weakly_connected_components(surveyed_set, adjacency)
+
+    n_surveyed = len(surveyed_set)
+    largest_fraction = (
+        max((len(c) for c in raw_components), default=0) / n_surveyed if n_surveyed else 0.0
+    )
+
+    # Identify the seed/core component. Prefer the component containing a seed;
+    # fall back to the largest component when no seed is resolved (so a seedless
+    # map still has a defined core and meaningful orphans).
+    core_members: set[str] = set()
+    if seed_set:
+        for comp in raw_components:
+            if comp & seed_set:
+                core_members |= comp
+    elif raw_components:
+        core_members = max(raw_components, key=lambda c: (len(c), sorted(c)))
+
+    # Index ratified separations by their member set for exact per-component match.
+    ratified_by_members: dict[frozenset[str], RatifiedSeparation] = {
+        r.member_qids: r for r in ratified
+    }
+
+    components: list[Component] = []
+    orphans: list[Component] = []
+    reopened: list[Component] = []
+    unratified_orphan_count = 0
+    orphan_nodes = 0
+
+    for comp in raw_components:
+        is_seed = bool(comp & core_members) and bool(core_members)
+        members = tuple(sorted(comp))
+        rat = ratified_by_members.get(frozenset(comp))
+        is_ratified = rat is not None
+        is_reopened = False
+        bridge_qid: str | None = None
+
+        if not is_seed:
+            orphan_nodes += len(comp)
+            # Does a connecting edge to the core now exist? Reuse the bridge check.
+            bridge_qid = _bridges_to_core(comp, core_members, edges, adjacency)
+            if is_ratified and bridge_qid is not None:
+                # Provisional reopen: the ratification's premise is stale.
+                is_reopened = True
+            if (not is_ratified) or is_reopened:
+                unratified_orphan_count += 1
+
+        component = Component(
+            members=members,
+            is_seed=is_seed,
+            ratified=is_ratified,
+            reopened=is_reopened,
+            bridge_qid=bridge_qid if (not is_seed) else None,
+        )
+        components.append(component)
+        if not is_seed:
+            orphans.append(component)
+        if is_reopened:
+            reopened.append(component)
+
+    # Order: seed component(s) first, then orphans by descending size then members.
+    components.sort(key=lambda c: (not c.is_seed, -len(c.members), c.members))
+    orphans.sort(key=lambda c: (-len(c.members), c.members))
+
+    orphan_node_fraction = orphan_nodes / n_surveyed if n_surveyed else 0.0
+
+    return MapHealth(
+        components=tuple(components),
+        largest_fraction=largest_fraction,
+        orphans=tuple(orphans),
+        orphan_node_fraction=orphan_node_fraction,
+        unratified_orphan_count=unratified_orphan_count,
+        reopened=tuple(reopened),
+    )
+
+
+__all__ = [
+    "DEFAULT_MIN_ORPHAN_COMPONENTS",
+    "DEFAULT_ORPHAN_FRACTION",
+    "Component",
+    "MapHealth",
+    "RatifiedSeparation",
+    "compute_map_health",
+]

--- a/gaia/engine/exploration/render.py
+++ b/gaia/engine/exploration/render.py
@@ -32,6 +32,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from gaia.engine.exploration.health import MapHealth
     from gaia.engine.exploration.state import ExplorationMap
 
 _PANEL_FILL = "#0c1124"
@@ -129,8 +130,19 @@ def frontier_graph_elements(
     return nodes, edges
 
 
-def exploration_header_fields(exploration_map: ExplorationMap) -> list[tuple[str, str]]:
-    """The exploration state header pairs (seed / doctrine / round / surveyed / frontier)."""
+def exploration_header_fields(
+    exploration_map: ExplorationMap,
+    *,
+    health: MapHealth | None = None,
+) -> list[tuple[str, str]]:
+    """The exploration state header pairs (seed / doctrine / round / surveyed / …).
+
+    When a :class:`~gaia.engine.exploration.health.MapHealth` is supplied
+    (EXPANSION.md §3 / Phase 3), the header also reports connectivity:
+    ``components``, ``orphans`` (un-ratified), ``ratified``, and ``reopened`` — so
+    a reader sees at a glance whether the map is a single connected story, a
+    legitimately multi-domain (ratified) map, or fragmented.
+    """
     seed_texts = [str(s.get("text") or s.get("qid") or "?") for s in exploration_map.seeds]
     seed_display = "; ".join(seed_texts) if seed_texts else "(none)"
     if len(seed_display) > 80:
@@ -141,13 +153,56 @@ def exploration_header_fields(exploration_map: ExplorationMap) -> list[tuple[str
         "frontier_open",
         sum(1 for c in exploration_map.frontier if c.status == "open"),
     )
-    return [
+    fields = [
         ("seed", seed_display),
         ("doctrine", exploration_map.policy.doctrine),
         ("round", str(exploration_map.round)),
         ("surveyed", str(surveyed_count)),
         ("frontier open", str(frontier_open)),
     ]
+    if health is not None:
+        fields.append(("components", str(health.component_count)))
+        fields.append(("orphans", str(health.unratified_orphan_count)))
+        fields.append(("ratified", str(health.ratified_count)))
+        if health.reopened:
+            fields.append(("reopened", str(len(health.reopened))))
+    elif exploration_map.ratified_separations:
+        # No live health, but the map records ratifications — surface the count.
+        fields.append(("ratified", str(len(exploration_map.ratified_separations))))
+    return fields
+
+
+def ratified_node_classes(
+    exploration_map: ExplorationMap,
+    *,
+    health: MapHealth | None = None,
+) -> dict[str, str]:
+    """Classify surveyed nodes by ratified-separation state for distinct styling.
+
+    Returns ``qid -> "ratified" | "reopened"`` for nodes in a ratified (or
+    reopened) island, so the caller can draw a ratified boundary **distinctly from
+    a fog gap** (EXPANSION.md §3.E) — a deliberate border, not "unexplored" — and
+    **flag a REOPENED one**. A node in a still-valid ratified island maps to
+    ``"ratified"``; one in a reopened island maps to ``"reopened"``.
+
+    When a live :class:`~gaia.engine.exploration.health.MapHealth` is given the
+    reopened state is authoritative (its provisional-reopen test ran against the
+    current graph). Without it, every recorded ratified member is ``"ratified"``
+    (no reopen info available) — still a deliberate border, just not flagged.
+    """
+    classes: dict[str, str] = {}
+    reopened_members: set[str] = set()
+    if health is not None:
+        for comp in health.reopened:
+            reopened_members.update(comp.members)
+    for row in exploration_map.ratified_separations:
+        for q in row.get("member_qids", []):
+            qid = str(q)
+            classes[qid] = "reopened" if qid in reopened_members else "ratified"
+    # A reopened member not in any recorded row (defensive) is still flagged.
+    for qid in reopened_members:
+        classes.setdefault(qid, "reopened")
+    return classes
 
 
 def _svg_viewbox_width(svg_text: str) -> float:

--- a/gaia/engine/exploration/scorer.py
+++ b/gaia/engine/exploration/scorer.py
@@ -132,10 +132,27 @@ def sanitize_score_features(score_features: dict[str, Any]) -> dict[str, Any]:
 
 # SCHEMA.md §7f — survey cost of an LKM paper-contact. A qid contact is
 # materialize-only (flat 1.0); pulling a whole paper via `gaia pkg add
-# --lkm-paper` is strictly heavier, so an lkm contact costs more. 2.0 keeps the
-# ordering qid < lkm without overwhelming the live w_uncertainty/w_relevance
-# terms at the default doctrine weights (w_cost ~ 0.2 ⇒ a 0.2 cost penalty).
-LKM_SURVEY_COST = 2.0
+# --lkm-paper` is genuinely heavier *effort*, so an lkm contact still costs more.
+#
+# The constant is bounded, though, so the cost asymmetry cannot defeat the
+# expansion goal (EXPANSION.md §1, the 0327 acceptance test). The pathology: an
+# external pull is *rewarded* with `new_territory` AND *penalised* with the
+# heavier cost - and at the old ``2.0`` the cost penalty (``w_cost*(2.0-1.0)``)
+# out-weighed the coverage benefit (``w_coverage*(nt_lkm-nt_drill)``) under the
+# coverage-light doctrines (Surveyor/Diplomat, ``w_coverage=0.3``), so a pulled
+# paper's own intra-paper drilling contacts still out-ranked external papers even
+# after the coverage slot was activated. That double-counts the same act (open
+# territory) once as benefit and once as cost.
+#
+# Fix: keep the effort signal (lkm > qid) but cap the cost so the cost *gap*
+# never exceeds the coverage *benefit* an external pull buys, in any doctrine.
+# Tightest doctrine: Surveyor/Diplomat ``w_coverage=0.3``, ``w_cost=0.2``;
+# minimum coverage benefit is ``0.3*(0.5-0.2)=0.09`` (external floor 0.5 vs.
+# intra-paper drilling 0.2), so we need ``0.2*(C-1) < 0.09`` -> ``C < 1.45``.
+# ``1.25`` keeps a clear margin (cost gap ``0.2*0.25=0.05 < 0.09``) while leaving
+# lkm strictly heavier than a qid. (There is still no real LKM-pull cost model;
+# this stays a principled placeholder, just one that no longer fights the design.)
+LKM_SURVEY_COST = 1.25
 
 
 def binary_entropy(p: float) -> float:
@@ -359,6 +376,8 @@ def _bridge_potential(
     ref_value: str | None,
     index: _ComponentIndex | None,
     adjacency: dict[str, set[str]],
+    *,
+    is_drilling: bool = False,
 ) -> float:
     """``1.0`` iff surveying/wiring this contact would connect an orphan to the core.
 
@@ -376,8 +395,21 @@ def _bridge_potential(
     ``w_bridge`` *is* the bump a bridging contact gets, so Diplomat / Cartographer
     reliably surface it. ``0.0`` when no MapHealth is available (the pre-expansion
     behaviour) or there are no orphans to bridge.
+
+    ``is_drilling`` (0327 acceptance fix, live-surfaced): a *pulled-but-
+    unformalized* contact references a single materialized internal claim of a
+    pulled paper's orphan island. Its ref QID **is** an orphan member, so the
+    "touches an orphan" branch below would mark it a bridge — but formalizing one
+    more internal claim of an island does NOT connect that island to the core
+    (the island stays orphan relative to root; the true bridge is a root→island
+    ``derive`` the agent authors in a consolidate turn, not a frontier
+    drilling-contact). Under Cartographer/Diplomat (``w_bridge=1.0``) this bogus
+    bridge bonus floods the frontier with all N internal claims of every pulled
+    paper, defeating the expansion goal exactly as the territory bug did. So a
+    drilling contact never claims bridge potential — it is intra-island drilling,
+    not a core bridge.
     """
-    if index is None or not index.orphan_members:
+    if index is None or not index.orphan_members or is_drilling:
         return 0.0
     anchors = set(source_qids)
     if ref_value is not None:
@@ -399,6 +431,8 @@ def _bridge_potential(
 def _qid_new_territory(
     source_qids: list[str],
     index: _ComponentIndex | None,
+    *,
+    is_drilling: bool = False,
 ) -> float:
     """Coverage for a qid contact: external expansion vs. intra-paper drilling.
 
@@ -415,9 +449,24 @@ def _qid_new_territory(
 
     Scale:
 
+    * **``is_drilling``** ⇒ ``0.2`` (intra-paper drilling, regardless of sources) —
+      see below;
     * no surveyed source ⇒ ``1.0`` (a pure reach into the fog — maximal novelty);
     * sources span ≥2 components ⇒ ``0.7`` (cross-region — opening new territory);
     * sources all in one component ⇒ ``0.2`` (intra-paper drilling — low).
+
+    ``is_drilling`` (0327 acceptance fix): the *pulled-but-unformalized* worklist
+    contacts (``JointView._pulled_unformalized_contacts``) reference a claim that
+    is **already materialized** in a pulled dependency package — its body is on
+    disk, it just is not wired into the root graph yet. Formalizing it drills into
+    a paper you have already pulled; it opens NO new territory. But those contacts
+    carry **empty ``sources``** (a freshly-pulled paper has no co-reference into
+    the surveyed core yet), so the ``not in_set`` branch below would otherwise
+    score them ``1.0`` — the "fog-reach" branch — and they would out-rank external
+    ``lkm_related`` papers (EXPANSION.md §1 / project INDEX open thread). The
+    *materialized-set* provenance (carried by the caller as ``is_drilling``, since
+    ``sources`` are empty) is the right signal: a materialized ref is drilling,
+    not fog. So drilling pins to the low ``0.2`` and never reaches the fog branch.
 
     ``0.0`` when no MapHealth is available (pre-expansion behaviour). Distinct
     from ``closeness_to_seed`` (relevance): a far-flung dangling ref is high
@@ -425,6 +474,8 @@ def _qid_new_territory(
     """
     if index is None:
         return 0.0
+    if is_drilling:
+        return 0.2
     in_set = [q for q in source_qids if q in index.component_of]
     if not in_set:
         return 1.0
@@ -563,6 +614,7 @@ def score_frontier(
     edges: list[tuple[str, list[str]]] | None = None,
     obligations: Iterable[SyntheticObligation] | None = None,
     health: MapHealth | None = None,
+    materialized: Iterable[str] | None = None,
 ) -> None:
     """Score every open frontier contact in place (SCHEMA.md §7b / §7e).
 
@@ -615,6 +667,15 @@ def score_frontier(
             contacts (the pre-expansion behaviour); lkm ``new_territory`` is still
             its rank-derived signal. ``tension_potential`` stays ``0.0`` regardless
             (Inquisitor deferred — EXPANSION.md §3.B).
+        materialized: The JOINT materialized-QID set (``JointView.materialized``).
+            Used only as the *provenance* signal that classifies a qid contact as
+            intra-paper **drilling** rather than fog-reach (0327 acceptance fix): a
+            qid contact whose ``ref`` QID is in this set references a claim already
+            materialized in a pulled dependency — formalizing it drills into a
+            paper you already have (``new_territory = 0.2``), even though its
+            ``sources`` are empty (which would otherwise hit the ``1.0`` fog-reach
+            branch). ``None`` ⇒ no contact is treated as drilling (the
+            pre-expansion behaviour); harmless when ``health`` is also absent.
     """
     if edges is None and ir is None:
         raise ValueError("score_frontier requires exactly one of `edges` or `ir`")
@@ -629,6 +690,7 @@ def score_frontier(
 
     obligation_targets = _obligation_targets(obligations)
     component_index = _component_index(health)
+    materialized_set = set(materialized) if materialized is not None else set()
     seeds = _resolved_seed_qids(exploration_map)
     if edges is not None:
         adjacency = _adjacency_from_edges(edges)
@@ -644,6 +706,12 @@ def score_frontier(
         source_qids = [str(s["qid"]) for s in contact.sources if s.get("qid")]
         is_lkm = contact.ref.get("kind") == "lkm"
         ref_value = contact.ref.get("value")
+        # 0327 acceptance fix (provenance signal): a qid contact whose ref QID is
+        # already in the joint materialized set is a *pulled-but-unformalized*
+        # claim — drilling into a paper you have, not a fog-reach into new
+        # territory and not a core bridge. An lkm contact's ref is a paper id, so
+        # it is never in the materialized claim-QID set ⇒ never drilling.
+        is_drilling = not is_lkm and ref_value is not None and str(ref_value) in materialized_set
 
         # Both flavours proxy belief_entropy / closeness from the SOURCE node(s)
         # — an lkm paper-contact has no graph position of its own, so it borrows
@@ -660,12 +728,15 @@ def score_frontier(
         )
         # Activated bridge slot (EXPANSION.md §3.B) — identical for qid & lkm:
         # high iff surveying/wiring this contact would connect an orphan to the
-        # core. 0.0 when no MapHealth was supplied (pre-expansion behaviour).
+        # core. 0.0 when no MapHealth was supplied (pre-expansion behaviour) or
+        # the contact is intra-island drilling (a pulled-unformalized internal
+        # claim is not a core bridge — see _bridge_potential).
         bridge_potential = _bridge_potential(
             source_qids,
             str(ref_value) if ref_value is not None else None,
             component_index,
             adjacency,
+            is_drilling=is_drilling,
         )
 
         if is_lkm:
@@ -694,7 +765,12 @@ def score_frontier(
             # ``new_territory`` is now ACTIVATED via MapHealth (external expansion
             # vs. intra-paper drilling — EXPANSION.md §3.B); ``tension_potential``
             # stays a 0.0 deferred slot (Inquisitor deferred this iteration).
-            new_territory = _qid_new_territory(source_qids, component_index)
+            # ``is_drilling`` (computed above from the materialized-set provenance)
+            # pins a pulled-but-unformalized claim to the low drilling territory
+            # even though its sources are empty (which would otherwise score 1.0).
+            new_territory = _qid_new_territory(
+                source_qids, component_index, is_drilling=is_drilling
+            )
             survey_cost = 1.0
             features = {
                 "belief_entropy": belief_entropy,

--- a/gaia/engine/exploration/scorer.py
+++ b/gaia/engine/exploration/scorer.py
@@ -27,9 +27,15 @@ feature           tag        computation
 ``survey_cost``     wire-up  flat ``1.0`` for qid contacts (materialize-only placeholder;
                              refine when an LKM-pull cost model exists — ``w_cost`` has
                              little bite until then).
-``tension_potential``, deferred ``0.0`` (schema slots only — DESIGN §8 defers
-``bridge_potential``,           bridge/coverage; tension-wiring is a later build 3b).
-``new_territory``
+``bridge_potential``  activated ``1.0`` iff surveying/wiring the contact connects an orphan
+                             component to the seed core (sources span ≥2 components, or it is
+                             adjacent to an orphan) — needs a ``MapHealth`` (EXPANSION.md §3.B);
+                             ``0.0`` without one. Identical for qid + lkm contacts.
+``new_territory``   activated qid coverage via ``MapHealth`` (EXPANSION.md §3.B): low for
+                             intra-paper drilling (all sources in one surveyed component),
+                             higher for reaching a fresh region; lkm keeps its rank-derived
+                             signal. ``0.0`` for qid without a ``MapHealth``.
+``tension_potential`` deferred ``0.0`` (Inquisitor deferred this iteration — EXPANSION.md §3.B).
 ``obligation_pressure`` build 12 ``1.0`` iff the contact's ``ref`` QID or any of its
                              ``sources[].qid`` matches an OPEN synthetic obligation's
                              ``target_qid`` — **or is one hop from it** in the IR
@@ -84,20 +90,25 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from gaia.engine.exploration.frontier import _edges_from_ir
 
 if TYPE_CHECKING:
+    from gaia.engine.exploration.health import MapHealth
     from gaia.engine.exploration.state import ExplorationMap
     from gaia.engine.inquiry.state import SyntheticObligation
     from gaia.engine.ir.graphs import LocalCanonicalGraph
 
 # SCHEMA.md §4 — the six score_features keys. belief_entropy is [free];
-# closeness_to_seed / survey_cost are [wire-up]; the remaining three are
-# deferred 0.0 slots (DESIGN §8) for a qid contact.
-_DEFERRED_FEATURES = ("tension_potential", "bridge_potential", "new_territory")
+# closeness_to_seed / survey_cost are [wire-up]. ``tension_potential`` stays a
+# deferred 0.0 slot (Inquisitor, EXPANSION.md §3.B — deferred this iteration);
+# ``bridge_potential`` and qid ``new_territory`` are now ACTIVATED via MapHealth
+# (EXPANSION.md §3.B). When no MapHealth is supplied they fall back to 0.0 (the
+# pre-expansion behaviour), so the qid-deferred set is just tension.
+_QID_DEFERRED_FEATURES = ("tension_potential",)
 
 # CLIENT.md build 11 steer 4 (Jaynes' robot) — the belief-derived score_features
 # keys stripped from every AGENT-FACING surface. The engine still RANKS by
@@ -302,6 +313,127 @@ def _lkm_new_territory(contact_meta: dict[str, Any]) -> float:
     return 0.5 + 0.5 * bonus
 
 
+@dataclass(frozen=True)
+class _ComponentIndex:
+    """Precomputed component membership used by the activated coverage/bridge slots.
+
+    Derived once per ``score_frontier`` from a :class:`MapHealth`:
+
+    * ``component_of`` — surveyed QID → its component index;
+    * ``core_members`` — surveyed QIDs in the seed/core component;
+    * ``orphan_members`` — surveyed QIDs in any orphan (non-core) component;
+    * ``surveyed_papers`` — count of distinct surveyed components (a proxy for
+      "how many already-surveyed regions exist", used to scale qid coverage).
+    """
+
+    component_of: dict[str, int]
+    core_members: frozenset[str]
+    orphan_members: frozenset[str]
+    component_count: int
+
+
+def _component_index(health: MapHealth | None) -> _ComponentIndex | None:
+    """Build a :class:`_ComponentIndex` from a MapHealth, or ``None`` if absent."""
+    if health is None:
+        return None
+    component_of: dict[str, int] = {}
+    core: set[str] = set()
+    orphan: set[str] = set()
+    for i, comp in enumerate(health.components):
+        for qid in comp.members:
+            component_of[qid] = i
+        if comp.is_seed:
+            core.update(comp.members)
+        else:
+            orphan.update(comp.members)
+    return _ComponentIndex(
+        component_of=component_of,
+        core_members=frozenset(core),
+        orphan_members=frozenset(orphan),
+        component_count=len(health.components),
+    )
+
+
+def _bridge_potential(
+    source_qids: list[str],
+    ref_value: str | None,
+    index: _ComponentIndex | None,
+    adjacency: dict[str, set[str]],
+) -> float:
+    """``1.0`` iff surveying/wiring this contact would connect an orphan to the core.
+
+    Activated bridge slot (EXPANSION.md §3.B), high iff the contact is the kind of
+    edge that heals fragmentation:
+
+    * **spans ≥2 components** — its sources (the surveyed nodes it is reached
+      from) fall in two or more distinct surveyed components, so authoring the
+      contact ties those components together; OR
+    * **adjacent to an orphan** — a source (or the ref QID itself) is in an orphan
+      component, or is a graph neighbour of an orphan member — so wiring the
+      contact pulls a disconnected island toward the core.
+
+    Binary by design (mirrors ``obligation_pressure``): the doctrine weight
+    ``w_bridge`` *is* the bump a bridging contact gets, so Diplomat / Cartographer
+    reliably surface it. ``0.0`` when no MapHealth is available (the pre-expansion
+    behaviour) or there are no orphans to bridge.
+    """
+    if index is None or not index.orphan_members:
+        return 0.0
+    anchors = set(source_qids)
+    if ref_value is not None:
+        anchors.add(ref_value)
+    # Spans >=2 distinct surveyed components.
+    comps = {index.component_of[a] for a in anchors if a in index.component_of}
+    if len(comps) >= 2:
+        return 1.0
+    # Touches an orphan directly...
+    if anchors & index.orphan_members:
+        return 1.0
+    # ...or is one hop from an orphan member in the joint adjacency.
+    for a in anchors:
+        if adjacency.get(a, set()) & index.orphan_members:
+            return 1.0
+    return 0.0
+
+
+def _qid_new_territory(
+    source_qids: list[str],
+    index: _ComponentIndex | None,
+) -> float:
+    """Coverage for a qid contact: external expansion vs. intra-paper drilling.
+
+    Activated qid coverage slot (EXPANSION.md §3.B) — the *unthrottle*. A qid
+    contact whose sources are all inside ONE already-surveyed component is
+    *drilling* into a paper you already have (low territory); one whose sources
+    reach across components, or that has no surveyed source at all (a dangling
+    reference into the unsurveyed), is opening fresher territory (higher).
+
+    This fixes the documented ranking pathology: a freshly-pulled paper's own
+    intra-paper ``depends_on`` contacts (all sources in that one paper's
+    component) now get a LOW ``new_territory`` and stop out-ranking external
+    ``lkm_related`` papers under an uncertainty/coverage-weighted doctrine.
+
+    Scale:
+
+    * no surveyed source ⇒ ``1.0`` (a pure reach into the fog — maximal novelty);
+    * sources span ≥2 components ⇒ ``0.7`` (cross-region — opening new territory);
+    * sources all in one component ⇒ ``0.2`` (intra-paper drilling — low).
+
+    ``0.0`` when no MapHealth is available (pre-expansion behaviour). Distinct
+    from ``closeness_to_seed`` (relevance): a far-flung dangling ref is high
+    territory but may be low relevance — the doctrine weights trade them off.
+    """
+    if index is None:
+        return 0.0
+    in_set = [q for q in source_qids if q in index.component_of]
+    if not in_set:
+        return 1.0
+    comps = {index.component_of[q] for q in in_set}
+    if len(comps) >= 2:
+        return 0.7
+    return 0.2
+
+
 def _obligation_targets(
     obligations: Iterable[SyntheticObligation] | None,
 ) -> set[str]:
@@ -430,17 +562,20 @@ def score_frontier(
     ir: LocalCanonicalGraph | None = None,
     edges: list[tuple[str, list[str]]] | None = None,
     obligations: Iterable[SyntheticObligation] | None = None,
+    health: MapHealth | None = None,
 ) -> None:
     """Score every open frontier contact in place (SCHEMA.md §7b / §7e).
 
     For each ``status == "open"`` contact, computes the full ``score_features``
     dict (``belief_entropy`` [free], ``closeness_to_seed`` / ``survey_cost``
-    [wire-up], the deferred ``0.0`` slots, and ``obligation_pressure`` [build 12]),
-    the weighted ``score``::
+    [wire-up], ``new_territory`` / ``bridge_potential`` [activated via MapHealth —
+    EXPANSION.md §3.B], the deferred ``tension_potential`` ``0.0`` slot, and
+    ``obligation_pressure`` [build 12]), the weighted ``score``::
 
         score = w_uncertainty*belief_entropy
               + w_relevance*closeness_to_seed
               + w_coverage*new_territory
+              + w_bridge*bridge_potential
               + w_obligation*obligation_pressure
               - w_cost*survey_cost
 
@@ -471,6 +606,15 @@ def score_frontier(
             ``ref`` QID or any ``sources[].qid`` matches an obligation's
             ``target_qid`` gets ``obligation_pressure = 1.0``. ``None`` ⇒ the
             feature is ``0.0`` everywhere (CLIENT.md steer 3, graceful default).
+        health: The :class:`~gaia.engine.exploration.health.MapHealth` for the
+            joint graph (EXPANSION.md §3.B). When supplied, it activates
+            ``bridge_potential`` (qid + lkm: high iff surveying/wiring the contact
+            connects an orphan component to the core) and a real qid
+            ``new_territory`` (low for intra-paper drilling, higher for reaching a
+            sparsely-surveyed region). ``None`` ⇒ both stay ``0.0`` for qid
+            contacts (the pre-expansion behaviour); lkm ``new_territory`` is still
+            its rank-derived signal. ``tension_potential`` stays ``0.0`` regardless
+            (Inquisitor deferred — EXPANSION.md §3.B).
     """
     if edges is None and ir is None:
         raise ValueError("score_frontier requires exactly one of `edges` or `ir`")
@@ -479,10 +623,12 @@ def score_frontier(
     w_uncertainty = float(weights.get("w_uncertainty", 0.0))
     w_relevance = float(weights.get("w_relevance", 0.0))
     w_coverage = float(weights.get("w_coverage", 0.0))
+    w_bridge = float(weights.get("w_bridge", 0.0))
     w_cost = float(weights.get("w_cost", 0.0))
     w_obligation = float(weights.get("w_obligation", 0.0))
 
     obligation_targets = _obligation_targets(obligations)
+    component_index = _component_index(health)
     seeds = _resolved_seed_qids(exploration_map)
     if edges is not None:
         adjacency = _adjacency_from_edges(edges)
@@ -512,6 +658,15 @@ def score_frontier(
             obligation_targets,
             adjacency,
         )
+        # Activated bridge slot (EXPANSION.md §3.B) — identical for qid & lkm:
+        # high iff surveying/wiring this contact would connect an orphan to the
+        # core. 0.0 when no MapHealth was supplied (pre-expansion behaviour).
+        bridge_potential = _bridge_potential(
+            source_qids,
+            str(ref_value) if ref_value is not None else None,
+            component_index,
+            adjacency,
+        )
 
         if is_lkm:
             # An unpulled related paper *is* fresh territory; the stored LKM rank
@@ -530,21 +685,25 @@ def score_frontier(
                 "closeness_to_seed": closeness_to_seed,
                 "survey_cost": survey_cost,
                 "tension_potential": 0.0,
-                "bridge_potential": 0.0,
+                "bridge_potential": bridge_potential,
                 "new_territory": new_territory,
                 "obligation_pressure": obligation_pressure,
             }
         else:
-            # qid contacts are materialize-only ⇒ flat placeholder cost; the
-            # three deferred features stay 0.0 (build 3/4c behaviour, unchanged).
-            new_territory = 0.0
+            # qid contacts are materialize-only ⇒ flat placeholder cost.
+            # ``new_territory`` is now ACTIVATED via MapHealth (external expansion
+            # vs. intra-paper drilling — EXPANSION.md §3.B); ``tension_potential``
+            # stays a 0.0 deferred slot (Inquisitor deferred this iteration).
+            new_territory = _qid_new_territory(source_qids, component_index)
             survey_cost = 1.0
             features = {
                 "belief_entropy": belief_entropy,
                 "closeness_to_seed": closeness_to_seed,
                 "survey_cost": survey_cost,
+                "bridge_potential": bridge_potential,
+                "new_territory": new_territory,
             }
-            for key in _DEFERRED_FEATURES:
+            for key in _QID_DEFERRED_FEATURES:
                 features[key] = 0.0
             features["obligation_pressure"] = obligation_pressure
 
@@ -553,6 +712,7 @@ def score_frontier(
             w_uncertainty * belief_entropy
             + w_relevance * closeness_to_seed
             + w_coverage * new_territory
+            + w_bridge * bridge_potential
             + w_obligation * obligation_pressure
             - w_cost * survey_cost
         )

--- a/gaia/engine/exploration/state.py
+++ b/gaia/engine/exploration/state.py
@@ -84,6 +84,27 @@ POLICY_WEIGHT_KEYS = (
     "w_obligation",
 )
 
+# EXPANSION.md §3.C — the policy mode dial. The doctrine IS the expand↔consolidate
+# mode; ``mode_select`` only decides WHEN to consolidate:
+# - "auto"        : at IDLE the orchestrator computes MapHealth and consolidates
+#                   iff the map is unhealthy past the fragmentation threshold,
+#                   else expands (the default — fragment a little, heal in sweeps);
+# - "expand"      : always run an expand turn (today's behaviour), pinned;
+# - "consolidate" : always run a consolidate (bridging) turn, pinned.
+MODE_SELECT_AUTO = "auto"
+MODE_SELECT_EXPAND = "expand"
+MODE_SELECT_CONSOLIDATE = "consolidate"
+VALID_MODE_SELECTS = {MODE_SELECT_AUTO, MODE_SELECT_EXPAND, MODE_SELECT_CONSOLIDATE}
+
+# EXPANSION.md §4 — the dialable fragmentation threshold (defaults mirror
+# health.DEFAULT_MIN_ORPHAN_COMPONENTS / DEFAULT_ORPHAN_FRACTION). The map is
+# "unhealthy past the threshold" iff there are at least this many un-ratified
+# orphan components OR the orphan node fraction exceeds the fraction. Threshold
+# over hair-trigger (user, 2026-05-25). Kept on the Policy so the dial travels
+# with the per-round state and a back-compat map loads the defaults.
+DEFAULT_FRAGMENT_MIN_ORPHANS = 2
+DEFAULT_FRAGMENT_ORPHAN_FRACTION = 0.34
+
 # Build 12 (CLIENT.md steer 3): the STRONG default obligation-pressure weight.
 # obligation_pressure is binary (0.0 / 1.0), so w_obligation IS the score bump a
 # matching contact gets. 1.0 puts it on par with the strongest single live term in
@@ -273,9 +294,15 @@ class Policy:
     doctrine: str = "Cartographer"
     weights: dict[str, float] = field(default_factory=dict)
     budget_k: int = 5
+    # EXPANSION.md §3.C / §4 — the expand↔consolidate dial + fragmentation
+    # threshold. All additive + back-compat (a map saved before these existed
+    # loads the defaults via from_dict).
+    mode_select: str = MODE_SELECT_AUTO
+    fragment_min_orphans: int = DEFAULT_FRAGMENT_MIN_ORPHANS
+    fragment_orphan_fraction: float = DEFAULT_FRAGMENT_ORPHAN_FRACTION
 
     def __post_init__(self) -> None:
-        """Resolve a named doctrine to its preset; validate the weight vector."""
+        """Resolve a named doctrine to its preset; validate weights + mode."""
         if self.doctrine != "custom" and not self.weights:
             preset = DOCTRINE_PRESETS.get(self.doctrine)
             if preset is None:
@@ -291,6 +318,10 @@ class Policy:
         missing = [k for k in POLICY_WEIGHT_KEYS if k not in self.weights]
         if missing:
             raise ValueError(f"policy weights missing keys: {missing}")
+        if self.mode_select not in VALID_MODE_SELECTS:
+            raise ValueError(
+                f"invalid mode_select {self.mode_select!r}; allowed: {sorted(VALID_MODE_SELECTS)}"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """Return the JSON-compatible payload for this policy."""
@@ -298,15 +329,26 @@ class Policy:
             "doctrine": self.doctrine,
             "weights": dict(self.weights),
             "budget_k": self.budget_k,
+            "mode_select": self.mode_select,
+            "fragment_min_orphans": self.fragment_min_orphans,
+            "fragment_orphan_fraction": self.fragment_orphan_fraction,
         }
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> Policy:
-        """Rehydrate a policy from its persisted payload."""
+        """Rehydrate a policy from its persisted payload (defaults for new fields)."""
         return cls(
             doctrine=raw.get("doctrine", "Cartographer"),
             weights=dict(raw.get("weights", {})),
             budget_k=int(raw.get("budget_k", 5)),
+            # Back-compat: a policy saved before the expand↔consolidate dial
+            # existed has none of these keys — default to auto + the standard
+            # threshold so old maps load unchanged.
+            mode_select=raw.get("mode_select", MODE_SELECT_AUTO),
+            fragment_min_orphans=int(raw.get("fragment_min_orphans", DEFAULT_FRAGMENT_MIN_ORPHANS)),
+            fragment_orphan_fraction=float(
+                raw.get("fragment_orphan_fraction", DEFAULT_FRAGMENT_ORPHAN_FRACTION)
+            ),
         )
 
 
@@ -346,6 +388,12 @@ class ExplorationMap:
     frontier: list[Contact] = field(default_factory=list)
     stats: dict[str, Any] = field(default_factory=dict)
     turn_phase: str = TURN_PHASE_IDLE
+    # EXPANSION.md §3.E — islands the agent has ratified as legitimately separate
+    # regions (per COMPONENT). Each row is
+    # ``{member_qids: [...], rationale: str, round: int, evidence_fingerprint: {}}``.
+    # MapHealth excludes a still-valid ratified island from the unhealthy count;
+    # new bridging evidence reopens it (provisional). Additive + back-compat.
+    ratified_separations: list[dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Fill creation/update timestamps; validate the turn phase."""
@@ -371,6 +419,7 @@ class ExplorationMap:
             "frontier": [c.to_dict() for c in self.frontier],
             "stats": dict(self.stats),
             "turn_phase": self.turn_phase,
+            "ratified_separations": [dict(r) for r in self.ratified_separations],
         }
 
     @classmethod
@@ -391,6 +440,9 @@ class ExplorationMap:
             # Back-compat: a map.json written before turn_phase existed has no
             # such key — default to IDLE so old saves load unchanged.
             turn_phase=raw.get("turn_phase", TURN_PHASE_IDLE),
+            # Back-compat: a map written before ratified_separations existed has
+            # no such key — default to none (EXPANSION.md §3.E).
+            ratified_separations=[dict(r) for r in raw.get("ratified_separations", [])],
         )
 
     def find_contact(self, contact_id: str) -> Contact | None:
@@ -399,6 +451,60 @@ class ExplorationMap:
             if contact.id == contact_id:
                 return contact
         return None
+
+    def ratified_as_health_objects(self) -> list[Any]:
+        """Return ``ratified_separations`` as ``health.RatifiedSeparation`` objects.
+
+        The persisted rows are plain dicts (EXPANSION.md §3.E); ``MapHealth``
+        consumes the typed dataclass. This is the single seam both the
+        orchestrator and ``status`` use to feed health. Local import avoids an
+        import cycle (``health`` imports ``scorer`` which imports ``frontier``,
+        all of which import this module).
+        """
+        from gaia.engine.exploration.health import RatifiedSeparation
+
+        return [RatifiedSeparation.from_dict(r) for r in self.ratified_separations]
+
+    def add_ratified_separation(
+        self,
+        member_qids: list[str],
+        *,
+        rationale: str,
+        round_index: int,
+        evidence_fingerprint: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Record (or refresh) a per-component ratified separation (EXPANSION.md §3.E).
+
+        Ratification is per *component* (user, 2026-05-25). If a row already
+        exists for the same member set it is replaced (a re-ratification with an
+        updated rationale after a reopen), so the list never accumulates stale
+        duplicates for one island.
+
+        Args:
+            member_qids: the surveyed-node set of the island at ratification time.
+            rationale: the agent's one-line scientific reason it is disjoint.
+            round_index: the round the ratification was made.
+            evidence_fingerprint: cheap snapshot of the joint-graph state it was
+                judged under (e.g. the island's adjacency neighbourhood).
+
+        Returns:
+            The recorded row.
+        """
+        members = sorted(set(member_qids))
+        row = {
+            "member_qids": members,
+            "rationale": rationale,
+            "round": round_index,
+            "evidence_fingerprint": dict(evidence_fingerprint or {}),
+        }
+        member_set = set(members)
+        self.ratified_separations = [
+            r
+            for r in self.ratified_separations
+            if {str(q) for q in r.get("member_qids", [])} != member_set
+        ]
+        self.ratified_separations.append(row)
+        return row
 
     def promote_contact(
         self,

--- a/gaia/explore_client/cli.py
+++ b/gaia/explore_client/cli.py
@@ -70,17 +70,39 @@ _PKG_ARG = typer.Argument(..., help="Knowledge-package path (holds .gaia/explora
 _JSON_OPT = typer.Option(False, "--json", help="Emit the turn outcome as JSON.")
 
 
+def _echo_health(health: dict[str, object]) -> None:
+    """Print the MapHealth connectivity readout line, if present (EXPANSION.md §3)."""
+    if not health:
+        return
+    verdict = "FRAGMENTED (consolidate)" if health.get("unhealthy") else "maintainable"
+    typer.echo(
+        f"  connectivity:   {health.get('components', 0)} component(s), "
+        f"{health.get('orphans', 0)} orphan(s) "
+        f"({health.get('unratified_orphans', 0)} un-ratified), "
+        f"{health.get('ratified', 0)} ratified, {health.get('reopened', 0)} reopened "
+        f"— {verdict}"
+    )
+
+
 def _render_outcome(outcome: TurnOutcome) -> None:
     """Print a human-readable summary of a turn outcome."""
     for msg in outcome.messages:
         typer.echo(f"  {msg}")
 
     if outcome.action == "emitted_task":
-        kind = "seed-survey" if outcome.seed_survey else "frontier"
-        typer.echo(
-            f"Turn {outcome.round}: emitted a {kind} task "
-            f"({len(outcome.contacts)} contact(s)) → AWAITING_SURVEY."
-        )
+        if outcome.task_kind == "consolidate":
+            # EXPANSION.md §3.D — a consolidate (bridging) turn over surveyed nodes.
+            typer.echo(
+                f"Turn {outcome.round}: emitted a CONSOLIDATE task "
+                f"({outcome.islands} island(s) to bridge or ratify) → AWAITING_SURVEY."
+            )
+        else:
+            kind = "seed-survey" if outcome.seed_survey else "frontier"
+            typer.echo(
+                f"Turn {outcome.round}: emitted a {kind} task "
+                f"({len(outcome.contacts)} contact(s)) → AWAITING_SURVEY."
+            )
+        _echo_health(outcome.health)
         typer.echo(f"  task:   {outcome.task_path}")
         typer.echo(f"  result: {outcome.result_path}")
         typer.echo(
@@ -100,6 +122,22 @@ def _render_outcome(outcome: TurnOutcome) -> None:
             # the node has no label.
             ids = ", ".join(outcome.discovery_labels.get(qid, qid) for qid in disc.get("ids", []))
             typer.echo(f"  - {disc.get('kind')}: {ids}  {disc.get('note', '')}".rstrip())
+        # EXPANSION.md §3.D — connectivity readout + delta + any reopened islands.
+        _echo_health(outcome.health)
+        if outcome.connectivity_delta:
+            d = outcome.connectivity_delta
+            typer.echo(
+                f"  connectivity Δ: components {d.get('components', 0):+d}, "
+                f"un-ratified orphans {d.get('unratified_orphans', 0):+d}, "
+                f"ratified {d.get('ratified', 0):+d}"
+            )
+        if outcome.ratified:
+            typer.echo(f"  ratified {len(outcome.ratified)} island(s) as separate this turn.")
+        for members in outcome.reopened:
+            typer.echo(
+                f"  - REOPENED ratified island: {', '.join(members[:3])} "
+                "(new bridging evidence — reconsider)"
+            )
         typer.echo(
             "Re-dial the doctrine if desired, then `gaia-lkm-explore turn` for the next turn."
         )

--- a/gaia/explore_client/instructions.py
+++ b/gaia/explore_client/instructions.py
@@ -290,6 +290,89 @@ the per-turn hand-off.
 """
 
 
+# EXPANSION.md §3.D/§3.E — the consolidate-task instructions. A consolidate turn
+# emits a bridge worklist over ALREADY-surveyed nodes (no new pulls); the agent
+# either authors a connecting edge OR ratifies the island as legitimately
+# separate. The "ratify as separate" option is EQUAL-STATUS, never a failure path,
+# and consolidation must NEVER pressure fabricating an unsound edge.
+_CONSOLIDATE = """\
+# Consolidation task — bridge or ratify the disconnected islands
+
+Your map has fragmented: some surveyed regions are **disconnected islands**, not
+wired to the seed core. This is a CONSOLIDATE turn (no new paper pulls): you work
+entirely over the nodes you have ALREADY surveyed. The task's `bridge_worklist`
+lists each island with a short brief of its member nodes.
+
+> Integrity contract — LLM proposes, engine adjudicates (unchanged).
+> You propose a connecting relation OR a ratification; the engine adjudicates the
+> belief consequence of a bridge. You never decide what is true, and you NEVER
+> fabricate a connection that is not scientifically sound.
+
+## For EACH island in `bridge_worklist`, do ONE of:
+
+(a) **Bridge it** — author the connecting relation that wires the island to your
+    core reasoning, REFERENCING the already-materialized QIDs (do not restate
+    them). Choose the relation the science actually warrants:
+    - support: `gaia author derive --conclusion <core_qid> --given <island_qid>
+      --rationale "<why it supports>"` (or the reverse direction);
+    - dependency: `gaia author depends-on --conclusion <core_qid>
+      --given <island_qid>` (a surveyed island node is a materialized target);
+    - tension: pre-mark `candidate_relation(claims=[<core_qid>, <island_qid>],
+      pattern="contradict")`, then promote with
+      `materialize(scaffold, by=[contradict(<core_qid>, <island_qid>)])` only when
+      it is an adjudicable scientific conflict (label `<a>_vs_<b>`, warrant in
+      `rationale=`).
+    The engine reports the belief consequence at the checkpoint.
+
+(b) **Ratify it as separate** — an EQUAL-STATUS option, not a failure. If no
+    scientifically sound connection exists (the island is a genuinely different
+    domain), record it as a legitimately-separate region. Add it to your result
+    manifest's `ratified` list with a ONE-LINE scientific rationale:
+        {"member_qids": ["<island qid>", ...],
+         "rationale": "<why these are legitimately disjoint from the core>"}
+    The engine then EXCLUDES this island from the fragmentation count — a map of
+    several ratified domains reads HEALTHY, not degraded. Ratification is
+    PROVISIONAL: if a later turn surfaces evidence that could connect the island,
+    the engine REOPENS it and it returns here with a "reconsider" note — at which
+    point you either author the now-possible bridge or re-ratify with an updated
+    rationale.
+
+A worklist entry flagged `reopened` (with a `bridge_hint` QID) was previously
+ratified; new evidence `<bridge_hint>` may now connect it — re-decide it against
+the new evidence (bridge it, or re-ratify saying why the new node still doesn't
+soundly connect).
+
+**Never invent an unsound edge to make the map look connected.** A legitimate
+ratification is a first-class, honest outcome. Bridge only what the science
+warrants; ratify the rest.
+
+## When you are done
+
+1. Write the result manifest to the `result_path` named in this task:
+       {"surveyed_qids": [<any nodes you authored/referenced>],
+        "ratified": [{"member_qids": [...], "rationale": "..."}, ...]}
+   `surveyed_qids` records nodes you authored/wired; `ratified` records the
+   islands you judged legitimately separate. Either list may be empty.
+2. Re-invoke the orchestrator to checkpoint:
+       gaia-lkm-explore turn <pkg>
+   It recompiles + infers, recomputes connectivity, reports the delta (components
+   closed, orphans wired, ratifications recorded, any island REOPENED by new
+   evidence), and returns to IDLE. You do NOT run compile/infer/round yourself.
+"""
+
+
+def build_consolidate_instructions() -> str:
+    """Return the self-contained consolidate-task procedure (EXPANSION.md §3.D/§3.E).
+
+    A consolidate turn's bridge worklist + the equal-status "ratify as separate"
+    option (with a one-line scientific rationale), keeping every scientific-
+    integrity rule. The LLM proposes a bridge OR a ratification; the engine
+    adjudicates the bridge's belief consequence — and new evidence can always
+    reopen a ratification, so a verdict is never silently frozen.
+    """
+    return _CONSOLIDATE
+
+
 def build_survey_instructions(*, seed_survey: bool) -> str:
     """Return the full self-contained survey procedure for a task envelope.
 
@@ -332,4 +415,4 @@ def build_survey_instructions(*, seed_survey: bool) -> str:
     return "\n".join([_CONTRACT, round_note, _SURVEY_PROCEDURE, _HANDOFF])
 
 
-__all__ = ["build_survey_instructions"]
+__all__ = ["build_consolidate_instructions", "build_survey_instructions"]

--- a/gaia/explore_client/instructions.py
+++ b/gaia/explore_client/instructions.py
@@ -104,12 +104,15 @@ materialize them into the Gaia package. The engine then adjudicates the
   manual step. What still needs YOUR hand (step 3b) is connecting the pulled
   paper UP to your root reasoning — the `depends_on` contacts are that worklist.
 - Survey-facing contact signals: `closeness_to_seed` (relevance),
-  `new_territory` (coverage; live for lkm contacts only), `obligation_pressure`
-  (1.0 iff the contact discharges an open obligation you marked — see "Mark
-  obligations" below), and `survey_cost`. The engine ranks the frontier for you
-  and hands you the shortlist already ordered — survey in the order given.
-  `tension_potential` / `bridge_potential` are 0.0 slots, so the `Inquisitor`
-  doctrine is currently inert; prefer `Surveyor` / `Cartographer`.
+  `new_territory` (coverage; live for BOTH lkm and qid contacts — low for
+  intra-paper drilling, higher for opening new territory), `bridge_potential`
+  (1.0 iff surveying/wiring the contact would connect an orphan island to the
+  core — now live, EXPANSION.md §3.B), `obligation_pressure` (1.0 iff the contact
+  discharges an open obligation you marked — see "Mark obligations" below), and
+  `survey_cost`. The engine ranks the frontier for you and hands you the
+  shortlist already ordered — survey in the order given. `tension_potential` is
+  still a 0.0 slot, so the `Inquisitor` doctrine remains inert; prefer
+  `Surveyor` / `Cartographer` (bridge-led `Diplomat` is now live too).
 """
 
 # The per-contact survey procedure (absorbed from survey-one-contact.md + the

--- a/gaia/explore_client/orchestrator.py
+++ b/gaia/explore_client/orchestrator.py
@@ -810,6 +810,24 @@ def _prior_round_health(pkg: str | Path, current_round: int) -> dict[str, Any]:
     return dict(health) if isinstance(health, dict) else {}
 
 
+def _prior_round_components(pkg: str | Path, current_round: int) -> list[frozenset[str]]:
+    """The component partition the most recent prior round recorded (or ``[]``).
+
+    Reads ``rounds.jsonl``'s latest ``frontier_summary.component_members`` (a list
+    of member lists, written by a previous checkpoint) so ``bridge`` detection can
+    diff this round's partition against the prior one.
+    """
+    from gaia.engine.exploration.state import read_rounds
+
+    rounds = [r for r in read_rounds(pkg) if int(r.get("round", -1)) < current_round]
+    if not rounds:
+        return []
+    members = rounds[-1].get("frontier_summary", {}).get("component_members", [])
+    if not isinstance(members, list):
+        return []
+    return [frozenset(str(q) for q in comp) for comp in members if isinstance(comp, list)]
+
+
 def _record_surveyed(
     exploration_map: ExplorationMap, surveyed_qids: list[str], *, survey_round: int
 ) -> None:
@@ -889,7 +907,67 @@ def _checkpoint(
     if ratified_now:
         messages.append(f"recorded {len(ratified_now)} ratified separation(s) this turn.")
 
-    discoveries = compute_discoveries(graph, beliefs, prev_beliefs, ir_dict=ir_dict)
+    # Credit the round with the papers materialized during this turn's
+    # survey (pulled via `pkg add --lkm-paper`, outside the round step) so the
+    # durable record no longer shows `lkm_pulls: 0`. The same joint view also
+    # drives the post-checkpoint MapHealth (computed BEFORE discoveries so the
+    # connectivity discovery kinds can use its component partition).
+    from gaia.engine.exploration.observe import materialized_paper_ids_from_roots
+    from gaia.engine.exploration.state import lkm_pulls_this_round
+
+    lkm_pulls = 0
+    health_summary: dict[str, Any] = {}
+    connectivity_delta: dict[str, Any] = {}
+    reopened_now: list[list[str]] = []
+    curr_components: list[frozenset[str]] | None = None
+    orphan_components: list[frozenset[str]] | None = None
+    try:
+        view = _joint_view(pkg, graph)
+        materialized_papers = set(view.materialized_paper_ids) | materialized_paper_ids_from_roots(
+            view.package_roots
+        )
+        lkm_pulls = lkm_pulls_this_round(pkg, len(materialized_papers))
+
+        # EXPANSION.md §3.D/§3.E — recompute MapHealth on the post-checkpoint
+        # joint graph. The reopen test (a ratified island whose premise is now
+        # stale because new bridging evidence exists) falls straight out of it.
+        health = _compute_health(exploration_map, view)
+        health_summary = _health_summary(exploration_map, health)
+        curr_components = [frozenset(c.members) for c in health.components]
+        orphan_components = [frozenset(c.members) for c in health.orphans]
+        reopened_now = [list(c.members) for c in health.reopened]
+        if reopened_now:
+            messages.append(
+                f"REOPENED {len(reopened_now)} ratified separation(s): new evidence "
+                "may now connect a previously-ratified island — reconsider next "
+                "consolidate turn."
+            )
+        prior_health = _prior_round_health(pkg, current_round)
+        if prior_health:
+            connectivity_delta = {
+                "components": health_summary.get("components", 0)
+                - prior_health.get("components", 0),
+                "unratified_orphans": health_summary.get("unratified_orphans", 0)
+                - prior_health.get("unratified_orphans", 0),
+                "ratified": health_summary.get("ratified", 0) - prior_health.get("ratified", 0),
+            }
+    except Exception:
+        # A degraded joint view (e.g. uncompiled deps) must not break the
+        # checkpoint; default to no credit / no health rather than crashing.
+        lkm_pulls = 0
+
+    # EXPANSION.md §3 / Phase 3 — bridge/fault_line discoveries use the current vs.
+    # prior MapHealth component partition (the prior round stored its members).
+    prev_components = _prior_round_components(pkg, current_round)
+    discoveries = compute_discoveries(
+        graph,
+        beliefs,
+        prev_beliefs,
+        ir_dict=ir_dict,
+        prev_components=prev_components if curr_components is not None else None,
+        curr_components=curr_components,
+        orphan_components=orphan_components,
+    )
 
     # Author labels for the discovered nodes, so the report names a labeled node
     # (e.g. a `contradict` the user named `spinfluc_vs_phonon`) by its label rather
@@ -910,53 +988,12 @@ def _checkpoint(
         "open_after": open_after,
         "top_score": max(scored) if scored else None,
     }
-
-    # Credit the round with the papers materialized during this turn's
-    # survey (pulled via `pkg add --lkm-paper`, outside the round step) so the
-    # durable record no longer shows `lkm_pulls: 0`. Count the joint view's
-    # materialized paper QIDs and credit the net-new ones since the prior round.
-    # The same joint view also drives the post-checkpoint MapHealth.
-    from gaia.engine.exploration.observe import materialized_paper_ids_from_roots
-    from gaia.engine.exploration.state import lkm_pulls_this_round
-
-    lkm_pulls = 0
-    health_summary: dict[str, Any] = {}
-    connectivity_delta: dict[str, Any] = {}
-    reopened_now: list[list[str]] = []
-    try:
-        view = _joint_view(pkg, graph)
-        materialized_papers = set(view.materialized_paper_ids) | materialized_paper_ids_from_roots(
-            view.package_roots
-        )
-        lkm_pulls = lkm_pulls_this_round(pkg, len(materialized_papers))
-
-        # EXPANSION.md §3.D/§3.E — recompute MapHealth on the post-checkpoint
-        # joint graph and report the connectivity delta vs. the prior round. The
-        # reopen test (a ratified island whose premise is now stale because new
-        # bridging evidence exists) falls straight out of MapHealth.
-        health = _compute_health(exploration_map, view)
-        health_summary = _health_summary(exploration_map, health)
-        reopened_now = [list(c.members) for c in health.reopened]
-        if reopened_now:
-            messages.append(
-                f"REOPENED {len(reopened_now)} ratified separation(s): new evidence "
-                "may now connect a previously-ratified island — reconsider next "
-                "consolidate turn."
-            )
+    if health_summary:
         frontier_summary["health"] = health_summary
-        prior_health = _prior_round_health(pkg, current_round)
-        if prior_health:
-            connectivity_delta = {
-                "components": health_summary.get("components", 0)
-                - prior_health.get("components", 0),
-                "unratified_orphans": health_summary.get("unratified_orphans", 0)
-                - prior_health.get("unratified_orphans", 0),
-                "ratified": health_summary.get("ratified", 0) - prior_health.get("ratified", 0),
-            }
-    except Exception:
-        # A degraded joint view (e.g. uncompiled deps) must not break the
-        # checkpoint; default to no credit / no health rather than crashing.
-        lkm_pulls = 0
+    if curr_components is not None:
+        # Persist the component partition so the NEXT round's bridge detection has
+        # a prior partition to diff against (sorted member lists, JSON-able).
+        frontier_summary["component_members"] = [sorted(c) for c in curr_components]
 
     append_round(
         pkg,

--- a/gaia/explore_client/orchestrator.py
+++ b/gaia/explore_client/orchestrator.py
@@ -473,9 +473,10 @@ def _score_feature_hint(score_features: dict[str, Any]) -> str:
     by build 11 steer 4) and renders them as a natural-language nudge appended to
     the brief; returns ``""`` when no signal is strong enough to be worth citing.
     The belief-derived ``belief_entropy`` ("undecided territory") hint is NOT
-    cited — belief stays internal to the engine (Jaynes' robot). ``tension_potential``
-    / ``bridge_potential`` are 0.0 v1 slots and are never cited (the ``Inquisitor``
-    doctrine is inert).
+    cited — belief stays internal to the engine (Jaynes' robot). ``bridge_potential``
+    is now a live slot (EXPANSION.md §3.B) and IS cited when high (a bridging
+    contact heals fragmentation). ``tension_potential`` stays a 0.0 deferred slot
+    and is never cited (the ``Inquisitor`` doctrine remains inert).
     """
 
     def _f(key: str) -> float:
@@ -491,6 +492,10 @@ def _score_feature_hint(score_features: dict[str, Any]) -> str:
         candidates.append((v, "on-topic / close to your seed"))
     if (v := _f("new_territory")) >= 0.6:
         candidates.append((v, "fresh unexplored territory"))
+    # bridge_potential is binary (0.0/1.0); when high, surveying/wiring this
+    # contact would connect an orphan island to the core (EXPANSION.md §3.B).
+    if (v := _f("bridge_potential")) >= 1.0:
+        candidates.append((v, "bridges a disconnected island to your core"))
 
     if not candidates:
         return ""
@@ -701,6 +706,7 @@ def _emit_survey_task(pkg: str | Path, exploration_map: ExplorationMap) -> TurnO
             edges=view.edges,
             obligations=obligations,
             health=health,
+            materialized=view.materialized,
         )
         _refresh_stats(exploration_map)
 

--- a/gaia/explore_client/orchestrator.py
+++ b/gaia/explore_client/orchestrator.py
@@ -36,14 +36,18 @@ from gaia.engine.exploration.frontier import (
     reconcile_frontier,
 )
 from gaia.engine.exploration.handoff import (
+    IslandBrief,
     SurveyResult,
     SurveyTask,
     TaskContact,
     result_path,
     task_path,
 )
+from gaia.engine.exploration.health import MapHealth, compute_map_health
 from gaia.engine.exploration.scorer import sanitize_score_features, score_frontier
 from gaia.engine.exploration.state import (
+    MODE_SELECT_CONSOLIDATE,
+    MODE_SELECT_EXPAND,
     TURN_PHASE_AWAITING_CHECKPOINT,
     TURN_PHASE_AWAITING_SURVEY,
     TURN_PHASE_IDLE,
@@ -57,7 +61,10 @@ from gaia.engine.exploration.state import (
     save_map,
     save_round_beliefs,
 )
-from gaia.explore_client.instructions import build_survey_instructions
+from gaia.explore_client.instructions import (
+    build_consolidate_instructions,
+    build_survey_instructions,
+)
 
 
 class OrchestratorError(Exception):
@@ -102,6 +109,15 @@ class TurnOutcome:
     discoveries: list[dict[str, Any]] = field(default_factory=list)
     discovery_labels: dict[str, str] = field(default_factory=dict)
     messages: list[str] = field(default_factory=list)
+    # EXPANSION.md §3 — the expand↔consolidate turn dimension.
+    task_kind: str = "expand"
+    islands: int = 0
+    # Connectivity readout (component / orphan / ratified / reopened counts) so the
+    # CLI and tests can surface MapHealth without re-deriving it.
+    health: dict[str, Any] = field(default_factory=dict)
+    connectivity_delta: dict[str, Any] = field(default_factory=dict)
+    ratified: list[list[str]] = field(default_factory=list)
+    reopened: list[list[str]] = field(default_factory=list)
 
 
 # --------------------------------------------------------------------------- #
@@ -169,6 +185,63 @@ def _project_config(pkg: str | Path) -> dict[str, Any]:
 def _joint_view(pkg: str | Path, graph: Any) -> JointView:
     """Build the joint root+dependency view (SDK; SCHEMA.md §7e)."""
     return build_joint_view(str(pkg), graph, project_config=_project_config(pkg), depth=-1)
+
+
+def _compute_health(exploration_map: ExplorationMap, view: JointView) -> MapHealth:
+    """Compute the joint-graph MapHealth for the map (EXPANSION.md §3.A).
+
+    The surveyed set is ``map.surveyed`` keys; the seeds are the resolved seed
+    QIDs; the edges are the joint view's edge set (the same one the scorer
+    adjacency spans); the ratified separations are the map's recorded islands.
+    Pure (no I/O) — the view was already built by the caller.
+    """
+    surveyed = list(exploration_map.surveyed.keys())
+    seeds = [str(s["qid"]) for s in exploration_map.seeds if s.get("qid")]
+    return compute_map_health(
+        surveyed,
+        seeds,
+        view.edges,
+        ratified=exploration_map.ratified_as_health_objects(),
+    )
+
+
+def _health_summary(exploration_map: ExplorationMap, health: MapHealth) -> dict[str, Any]:
+    """A small JSON-able connectivity readout for the outcome / status."""
+    policy = exploration_map.policy
+    return {
+        "components": health.component_count,
+        "orphans": len(health.orphans),
+        "unratified_orphans": health.unratified_orphan_count,
+        "ratified": health.ratified_count,
+        "reopened": len(health.reopened),
+        "largest_fraction": round(health.largest_fraction, 4),
+        "orphan_fraction": round(health.orphan_node_fraction, 4),
+        "unhealthy": health.is_unhealthy(
+            min_orphan_components=policy.fragment_min_orphans,
+            orphan_fraction=policy.fragment_orphan_fraction,
+        ),
+    }
+
+
+def _select_mode(exploration_map: ExplorationMap, health: MapHealth) -> str:
+    """Pick expand vs. consolidate for this IDLE turn (EXPANSION.md §3.C / §4).
+
+    ``mode_select`` pins the mode when set to ``expand`` / ``consolidate``; under
+    ``auto`` the orchestrator consolidates iff the map is unhealthy past the
+    policy's fragmentation threshold (a reopened ratification counts as
+    un-ratified, handled inside MapHealth), else expands.
+    """
+    mode = exploration_map.policy.mode_select
+    if mode == MODE_SELECT_EXPAND:
+        return MODE_SELECT_EXPAND
+    if mode == MODE_SELECT_CONSOLIDATE:
+        return MODE_SELECT_CONSOLIDATE
+    # auto
+    unhealthy = health.is_unhealthy(
+        min_orphan_components=exploration_map.policy.fragment_min_orphans,
+        orphan_fraction=exploration_map.policy.fragment_orphan_fraction,
+    )
+    return MODE_SELECT_CONSOLIDATE if unhealthy else MODE_SELECT_EXPAND
 
 
 def _promote_lkm_from_view(
@@ -489,6 +562,53 @@ def _contact_survey_brief(contact: Contact, obligations: list[Any] | None = None
     )
 
 
+def _island_brief_text(member_qids: list[str], node_texts: dict[str, str]) -> str:
+    """A short NL description of an orphan island for the consolidate worklist."""
+    parts: list[str] = []
+    for qid in member_qids[:6]:
+        label = qid.rsplit("::", 1)[1] if "::" in qid else qid
+        text = node_texts.get(qid, "").strip()
+        # node_texts() yields "label content"; keep it short.
+        snippet = text[:120] + ("…" if len(text) > 120 else "") if text else label
+        parts.append(f"{label}: {snippet}" if text else label)
+    more = f" (+{len(member_qids) - 6} more nodes)" if len(member_qids) > 6 else ""
+    return "; ".join(parts) + more
+
+
+def _island_briefs(
+    exploration_map: ExplorationMap, health: MapHealth, view: JointView
+) -> list[IslandBrief]:
+    """Build the consolidate bridge worklist from the orphan islands (EXPANSION.md §3.D).
+
+    One :class:`IslandBrief` per un-ratified-or-reopened orphan component (a
+    still-valid ratified island is NOT re-nagged — EXPANSION.md §3.E). A reopened
+    island carries its ``bridge_hint`` (the QID whose new presence may now connect
+    it) and the ``reopened`` flag so the brief can say "reconsider".
+    """
+    node_texts = view.node_texts()
+    ratified_members = {
+        frozenset(str(q) for q in r.get("member_qids", []))
+        for r in exploration_map.ratified_separations
+    }
+    briefs: list[IslandBrief] = []
+    for comp in health.orphans:
+        members = list(comp.members)
+        is_ratified = frozenset(members) in ratified_members
+        # Skip still-valid ratified islands (honored, not re-nagged); a reopened
+        # one (ratified but stale premise) DOES return to the worklist.
+        if is_ratified and not comp.reopened:
+            continue
+        briefs.append(
+            IslandBrief(
+                member_qids=members,
+                brief=_island_brief_text(members, node_texts),
+                reopened=comp.reopened,
+                bridge_hint=comp.bridge_qid,
+            )
+        )
+    return briefs
+
+
 def _seed_contacts(exploration_map: ExplorationMap) -> list[TaskContact]:
     """Build round-0 seed-survey contact rows from the map's seeds."""
     rows: list[TaskContact] = []
@@ -530,7 +650,10 @@ def _emit_survey_task(pkg: str | Path, exploration_map: ExplorationMap) -> TurnO
     graph = _resolve_graph(pkg)
 
     contacts: list[TaskContact] = []
+    bridge_worklist: list[IslandBrief] = []
     seed_survey = False
+    task_kind = MODE_SELECT_EXPAND
+    health_summary: dict[str, Any] = {}
 
     if graph is None:
         # Round 0 before any compile/materialize: survey the seed(s).
@@ -560,52 +683,93 @@ def _emit_survey_task(pkg: str | Path, exploration_map: ExplorationMap) -> TurnO
             )
         extracted = view.extract(exploration_map)
         reconcile_frontier(exploration_map, extracted, discovered_round=round_index)
+
+        # EXPANSION.md §3.A/§3.C — compute MapHealth and pick the turn mode
+        # (auto → consolidate iff unhealthy past the threshold; pinned values
+        # override). The doctrine IS the mode; mode_select only decides WHEN.
+        health = _compute_health(exploration_map, view)
+        health_summary = _health_summary(exploration_map, health)
+        mode = _select_mode(exploration_map, health)
+
         # Build 12 (CLIENT.md steer 3): load the package's open synthetic
-        # obligations so this live turn scores obligation_pressure — contacts
-        # discharging an open obligation get boosted in the ranking below.
+        # obligations so this live turn scores obligation_pressure. The MapHealth
+        # now also activates bridge_potential + qid new_territory (EXPANSION §3.B).
         obligations = _load_open_obligations(pkg)
-        score_frontier(exploration_map, beliefs=beliefs, edges=view.edges, obligations=obligations)
+        score_frontier(
+            exploration_map,
+            beliefs=beliefs,
+            edges=view.edges,
+            obligations=obligations,
+            health=health,
+        )
         _refresh_stats(exploration_map)
 
-        ranked = _rank_open_contacts(exploration_map)
-        top_k = ranked[: exploration_map.policy.budget_k]
-        if not top_k:
-            # No frontier yet (round 0, or a survey that grew nothing): fall back
-            # to a seed survey so the loop can still make progress.
-            seed_survey = True
-            contacts = _seed_contacts(exploration_map)
-            messages.append(
-                "frontier empty — emitting a seed-survey task; observe related "
-                "papers during the survey to grow the frontier for next round."
-            )
-        else:
-            # Build 11 steer 4: rank on the FULL features (done above by
-            # score_frontier + _rank_open_contacts), then sanitize for the
-            # agent-facing envelope — drop belief_entropy and the raw
-            # belief-weighted score so the agent never sees the belief math
-            # (Jaynes' robot). Ordering is already fixed by top_k.
-            contacts = [
-                TaskContact(
-                    id=c.id,
-                    ref=c.ref,
-                    score=None,
-                    score_features=sanitize_score_features(c.score_features),
-                    sources=c.sources,
-                    survey_brief=_contact_survey_brief(c, obligations),
+        if mode == MODE_SELECT_CONSOLIDATE:
+            bridge_worklist = _island_briefs(exploration_map, health, view)
+            if bridge_worklist:
+                task_kind = MODE_SELECT_CONSOLIDATE
+                n_reopened = sum(1 for b in bridge_worklist if b.reopened)
+                messages.append(
+                    f"consolidate turn: {len(bridge_worklist)} island(s) to bridge or "
+                    f"ratify (over already-surveyed nodes; no new pulls)"
+                    + (f", {n_reopened} reopened by new evidence" if n_reopened else "")
+                    + "."
                 )
-                for c in top_k
-            ]
+            else:
+                # Pinned/auto consolidate but nothing left to bridge (all islands
+                # are validly ratified, or the map is connected) — fall back to an
+                # expand turn so the loop still makes progress.
+                messages.append(
+                    "consolidate requested but no un-ratified islands remain — "
+                    "running an expand turn instead."
+                )
+
+        if task_kind == MODE_SELECT_EXPAND:
+            ranked = _rank_open_contacts(exploration_map)
+            top_k = ranked[: exploration_map.policy.budget_k]
+            if not top_k:
+                # No frontier yet (round 0, or a survey that grew nothing): fall
+                # back to a seed survey so the loop can still make progress.
+                seed_survey = True
+                contacts = _seed_contacts(exploration_map)
+                messages.append(
+                    "frontier empty — emitting a seed-survey task; observe related "
+                    "papers during the survey to grow the frontier for next round."
+                )
+            else:
+                # Build 11 steer 4: rank on the FULL features (done above by
+                # score_frontier + _rank_open_contacts), then sanitize for the
+                # agent-facing envelope — drop belief_entropy and the raw
+                # belief-weighted score so the agent never sees the belief math
+                # (Jaynes' robot). Ordering is already fixed by top_k.
+                contacts = [
+                    TaskContact(
+                        id=c.id,
+                        ref=c.ref,
+                        score=None,
+                        score_features=sanitize_score_features(c.score_features),
+                        sources=c.sources,
+                        survey_brief=_contact_survey_brief(c, obligations),
+                    )
+                    for c in top_k
+                ]
 
     edir = exploration_dir(pkg)
     res_path = result_path(edir, round_index)
+    if task_kind == MODE_SELECT_CONSOLIDATE:
+        instructions = build_consolidate_instructions()
+    else:
+        instructions = build_survey_instructions(seed_survey=seed_survey)
     task = SurveyTask(
         pkg=str(pkg),
         round=round_index,
         doctrine=exploration_map.policy.doctrine,
         budget_k=exploration_map.policy.budget_k,
+        kind=task_kind,
         contacts=contacts,
+        bridge_worklist=bridge_worklist,
         seed_survey=seed_survey,
-        instructions=build_survey_instructions(seed_survey=seed_survey),
+        instructions=instructions,
         result_path=str(res_path),
     )
     written = task.write(task_path(edir, round_index))
@@ -622,8 +786,28 @@ def _emit_survey_task(pkg: str | Path, exploration_map: ExplorationMap) -> TurnO
         result_path=str(res_path),
         contacts=[c.id for c in contacts],
         seed_survey=seed_survey,
+        task_kind=task_kind,
+        islands=len(bridge_worklist),
+        health=health_summary,
         messages=messages,
     )
+
+
+def _prior_round_health(pkg: str | Path, current_round: int) -> dict[str, Any]:
+    """The health summary recorded by the most recent prior round, or ``{}``.
+
+    Reads ``rounds.jsonl`` and returns the latest record's
+    ``frontier_summary.health`` (written by a previous checkpoint), so the
+    connectivity delta is measured against the last completed round.
+    """
+    from gaia.engine.exploration.state import read_rounds
+
+    rounds = [r for r in read_rounds(pkg) if int(r.get("round", -1)) < current_round]
+    if not rounds:
+        return {}
+    last = rounds[-1]
+    health = last.get("frontier_summary", {}).get("health", {})
+    return dict(health) if isinstance(health, dict) else {}
 
 
 def _record_surveyed(
@@ -685,6 +869,26 @@ def _checkpoint(
     surveyed_qids = list(survey_result.surveyed_qids)
     _record_surveyed(exploration_map, surveyed_qids, survey_round=current_round)
 
+    # EXPANSION.md §3.E — record any islands the agent ratified-as-separate this
+    # turn (the one consolidate signal that has no graph footprint). Stamp the
+    # round + a cheap evidence fingerprint (the ratifying round) so the
+    # provisional-reopen test can tell whether later evidence has changed the
+    # premise. Recorded per component; a re-ratification replaces the prior row.
+    ratified_now: list[list[str]] = []
+    for r in survey_result.ratified:
+        members = [str(q) for q in r.member_qids if q]
+        if not members:
+            continue
+        exploration_map.add_ratified_separation(
+            members,
+            rationale=r.rationale,
+            round_index=current_round,
+            evidence_fingerprint={"ratified_round": current_round},
+        )
+        ratified_now.append(sorted(members))
+    if ratified_now:
+        messages.append(f"recorded {len(ratified_now)} ratified separation(s) this turn.")
+
     discoveries = compute_discoveries(graph, beliefs, prev_beliefs, ir_dict=ir_dict)
 
     # Author labels for the discovered nodes, so the report names a labeled node
@@ -702,24 +906,56 @@ def _checkpoint(
     scored = [
         c.score for c in exploration_map.frontier if c.status == "open" and c.score is not None
     ]
-    frontier_summary = {"open_after": open_after, "top_score": max(scored) if scored else None}
+    frontier_summary: dict[str, Any] = {
+        "open_after": open_after,
+        "top_score": max(scored) if scored else None,
+    }
 
     # Credit the round with the papers materialized during this turn's
     # survey (pulled via `pkg add --lkm-paper`, outside the round step) so the
     # durable record no longer shows `lkm_pulls: 0`. Count the joint view's
     # materialized paper QIDs and credit the net-new ones since the prior round.
+    # The same joint view also drives the post-checkpoint MapHealth.
     from gaia.engine.exploration.observe import materialized_paper_ids_from_roots
     from gaia.engine.exploration.state import lkm_pulls_this_round
 
+    lkm_pulls = 0
+    health_summary: dict[str, Any] = {}
+    connectivity_delta: dict[str, Any] = {}
+    reopened_now: list[list[str]] = []
     try:
         view = _joint_view(pkg, graph)
         materialized_papers = set(view.materialized_paper_ids) | materialized_paper_ids_from_roots(
             view.package_roots
         )
         lkm_pulls = lkm_pulls_this_round(pkg, len(materialized_papers))
+
+        # EXPANSION.md §3.D/§3.E — recompute MapHealth on the post-checkpoint
+        # joint graph and report the connectivity delta vs. the prior round. The
+        # reopen test (a ratified island whose premise is now stale because new
+        # bridging evidence exists) falls straight out of MapHealth.
+        health = _compute_health(exploration_map, view)
+        health_summary = _health_summary(exploration_map, health)
+        reopened_now = [list(c.members) for c in health.reopened]
+        if reopened_now:
+            messages.append(
+                f"REOPENED {len(reopened_now)} ratified separation(s): new evidence "
+                "may now connect a previously-ratified island — reconsider next "
+                "consolidate turn."
+            )
+        frontier_summary["health"] = health_summary
+        prior_health = _prior_round_health(pkg, current_round)
+        if prior_health:
+            connectivity_delta = {
+                "components": health_summary.get("components", 0)
+                - prior_health.get("components", 0),
+                "unratified_orphans": health_summary.get("unratified_orphans", 0)
+                - prior_health.get("unratified_orphans", 0),
+                "ratified": health_summary.get("ratified", 0) - prior_health.get("ratified", 0),
+            }
     except Exception:
         # A degraded joint view (e.g. uncompiled deps) must not break the
-        # checkpoint; default to no credit rather than crashing the round.
+        # checkpoint; default to no credit / no health rather than crashing.
         lkm_pulls = 0
 
     append_round(
@@ -746,6 +982,10 @@ def _checkpoint(
         surveyed=surveyed_qids,
         discoveries=discoveries,
         discovery_labels=discovery_labels,
+        health=health_summary,
+        connectivity_delta=connectivity_delta,
+        ratified=ratified_now,
+        reopened=reopened_now,
         messages=messages,
     )
 

--- a/gaia/explore_client/verbs.py
+++ b/gaia/explore_client/verbs.py
@@ -104,8 +104,10 @@ _DOCTRINE_OPT = typer.Option(
     "--doctrine",
     help=(
         f"Named doctrine preset: {sorted(DOCTRINE_PRESETS)}. "
-        "Note: tension/bridge scoring is not yet wired (DESIGN §8), so "
-        "tension/bridge-led presets (e.g. 'Inquisitor') are currently inert."
+        "Note: bridge scoring is now wired (EXPANSION.md §3.B), so bridge-led "
+        "presets (Cartographer / Diplomat) are live; tension scoring is still "
+        "deferred (EXPANSION.md §3.B), so the tension-led 'Inquisitor' preset "
+        "remains inert."
     ),
 )
 _BUDGET_K_OPT = typer.Option(5, "--budget-k", help="Top-k contacts to survey per round.")
@@ -474,22 +476,24 @@ def init_command(
         )
         raise typer.Exit(2)
 
-    # Warn when the chosen doctrine leads on the currently-inert tension/bridge
-    # potential slots (DESIGN §8 defers tension/bridge wiring), so its headline
-    # lever does nothing yet — surfaced here at init rather than only later in the
-    # survey task envelope. Mirrors that note.
+    # Warn when the chosen doctrine leads on the still-inert TENSION potential
+    # slot (EXPANSION.md §3.B defers tension wiring this iteration), so its
+    # headline lever does nothing yet — surfaced here at init rather than only
+    # later in the survey task envelope. Bridge is now WIRED (EXPANSION.md §3.B),
+    # so w_bridge counts as live, not inert.
     _weights = DOCTRINE_PRESETS[doctrine]
-    _inert = _weights.get("w_tension", 0.0) + _weights.get("w_bridge", 0.0)
+    _inert = _weights.get("w_tension", 0.0)
     _live = (
         _weights.get("w_uncertainty", 0.0)
         + _weights.get("w_coverage", 0.0)
         + _weights.get("w_relevance", 0.0)
+        + _weights.get("w_bridge", 0.0)
     )
     if _inert > _live:
         typer.echo(
-            f"Warning: doctrine {doctrine!r} leads on tension/bridge potential, "
-            "which are currently inert (0.0 scoring slots; DESIGN §8 defers "
-            "tension/bridge wiring), so its ranking is dominated by the remaining "
+            f"Warning: doctrine {doctrine!r} leads on tension potential, "
+            "which is still inert (a 0.0 scoring slot; EXPANSION.md §3.B defers "
+            "tension wiring), so its ranking is dominated by the remaining "
             "terms. Prefer 'Surveyor' or 'Cartographer' for now.",
             err=True,
         )
@@ -688,6 +692,7 @@ def frontier_command(
         edges=view.edges,
         obligations=obligations,
         health=health,
+        materialized=view.materialized,
     )
     _refresh_stats(exploration_map)
     save_map(pkg, exploration_map)

--- a/gaia/explore_client/verbs.py
+++ b/gaia/explore_client/verbs.py
@@ -67,6 +67,7 @@ from gaia.engine.exploration.render import (
     exploration_header_fields,
     frontier_graph_elements,
     inject_exploration_header,
+    ratified_node_classes,
     wrap_self_contained_html,
 )
 from gaia.engine.exploration.scorer import (
@@ -161,6 +162,39 @@ def _map_health(exploration_map: ExplorationMap, view: JointView) -> MapHealth:
         view.edges,
         ratified=exploration_map.ratified_as_health_objects(),
     )
+
+
+def _echo_status_connectivity(pkg: str, exploration_map: ExplorationMap) -> None:
+    """Print the MapHealth connectivity readout for ``status`` (EXPANSION.md §3/§4).
+
+    Best-effort: a degraded joint view (uncompiled deps, no IR) must not break
+    status, so the whole compute is guarded. No output when no graph is resolved.
+    """
+    try:
+        graph = resolve_graph(pkg)
+        if graph is None:
+            return
+        view = _require_joint_view(pkg, graph)
+        health = _map_health(exploration_map, view)
+    except Exception:
+        # status must never crash on a degraded view — skip the readout.
+        return
+    policy = exploration_map.policy
+    unhealthy = health.is_unhealthy(
+        min_orphan_components=policy.fragment_min_orphans,
+        orphan_fraction=policy.fragment_orphan_fraction,
+    )
+    verdict = "FRAGMENTED (consolidate)" if unhealthy else "maintainable"
+    typer.echo(
+        f"  connectivity:   {health.component_count} component(s), "
+        f"{len(health.orphans)} orphan(s) "
+        f"({health.unratified_orphan_count} un-ratified), "
+        f"{health.ratified_count} ratified, {len(health.reopened)} reopened "
+        f"— {verdict}"
+    )
+    for comp in health.reopened:
+        members = ", ".join(comp.members[:3])
+        typer.echo(f"    - REOPENED island: {members} (new bridging evidence)")
 
 
 def _load_beliefs(pkg: str) -> dict[str, float]:
@@ -904,8 +938,13 @@ def status_command(
     typer.echo(f"Exploration status for {pkg}")
     typer.echo(f"  round:          {exploration_map.round}")
     typer.echo(f"  doctrine:       {exploration_map.policy.doctrine}")
+    typer.echo(f"  mode_select:    {exploration_map.policy.mode_select}")
     typer.echo(f"  seeds:          {len(exploration_map.seeds)}")
     typer.echo(f"  surveyed:       {len(exploration_map.surveyed)}")
+
+    # (EXPANSION.md §3/§4) Connectivity readout — components / orphans / ratified /
+    # reopened, and whether the map is unhealthy past the fragmentation threshold.
+    _echo_status_connectivity(pkg, exploration_map)
     # Split the open frontier into paper vs claim contacts with the
     # same vocabulary `render` uses, so the two surfaces never appear to disagree.
     n_papers, n_claims = _open_frontier_split(ranked)
@@ -1068,9 +1107,31 @@ def render_command(
     graph_payload.setdefault("nodes", []).extend(frontier_nodes)
     graph_payload.setdefault("edges", []).extend(frontier_edges)
 
+    # (EXPANSION.md §3.E / Phase 3) Mark surveyed nodes in a ratified (or reopened)
+    # island so the figure can draw a ratified boundary DISTINCTLY from a fog gap —
+    # a deliberate border, not "unexplored" — and FLAG a reopened one. Best-effort
+    # MapHealth (a degraded joint view must not break render); the classifier falls
+    # back to "ratified" for every recorded member when no live health is available.
+    health = None
+    try:
+        graph_for_health = resolve_graph(pkg)
+        if graph_for_health is not None:
+            health = _map_health(exploration_map, _require_joint_view(pkg, graph_for_health))
+    except Exception:
+        # render must not crash on a degraded view — skip the ratified styling.
+        health = None
+    node_classes = ratified_node_classes(exploration_map, health=health)
+    if node_classes:
+        for node in graph_payload.get("nodes", []):
+            cls = node_classes.get(str(node.get("id")))
+            if cls is not None:
+                meta = node.setdefault("metadata", {}) or {}
+                meta["ratified_separation"] = cls  # "ratified" | "reopened"
+                node["metadata"] = meta
+
     dot_source = to_dot(json.dumps(graph_payload), theme="stellaris")
     svg = _render_stellaris_svg(dot_source, include_frontier=bool(frontier_nodes))
-    svg = inject_exploration_header(svg, exploration_header_fields(exploration_map))
+    svg = inject_exploration_header(svg, exploration_header_fields(exploration_map, health=health))
     html_doc = wrap_self_contained_html(svg)
 
     out_path = Path(out).resolve() if out is not None else gaia_dir / "exploration" / "map.html"

--- a/gaia/explore_client/verbs.py
+++ b/gaia/explore_client/verbs.py
@@ -57,6 +57,7 @@ from gaia.engine.exploration.frontier import (
     reconcile_frontier,
     resolve_freetext_seed_qid,
 )
+from gaia.engine.exploration.health import MapHealth, compute_map_health
 from gaia.engine.exploration.observe import (
     materialized_paper_ids_from_roots,
     observe_lkm_results,
@@ -142,6 +143,24 @@ _RENDER_OUT_OPT = typer.Option(
 
 def _gaia_dir(pkg: str) -> Path:
     return Path(pkg).resolve() / ".gaia"
+
+
+def _map_health(exploration_map: ExplorationMap, view: JointView) -> MapHealth:
+    """Compute the joint-graph MapHealth for the map (EXPANSION.md §3.A).
+
+    The surveyed set is ``map.surveyed`` keys, the seeds the resolved seed QIDs,
+    the edges the joint view's edge set, and the ratified separations the map's
+    recorded islands — the same inputs the orchestrator uses, so the standalone
+    verbs and ``turn`` agree on connectivity.
+    """
+    surveyed = list(exploration_map.surveyed.keys())
+    seeds = [str(s["qid"]) for s in exploration_map.seeds if s.get("qid")]
+    return compute_map_health(
+        surveyed,
+        seeds,
+        view.edges,
+        ratified=exploration_map.ratified_as_health_objects(),
+    )
 
 
 def _load_beliefs(pkg: str) -> dict[str, float]:
@@ -626,7 +645,16 @@ def frontier_command(
     # ``obligation_pressure`` exactly as ``gaia-lkm-explore turn`` does — the two
     # surfaces must agree (a contact discharging an open obligation scores 1.0).
     obligations = load_open_obligations(pkg)
-    score_frontier(exploration_map, beliefs=beliefs, edges=view.edges, obligations=obligations)
+    # (EXPANSION.md §3.B) MapHealth activates bridge_potential + qid new_territory
+    # in the score, so this standalone verb ranks identically to the orchestrator.
+    health = _map_health(exploration_map, view)
+    score_frontier(
+        exploration_map,
+        beliefs=beliefs,
+        edges=view.edges,
+        obligations=obligations,
+        health=health,
+    )
     _refresh_stats(exploration_map)
     save_map(pkg, exploration_map)
 

--- a/tests/exploration/test_cli_explore.py
+++ b/tests/exploration/test_cli_explore.py
@@ -606,9 +606,14 @@ def test_explore_frontier_ranks_lkm_contacts(galileo_pkg: Path):
             "obligation_pressure",
         }
         assert "belief_entropy" not in feats
-        # An lkm contact's new_territory is live (>= 0.5) and survey_cost heavier.
+        # An lkm contact's new_territory is live (>= 0.5) and survey_cost heavier
+        # than a qid's flat 1.0 (the bounded LKM_SURVEY_COST — the cost asymmetry
+        # was capped so it can't defeat the expansion goal; EXPANSION.md §1).
+        from gaia.engine.exploration.scorer import LKM_SURVEY_COST
+
         assert feats["new_territory"] >= 0.5
-        assert feats["survey_cost"] == 2.0
+        assert feats["survey_cost"] == LKM_SURVEY_COST
+        assert LKM_SURVEY_COST > 1.0
 
 
 def test_explore_observe_without_init_fails(galileo_pkg: Path):

--- a/tests/exploration/test_cli_explore.py
+++ b/tests/exploration/test_cli_explore.py
@@ -618,3 +618,21 @@ def test_explore_observe_without_init_fails(galileo_pkg: Path):
     )
     assert result.exit_code == 1
     assert "no exploration map" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# Phase 3 (EXPANSION.md §3/§4): status connectivity readout                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_status_surfaces_connectivity_and_mode(galileo_pkg: Path):
+    """`status` shows mode_select and the MapHealth connectivity readout."""
+    runner.invoke(app, ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")])
+    # Build the frontier so there is a joint view + a map to read.
+    runner.invoke(app, ["frontier", str(galileo_pkg)])
+    result = runner.invoke(app, ["status", str(galileo_pkg)])
+    assert result.exit_code == 0, result.output
+    assert "mode_select:" in result.output
+    assert "connectivity:" in result.output
+    # The galileo seed graph is a single connected story → maintainable.
+    assert "maintainable" in result.output or "component(s)" in result.output

--- a/tests/exploration/test_discoveries.py
+++ b/tests/exploration/test_discoveries.py
@@ -224,3 +224,72 @@ def test_compute_discoveries_threads_labels_into_notes():
     keystone = next(d for d in discoveries if d["kind"] == KIND_KEYSTONE)
     assert keystone["ids"] == [qid("_anon_h")]  # durable key unchanged
     assert "grand_hub" in keystone["note"]
+
+
+# --------------------------------------------------------------------------- #
+# Phase 3 (EXPANSION.md §3): bridge / fault_line discovery kinds                #
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_bridges_fires_on_merged_components():
+    from gaia.engine.exploration.discoveries import KIND_BRIDGE, detect_bridges
+
+    # Prior round: two disjoint components {a} and {b}. Now: merged into {a,b}.
+    prev = [frozenset({qid("a")}), frozenset({qid("b")})]
+    curr = [frozenset({qid("a"), qid("b")})]
+    bridges = detect_bridges(prev, curr)
+    assert len(bridges) == 1
+    assert bridges[0]["kind"] == KIND_BRIDGE
+    assert set(bridges[0]["ids"]) == {qid("a"), qid("b")}
+
+
+def test_detect_bridges_no_prior_partition_is_empty():
+    from gaia.engine.exploration.discoveries import detect_bridges
+
+    curr = [frozenset({qid("a"), qid("b")})]
+    assert detect_bridges([], curr) == []
+
+
+def test_detect_bridges_silent_when_still_disjoint():
+    from gaia.engine.exploration.discoveries import detect_bridges
+
+    prev = [frozenset({qid("a")}), frozenset({qid("b")})]
+    curr = [frozenset({qid("a")}), frozenset({qid("b")})]  # unchanged
+    assert detect_bridges(prev, curr) == []
+
+
+def test_detect_fault_lines_reports_orphans():
+    from gaia.engine.exploration.discoveries import KIND_FAULT_LINE, detect_fault_lines
+
+    orphans = [frozenset({qid("b"), qid("c")})]
+    faults = detect_fault_lines(orphans)
+    assert len(faults) == 1
+    assert faults[0]["kind"] == KIND_FAULT_LINE
+    assert set(faults[0]["ids"]) == {qid("b"), qid("c")}
+
+
+def test_compute_discoveries_includes_bridge_and_fault_line():
+    from gaia.engine.exploration.discoveries import KIND_BRIDGE, KIND_FAULT_LINE
+
+    graph = make_graph(knowledges=[claim("a"), claim("b")])
+    discoveries = compute_discoveries(
+        graph,
+        beliefs={},
+        prev_beliefs={},
+        prev_components=[frozenset({qid("a")}), frozenset({qid("b")})],
+        curr_components=[frozenset({qid("a"), qid("b")})],
+        orphan_components=[frozenset({qid("c")})],
+    )
+    kinds = {d["kind"] for d in discoveries}
+    assert KIND_BRIDGE in kinds
+    assert KIND_FAULT_LINE in kinds
+
+
+def test_compute_discoveries_omits_connectivity_without_partitions():
+    from gaia.engine.exploration.discoveries import KIND_BRIDGE, KIND_FAULT_LINE
+
+    graph = make_graph(knowledges=[claim("a")])
+    discoveries = compute_discoveries(graph, beliefs={}, prev_beliefs={})
+    kinds = {d["kind"] for d in discoveries}
+    assert KIND_BRIDGE not in kinds
+    assert KIND_FAULT_LINE not in kinds

--- a/tests/exploration/test_handoff.py
+++ b/tests/exploration/test_handoff.py
@@ -63,7 +63,9 @@ def test_task_roundtrips_full_shape(tmp_path: Path):
         "round",
         "doctrine",
         "budget_k",
+        "kind",
         "contacts",
+        "bridge_worklist",
         "seed_survey",
         "instructions",
         "result_path",
@@ -127,3 +129,87 @@ def test_result_tolerates_legacy_fields(tmp_path: Path):
 def test_task_rejects_missing_required_fields():
     with pytest.raises(ValidationError):
         SurveyTask.model_validate({"round": 1})
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2 (EXPANSION.md §3.D / §3.E): kind discriminator + bridge worklist      #
+# --------------------------------------------------------------------------- #
+
+
+def test_task_kind_defaults_to_expand():
+    task = SurveyTask(pkg="p", round=1, doctrine="Surveyor", budget_k=5)
+    assert task.kind == "expand"
+    assert task.bridge_worklist == []
+
+
+def test_consolidate_task_roundtrips_with_islands(tmp_path: Path):
+    from gaia.engine.exploration.handoff import IslandBrief
+
+    task = SurveyTask(
+        pkg="p",
+        round=2,
+        doctrine="Diplomat",
+        budget_k=5,
+        kind="consolidate",
+        bridge_worklist=[
+            IslandBrief(
+                member_qids=["lkm:pkg::b", "lkm:pkg::c"],
+                brief="b: ...; c: ...",
+                reopened=True,
+                bridge_hint="lkm:pkg::b",
+            )
+        ],
+        instructions="bridge or ratify",
+    )
+    p = task.write(task_path(tmp_path, 2))
+    back = SurveyTask.read(p)
+    assert back.kind == "consolidate"
+    assert len(back.bridge_worklist) == 1
+    assert back.bridge_worklist[0].member_qids == ["lkm:pkg::b", "lkm:pkg::c"]
+    assert back.bridge_worklist[0].reopened is True
+    assert back.bridge_worklist[0].bridge_hint == "lkm:pkg::b"
+
+
+def test_old_task_without_kind_reads_as_expand(tmp_path: Path):
+    legacy = {
+        "pkg": "p",
+        "round": 0,
+        "doctrine": "Surveyor",
+        "budget_k": 5,
+        "contacts": [],
+        "instructions": "x",
+        "result_path": "r",
+        # NB: no kind / bridge_worklist.
+    }
+    p = task_path(tmp_path, 0)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(legacy), encoding="utf-8")
+    task = SurveyTask.read(p)
+    assert task.kind == "expand"
+    assert task.bridge_worklist == []
+
+
+def test_result_carries_ratified_and_back_compat(tmp_path: Path):
+    from gaia.engine.exploration.handoff import RatifiedSeparationResult
+
+    res = SurveyResult(
+        surveyed_qids=["lkm:pkg::x"],
+        ratified=[
+            RatifiedSeparationResult(member_qids=["lkm:pkg::b"], rationale="separate domain")
+        ],
+    )
+    p = res.write(result_path(tmp_path, 1))
+    back = SurveyResult.read(p)
+    assert back.surveyed_qids == ["lkm:pkg::x"]
+    assert len(back.ratified) == 1
+    assert back.ratified[0].member_qids == ["lkm:pkg::b"]
+
+
+def test_old_result_without_ratified_reads_empty(tmp_path: Path):
+    legacy = {"surveyed_qids": ["lkm:pkg::x"], "notes": "ignored", "observed": ["ignored"]}
+    p = result_path(tmp_path, 0)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(legacy), encoding="utf-8")
+    res = SurveyResult.read(p)
+    assert res.surveyed_qids == ["lkm:pkg::x"]
+    assert res.ratified == []

--- a/tests/exploration/test_health.py
+++ b/tests/exploration/test_health.py
@@ -1,0 +1,164 @@
+"""Unit tests for gaia.engine.exploration.health (EXPANSION.md §3.A / §4)."""
+
+from __future__ import annotations
+
+from gaia.engine.exploration.health import (
+    DEFAULT_MIN_ORPHAN_COMPONENTS,
+    RatifiedSeparation,
+    compute_map_health,
+)
+
+NS = "github"
+PKG = "healthtest"
+
+
+def qid(label: str) -> str:
+    return f"{NS}:{PKG}::{label}"
+
+
+def edge(*labels: str) -> tuple[str, list[str]]:
+    """A reference edge co-referencing the given labels (operator_target kind)."""
+    return ("operator_target", [qid(x) for x in labels])
+
+
+# --------------------------------------------------------------------------- #
+# components / largest_fraction
+# --------------------------------------------------------------------------- #
+
+
+def test_single_connected_component_is_healthy():
+    # seed-s, a, b all wired into one component.
+    surveyed = [qid(x) for x in ("s", "a", "b")]
+    edges = [edge("s", "a"), edge("a", "b")]
+    health = compute_map_health(surveyed, [qid("s")], edges)
+    assert health.component_count == 1
+    assert health.largest_fraction == 1.0
+    assert health.orphans == ()
+    assert health.unratified_orphan_count == 0
+    assert not health.is_unhealthy()
+
+
+def test_two_islands_one_orphan():
+    # Core {s,a}; island {b,c} disjoint.
+    surveyed = [qid(x) for x in ("s", "a", "b", "c")]
+    edges = [edge("s", "a"), edge("b", "c")]
+    health = compute_map_health(surveyed, [qid("s")], edges)
+    assert health.component_count == 2
+    assert len(health.orphans) == 1
+    assert health.orphans[0].members == (qid("b"), qid("c"))
+    assert health.largest_fraction == 0.5
+    assert health.unratified_orphan_count == 1
+
+
+def test_seed_component_identified_as_core():
+    surveyed = [qid(x) for x in ("s", "a", "x", "y")]
+    edges = [edge("s", "a"), edge("x", "y")]
+    health = compute_map_health(surveyed, [qid("x")], edges)
+    core = [c for c in health.components if c.is_seed]
+    assert len(core) == 1
+    assert qid("x") in core[0].members
+
+
+def test_no_seed_falls_back_to_largest_component():
+    # No resolved seed: the largest component is the core.
+    surveyed = [qid(x) for x in ("a", "b", "c", "d", "e")]
+    edges = [edge("a", "b"), edge("b", "c"), edge("d", "e")]
+    health = compute_map_health(surveyed, [], edges)
+    core = [c for c in health.components if c.is_seed]
+    assert len(core) == 1
+    assert len(core[0].members) == 3  # {a,b,c} is larger than {d,e}
+
+
+# --------------------------------------------------------------------------- #
+# threshold / is_unhealthy
+# --------------------------------------------------------------------------- #
+
+
+def test_one_orphan_below_default_threshold_is_healthy_when_fraction_low():
+    # 1 orphan node of 10 surveyed: count 1 < 2 and fraction 0.1 < 0.34 → healthy.
+    core = [qid(f"c{i}") for i in range(9)]
+    core_edges = [edge(f"c{i}", f"c{i + 1}") for i in range(8)]
+    surveyed = [*core, qid("orphan")]
+    health = compute_map_health(surveyed, [qid("c0")], core_edges)
+    assert health.unratified_orphan_count == 1
+    assert not health.is_unhealthy()
+
+
+def test_two_orphans_crosses_count_threshold():
+    surveyed = [qid(x) for x in ("s", "a", "b", "c")]
+    edges = [edge("s", "a")]  # b and c are each their own singleton orphan
+    health = compute_map_health(surveyed, [qid("s")], edges)
+    assert health.unratified_orphan_count >= DEFAULT_MIN_ORPHAN_COMPONENTS
+    assert health.is_unhealthy()
+
+
+def test_orphan_fraction_crosses_threshold():
+    # One big orphan: 3 of 5 surveyed nodes are off the core → fraction 0.6 > 0.34.
+    surveyed = [qid(x) for x in ("s", "a", "b", "c", "d")]
+    edges = [edge("s", "a"), edge("b", "c"), edge("c", "d")]
+    health = compute_map_health(surveyed, [qid("s")], edges)
+    assert health.unratified_orphan_count == 1
+    assert health.orphan_node_fraction == 0.6
+    assert health.is_unhealthy()
+
+
+# --------------------------------------------------------------------------- #
+# ratification (exclusion) + provisional reopening (EXPANSION.md §3.E)
+# --------------------------------------------------------------------------- #
+
+
+def test_ratified_islands_read_healthy():
+    # Two orphan islands, both ratified → HEALTHY (legitimately multi-domain).
+    surveyed = [qid(x) for x in ("s", "a", "b", "c")]
+    edges = [edge("s", "a")]
+    ratified = [
+        RatifiedSeparation(member_qids=frozenset({qid("b")}), rationale="different domain"),
+        RatifiedSeparation(member_qids=frozenset({qid("c")}), rationale="different domain"),
+    ]
+    health = compute_map_health(surveyed, [qid("s")], edges, ratified=ratified)
+    assert len(health.orphans) == 2
+    assert all(o.ratified for o in health.orphans)
+    assert health.unratified_orphan_count == 0
+    assert not health.is_unhealthy()
+    assert health.ratified_count == 2
+
+
+def test_ratification_reopens_on_new_bridging_evidence():
+    # Island {b,c} ratified, disjoint from core {s,a}.
+    surveyed = [qid(x) for x in ("s", "a", "b", "c")]
+    ratified = [RatifiedSeparation(member_qids=frozenset({qid("b"), qid("c")}), rationale="x")]
+
+    # Premise still holds: no edge / candidate node spans island↔core → stays
+    # ratified, healthy, not reopened.
+    edges_before = [edge("s", "a"), edge("b", "c")]
+    h0 = compute_map_health(surveyed, [qid("s")], edges_before, ratified=ratified)
+    assert h0.unratified_orphan_count == 0
+    assert h0.reopened == ()
+
+    # New evidence: an as-yet-unmaterialized node x (a fog contact) is now
+    # referenced alongside b (island) in one edge and alongside s (core) in
+    # another. b/c stay their own component (x is unsurveyed, so it does not merge
+    # them), but a candidate connecting edge now EXISTS → the ratification's
+    # premise is stale → REOPEN.
+    x = qid("x")  # NOT in `surveyed`
+    edges_after = [
+        edge("s", "a"),
+        edge("b", "c"),
+        ("depends_on", [qid("b"), x]),  # x adjacent to island
+        ("depends_on", [qid("s"), x]),  # x adjacent to core
+    ]
+    h1 = compute_map_health(surveyed, [qid("s")], edges_after, ratified=ratified)
+    reopened = [c for c in h1.components if c.reopened]
+    assert len(reopened) == 1
+    assert qid("b") in reopened[0].members
+    assert reopened[0].bridge_qid == qid("b")
+    assert h1.unratified_orphan_count == 1
+    # The reopened island re-enters the unhealthy count (orphan fraction 0.5 > 0.34).
+    assert h1.is_unhealthy()
+
+
+def test_empty_map_is_healthy():
+    health = compute_map_health([], [], [])
+    assert health.component_count == 0
+    assert health.largest_fraction == 0.0
+    assert not health.is_unhealthy()

--- a/tests/exploration/test_joint.py
+++ b/tests/exploration/test_joint.py
@@ -8,8 +8,12 @@ view:
 
 * a `depends_on` given that is unmaterialized in BOTH packages surfaces as a
   contact against the joint materialized set;
-* a `depends_on` given that IS materialized in the dep does NOT surface (it is
-  a joint-materialized source, not a contact);
+* a `depends_on` given that IS materialized in the dep but is NOT referenced by
+  any ROOT edge surfaces as a *pulled-but-unformalized* contact (build-16
+  `_pulled_unformalized_contacts` worklist; contract change reconciled
+  2026-05-25 — see the test below). A dep-materialized QID that a ROOT edge DOES
+  reference is a joint-materialized source, not a contact
+  (`test_joint_materialization_in_dep_suppresses_contact`);
 * the dep's graph edges + manifest fold into the joint edge set;
 * `build_joint_view` degrades gracefully (root-only) when a dep can't be loaded.
 """
@@ -143,10 +147,31 @@ def test_joint_view_surfaces_cross_package_unmaterialized_contact(tmp_path, monk
     contact_values = {c.ref["value"] for c in contacts}
 
     # `dep_concl` (manifest conclusion, unmaterialized) AND `dep_unmaterialized`
-    # are contacts; `dep_fact` is materialized in the dep -> NOT a contact.
+    # are contacts via the standard frontier core (referenced-but-unmaterialized).
     assert dep_qid("dep_unmaterialized") in contact_values
     assert dep_qid("dep_concl") in contact_values
-    assert dep_qid("dep_fact") not in contact_values
+
+    # CONTRACT CHANGE (build 16 + expand-consolidate, reconciled 2026-05-25).
+    # Pre-build-16 this asserted `dep_fact` (materialized in the dep) is NOT a
+    # contact — "a joint-materialized source is never a contact". Build 16's
+    # `JointView._pulled_unformalized_contacts` (the "formalize me" worklist)
+    # changed that contract on purpose: a dep claim that IS materialized but is
+    # NOT referenced by any ROOT edge is *pulled-but-unformalized* (inert until
+    # the agent wires it into the root graph), and the joint view now surfaces it
+    # as a `qid` contact tagged `meta.pulled_unformalized` so it ranks/surveys
+    # through the normal machinery and retires once formalized. `dep_fact` is
+    # exactly that case here (the root references nothing in the dep), so under
+    # the current contract it DOES surface — as a pulled-unformalized contact,
+    # distinct from the two ordinary unmaterialized contacts above. (Verified
+    # legitimate, not a regression: see project INDEX open-thread reconciliation.)
+    assert dep_qid("dep_fact") in contact_values
+    fact = next(c for c in contacts if c.ref["value"] == dep_qid("dep_fact"))
+    assert fact.meta.get("pulled_unformalized") is True
+    # The two ordinary contacts are NOT pulled-unformalized (they are
+    # genuinely unmaterialized refs, surfaced by the standard frontier core).
+    for label in ("dep_unmaterialized", "dep_concl"):
+        ordinary = next(c for c in contacts if c.ref["value"] == dep_qid(label))
+        assert not ordinary.meta.get("pulled_unformalized")
 
     # The unmaterialized contact is sourced by the materialized co-reference
     # (dep_fact) under the depends_on edge.

--- a/tests/exploration/test_orchestrator.py
+++ b/tests/exploration/test_orchestrator.py
@@ -484,3 +484,270 @@ def test_full_turn_cycle_against_galileo(galileo_pkg: Path):
 
     rounds = read_rounds(galileo_pkg)
     assert [r["round"] for r in rounds] == [0]
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2 (EXPANSION.md §3.C/D/E): expand↔consolidate loop                      #
+# --------------------------------------------------------------------------- #
+
+
+def _surveyed_map_with_orphans(*, mode_select: str = "auto", doctrine: str = "Surveyor"):
+    """A map with core {seed,a} + two singleton orphan islands {b},{c}, surveyed."""
+    from gaia.engine.exploration.state import Policy, SurveyRecord
+
+    seed = "example:pkg::seed"
+    m = ExplorationMap(
+        round=3,
+        seeds=[{"kind": "claim", "text": seed, "qid": seed}],
+        policy=Policy(doctrine=doctrine, mode_select=mode_select),
+    )
+    for q in (seed, "example:pkg::a", "example:pkg::b", "example:pkg::c"):
+        m.surveyed[q] = SurveyRecord(qid=q, survey_round=1)
+    return m
+
+
+def _orphan_view():
+    """A JointView whose edges connect seed-a but leave b and c disjoint.
+
+    ``materialized`` includes the surveyed nodes so frontier extraction does not
+    spuriously surface them as contacts.
+    """
+    from gaia.engine.exploration.frontier import JointView
+
+    return JointView(
+        materialized={
+            "example:pkg::seed",
+            "example:pkg::a",
+            "example:pkg::b",
+            "example:pkg::c",
+        },
+        edges=[
+            ("operator_target", ["example:pkg::seed", "example:pkg::a"]),
+        ],
+    )
+
+
+def _stub_view(monkeypatch, view):
+    from gaia.engine.exploration.frontier import JointView
+
+    monkeypatch.setattr(orchestrator, "_resolve_graph", lambda _pkg: object())
+    monkeypatch.setattr(orchestrator, "_joint_view", lambda _pkg, _g: view)
+    monkeypatch.setattr(orchestrator, "_load_beliefs", lambda _pkg: {})
+    _ = JointView
+
+
+def test_auto_mode_consolidates_when_fragmented(tmp_path: Path, monkeypatch):
+    """Auto + 2 un-ratified orphans (past threshold) → a consolidate task."""
+    m = _surveyed_map_with_orphans(mode_select="auto")
+    save_map(tmp_path, m)
+    _stub_view(monkeypatch, _orphan_view())
+
+    outcome = run_turn(tmp_path)
+
+    assert outcome.action == "emitted_task"
+    assert outcome.task_kind == "consolidate"
+    assert outcome.islands == 2  # {b} and {c}
+    task = SurveyTask.read(handoff.task_path(exploration_dir(tmp_path), 3))
+    assert task.kind == "consolidate"
+    assert len(task.bridge_worklist) == 2
+    assert "ratify" in task.instructions.lower()
+
+
+def test_auto_mode_expands_when_healthy(tmp_path: Path, monkeypatch):
+    """Auto + a connected map → an expand task (today's behaviour)."""
+    from gaia.engine.exploration.frontier import JointView
+    from gaia.engine.exploration.state import Policy, SurveyRecord
+
+    seed = "example:pkg::seed"
+    m = ExplorationMap(
+        round=2,
+        seeds=[{"kind": "claim", "text": seed, "qid": seed}],
+        policy=Policy(doctrine="Surveyor", mode_select="auto"),
+    )
+    m.surveyed[seed] = SurveyRecord(qid=seed, survey_round=0)
+    m.surveyed["example:pkg::a"] = SurveyRecord(qid="example:pkg::a", survey_round=1)
+    save_map(tmp_path, m)
+    # Connected view + an open contact to expand into.
+    view = JointView(
+        materialized={seed, "example:pkg::a"},
+        edges=[("operator_target", [seed, "example:pkg::a"])],
+    )
+    _stub_view(monkeypatch, view)
+    # An open frontier contact so the expand path has something to emit.
+    reloaded = load_map(tmp_path)
+    reloaded.frontier = [
+        Contact(
+            id="ct_x",
+            ref={"kind": "qid", "value": "example:pkg::Foo"},
+            sources=[{"qid": seed, "edge": "depends_on"}],
+            status="open",
+        )
+    ]
+    save_map(tmp_path, reloaded)
+
+    outcome = run_turn(tmp_path)
+    assert outcome.task_kind == "expand"
+    assert outcome.contacts == ["ct_x"]
+
+
+def test_pinned_expand_ignores_fragmentation(tmp_path: Path, monkeypatch):
+    """mode_select=expand → expand even when the map is fragmented."""
+    m = _surveyed_map_with_orphans(mode_select="expand")
+    # Give it an open contact so expand has something to emit.
+    m.frontier = [
+        Contact(
+            id="ct_x",
+            ref={"kind": "qid", "value": "example:pkg::Foo"},
+            sources=[{"qid": "example:pkg::seed", "edge": "depends_on"}],
+            status="open",
+        )
+    ]
+    save_map(tmp_path, m)
+    _stub_view(monkeypatch, _orphan_view())
+
+    outcome = run_turn(tmp_path)
+    assert outcome.task_kind == "expand"
+
+
+def test_pinned_consolidate_emits_bridge_task(tmp_path: Path, monkeypatch):
+    """mode_select=consolidate → a bridge task even if below the auto threshold."""
+    from gaia.engine.exploration.frontier import JointView
+    from gaia.engine.exploration.state import Policy, SurveyRecord
+
+    seed = "example:pkg::seed"
+    m = ExplorationMap(
+        round=3,
+        seeds=[{"kind": "claim", "text": seed, "qid": seed}],
+        policy=Policy(doctrine="Diplomat", mode_select="consolidate"),
+    )
+    # Only ONE orphan — below the auto count threshold — but pinned consolidate
+    # still emits a bridge task.
+    for q in (seed, "example:pkg::a", "example:pkg::b"):
+        m.surveyed[q] = SurveyRecord(qid=q, survey_round=1)
+    save_map(tmp_path, m)
+    view = JointView(
+        materialized={seed, "example:pkg::a", "example:pkg::b"},
+        edges=[("operator_target", [seed, "example:pkg::a"])],
+    )
+    _stub_view(monkeypatch, view)
+
+    outcome = run_turn(tmp_path)
+    assert outcome.task_kind == "consolidate"
+    assert outcome.islands == 1
+
+
+def test_ratified_islands_not_in_worklist(tmp_path: Path, monkeypatch):
+    """A still-valid ratified island is excluded from the consolidate worklist."""
+    m = _surveyed_map_with_orphans(mode_select="consolidate", doctrine="Diplomat")
+    # Ratify island {c} — it should drop out of the worklist; {b} stays.
+    m.add_ratified_separation(["example:pkg::c"], rationale="separate", round_index=2)
+    save_map(tmp_path, m)
+    _stub_view(monkeypatch, _orphan_view())
+
+    outcome = run_turn(tmp_path)
+    assert outcome.task_kind == "consolidate"
+    assert outcome.islands == 1  # only {b}
+    task = SurveyTask.read(handoff.task_path(exploration_dir(tmp_path), 3))
+    members = {q for isl in task.bridge_worklist for q in isl.member_qids}
+    assert members == {"example:pkg::b"}
+
+
+def test_all_ratified_falls_back_to_expand(tmp_path: Path, monkeypatch):
+    """If every island is validly ratified, consolidate falls back to expand."""
+    m = _surveyed_map_with_orphans(mode_select="consolidate", doctrine="Diplomat")
+    m.add_ratified_separation(["example:pkg::b"], rationale="sep", round_index=2)
+    m.add_ratified_separation(["example:pkg::c"], rationale="sep", round_index=2)
+    save_map(tmp_path, m)
+    _stub_view(monkeypatch, _orphan_view())
+
+    outcome = run_turn(tmp_path)
+    assert outcome.task_kind == "expand"
+
+
+def test_checkpoint_records_ratification_from_result(tmp_path: Path, monkeypatch):
+    """The checkpoint records the agent's ratified islands into the map."""
+    from gaia.engine.exploration.handoff import RatifiedSeparationResult
+
+    m = _surveyed_map_with_orphans()
+    m.turn_phase = TURN_PHASE_AWAITING_SURVEY
+    save_map(tmp_path, m)
+    res = SurveyResult(
+        surveyed_qids=[],
+        ratified=[
+            RatifiedSeparationResult(member_qids=["example:pkg::c"], rationale="other field")
+        ],
+    )
+    res.write(handoff.result_path(exploration_dir(tmp_path), 3))
+
+    monkeypatch.setattr(orchestrator, "_compile_and_infer", lambda _pkg: None)
+    monkeypatch.setattr(orchestrator, "_resolve_graph", lambda _pkg: object())
+    monkeypatch.setattr(orchestrator, "_load_beliefs", lambda _pkg: {})
+    import gaia.engine.exploration.discoveries as disc_mod
+
+    monkeypatch.setattr(disc_mod, "compute_discoveries", lambda *_a, **_k: [])
+
+    outcome = run_turn(tmp_path)
+    assert outcome.ratified == [["example:pkg::c"]]
+    reloaded = load_map(tmp_path)
+    assert any(set(r["member_qids"]) == {"example:pkg::c"} for r in reloaded.ratified_separations)
+
+
+def test_ratification_excluded_from_health_then_reopens(tmp_path: Path, monkeypatch):
+    """A ratified island reads HEALTHY; new bridging evidence reopens it.
+
+    Drives the health helper end-to-end through the orchestrator's selector:
+    with island {b,c} ratified and no bridge, auto stays expand (healthy); once a
+    candidate bridging contact appears, the island reopens → consolidate.
+    """
+    from gaia.engine.exploration.frontier import JointView
+    from gaia.engine.exploration.state import Policy, SurveyRecord
+
+    seed = "example:pkg::seed"
+    m = ExplorationMap(
+        round=3,
+        seeds=[{"kind": "claim", "text": seed, "qid": seed}],
+        policy=Policy(doctrine="Surveyor", mode_select="auto"),
+    )
+    for q in (seed, "example:pkg::a", "example:pkg::b", "example:pkg::c"):
+        m.surveyed[q] = SurveyRecord(qid=q, survey_round=1)
+    # Ratify the whole island {b,c}.
+    m.add_ratified_separation(
+        ["example:pkg::b", "example:pkg::c"], rationale="separate", round_index=2
+    )
+    save_map(tmp_path, m)
+
+    surveyed_set = {seed, "example:pkg::a", "example:pkg::b", "example:pkg::c"}
+    # Premise holds: b,c disjoint from core, no bridge → healthy → auto expands.
+    view_ok = JointView(
+        materialized=set(surveyed_set),
+        edges=[
+            ("operator_target", [seed, "example:pkg::a"]),
+            ("operator_target", ["example:pkg::b", "example:pkg::c"]),
+        ],
+    )
+    _stub_view(monkeypatch, view_ok)
+    out_ok = run_turn(tmp_path)
+    assert out_ok.task_kind == "expand"  # ratified island excluded → healthy
+
+    # Reset phase to IDLE for the next IDLE turn.
+    reloaded = load_map(tmp_path)
+    reloaded.turn_phase = TURN_PHASE_IDLE
+    save_map(tmp_path, reloaded)
+
+    # New evidence: an unmaterialized node x adjacent to both island (b) and core
+    # (seed) → bridge candidate exists → ratification reopens → auto consolidates.
+    x = "example:pkg::x"  # not surveyed
+    view_bridge = JointView(
+        materialized=set(surveyed_set),
+        edges=[
+            ("operator_target", [seed, "example:pkg::a"]),
+            ("operator_target", ["example:pkg::b", "example:pkg::c"]),
+            ("depends_on", ["example:pkg::b", x]),
+            ("depends_on", [seed, x]),
+        ],
+    )
+    _stub_view(monkeypatch, view_bridge)
+    out_reopen = run_turn(tmp_path)
+    assert out_reopen.task_kind == "consolidate"
+    task = SurveyTask.read(handoff.task_path(exploration_dir(tmp_path), 3))
+    assert any(isl.reopened for isl in task.bridge_worklist)

--- a/tests/exploration/test_render.py
+++ b/tests/exploration/test_render.py
@@ -317,3 +317,63 @@ def test_cli_render_without_init_fails_gracefully(galileo_pkg: Path) -> None:
     result = runner.invoke(app, ["render", str(galileo_pkg)])
     assert result.exit_code == 1
     assert "no exploration map" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# Phase 3 (EXPANSION.md §3.E): ratified boundary / reopened flag in render       #
+# --------------------------------------------------------------------------- #
+
+
+def test_ratified_node_classes_marks_ratified_and_reopened() -> None:
+    from gaia.engine.exploration.health import Component, MapHealth
+    from gaia.engine.exploration.render import ratified_node_classes
+
+    m = ExplorationMap()
+    m.add_ratified_separation(["lkm:pkg::b"], rationale="sep", round_index=1)
+    m.add_ratified_separation(["lkm:pkg::c"], rationale="sep", round_index=1)
+    # A live health whose {c} island reopened (stale premise).
+    health = MapHealth(
+        components=(),
+        largest_fraction=0.0,
+        orphans=(),
+        orphan_node_fraction=0.0,
+        unratified_orphan_count=0,
+        reopened=(Component(members=("lkm:pkg::c",), reopened=True),),
+    )
+    classes = ratified_node_classes(m, health=health)
+    assert classes["lkm:pkg::b"] == "ratified"
+    assert classes["lkm:pkg::c"] == "reopened"
+
+
+def test_ratified_node_classes_without_health_all_ratified() -> None:
+    from gaia.engine.exploration.render import ratified_node_classes
+
+    m = ExplorationMap()
+    m.add_ratified_separation(["lkm:pkg::b", "lkm:pkg::c"], rationale="sep", round_index=1)
+    classes = ratified_node_classes(m)
+    assert classes == {"lkm:pkg::b": "ratified", "lkm:pkg::c": "ratified"}
+
+
+def test_header_fields_surface_connectivity_with_health() -> None:
+    from gaia.engine.exploration.health import Component, MapHealth
+
+    m = _demo_map()
+    health = MapHealth(
+        components=(Component(members=("x",), is_seed=True), Component(members=("y",))),
+        largest_fraction=0.5,
+        orphans=(Component(members=("y",)),),
+        orphan_node_fraction=0.5,
+        unratified_orphan_count=1,
+        reopened=(),
+    )
+    fields = dict(exploration_header_fields(m, health=health))
+    assert fields["components"] == "2"
+    assert fields["orphans"] == "1"
+    assert "ratified" in fields
+
+
+def test_header_fields_surface_ratified_count_without_health() -> None:
+    m = _demo_map()
+    m.add_ratified_separation(["lkm:pkg::b"], rationale="sep", round_index=1)
+    fields = dict(exploration_header_fields(m))
+    assert fields["ratified"] == "1"

--- a/tests/exploration/test_scorer.py
+++ b/tests/exploration/test_scorer.py
@@ -814,3 +814,240 @@ def test_lkm_contact_gets_obligation_pressure():
     c = m.frontier[0]
     assert set(c.score_features) == ALL_FEATURE_KEYS
     assert c.score_features["obligation_pressure"] == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Phase 1 (EXPANSION.md §3.B): activated bridge_potential + qid new_territory   #
+# --------------------------------------------------------------------------- #
+
+
+def _health_two_components():
+    """A MapHealth with core {seed, a} and an orphan island {b, c}."""
+    from gaia.engine.exploration.health import compute_map_health
+
+    surveyed = [qid(x) for x in ("seed", "a", "b", "c")]
+    edges = [
+        ("operator_target", [qid("seed"), qid("a")]),
+        ("operator_target", [qid("b"), qid("c")]),
+    ]
+    return compute_map_health(surveyed, [qid("seed")], edges), edges
+
+
+def test_qid_new_territory_zero_without_health():
+    # Back-compat: no MapHealth -> qid new_territory stays 0.0 (pre-expansion).
+    graph = _chain_graph()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    reconcile_frontier(m, extract_frontier(graph, m))
+    score_frontier(m, beliefs={}, ir=graph)  # no health=
+    for c in m.frontier:
+        assert c.score_features["new_territory"] == 0.0
+        assert c.score_features["bridge_potential"] == 0.0
+
+
+def test_qid_intra_paper_drilling_low_territory():
+    # A contact whose only source is inside the (one) seed component is drilling.
+    health, edges = _health_two_components()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(
+        Contact(
+            id="ct_drill",
+            ref={"kind": "qid", "value": qid("intra")},
+            sources=[{"qid": qid("a"), "edge": "depends_on"}],  # a is in the core
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    assert m.frontier[0].score_features["new_territory"] == 0.2  # drilling
+
+
+def test_qid_cross_region_higher_territory():
+    # Sources spanning two components -> opening new territory.
+    health, edges = _health_two_components()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(
+        Contact(
+            id="ct_cross",
+            ref={"kind": "qid", "value": qid("cross")},
+            sources=[
+                {"qid": qid("a"), "edge": "depends_on"},  # core
+                {"qid": qid("b"), "edge": "depends_on"},  # orphan
+            ],
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    assert m.frontier[0].score_features["new_territory"] == 0.7
+
+
+def test_qid_no_surveyed_source_is_maximal_territory():
+    health, edges = _health_two_components()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(
+        Contact(
+            id="ct_fog",
+            ref={"kind": "qid", "value": qid("fog")},
+            sources=[{"qid": qid("unsurveyed"), "edge": "depends_on"}],
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    assert m.frontier[0].score_features["new_territory"] == 1.0
+
+
+def test_bridge_potential_high_when_spanning_components():
+    health, edges = _health_two_components()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(
+        Contact(
+            id="ct_bridge",
+            ref={"kind": "qid", "value": qid("bridge")},
+            sources=[
+                {"qid": qid("a"), "edge": "depends_on"},  # core
+                {"qid": qid("b"), "edge": "depends_on"},  # orphan
+            ],
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    assert m.frontier[0].score_features["bridge_potential"] == 1.0
+
+
+def test_bridge_potential_high_when_adjacent_to_orphan():
+    # A contact whose source is an orphan member -> wiring it pulls the island in.
+    health, edges = _health_two_components()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(
+        Contact(
+            id="ct_orphan_adj",
+            ref={"kind": "qid", "value": qid("oadj")},
+            sources=[{"qid": qid("b"), "edge": "depends_on"}],  # b is orphan
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    assert m.frontier[0].score_features["bridge_potential"] == 1.0
+
+
+def test_bridge_potential_zero_when_intra_core():
+    health, edges = _health_two_components()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(
+        Contact(
+            id="ct_core_only",
+            ref={"kind": "qid", "value": qid("co")},
+            sources=[{"qid": qid("a"), "edge": "depends_on"}],  # only core
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    assert m.frontier[0].score_features["bridge_potential"] == 0.0
+
+
+def test_bridge_potential_zero_without_health():
+    _health, edges = _health_two_components()
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(
+        Contact(
+            id="ct_x",
+            ref={"kind": "qid", "value": qid("x")},
+            sources=[
+                {"qid": qid("a"), "edge": "depends_on"},
+                {"qid": qid("b"), "edge": "depends_on"},
+            ],
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges)  # no health
+    assert m.frontier[0].score_features["bridge_potential"] == 0.0
+
+
+def test_regression_external_lkm_not_dominated_by_intra_paper_qid():
+    """Regression: external lkm not dominated by intra-paper qid (EXPANSION §1).
+
+    The documented pathology (INDEX open thread): a pulled paper's intra-paper
+    depends_on qid contacts must NOT outrank an external lkm_related paper under
+    an uncertainty-weighted (Surveyor) doctrine.
+    """
+    health, edges = _health_two_components()
+    m = ExplorationMap(
+        seeds=[{"kind": "claim", "qid": qid("seed")}],
+        policy=doctrine_policy("Surveyor"),
+    )
+    # An intra-paper qid contact: source inside one component, high belief
+    # entropy (its source sits at 0.5 -> H=1.0) — exactly what used to let it win.
+    m.frontier.append(
+        Contact(
+            id="ct_intra",
+            ref={"kind": "qid", "value": qid("intra")},
+            sources=[{"qid": qid("a"), "edge": "depends_on"}],
+        )
+    )
+    # An external lkm_related paper contact off the seed.
+    m.frontier.append(
+        Contact(
+            id="ct_ext",
+            ref={"kind": "lkm", "value": "extpaper"},
+            sources=[{"qid": qid("seed"), "edge": "lkm_related"}],
+            meta={"paper_id": "extpaper", "rank": 0.6},
+        )
+    )
+    # Both sources at 0.5 belief so belief_entropy is equal (1.0) — isolating the
+    # coverage signal that the fix introduces.
+    score_frontier(
+        m,
+        beliefs={qid("a"): 0.5, qid("seed"): 0.5},
+        edges=edges,
+        health=health,
+    )
+    intra = next(c for c in m.frontier if c.id == "ct_intra")
+    ext = next(c for c in m.frontier if c.id == "ct_ext")
+    # Surveyor has w_coverage=0.3: external paper new_territory (>=0.5) beats the
+    # intra-paper drilling new_territory (0.2), so the external paper outranks.
+    assert ext.score_features["new_territory"] >= 0.5
+    assert intra.score_features["new_territory"] == 0.2
+    assert ext.score > intra.score
+
+
+def test_diplomat_ranks_bridge_contact_top():
+    """Diplomat (w_bridge=1.0) now actually surfaces a bridging contact top."""
+    health, edges = _health_two_components()
+    m = ExplorationMap(
+        seeds=[{"kind": "claim", "qid": qid("seed")}],
+        policy=doctrine_policy("Diplomat"),
+    )
+    # A bridge contact (spans core + orphan) and a plain intra-core contact.
+    m.frontier.append(
+        Contact(
+            id="ct_bridge",
+            ref={"kind": "qid", "value": qid("bridge")},
+            sources=[
+                {"qid": qid("a"), "edge": "depends_on"},
+                {"qid": qid("b"), "edge": "depends_on"},
+            ],
+        )
+    )
+    m.frontier.append(
+        Contact(
+            id="ct_plain",
+            ref={"kind": "qid", "value": qid("plain")},
+            sources=[{"qid": qid("a"), "edge": "depends_on"}],
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    bridge = next(c for c in m.frontier if c.id == "ct_bridge")
+    plain = next(c for c in m.frontier if c.id == "ct_plain")
+    assert bridge.score_features["bridge_potential"] == 1.0
+    assert plain.score_features["bridge_potential"] == 0.0
+    assert bridge.score > plain.score
+
+
+def test_lkm_contact_bridge_potential_activates():
+    # An lkm contact sourced from an orphan member is also a bridge candidate.
+    health, edges = _health_two_components()
+    m = ExplorationMap(
+        seeds=[{"kind": "claim", "qid": qid("seed")}],
+        policy=doctrine_policy("Diplomat"),
+    )
+    m.frontier.append(
+        Contact(
+            id="ct_lkm_bridge",
+            ref={"kind": "lkm", "value": "p"},
+            sources=[{"qid": qid("b"), "edge": "lkm_related"}],  # orphan source
+            meta={"paper_id": "p", "rank": 0.2},
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health)
+    assert m.frontier[0].score_features["bridge_potential"] == 1.0

--- a/tests/exploration/test_scorer.py
+++ b/tests/exploration/test_scorer.py
@@ -1034,6 +1034,154 @@ def test_diplomat_ranks_bridge_contact_top():
     assert bridge.score > plain.score
 
 
+# --------------------------------------------------------------------------- #
+# 0327 acceptance test: empty-source pulled-unformalized qid (materialized ref) #
+# is DRILLING, not fog — and ranks BELOW external lkm_related (EXPANSION.md §1) #
+# --------------------------------------------------------------------------- #
+
+
+def _pulled_repro(doctrine: str, *, lkm_rank: float):
+    """Build the 0327 repro: empty-source intra-paper qid vs. external lkm.
+
+    A freshly-pulled paper's empty-source intra-paper contact vs. an external
+    lkm_related paper off the seed subgraph.
+
+    Joint state: core {seed, a}; a pulled-paper island {p1, p2} that is
+    *materialized* (its claims have bodies in a dep package) but not yet wired to
+    the root. The pulled-unformalized worklist surfaces ``p1`` as a qid contact
+    with EMPTY sources (no co-reference into the core yet) — exactly the live
+    shape. ``materialized`` carries the joint materialized set so the scorer can
+    tell this is drilling (its ref QID is materialized), not a fog-reach.
+    """
+    from gaia.engine.exploration.health import compute_map_health
+
+    surveyed = [qid(x) for x in ("seed", "a", "p1", "p2")]
+    edges = [
+        ("operator_target", [qid("seed"), qid("a")]),
+        ("operator_target", [qid("p1"), qid("p2")]),
+    ]
+    health = compute_map_health(surveyed, [qid("seed")], edges)
+    m = ExplorationMap(
+        seeds=[{"kind": "claim", "qid": qid("seed")}],
+        policy=doctrine_policy(doctrine),
+    )
+    # Empty-source pulled-unformalized qid contact referencing a materialized
+    # dep claim (p1). This used to hit the new_territory=1.0 fog-reach branch.
+    m.frontier.append(
+        Contact(
+            id="ct_pulled",
+            ref={"kind": "qid", "value": qid("p1")},
+            sources=[],
+            meta={"pulled_unformalized": True, "title": "internal claim"},
+        )
+    )
+    # External lkm_related paper, off the resolved seed subgraph (source in the
+    # orphan island), so its only relevance is its (small) LKM rank.
+    m.frontier.append(
+        Contact(
+            id="ct_lkm",
+            ref={"kind": "lkm", "value": "extpaper"},
+            sources=[{"qid": qid("p2"), "edge": "lkm_related"}],
+            meta={"paper_id": "extpaper", "rank": lkm_rank},
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health, materialized=set(surveyed))
+    pulled = next(c for c in m.frontier if c.id == "ct_pulled")
+    lkm = next(c for c in m.frontier if c.id == "ct_lkm")
+    return pulled, lkm
+
+
+def test_pulled_unformalized_empty_source_is_drilling_not_fog():
+    # The fix proper: an empty-source qid contact whose ref QID is materialized
+    # (a pulled-but-unformalized claim) is DRILLING (0.2), NOT the fog-reach 1.0.
+    pulled, _lkm = _pulled_repro("Surveyor", lkm_rank=0.034)
+    assert pulled.score_features["new_territory"] == 0.2
+
+
+def test_pulled_unformalized_empty_source_without_materialized_is_fog():
+    # Provenance is the signal: WITHOUT the materialized set, an empty-source qid
+    # contact is indistinguishable from a fog-reach and keeps the 1.0 branch.
+    from gaia.engine.exploration.health import compute_map_health
+
+    surveyed = [qid(x) for x in ("seed", "a", "p1", "p2")]
+    edges = [
+        ("operator_target", [qid("seed"), qid("a")]),
+        ("operator_target", [qid("p1"), qid("p2")]),
+    ]
+    health = compute_map_health(surveyed, [qid("seed")], edges)
+    m = ExplorationMap(seeds=[{"kind": "claim", "qid": qid("seed")}])
+    m.frontier.append(Contact(id="ct", ref={"kind": "qid", "value": qid("p1")}, sources=[]))
+    score_frontier(m, beliefs={}, edges=edges, health=health)  # no materialized=
+    assert m.frontier[0].score_features["new_territory"] == 1.0
+
+
+def test_acceptance_pulled_qid_ranks_below_external_lkm_surveyor():
+    # 0327 ACCEPTANCE TEST (Surveyor, faithful low-rank repro): the empty-source
+    # pulled intra-paper qid must rank BELOW the external lkm_related paper.
+    # Both the drilling reclassification AND the bounded cost are needed here:
+    # with the drilling fix alone the 0.2 cost gap would still leave qid ahead.
+    pulled, lkm = _pulled_repro("Surveyor", lkm_rank=0.034)
+    assert pulled.score_features["new_territory"] == 0.2
+    assert lkm.score_features["new_territory"] >= 0.5
+    assert lkm.score > pulled.score
+
+
+def test_acceptance_pulled_qid_ranks_below_external_lkm_cartographer():
+    # 0327 ACCEPTANCE TEST (Cartographer, the default/expand doctrine): same
+    # ordering must hold — the drilling reclassification removes the bogus
+    # w_coverage=1.0 * 1.0 fog bonus, AND a drilling contact never claims
+    # bridge_potential (a pulled-paper internal claim is not a core bridge —
+    # otherwise w_bridge=1.0 would re-flood the frontier with all its claims).
+    pulled, lkm = _pulled_repro("Cartographer", lkm_rank=0.034)
+    assert pulled.score_features["new_territory"] == 0.2
+    assert pulled.score_features["bridge_potential"] == 0.0  # drilling != bridge
+    assert lkm.score > pulled.score
+
+
+def test_drilling_contact_does_not_claim_bridge_potential():
+    # A pulled-unformalized contact whose ref QID is a surveyed ORPHAN member
+    # would naively look like a bridge ("touches an orphan"), but formalizing one
+    # internal claim does not connect the island to the core — so a drilling
+    # contact gets bridge_potential 0.0 (live-surfaced under Cartographer).
+    health, edges = _health_two_components()  # core {seed,a}; orphan {b,c}
+    m = ExplorationMap(
+        seeds=[{"kind": "claim", "qid": qid("seed")}],
+        policy=doctrine_policy("Cartographer"),
+    )
+    # ref is orphan member `b`, sources empty (the pulled-unformalized shape).
+    m.frontier.append(
+        Contact(
+            id="ct_drill_orphan",
+            ref={"kind": "qid", "value": qid("b")},
+            sources=[],
+            meta={"pulled_unformalized": True},
+        )
+    )
+    # Same contact but NOT materialized (a genuine unmaterialized ref adjacent to
+    # the orphan) DOES bridge — the suppression is provenance-gated, not blanket.
+    m.frontier.append(
+        Contact(
+            id="ct_real_bridge",
+            ref={"kind": "qid", "value": qid("unmat")},
+            sources=[{"qid": qid("b"), "edge": "depends_on"}],  # orphan source
+        )
+    )
+    score_frontier(m, beliefs={}, edges=edges, health=health, materialized={qid("b")})
+    drill = next(c for c in m.frontier if c.id == "ct_drill_orphan")
+    real = next(c for c in m.frontier if c.id == "ct_real_bridge")
+    assert drill.score_features["bridge_potential"] == 0.0  # drilling suppressed
+    assert real.score_features["bridge_potential"] == 1.0  # genuine bridge kept
+
+
+def test_lkm_survey_cost_bounded_below_fragmentation_flip():
+    # The cost fix: LKM_SURVEY_COST stays strictly heavier than a qid (the effort
+    # signal) but is bounded so the cost gap can't exceed the coverage benefit an
+    # external pull buys under the tightest (coverage-light) doctrine.
+    from gaia.engine.exploration.scorer import LKM_SURVEY_COST
+
+    assert 1.0 < LKM_SURVEY_COST < 1.45
+
+
 def test_lkm_contact_bridge_potential_activates():
     # An lkm contact sourced from an orphan member is also a bridge candidate.
     health, edges = _health_two_components()

--- a/tests/exploration/test_state.py
+++ b/tests/exploration/test_state.py
@@ -301,3 +301,105 @@ def test_old_map_without_turn_phase_loads_as_idle(tmp_path: Path):
     assert m.turn_phase == TURN_PHASE_IDLE
     assert m.round == 4
     assert m.policy.doctrine == "Surveyor"
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2 (EXPANSION.md §3.C / §3.E): mode_select + ratified_separations        #
+# --------------------------------------------------------------------------- #
+
+
+def test_policy_mode_select_defaults_to_auto():
+    from gaia.engine.exploration.state import MODE_SELECT_AUTO
+
+    p = Policy()
+    assert p.mode_select == MODE_SELECT_AUTO
+    assert p.fragment_min_orphans == 2
+    assert p.fragment_orphan_fraction == 0.34
+
+
+def test_policy_mode_select_validates():
+    with pytest.raises(ValueError, match="invalid mode_select"):
+        Policy(mode_select="bogus")
+
+
+def test_policy_mode_select_roundtrips(tmp_path: Path):
+    m = ExplorationMap(
+        policy=Policy(doctrine="Diplomat", mode_select="consolidate", fragment_min_orphans=3)
+    )
+    save_map(tmp_path, m)
+    again = load_map(tmp_path)
+    assert again.policy.mode_select == "consolidate"
+    assert again.policy.fragment_min_orphans == 3
+
+
+def test_old_policy_without_mode_select_loads_as_auto(tmp_path: Path):
+    from gaia.engine.exploration.state import MODE_SELECT_AUTO
+
+    legacy = {
+        "version": EXPLORATION_SCHEMA_VERSION,
+        "round": 0,
+        "seeds": [],
+        "policy": {
+            "doctrine": "Surveyor",
+            "weights": dict(DOCTRINE_PRESETS["Surveyor"]),
+            "budget_k": 5,
+            # NB: no mode_select / fragment_* keys.
+        },
+        "surveyed": {},
+        "frontier": [],
+        "stats": {},
+    }
+    exploration_dir(tmp_path).joinpath("map.json").write_text(json.dumps(legacy), encoding="utf-8")
+    m = load_map(tmp_path)
+    assert m.policy.mode_select == MODE_SELECT_AUTO
+    assert m.policy.fragment_min_orphans == 2
+
+
+def test_ratified_separations_default_empty_and_roundtrip(tmp_path: Path):
+    m = ExplorationMap()
+    assert m.ratified_separations == []
+    row = m.add_ratified_separation(
+        ["lkm:pkg::b", "lkm:pkg::c"], rationale="different domain", round_index=2
+    )
+    assert row["member_qids"] == ["lkm:pkg::b", "lkm:pkg::c"]
+    save_map(tmp_path, m)
+    again = load_map(tmp_path)
+    assert len(again.ratified_separations) == 1
+    assert again.ratified_separations[0]["rationale"] == "different domain"
+
+
+def test_re_ratification_replaces_same_island():
+    m = ExplorationMap()
+    m.add_ratified_separation(["lkm:pkg::b"], rationale="v1", round_index=1)
+    m.add_ratified_separation(["lkm:pkg::b"], rationale="v2 updated", round_index=3)
+    assert len(m.ratified_separations) == 1
+    assert m.ratified_separations[0]["rationale"] == "v2 updated"
+
+
+def test_old_map_without_ratified_separations_loads_empty(tmp_path: Path):
+    legacy = {
+        "version": EXPLORATION_SCHEMA_VERSION,
+        "round": 0,
+        "seeds": [],
+        "policy": {
+            "doctrine": "Surveyor",
+            "weights": dict(DOCTRINE_PRESETS["Surveyor"]),
+            "budget_k": 5,
+        },
+        "surveyed": {},
+        "frontier": [],
+        "stats": {},
+        # NB: no ratified_separations key.
+    }
+    exploration_dir(tmp_path).joinpath("map.json").write_text(json.dumps(legacy), encoding="utf-8")
+    m = load_map(tmp_path)
+    assert m.ratified_separations == []
+
+
+def test_ratified_as_health_objects():
+    m = ExplorationMap()
+    m.add_ratified_separation(["lkm:pkg::b", "lkm:pkg::c"], rationale="x", round_index=1)
+    objs = m.ratified_as_health_objects()
+    assert len(objs) == 1
+    assert objs[0].member_qids == frozenset({"lkm:pkg::b", "lkm:pkg::c"})
+    assert objs[0].rationale == "x"


### PR DESCRIPTION
## Expand ↔ consolidate — maximizing *maintainable* graph growth

Refines the `gaia-lkm-explore` turn loop so the living map **expands as much as possible while
staying maintainable by an agent or user**. Design: `projects/gaia-lkm-explorer/EXPANSION.md`
(home_agent). Additive + back-compat throughout (old `map.json` loads unchanged).

### What & why
The loop grew the graph but (a) **throttled expansion** — a freshly-pulled paper's own intra-paper
contacts outranked the external `lkm_related` papers that open new territory — and (b) **fragmented
silently** — pulled papers floated as disconnected islands, with no metric to see it and the
consolidate-leaning doctrines (Diplomat/Cartographer) inert (`bridge_potential` hardcoded `0.0`).

### Changes
- **`MapHealth` connectivity primitive** (`engine/exploration/health.py`, new, pure): weakly-connected
  components / orphans / largest-fraction over the joint graph; a fragmentation-threshold predicate.
- **Activated scorer slots**: `bridge_potential` (makes Diplomat/Cartographer real) + a real qid
  `new_territory` that distinguishes *opening territory* from *drilling into the paper you just
  pulled* — pulled-but-unformalized internal claims (provenance: already in the joint materialized
  set) are scored as drilling, and `LKM_SURVEY_COST` bounded (2.0→1.25) so an external pull is no
  longer cost-dominated. Net: **external `lkm_related` contacts now rank above intra-paper drilling**
  under Cartographer/Surveyor/Diplomat (unit-encoded + live-verified on real Bohrium LKM).
- **Expand↔consolidate as the doctrine dial**: `Policy.mode_select` (`auto`/`expand`/`consolidate`,
  default `auto`) + dialable fragmentation threshold. `auto` consolidates only once fragmentation
  crosses the threshold, else expands.
- **Consolidate bridging task** (`SurveyTask.kind`): over already-surveyed nodes — for each orphan
  island, author a connecting `derive`/`contradict`/`depends_on` to the core **or** *ratify it as a
  legitimately-separate region* (equal-status option; never coerces an unsound edge).
- **Provisional ratification** (`ExplorationMap.ratified_separations`, per-component): a ratified
  island is excluded from "unhealthy" — but only while its premise holds. New bridging evidence
  **reopens** it (reusing the bridge adjacency check), returning it to the worklist. So "maintainable"
  = *every separation is either bridged or consciously ratified under current evidence — no silent
  orphan.*
- **Readout**: `status` + checkpoint report surface mode / components / orphans / ratified / reopened
  / connectivity delta; new `bridge` / `fault_line` discoveries; `render` distinguishes ratified vs
  reopened borders from fog.

### Verification
- 226 exploration unit tests; `ruff` + `mypy --strict` clean; **pr_gate slice green (1157 passed,
  3 skipped)**.
- **Live-verified end-to-end on real Bohrium LKM**: expand → fragment past threshold →
  auto-consolidate → bridge one island + ratify another → pull evidence that **reopens** the ratified
  island. The ranking flip (external > intra-paper drilling) confirmed live under Cartographer &
  Surveyor.

### Notes
- Inquisitor / `tension_potential` intentionally **deferred** (slot + weight exist; clean future add).
- Reconciles `tests/exploration/test_joint.py::test_joint_view_surfaces_cross_package_unmaterialized_contact`
  to the post-build-16 contract (a dep-materialized claim not referenced by a root edge is now a
  `pulled_unformalized` contact) — a legitimate contract change, not a regression; the suppression
  rule for root-referenced deps still holds.
