### PR TITLE
docs(lkm): add explore assess design spec

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,4 +54,5 @@ The [Foundations](foundations/README.md) directory contains Gaia's conceptual re
 | `archive/` | Historical design docs, previous foundations versions, completed plans |
 | `design/` | Scaling belief propagation, engineering related work |
 | `ideas/` | Design ideas, academic related work survey |
+| `specs/` | Draft and accepted design specifications for Gaia features and workflows |
 | `examples/` | Worked examples (Galileo falling bodies, Mendel inheritance) |

--- a/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
+++ b/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
@@ -315,7 +315,6 @@ Required checks:
 - `focuses_present`
 - `has_assessable_focus`
 - `focuses_have_evidence_refs`
-- `artifact_present`
 - `schema_versions_supported`
 
 Warning checks:
@@ -323,6 +322,10 @@ Warning checks:
 - `compiled_ir_present`
 - `beliefs_present`
 - `rounds_present`
+
+`gate` loads or generates the Explore artifact envelope before report
+construction, so the envelope itself is a command invariant rather than a gate
+check row.
 
 Verdict rules:
 

--- a/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
+++ b/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
@@ -1,27 +1,25 @@
 # LKM Explore Artifact MVP Implementation Plan
 
-> **For implementers:** Execute this plan task-by-task. Steps use checkbox
-> (`- [ ]`) syntax for tracking. Keep the implementation test-driven, make
-> small commits, and preserve backward compatibility for the existing
-> `gaia-lkm-explore` commands.
+> **For implementers:** Execute this plan task-by-task. Keep the work
+> test-driven, make small commits, and preserve backward compatibility for the
+> existing `gaia-lkm-explore` commands.
 
-**Goal:** Add typed Explore sidecar artifacts to `gaia-lkm-explore`: `scope`, `focuses`, `artifact`, and `gate`, without breaking the existing frontier-driven exploration loop.
+**Goal:** Add typed Explore sidecar artifacts to `gaia-lkm-explore`: `scope`,
+`focuses`, `artifact`, and `gate`, without breaking the existing
+frontier-driven exploration loop.
 
-**Architecture:** Add a small deterministic artifact layer under `gaia.lkm_explorer.engine`, then expose it through thin Typer verbs in `gaia.lkm_explorer.client.verbs` and register them in `gaia.lkm_explorer.client.cli`. The MVP writes additive JSON sidecars under `.gaia/exploration/`; existing map, landscape, frontier, turn, and round semantics remain unchanged.
+**Architecture:** Add a deterministic artifact layer under
+`gaia.lkm_explorer.engine`, then expose it through thin Typer verbs in
+`gaia.lkm_explorer.client.verbs` and register them in
+`gaia.lkm_explorer.client.cli`. The MVP writes additive JSON sidecars under
+`.gaia/exploration/`; existing map, landscape, frontier, turn, and round
+semantics remain unchanged.
 
-**Tech Stack:** Python 3.12, Typer, dataclasses, JSON sidecar artifacts, pytest.
+**Tech Stack:** Python 3.12, Typer, JSON sidecar artifacts, pytest.
 
 **Spec reference:** `docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md`
 
 ---
-
-## Plan Code Policy
-
-Code snippets in this plan are illustrative implementation sketches, not a
-requirement to paste verbatim. The tests, artifact contracts, command names,
-paths, side effects, and compatibility rules are normative. If production code
-diverges from a snippet while satisfying the tests and contracts, prefer the
-cleaner production code.
 
 ## File Structure
 
@@ -42,50 +40,40 @@ tests/lkm_explorer/test_cli_explore.py
 
 Responsibilities:
 
-- `engine/artifacts.py`: pure artifact builders, dimension parsing, latest landscape discovery, gate checks.
-- `client/verbs.py`: Typer command wrappers, file reading/writing, user-facing text.
+- `engine/artifacts.py`: pure artifact builders, dimension parsing, latest
+  landscape discovery, and gate checks.
+- `client/verbs.py`: Typer command wrappers, file reading/writing, and
+  user-facing text.
 - `client/cli.py`: command registration.
 - `tests/lkm_explorer/test_artifacts.py`: pure engine tests.
-- `tests/lkm_explorer/test_cli_explore.py`: CLI smoke and backward-compatibility tests.
+- `tests/lkm_explorer/test_cli_explore.py`: CLI smoke and compatibility tests.
 
-## Task 1: Add artifact engine primitives
+Use `gaia.engine.packaging.write_text_atomic` for artifact writes in the CLI
+layer. Store `inputs.pkg` as `str(Path(pkg).resolve())` for path consistency.
+
+## Task 1: Artifact Helpers
 
 **Files:**
 - Create: `gaia/lkm_explorer/engine/artifacts.py`
 - Test: `tests/lkm_explorer/test_artifacts.py`
 
-- [ ] **Step 1: Write failing tests for dimension parsing and UTC ids**
+Implement small, deterministic helpers:
 
-Add tests:
+- `SOP_SCHEMA = "gaia.sop.artifact.v1"`
+- `utcnow() -> str`
+- `artifact_id(prefix: str) -> str`
+- `parse_dimensions(items: list[str] | None) -> dict[str, list[str]]`
+- `exploration_dir(pkg: str | Path) -> Path`
+- `latest_landscape_path(pkg: str | Path) -> Path | None`
+- `rel_artifact_path(pkg: str | Path, path: Path | None) -> str | None`
 
-```python
-from gaia.lkm_explorer.engine.artifacts import (
-    artifact_id,
-    parse_dimensions,
-)
+Required tests:
 
-
-def test_parse_dimensions_groups_repeated_keys():
-    assert parse_dimensions(["population=adults", "outcome=MI", "outcome=bleeding"]) == {
-        "population": ["adults"],
-        "outcome": ["MI", "bleeding"],
-    }
-
-
-def test_parse_dimensions_rejects_missing_equals():
-    try:
-        parse_dimensions(["population"])
-    except ValueError as exc:
-        assert "expected key=value" in str(exc)
-    else:
-        raise AssertionError("expected ValueError")
-
-
-def test_artifact_id_is_readable_and_prefixed():
-    value = artifact_id("scope")
-    assert value.startswith("scope-")
-    assert value.endswith("Z")
-```
+- repeated `--dimension key=value` entries group under the same key;
+- malformed dimensions without `=` raise `ValueError`;
+- artifact ids include the requested prefix and end with `Z`;
+- latest landscape selection returns the highest sorted `landscape-*.json`;
+- package-relative paths are used for artifacts inside the package.
 
 Run:
 
@@ -93,95 +81,14 @@ Run:
 uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py
 ```
 
-Expected: fail because `gaia.lkm_explorer.engine.artifacts` does not exist.
-
-- [ ] **Step 2: Implement helpers**
-
-Create `gaia/lkm_explorer/engine/artifacts.py`:
-
-```python
-"""Typed Explore sidecar artifacts for ``gaia-lkm-explore``.
-
-This module is deterministic and I/O-free except for helpers that inspect
-artifact paths. It does not call LKM, author Gaia source, or run inference.
-"""
-
-from __future__ import annotations
-
-from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
-
-SOP_SCHEMA = "gaia.sop.artifact.v1"
-
-
-def utcnow() -> str:
-    """Return an ISO-8601 UTC timestamp with a trailing ``Z``."""
-    return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
-
-
-def artifact_id(prefix: str) -> str:
-    """Return a human-readable timestamp id for an artifact."""
-    stamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-    return f"{prefix}-{stamp}"
-
-
-def parse_dimensions(items: list[str] | None) -> dict[str, list[str]]:
-    """Parse repeated ``key=value`` CLI values into grouped dimension lists."""
-    out: dict[str, list[str]] = {}
-    for item in items or []:
-        if "=" not in item:
-            raise ValueError(f"expected key=value dimension, got {item!r}")
-        key, value = item.split("=", 1)
-        key = key.strip()
-        value = value.strip()
-        if not key or not value:
-            raise ValueError(f"expected non-empty key=value dimension, got {item!r}")
-        out.setdefault(key, []).append(value)
-    return out
-
-
-def exploration_dir(pkg: str | Path) -> Path:
-    """Return ``<pkg>/.gaia/exploration``."""
-    return Path(pkg).resolve() / ".gaia" / "exploration"
-
-
-def latest_landscape_path(pkg: str | Path) -> Path | None:
-    """Return the latest round-numbered landscape artifact, if any."""
-    root = exploration_dir(pkg)
-    candidates = sorted(root.glob("landscape-*.json"))
-    return candidates[-1] if candidates else None
-
-
-def rel_artifact_path(pkg: str | Path, path: Path | None) -> str | None:
-    """Return a package-relative artifact path for stable JSON output."""
-    if path is None:
-        return None
-    pkg_root = Path(pkg).resolve()
-    try:
-        return str(path.resolve().relative_to(pkg_root))
-    except ValueError:
-        return str(path)
-```
-
-- [ ] **Step 3: Run helper tests**
-
-Run:
-
-```bash
-uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py
-```
-
-Expected: pass.
-
-- [ ] **Step 4: Commit**
+Commit:
 
 ```bash
 git add gaia/lkm_explorer/engine/artifacts.py tests/lkm_explorer/test_artifacts.py
 git commit -m "feat(lkm-explorer): add explore artifact helpers"
 ```
 
-## Task 2: Add `scope` artifact builder and CLI
+## Task 2: Scope Artifact
 
 **Files:**
 - Modify: `gaia/lkm_explorer/engine/artifacts.py`
@@ -190,236 +97,64 @@ git commit -m "feat(lkm-explorer): add explore artifact helpers"
 - Test: `tests/lkm_explorer/test_artifacts.py`
 - Test: `tests/lkm_explorer/test_cli_explore.py`
 
-- [ ] **Step 1: Write failing engine test**
+Add a pure builder:
 
-Add to `tests/lkm_explorer/test_artifacts.py`:
-
-```python
-from gaia.lkm_explorer.engine.artifacts import build_scope_artifact
-
-
-def test_build_scope_artifact_records_inputs(tmp_path):
-    pkg = tmp_path / "pkg"
-    (pkg / ".gaia" / "exploration").mkdir(parents=True)
-
-    payload = build_scope_artifact(
-        pkg,
-        seeds=["aspirin primary prevention"],
-        profile="medical",
-        dimensions={"outcome": ["MI", "major bleeding"]},
-        seed_source="cli",
-        map_round=0,
-    )
-
-    assert payload["schema"] == "gaia.sop.artifact.v1"
-    assert payload["kind"] == "exploration_scope"
-    assert payload["inputs"]["seeds"] == ["aspirin primary prevention"]
-    assert payload["inputs"]["profile"] == "medical"
-    assert payload["inputs"]["dimensions"]["outcome"] == ["MI", "major bleeding"]
-    assert payload["audit"]["allowed_next_steps"] == [
-        "landscape",
-        "focuses",
-        "artifact",
-        "gate",
-    ]
+```text
+build_scope_artifact(pkg, seeds, profile, dimensions, seed_source, map_round) -> dict
 ```
+
+Contract:
+
+- `kind == "exploration_scope"`
+- `schema == "gaia.sop.artifact.v1"`
+- `inputs.pkg` is resolved absolute path;
+- `inputs.seeds` is the explicit CLI seed list, or map seeds when omitted;
+- `inputs.profile` is optional;
+- `inputs.dimensions` stores grouped dimension lists;
+- `provenance.seed_source` is `cli` or `map`;
+- `audit.allowed_next_steps == ["landscape", "focuses", "artifact", "gate"]`.
+
+Add CLI:
+
+```bash
+gaia-lkm-explore scope <pkg> \
+  [--seed <text>]... \
+  [--profile <name>] \
+  [--dimension key=value]... \
+  [--out <path>] \
+  [--json]
+```
+
+CLI behavior:
+
+- fail with exit 1 if `.gaia/exploration/map.json` is missing;
+- fail with exit 2 on malformed dimensions;
+- default output path is `.gaia/exploration/scope.json`;
+- print a concise summary and the output path;
+- `--json` prints the payload after writing.
+
+Required tests:
+
+- builder records seeds, profile, dimensions, map round, and allowed next steps;
+- CLI writes `scope.json`;
+- CLI can derive seeds from `map.json` when `--seed` is omitted;
+- invalid `--dimension` exits 2;
+- `--help` includes `scope` options.
 
 Run:
 
 ```bash
-uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py::test_build_scope_artifact_records_inputs
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py::test_explore_scope_writes_scope_artifact
 ```
 
-Expected: fail because `build_scope_artifact` does not exist.
-
-- [ ] **Step 2: Implement `build_scope_artifact`**
-
-Add to `engine/artifacts.py`:
-
-```python
-def build_scope_artifact(
-    pkg: str | Path,
-    *,
-    seeds: list[str],
-    profile: str | None,
-    dimensions: dict[str, list[str]],
-    seed_source: str,
-    map_round: int,
-) -> dict[str, Any]:
-    """Build the first-class Explore scope artifact."""
-    return {
-        "schema": SOP_SCHEMA,
-        "kind": "exploration_scope",
-        "id": artifact_id("scope"),
-        "created_at": utcnow(),
-        "inputs": {
-            "pkg": str(Path(pkg).resolve()),
-            "seeds": list(seeds),
-            "profile": profile,
-            "dimensions": dimensions,
-        },
-        "artifacts": {
-            "map": ".gaia/exploration/map.json",
-        },
-        "provenance": {
-            "seed_source": seed_source,
-            "map_round": map_round,
-        },
-        "audit": {
-            "known_limitations": [
-                "Scope is user-authored; no automatic domain validation is performed."
-            ],
-            "allowed_next_steps": ["landscape", "focuses", "artifact", "gate"],
-        },
-    }
-```
-
-- [ ] **Step 3: Write failing CLI test**
-
-Add to `tests/lkm_explorer/test_cli_explore.py` using the existing runner
-fixture/pattern in that file:
-
-```python
-def test_explore_scope_writes_scope_artifact(galileo_pkg: Path):
-    result = runner.invoke(
-        explore_app,
-        [
-            "scope",
-            str(galileo_pkg),
-            "--seed",
-            "free fall",
-            "--profile",
-            "physics",
-            "--dimension",
-            "quantity=acceleration",
-        ],
-    )
-
-    assert result.exit_code == 0, result.output
-    payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "scope.json").read_text(
-            encoding="utf-8"
-        )
-    )
-    assert payload["kind"] == "exploration_scope"
-    assert payload["inputs"]["profile"] == "physics"
-    assert payload["inputs"]["dimensions"] == {"quantity": ["acceleration"]}
-```
-
-Run:
-
-```bash
-uv run python -m pytest -q tests/lkm_explorer/test_cli_explore.py::test_explore_scope_writes_scope_artifact
-```
-
-Expected: fail because command is not registered.
-
-- [ ] **Step 4: Implement `scope_command` and register it**
-
-In `client/verbs.py`, import:
-
-```python
-from gaia.engine.packaging import write_text_atomic
-from gaia.lkm_explorer.engine.artifacts import (
-    build_scope_artifact,
-    parse_dimensions,
-)
-```
-
-Add option singletons:
-
-```python
-_SCOPE_SEED_OPT = typer.Option(
-    None,
-    "--seed",
-    help="Seed text for the exploration scope (repeatable; defaults to map seeds).",
-)
-_SCOPE_PROFILE_OPT = typer.Option(None, "--profile", help="Optional domain profile.")
-_SCOPE_DIMENSION_OPT = typer.Option(
-    None,
-    "--dimension",
-    help="Scope dimension as key=value (repeatable).",
-)
-_SCOPE_OUT_OPT = typer.Option(
-    None,
-    "--out",
-    help="Output JSON path (default <pkg>/.gaia/exploration/scope.json).",
-)
-```
-
-Add command:
-
-```python
-def scope_command(
-    pkg: str = _PKG_ARG,
-    seed: list[str] | None = _SCOPE_SEED_OPT,
-    profile: str | None = _SCOPE_PROFILE_OPT,
-    dimension: list[str] | None = _SCOPE_DIMENSION_OPT,
-    out: str | None = _SCOPE_OUT_OPT,
-    json_out: bool = _LANDSCAPE_JSON_OPT,
-) -> None:
-    """Write a first-class exploration scope sidecar."""
-    if not (_gaia_dir(pkg) / "exploration" / "map.json").exists():
-        typer.echo(
-            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
-            err=True,
-        )
-        raise typer.Exit(1)
-    exploration_map = load_map(pkg)
-    seeds = list(seed or [])
-    seed_source = "cli"
-    if not seeds:
-        seeds = [str(s.get("raw", s.get("qid", ""))) for s in exploration_map.seeds]
-        seeds = [s for s in seeds if s]
-        seed_source = "map"
-    try:
-        dimensions = parse_dimensions(dimension)
-    except ValueError as exc:
-        typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(2) from exc
-    payload = build_scope_artifact(
-        pkg,
-        seeds=seeds,
-        profile=profile,
-        dimensions=dimensions,
-        seed_source=seed_source,
-        map_round=exploration_map.round,
-    )
-    output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "scope.json"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
-    typer.echo(f"Scope: {len(seeds)} seed(s), {len(dimensions)} dimension group(s).")
-    typer.echo(f"Output: {output_path}")
-    if json_out:
-        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
-```
-
-In `client/cli.py`, import and register:
-
-```python
-from gaia.lkm_explorer.client.verbs import scope_command
-
-app.command(name="scope")(scope_command)
-```
-
-- [ ] **Step 5: Run CLI test**
-
-Run:
-
-```bash
-uv run python -m pytest -q tests/lkm_explorer/test_cli_explore.py::test_explore_scope_writes_scope_artifact
-```
-
-Expected: pass.
-
-- [ ] **Step 6: Commit**
+Commit:
 
 ```bash
 git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py gaia/lkm_explorer/client/cli.py tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py
 git commit -m "feat(lkm-explorer): add scope artifact command"
 ```
 
-## Task 3: Add deterministic `focuses`
+## Task 3: Focuses Artifact
 
 **Files:**
 - Modify: `gaia/lkm_explorer/engine/artifacts.py`
@@ -428,182 +163,58 @@ git commit -m "feat(lkm-explorer): add scope artifact command"
 - Test: `tests/lkm_explorer/test_artifacts.py`
 - Test: `tests/lkm_explorer/test_cli_explore.py`
 
-- [ ] **Step 1: Write failing engine test for landscape focus generation**
+Add a pure builder:
 
-Add:
-
-```python
-from gaia.lkm_explorer.engine.artifacts import build_focuses_artifact
-
-
-def test_build_focuses_artifact_uses_landscape_paper_leads(tmp_path):
-    pkg = tmp_path / "pkg"
-    landscape_path = pkg / ".gaia" / "exploration" / "landscape-0.json"
-    landscape_path.parent.mkdir(parents=True)
-    landscape_path.write_text(
-        json.dumps(
-            {
-                "kind": "exploration_landscape",
-                "paper_leads": [
-                    {"paper_id": "P1", "title": "Paper One"},
-                    {"paper_id": "P2", "title": "Paper Two"},
-                ],
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    payload = build_focuses_artifact(
-        pkg,
-        scope_path=None,
-        landscape_path=landscape_path,
-        landscape={"kind": "exploration_landscape", "paper_leads": [{"paper_id": "P1"}]},
-        map_round=0,
-    )
-
-    assert payload["kind"] == "exploration_focuses"
-    assert payload["focuses"][0]["kind"] == "paper_lead_cluster"
-    assert payload["focuses"][0]["evidence_refs"][0]["paper_id"] == "P1"
+```text
+build_focuses_artifact(pkg, scope_path, landscape_path, landscape, map_round) -> dict
 ```
 
-- [ ] **Step 2: Implement `build_focuses_artifact`**
+MVP focus generation rules:
 
-Add:
+- deterministic only;
+- no LLM calls;
+- no domain-specific tension invention;
+- generate at least one `paper_lead_cluster` focus when landscape paper leads
+  exist;
+- every generated focus must have `evidence_refs`;
+- `recommended_next == "assess"` for assessable focuses.
 
-```python
-def build_focuses_artifact(
-    pkg: str | Path,
-    *,
-    scope_path: Path | None,
-    landscape_path: Path | None,
-    landscape: dict[str, Any] | None,
-    map_round: int,
-) -> dict[str, Any]:
-    """Build deterministic, provenance-backed assessment focuses."""
-    focuses: list[dict[str, Any]] = []
-    leads = []
-    if landscape:
-        raw_leads = landscape.get("paper_leads")
-        if isinstance(raw_leads, list):
-            leads = [lead for lead in raw_leads if isinstance(lead, dict)]
-    if leads:
-        refs = []
-        for lead in leads[:5]:
-            paper_id = lead.get("paper_id")
-            if isinstance(paper_id, str) and paper_id:
-                refs.append(
-                    {
-                        "kind": "landscape_paper_lead",
-                        "path": rel_artifact_path(pkg, landscape_path),
-                        "paper_id": paper_id,
-                    }
-                )
-        if refs:
-            focuses.append(
-                {
-                    "id": "focus_landscape_top_leads",
-                    "kind": "paper_lead_cluster",
-                    "text": "Top unpulled paper leads from the current landscape",
-                    "why_it_matters": (
-                        "These papers are the highest-ranked breadth-first leads "
-                        "and should be considered before local claim-level expansion."
-                    ),
-                    "evidence_refs": refs,
-                    "recommended_next": "assess",
-                    "confidence": "structural",
-                }
-            )
-    return {
-        "schema": SOP_SCHEMA,
-        "kind": "exploration_focuses",
-        "id": artifact_id("focuses"),
-        "created_at": utcnow(),
-        "inputs": {
-            "pkg": str(Path(pkg).resolve()),
-            "scope": rel_artifact_path(pkg, scope_path),
-            "landscape": rel_artifact_path(pkg, landscape_path),
-        },
-        "artifacts": {
-            "map": ".gaia/exploration/map.json",
-            "landscape": rel_artifact_path(pkg, landscape_path),
-        },
-        "focuses": focuses,
-        "provenance": {"generation": "deterministic", "map_round": map_round},
-        "audit": {
-            "known_limitations": [
-                "MVP focuses are structural and provenance-backed; domain-specific tension naming is external or future work."
-            ],
-            "allowed_next_steps": ["artifact", "gate"],
-        },
-    }
+Minimum focus fields:
+
+```text
+id
+kind
+text
+why_it_matters
+evidence_refs
+recommended_next
+confidence
 ```
 
-- [ ] **Step 3: Add CLI command and registration**
+Add CLI:
 
-Add `focuses_command` in `verbs.py`:
-
-```python
-def focuses_command(
-    pkg: str = _PKG_ARG,
-    landscape: str | None = typer.Option(
-        None,
-        "--landscape",
-        help="Landscape JSON path (default latest <pkg>/.gaia/exploration/landscape-*.json).",
-    ),
-    out: str | None = typer.Option(
-        None,
-        "--out",
-        help="Output JSON path (default <pkg>/.gaia/exploration/focuses.json).",
-    ),
-    json_out: bool = _LANDSCAPE_JSON_OPT,
-) -> None:
-    """Write deterministic assessment focuses from the latest landscape."""
+```bash
+gaia-lkm-explore focuses <pkg> \
+  [--landscape <path>] \
+  [--out <path>] \
+  [--json]
 ```
 
-Implementation details:
+CLI behavior:
 
-- load map with `load_map(pkg)`;
-- resolve `landscape_path = Path(landscape)` if provided else `latest_landscape_path(pkg)`;
-- if no landscape path exists, emit error and exit 2;
-- read landscape JSON with `_read_json_object`;
-- `scope_path = _gaia_dir(pkg) / "exploration" / "scope.json"` if exists else `None`;
-- write `.gaia/exploration/focuses.json`.
+- load the explicit landscape path, or default to the latest
+  `.gaia/exploration/landscape-*.json`;
+- fail with exit 2 if no landscape is available;
+- read `.gaia/exploration/scope.json` if present, but do not require it;
+- write `.gaia/exploration/focuses.json` by default.
 
-Register in `client/cli.py`:
+Required tests:
 
-```python
-app.command(name="focuses")(focuses_command)
-```
-
-- [ ] **Step 4: Add CLI test**
-
-Add:
-
-```python
-def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):
-    landscape_path = galileo_pkg / ".gaia" / "exploration" / "landscape-0.json"
-    landscape_path.write_text(
-        json.dumps(
-            {
-                "kind": "exploration_landscape",
-                "paper_leads": [{"paper_id": "P1", "title": "Paper One"}],
-            }
-        ),
-        encoding="utf-8",
-    )
-    result = runner.invoke(explore_app, ["focuses", str(galileo_pkg)])
-
-    assert result.exit_code == 0, result.output
-    payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(
-            encoding="utf-8"
-        )
-    )
-    assert payload["kind"] == "exploration_focuses"
-    assert payload["focuses"][0]["id"] == "focus_landscape_top_leads"
-```
-
-- [ ] **Step 5: Run tests and commit**
+- builder creates `exploration_focuses` from landscape paper leads;
+- generated focuses include paper lead provenance;
+- CLI writes `focuses.json`;
+- CLI fails clearly when no landscape exists;
+- existing `landscape` behavior remains unchanged.
 
 Run:
 
@@ -618,7 +229,7 @@ git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py 
 git commit -m "feat(lkm-explorer): add focuses artifact command"
 ```
 
-## Task 4: Add `artifact` envelope
+## Task 4: Exploration Artifact Envelope
 
 **Files:**
 - Modify: `gaia/lkm_explorer/engine/artifacts.py`
@@ -627,123 +238,46 @@ git commit -m "feat(lkm-explorer): add focuses artifact command"
 - Test: `tests/lkm_explorer/test_artifacts.py`
 - Test: `tests/lkm_explorer/test_cli_explore.py`
 
-- [ ] **Step 1: Write failing test for missing optional files**
+Add a pure builder:
 
-Add:
-
-```python
-from gaia.lkm_explorer.engine.artifacts import build_exploration_artifact
-
-
-def test_build_exploration_artifact_records_missing_optional_files(tmp_path):
-    pkg = tmp_path / "pkg"
-    (pkg / ".gaia" / "exploration").mkdir(parents=True)
-
-    payload = build_exploration_artifact(pkg, map_round=0, map_version=1)
-
-    assert payload["kind"] == "lkm_exploration"
-    assert payload["artifacts"]["scope"] is None
-    assert "missing scope" in payload["audit"]["known_limitations"]
-    assert payload["audit"]["allowed_next_steps"] == ["gate"]
+```text
+build_exploration_artifact(pkg, map_round, map_version) -> dict
 ```
 
-- [ ] **Step 2: Implement `build_exploration_artifact`**
+Contract:
 
-Add:
+- `kind == "lkm_exploration"`
+- `inputs.pkg` is resolved absolute path;
+- `artifacts.scope` points to `scope.json` or `null`;
+- `artifacts.landscape` points to the latest landscape or `null`;
+- `artifacts.focuses` points to `focuses.json` or `null`;
+- `artifacts.map` points to `map.json` or `null`;
+- `artifacts.rounds`, `artifacts.gaia_ir`, and `artifacts.beliefs` are present
+  as optional artifact refs;
+- missing core sidecars are recorded in `audit.known_limitations`;
+- `audit.allowed_next_steps == ["gate"]`;
+- `interface.assess.command` documents the future handoff command.
 
-```python
-def _maybe_rel(pkg: str | Path, path: Path) -> str | None:
-    return rel_artifact_path(pkg, path) if path.exists() else None
+Add CLI:
 
-
-def build_exploration_artifact(
-    pkg: str | Path,
-    *,
-    map_round: int,
-    map_version: int,
-) -> dict[str, Any]:
-    """Aggregate Explore sidecars into a single handoff envelope."""
-    root = exploration_dir(pkg)
-    scope = root / "scope.json"
-    landscape = latest_landscape_path(pkg)
-    focuses = root / "focuses.json"
-    map_path = root / "map.json"
-    rounds = root / "rounds.jsonl"
-    gaia_dir = Path(pkg).resolve() / ".gaia"
-    ir = gaia_dir / "ir.json"
-    beliefs = gaia_dir / "beliefs.json"
-    limitations = []
-    for label, path in [
-        ("scope", scope),
-        ("landscape", landscape),
-        ("focuses", focuses),
-        ("map", map_path),
-    ]:
-        if path is None or not path.exists():
-            limitations.append(f"missing {label}")
-    return {
-        "schema": SOP_SCHEMA,
-        "kind": "lkm_exploration",
-        "id": artifact_id("explore"),
-        "created_at": utcnow(),
-        "inputs": {"pkg": str(Path(pkg).resolve())},
-        "artifacts": {
-            "scope": _maybe_rel(pkg, scope),
-            "landscape": rel_artifact_path(pkg, landscape) if landscape else None,
-            "focuses": _maybe_rel(pkg, focuses),
-            "map": _maybe_rel(pkg, map_path),
-            "rounds": _maybe_rel(pkg, rounds),
-            "gaia_ir": _maybe_rel(pkg, ir),
-            "beliefs": _maybe_rel(pkg, beliefs),
-        },
-        "provenance": {
-            "map_round": map_round,
-            "map_version": map_version,
-        },
-        "audit": {
-            "coverage": {},
-            "known_limitations": limitations,
-            "allowed_next_steps": ["gate"],
-        },
-        "interface": {
-            "assess": {
-                "command": (
-                    "gaia-evidence assess --exploration "
-                    ".gaia/exploration/artifact.json --focus <focus-id>"
-                )
-            }
-        },
-    }
+```bash
+gaia-lkm-explore artifact <pkg> [--out <path>] [--json]
 ```
 
-- [ ] **Step 3: Add CLI command and test**
+CLI behavior:
 
-Add `artifact_command` analogous to `focuses_command`:
+- load `ExplorationMap` for map round and version;
+- write `.gaia/exploration/artifact.json` by default;
+- do not fail just because optional files are missing;
+- print the output path and limitation count.
 
-- load `ExplorationMap`;
-- call `build_exploration_artifact(pkg, map_round=exploration_map.round, map_version=exploration_map.version)`;
-- write `.gaia/exploration/artifact.json`;
-- print output path and limitation count.
+Required tests:
 
-Register `app.command(name="artifact")(artifact_command)`.
-
-CLI test:
-
-```python
-def test_explore_artifact_writes_handoff_envelope(galileo_pkg: Path):
-    result = runner.invoke(explore_app, ["artifact", str(galileo_pkg)])
-
-    assert result.exit_code == 0, result.output
-    payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "artifact.json").read_text(
-            encoding="utf-8"
-        )
-    )
-    assert payload["kind"] == "lkm_exploration"
-    assert payload["interface"]["assess"]["command"].startswith("gaia-evidence assess")
-```
-
-- [ ] **Step 4: Run tests and commit**
+- builder records missing optional sidecars as limitations;
+- builder records present sidecars as package-relative paths;
+- CLI writes `artifact.json`;
+- CLI output contains the future `gaia-evidence assess --exploration ...`
+  command.
 
 Run:
 
@@ -758,7 +292,7 @@ git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py 
 git commit -m "feat(lkm-explorer): add exploration artifact envelope"
 ```
 
-## Task 5: Add deterministic Explore gate
+## Task 5: Explore Gate
 
 **Files:**
 - Modify: `gaia/lkm_explorer/engine/artifacts.py`
@@ -767,214 +301,60 @@ git commit -m "feat(lkm-explorer): add exploration artifact envelope"
 - Test: `tests/lkm_explorer/test_artifacts.py`
 - Test: `tests/lkm_explorer/test_cli_explore.py`
 
-- [ ] **Step 1: Write failing gate tests**
+Add a pure builder:
 
-Add:
-
-```python
-from gaia.lkm_explorer.engine.artifacts import build_gate_report
-
-
-def test_gate_blocks_without_focuses():
-    artifact = {
-        "schema": "gaia.sop.artifact.v1",
-        "kind": "lkm_exploration",
-        "artifacts": {
-            "scope": ".gaia/exploration/scope.json",
-            "landscape": ".gaia/exploration/landscape-0.json",
-            "focuses": None,
-            "map": ".gaia/exploration/map.json",
-            "artifact": ".gaia/exploration/artifact.json",
-        },
-    }
-
-    report = build_gate_report(artifact, focuses=None)
-
-    assert report["verdict"] == "block"
-    assert "assess" not in report["allowed_next_steps"]
-
-
-def test_gate_passes_with_evidence_backed_focus():
-    artifact = {
-        "schema": "gaia.sop.artifact.v1",
-        "kind": "lkm_exploration",
-        "artifacts": {
-            "scope": ".gaia/exploration/scope.json",
-            "landscape": ".gaia/exploration/landscape-0.json",
-            "focuses": ".gaia/exploration/focuses.json",
-            "map": ".gaia/exploration/map.json",
-            "artifact": ".gaia/exploration/artifact.json",
-            "gaia_ir": ".gaia/ir.json",
-            "beliefs": ".gaia/beliefs.json",
-            "rounds": ".gaia/exploration/rounds.jsonl",
-        },
-    }
-    focuses = {"focuses": [{"id": "f1", "evidence_refs": [{"kind": "x"}]}]}
-
-    report = build_gate_report(artifact, focuses=focuses)
-
-    assert report["verdict"] == "pass"
-    assert report["allowed_next_steps"] == ["assess"]
-
-
-def test_gate_revises_when_optional_graph_artifacts_are_missing():
-    artifact = {
-        "schema": "gaia.sop.artifact.v1",
-        "kind": "lkm_exploration",
-        "artifacts": {
-            "scope": ".gaia/exploration/scope.json",
-            "landscape": ".gaia/exploration/landscape-0.json",
-            "focuses": ".gaia/exploration/focuses.json",
-            "map": ".gaia/exploration/map.json",
-            "artifact": ".gaia/exploration/artifact.json",
-            "gaia_ir": None,
-            "beliefs": None,
-            "rounds": None,
-        },
-    }
-    focuses = {"focuses": [{"id": "f1", "evidence_refs": [{"kind": "x"}]}]}
-
-    report = build_gate_report(artifact, focuses=focuses)
-
-    assert report["verdict"] == "revise"
-    assert report["allowed_next_steps"] == []
-    assert any(
-        c["id"] == "compiled_ir_present" and c["status"] == "warn"
-        for c in report["checks"]
-    )
+```text
+build_gate_report(artifact, focuses) -> dict
 ```
 
-- [ ] **Step 2: Implement `build_gate_report`**
+Required checks:
 
-Add:
+- `scope_present`
+- `map_present`
+- `landscape_present`
+- `focuses_present`
+- `has_assessable_focus`
+- `focuses_have_evidence_refs`
+- `artifact_present`
+- `schema_versions_supported`
 
-```python
-def _check(status: str, check_id: str, finding: str) -> dict[str, str]:
-    return {"id": check_id, "status": status, "finding": finding}
+Warning checks:
 
+- `compiled_ir_present`
+- `beliefs_present`
+- `rounds_present`
 
-def build_gate_report(
-    artifact: dict[str, Any],
-    *,
-    focuses: dict[str, Any] | None,
-) -> dict[str, Any]:
-    """Check whether an Explore artifact is structurally ready for Assess."""
-    checks = []
-    artifacts = artifact.get("artifacts", {}) if isinstance(artifact, dict) else {}
+Verdict rules:
 
-    schema_ok = artifact.get("schema") == SOP_SCHEMA
-    checks.append(
-        _check(
-            "pass" if schema_ok else "fail",
-            "schema_versions_supported",
-            "schema supported"
-            if schema_ok
-            else f"unsupported schema: {artifact.get('schema')!r}",
-        )
-    )
+- `block` if any required check fails;
+- `revise` if required checks pass but warning checks fail, or if assessable
+  focuses exist but some focuses lack refs;
+- `pass` only when all required and warning checks pass;
+- `allowed_next_steps == ["assess"]` only for `pass`.
 
-    for key in ["scope", "landscape", "focuses", "map", "artifact"]:
-        present = bool(artifacts.get(key))
-        checks.append(
-            _check(
-                "pass" if present else "fail",
-                f"{key}_present",
-                f"{key} {'present' if present else 'missing'}",
-            )
-        )
+Add CLI:
 
-    for key, check_id in [
-        ("gaia_ir", "compiled_ir_present"),
-        ("beliefs", "beliefs_present"),
-        ("rounds", "rounds_present"),
-    ]:
-        present = bool(artifacts.get(key))
-        checks.append(
-            _check(
-                "pass" if present else "warn",
-                check_id,
-                f"{key} {'present' if present else 'missing'}",
-            )
-        )
-
-    focus_rows = []
-    if isinstance(focuses, dict) and isinstance(focuses.get("focuses"), list):
-        focus_rows = [f for f in focuses["focuses"] if isinstance(f, dict)]
-    checks.append(
-        _check(
-            "pass" if focus_rows else "fail",
-            "has_assessable_focus",
-            f"{len(focus_rows)} focus(es) available.",
-        )
-    )
-    missing_refs = [f.get("id", "<unknown>") for f in focus_rows if not f.get("evidence_refs")]
-    checks.append(
-        _check(
-            "pass" if not missing_refs and focus_rows else "warn",
-            "focuses_have_evidence_refs",
-            "All focuses include evidence_refs." if not missing_refs and focus_rows else f"Missing refs: {missing_refs}",
-        )
-    )
-    failed = [c for c in checks if c["status"] == "fail"]
-    warned = [c for c in checks if c["status"] == "warn"]
-    if failed:
-        verdict = "block"
-    elif warned:
-        verdict = "revise"
-    else:
-        verdict = "pass"
-    return {
-        "schema": SOP_SCHEMA,
-        "kind": "quality_gate_report",
-        "id": artifact_id("explore-gate"),
-        "created_at": utcnow(),
-        "target_kind": "lkm_exploration",
-        "target": ".gaia/exploration/artifact.json",
-        "verdict": verdict,
-        "checks": checks,
-        "required_changes": [c["finding"] for c in failed],
-        "allowed_next_steps": ["assess"] if verdict == "pass" else [],
-    }
+```bash
+gaia-lkm-explore gate <pkg> [--out <path>] [--json]
 ```
 
-- [ ] **Step 3: Add CLI command**
-
-Add `gate_command`:
+CLI behavior:
 
 - read `.gaia/exploration/artifact.json`, or build and write it if missing;
 - read `.gaia/exploration/focuses.json` when present;
-- call `build_gate_report`;
-- write `.gaia/exploration/gate_report.json`;
+- write `.gaia/exploration/gate_report.json` by default;
 - print `Gate: pass|revise|block`;
-- return exit code 0 for `pass` and `revise`;
-- raise `typer.Exit(1)` when verdict is `block`.
+- exit 1 on `block`;
+- exit 0 on `pass` and `revise`.
 
-Register:
+Required tests:
 
-```python
-app.command(name="gate")(gate_command)
-```
-
-- [ ] **Step 4: Add CLI test**
-
-Add:
-
-```python
-def test_explore_gate_blocks_without_focuses(galileo_pkg: Path):
-    runner.invoke(explore_app, ["artifact", str(galileo_pkg)])
-
-    result = runner.invoke(explore_app, ["gate", str(galileo_pkg)])
-
-    assert result.exit_code == 1
-    payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(
-            encoding="utf-8"
-        )
-    )
-    assert payload["verdict"] == "block"
-```
-
-- [ ] **Step 5: Run tests and commit**
+- missing focuses yields `block`;
+- evidence-backed focus with all artifacts yields `pass`;
+- missing optional graph artifacts yields `revise`;
+- unsupported schema yields `block`;
+- CLI writes `gate_report.json`;
+- CLI exits 1 on `block`.
 
 Run:
 
@@ -989,49 +369,35 @@ git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py 
 git commit -m "feat(lkm-explorer): add explore gate report"
 ```
 
-## Task 6: Backward compatibility and help surface
+## Task 6: CLI Surface And Backward Compatibility
 
 **Files:**
-- Modify: `tests/lkm_explorer/test_cli_explore.py`
 - Modify: `gaia/lkm_explorer/client/cli.py`
+- Test: `tests/lkm_explorer/test_cli_explore.py`
 
-- [ ] **Step 1: Add CLI help test**
+Register commands in a readable order:
 
-Add:
-
-```python
-def test_explore_cli_lists_artifact_mvp_commands():
-    result = runner.invoke(explore_app, ["--help"])
-
-    assert result.exit_code == 0
-    assert "scope" in result.output
-    assert "focuses" in result.output
-    assert "artifact" in result.output
-    assert "gate" in result.output
-    assert "turn" in result.output
+```text
+init
+scope
+observe
+landscape
+focuses
+artifact
+gate
+frontier
+round
+status
+render
+turn
 ```
 
-- [ ] **Step 2: Ensure command registration order is readable**
+Required tests:
 
-In `client/cli.py`, register commands in this order:
-
-```python
-app.command(name="init")(init_command)
-app.command(name="scope")(scope_command)
-app.command(name="observe")(observe_command)
-app.command(name="landscape")(landscape_command)
-app.command(name="focuses")(focuses_command)
-app.command(name="artifact")(artifact_command)
-app.command(name="gate")(gate_command)
-app.command(name="frontier")(frontier_command)
-app.command(name="round")(round_command)
-app.command(name="status")(status_command)
-app.command(name="render")(render_command)
-```
-
-Keep `turn` registered below as it is today.
-
-- [ ] **Step 3: Run compatibility tests**
+- top-level help lists `scope`, `focuses`, `artifact`, `gate`, and `turn`;
+- existing `init`, `observe`, `landscape`, `frontier`, `round`, `status`,
+  `render`, and `turn` smoke tests still pass;
+- new sidecar commands do not mutate `map.json` except reading from it.
 
 Run:
 
@@ -1039,54 +405,44 @@ Run:
 uv run python -m pytest -q tests/lkm_explorer/test_landscape.py tests/lkm_explorer/test_cli_explore.py tests/lkm_explorer/test_frontier.py tests/lkm_explorer/test_orchestrator.py
 ```
 
-Expected: all pass. Existing `landscape`, `frontier`, and `turn` behavior still works.
-
-- [ ] **Step 4: Commit**
+Commit:
 
 ```bash
 git add gaia/lkm_explorer/client/cli.py tests/lkm_explorer/test_cli_explore.py
 git commit -m "test(lkm-explorer): cover artifact mvp cli surface"
 ```
 
-## Task 7: Final verification
+## Task 7: Final Verification
 
-**Files:**
-- No new code unless verification reveals a bug.
-
-- [ ] **Step 1: Run targeted Explore tests**
+Run targeted Explore tests:
 
 ```bash
 uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_landscape.py tests/lkm_explorer/test_cli_explore.py tests/lkm_explorer/test_frontier.py tests/lkm_explorer/test_orchestrator.py tests/lkm_explorer/test_promote.py
 ```
 
-Expected: all pass.
-
-- [ ] **Step 2: Run PR gate**
+Run PR gate:
 
 ```bash
 uv run python -m pytest -q -m "pr_gate and not slow"
 ```
 
-Expected: all pass. Use `uv run python -m pytest`, not `uv run pytest`, because
-the latter may resolve to an external conda pytest in this workspace.
+Use `uv run python -m pytest`, not `uv run pytest`, because the latter may
+resolve to an external conda pytest in this workspace.
 
-- [ ] **Step 3: Run whitespace check**
+Run whitespace check:
 
 ```bash
 git diff --check
 ```
 
-Expected: no output.
+Before final review:
 
-- [ ] **Step 4: Update docs if command help differs from the spec**
-
-If the implemented command names or paths differ from
-`docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md`, update the spec in
-the same PR before final review.
-
-- [ ] **Step 5: Final commit if needed**
+- update `docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md` if command
+  names, paths, or verdict semantics changed during implementation;
+- ensure the old workflow still works:
 
 ```bash
-git add docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
-git commit -m "docs(lkm): add explore artifact mvp plan"
+gaia-lkm-explore init ./pkg --seed "..."
+gaia-lkm-explore observe ./pkg --search-json leads.json
+gaia-lkm-explore turn ./pkg
 ```

--- a/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
+++ b/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
@@ -1,0 +1,1005 @@
+# LKM Explore Artifact MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add typed Explore sidecar artifacts to `gaia-lkm-explore`: `scope`, `focuses`, `artifact`, and `gate`, without breaking the existing frontier-driven exploration loop.
+
+**Architecture:** Add a small deterministic artifact layer under `gaia.lkm_explorer.engine`, then expose it through thin Typer verbs in `gaia.lkm_explorer.client.verbs` and register them in `gaia.lkm_explorer.client.cli`. The MVP writes additive JSON sidecars under `.gaia/exploration/`; existing map, landscape, frontier, turn, and round semantics remain unchanged.
+
+**Tech Stack:** Python 3.12, Typer, dataclasses, JSON sidecar artifacts, pytest.
+
+**Spec reference:** `docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md`
+
+---
+
+## File Structure
+
+Create:
+
+```text
+gaia/lkm_explorer/engine/artifacts.py
+tests/lkm_explorer/test_artifacts.py
+```
+
+Modify:
+
+```text
+gaia/lkm_explorer/client/cli.py
+gaia/lkm_explorer/client/verbs.py
+tests/lkm_explorer/test_cli_explore.py
+```
+
+Responsibilities:
+
+- `engine/artifacts.py`: pure artifact builders, dimension parsing, latest landscape discovery, gate checks.
+- `client/verbs.py`: Typer command wrappers, file reading/writing, user-facing text.
+- `client/cli.py`: command registration.
+- `tests/lkm_explorer/test_artifacts.py`: pure engine tests.
+- `tests/lkm_explorer/test_cli_explore.py`: CLI smoke and backward-compatibility tests.
+
+## Task 1: Add artifact engine primitives
+
+**Files:**
+- Create: `gaia/lkm_explorer/engine/artifacts.py`
+- Test: `tests/lkm_explorer/test_artifacts.py`
+
+- [ ] **Step 1: Write failing tests for dimension parsing and UTC ids**
+
+Add tests:
+
+```python
+from gaia.lkm_explorer.engine.artifacts import (
+    artifact_id,
+    parse_dimensions,
+)
+
+
+def test_parse_dimensions_groups_repeated_keys():
+    assert parse_dimensions(["population=adults", "outcome=MI", "outcome=bleeding"]) == {
+        "population": ["adults"],
+        "outcome": ["MI", "bleeding"],
+    }
+
+
+def test_parse_dimensions_rejects_missing_equals():
+    try:
+        parse_dimensions(["population"])
+    except ValueError as exc:
+        assert "expected key=value" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_artifact_id_is_readable_and_prefixed():
+    value = artifact_id("scope")
+    assert value.startswith("scope-")
+    assert value.endswith("Z")
+```
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py
+```
+
+Expected: fail because `gaia.lkm_explorer.engine.artifacts` does not exist.
+
+- [ ] **Step 2: Implement helpers**
+
+Create `gaia/lkm_explorer/engine/artifacts.py`:
+
+```python
+"""Typed Explore sidecar artifacts for ``gaia-lkm-explore``.
+
+This module is deterministic and I/O-free except for helpers that inspect
+artifact paths. It does not call LKM, author Gaia source, or run inference.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SOP_SCHEMA = "gaia.sop.artifact.v1"
+
+
+def utcnow() -> str:
+    """Return an ISO-8601 UTC timestamp with a trailing ``Z``."""
+    return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def artifact_id(prefix: str) -> str:
+    """Return a human-readable timestamp id for an artifact."""
+    stamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{prefix}-{stamp}"
+
+
+def parse_dimensions(items: list[str] | None) -> dict[str, list[str]]:
+    """Parse repeated ``key=value`` CLI values into grouped dimension lists."""
+    out: dict[str, list[str]] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise ValueError(f"expected key=value dimension, got {item!r}")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"expected non-empty key=value dimension, got {item!r}")
+        out.setdefault(key, []).append(value)
+    return out
+
+
+def exploration_dir(pkg: str | Path) -> Path:
+    """Return ``<pkg>/.gaia/exploration``."""
+    return Path(pkg).resolve() / ".gaia" / "exploration"
+
+
+def latest_landscape_path(pkg: str | Path) -> Path | None:
+    """Return the latest round-numbered landscape artifact, if any."""
+    root = exploration_dir(pkg)
+    candidates = sorted(root.glob("landscape-*.json"))
+    return candidates[-1] if candidates else None
+
+
+def rel_artifact_path(pkg: str | Path, path: Path | None) -> str | None:
+    """Return a package-relative artifact path for stable JSON output."""
+    if path is None:
+        return None
+    pkg_root = Path(pkg).resolve()
+    try:
+        return str(path.resolve().relative_to(pkg_root))
+    except ValueError:
+        return str(path)
+```
+
+- [ ] **Step 3: Run helper tests**
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lkm_explorer/engine/artifacts.py tests/lkm_explorer/test_artifacts.py
+git commit -m "feat(lkm-explorer): add explore artifact helpers"
+```
+
+## Task 2: Add `scope` artifact builder and CLI
+
+**Files:**
+- Modify: `gaia/lkm_explorer/engine/artifacts.py`
+- Modify: `gaia/lkm_explorer/client/verbs.py`
+- Modify: `gaia/lkm_explorer/client/cli.py`
+- Test: `tests/lkm_explorer/test_artifacts.py`
+- Test: `tests/lkm_explorer/test_cli_explore.py`
+
+- [ ] **Step 1: Write failing engine test**
+
+Add to `tests/lkm_explorer/test_artifacts.py`:
+
+```python
+from gaia.lkm_explorer.engine.artifacts import build_scope_artifact
+
+
+def test_build_scope_artifact_records_inputs(tmp_path):
+    pkg = tmp_path / "pkg"
+    (pkg / ".gaia" / "exploration").mkdir(parents=True)
+
+    payload = build_scope_artifact(
+        pkg,
+        seeds=["aspirin primary prevention"],
+        profile="medical",
+        dimensions={"outcome": ["MI", "major bleeding"]},
+        seed_source="cli",
+        map_round=0,
+    )
+
+    assert payload["schema"] == "gaia.sop.artifact.v1"
+    assert payload["kind"] == "exploration_scope"
+    assert payload["inputs"]["seeds"] == ["aspirin primary prevention"]
+    assert payload["inputs"]["profile"] == "medical"
+    assert payload["inputs"]["dimensions"]["outcome"] == ["MI", "major bleeding"]
+    assert payload["audit"]["allowed_next_steps"] == [
+        "landscape",
+        "focuses",
+        "artifact",
+        "gate",
+    ]
+```
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py::test_build_scope_artifact_records_inputs
+```
+
+Expected: fail because `build_scope_artifact` does not exist.
+
+- [ ] **Step 2: Implement `build_scope_artifact`**
+
+Add to `engine/artifacts.py`:
+
+```python
+def build_scope_artifact(
+    pkg: str | Path,
+    *,
+    seeds: list[str],
+    profile: str | None,
+    dimensions: dict[str, list[str]],
+    seed_source: str,
+    map_round: int,
+) -> dict[str, Any]:
+    """Build the first-class Explore scope artifact."""
+    return {
+        "schema": SOP_SCHEMA,
+        "kind": "exploration_scope",
+        "id": artifact_id("scope"),
+        "created_at": utcnow(),
+        "inputs": {
+            "pkg": str(pkg),
+            "seeds": list(seeds),
+            "profile": profile,
+            "dimensions": dimensions,
+        },
+        "artifacts": {
+            "map": ".gaia/exploration/map.json",
+        },
+        "provenance": {
+            "seed_source": seed_source,
+            "map_round": map_round,
+        },
+        "audit": {
+            "known_limitations": [
+                "Scope is user-authored; no automatic domain validation is performed."
+            ],
+            "allowed_next_steps": ["landscape", "focuses", "artifact", "gate"],
+        },
+    }
+```
+
+- [ ] **Step 3: Write failing CLI test**
+
+Add to `tests/lkm_explorer/test_cli_explore.py` using the existing runner
+fixture/pattern in that file:
+
+```python
+def test_explore_scope_writes_scope_artifact(galileo_pkg: Path):
+    result = runner.invoke(
+        explore_app,
+        [
+            "scope",
+            str(galileo_pkg),
+            "--seed",
+            "free fall",
+            "--profile",
+            "physics",
+            "--dimension",
+            "quantity=acceleration",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "scope.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["kind"] == "exploration_scope"
+    assert payload["inputs"]["profile"] == "physics"
+    assert payload["inputs"]["dimensions"] == {"quantity": ["acceleration"]}
+```
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_cli_explore.py::test_explore_scope_writes_scope_artifact
+```
+
+Expected: fail because command is not registered.
+
+- [ ] **Step 4: Implement `scope_command` and register it**
+
+In `client/verbs.py`, import:
+
+```python
+from gaia.lkm_explorer.engine.artifacts import (
+    build_scope_artifact,
+    parse_dimensions,
+)
+```
+
+Add option singletons:
+
+```python
+_SCOPE_SEED_OPT = typer.Option(
+    None,
+    "--seed",
+    help="Seed text for the exploration scope (repeatable; defaults to map seeds).",
+)
+_SCOPE_PROFILE_OPT = typer.Option(None, "--profile", help="Optional domain profile.")
+_SCOPE_DIMENSION_OPT = typer.Option(
+    None,
+    "--dimension",
+    help="Scope dimension as key=value (repeatable).",
+)
+_SCOPE_OUT_OPT = typer.Option(
+    None,
+    "--out",
+    help="Output JSON path (default <pkg>/.gaia/exploration/scope.json).",
+)
+```
+
+Add command:
+
+```python
+def scope_command(
+    pkg: str = _PKG_ARG,
+    seed: list[str] | None = _SCOPE_SEED_OPT,
+    profile: str | None = _SCOPE_PROFILE_OPT,
+    dimension: list[str] | None = _SCOPE_DIMENSION_OPT,
+    out: str | None = _SCOPE_OUT_OPT,
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    """Write a first-class exploration scope sidecar."""
+    if not (_gaia_dir(pkg) / "exploration" / "map.json").exists():
+        typer.echo(
+            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    exploration_map = load_map(pkg)
+    seeds = list(seed or [])
+    seed_source = "cli"
+    if not seeds:
+        seeds = [str(s.get("raw", s.get("qid", ""))) for s in exploration_map.seeds]
+        seeds = [s for s in seeds if s]
+        seed_source = "map"
+    try:
+        dimensions = parse_dimensions(dimension)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    payload = build_scope_artifact(
+        pkg,
+        seeds=seeds,
+        profile=profile,
+        dimensions=dimensions,
+        seed_source=seed_source,
+        map_round=exploration_map.round,
+    )
+    output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "scope.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+    typer.echo(f"Scope: {len(seeds)} seed(s), {len(dimensions)} dimension group(s).")
+    typer.echo(f"Output: {output_path}")
+    if json_out:
+        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+```
+
+In `client/cli.py`, import and register:
+
+```python
+from gaia.lkm_explorer.client.verbs import scope_command
+
+app.command(name="scope")(scope_command)
+```
+
+- [ ] **Step 5: Run CLI test**
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_cli_explore.py::test_explore_scope_writes_scope_artifact
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py gaia/lkm_explorer/client/cli.py tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py
+git commit -m "feat(lkm-explorer): add scope artifact command"
+```
+
+## Task 3: Add deterministic `focuses`
+
+**Files:**
+- Modify: `gaia/lkm_explorer/engine/artifacts.py`
+- Modify: `gaia/lkm_explorer/client/verbs.py`
+- Modify: `gaia/lkm_explorer/client/cli.py`
+- Test: `tests/lkm_explorer/test_artifacts.py`
+- Test: `tests/lkm_explorer/test_cli_explore.py`
+
+- [ ] **Step 1: Write failing engine test for landscape focus generation**
+
+Add:
+
+```python
+from gaia.lkm_explorer.engine.artifacts import build_focuses_artifact
+
+
+def test_build_focuses_artifact_uses_landscape_paper_leads(tmp_path):
+    pkg = tmp_path / "pkg"
+    landscape_path = pkg / ".gaia" / "exploration" / "landscape-0.json"
+    landscape_path.parent.mkdir(parents=True)
+    landscape_path.write_text(
+        json.dumps(
+            {
+                "kind": "exploration_landscape",
+                "paper_leads": [
+                    {"paper_id": "P1", "title": "Paper One"},
+                    {"paper_id": "P2", "title": "Paper Two"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = build_focuses_artifact(
+        pkg,
+        scope_path=None,
+        landscape_path=landscape_path,
+        landscape={"kind": "exploration_landscape", "paper_leads": [{"paper_id": "P1"}]},
+        map_round=0,
+    )
+
+    assert payload["kind"] == "exploration_focuses"
+    assert payload["focuses"][0]["kind"] == "paper_lead_cluster"
+    assert payload["focuses"][0]["evidence_refs"][0]["paper_id"] == "P1"
+```
+
+- [ ] **Step 2: Implement `build_focuses_artifact`**
+
+Add:
+
+```python
+def build_focuses_artifact(
+    pkg: str | Path,
+    *,
+    scope_path: Path | None,
+    landscape_path: Path | None,
+    landscape: dict[str, Any] | None,
+    map_round: int,
+) -> dict[str, Any]:
+    """Build deterministic, provenance-backed assessment focuses."""
+    focuses: list[dict[str, Any]] = []
+    leads = []
+    if landscape:
+        raw_leads = landscape.get("paper_leads")
+        if isinstance(raw_leads, list):
+            leads = [lead for lead in raw_leads if isinstance(lead, dict)]
+    if leads:
+        refs = []
+        for lead in leads[:5]:
+            paper_id = lead.get("paper_id")
+            if isinstance(paper_id, str) and paper_id:
+                refs.append(
+                    {
+                        "kind": "landscape_paper_lead",
+                        "path": rel_artifact_path(pkg, landscape_path),
+                        "paper_id": paper_id,
+                    }
+                )
+        if refs:
+            focuses.append(
+                {
+                    "id": "focus_landscape_top_leads",
+                    "kind": "paper_lead_cluster",
+                    "text": "Top unpulled paper leads from the current landscape",
+                    "why_it_matters": (
+                        "These papers are the highest-ranked breadth-first leads "
+                        "and should be considered before local claim-level expansion."
+                    ),
+                    "evidence_refs": refs,
+                    "recommended_next": "assess",
+                    "confidence": "structural",
+                }
+            )
+    return {
+        "schema": SOP_SCHEMA,
+        "kind": "exploration_focuses",
+        "id": artifact_id("focuses"),
+        "created_at": utcnow(),
+        "inputs": {
+            "pkg": str(pkg),
+            "scope": rel_artifact_path(pkg, scope_path),
+            "landscape": rel_artifact_path(pkg, landscape_path),
+        },
+        "artifacts": {
+            "map": ".gaia/exploration/map.json",
+            "landscape": rel_artifact_path(pkg, landscape_path),
+        },
+        "focuses": focuses,
+        "provenance": {"generation": "deterministic", "map_round": map_round},
+        "audit": {
+            "known_limitations": [
+                "MVP focuses are structural and provenance-backed; domain-specific tension naming is external or future work."
+            ],
+            "allowed_next_steps": ["artifact", "gate"],
+        },
+    }
+```
+
+- [ ] **Step 3: Add CLI command and registration**
+
+Add `focuses_command` in `verbs.py`:
+
+```python
+def focuses_command(
+    pkg: str = _PKG_ARG,
+    landscape: str | None = typer.Option(
+        None,
+        "--landscape",
+        help="Landscape JSON path (default latest <pkg>/.gaia/exploration/landscape-*.json).",
+    ),
+    out: str | None = typer.Option(
+        None,
+        "--out",
+        help="Output JSON path (default <pkg>/.gaia/exploration/focuses.json).",
+    ),
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    """Write deterministic assessment focuses from the latest landscape."""
+```
+
+Implementation details:
+
+- load map with `load_map(pkg)`;
+- resolve `landscape_path = Path(landscape)` if provided else `latest_landscape_path(pkg)`;
+- if no landscape path exists, emit error and exit 2;
+- read landscape JSON with `_read_json_object`;
+- `scope_path = _gaia_dir(pkg) / "exploration" / "scope.json"` if exists else `None`;
+- write `.gaia/exploration/focuses.json`.
+
+Register in `client/cli.py`:
+
+```python
+app.command(name="focuses")(focuses_command)
+```
+
+- [ ] **Step 4: Add CLI test**
+
+Add:
+
+```python
+def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):
+    landscape_path = galileo_pkg / ".gaia" / "exploration" / "landscape-0.json"
+    landscape_path.write_text(
+        json.dumps(
+            {
+                "kind": "exploration_landscape",
+                "paper_leads": [{"paper_id": "P1", "title": "Paper One"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(explore_app, ["focuses", str(galileo_pkg)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["kind"] == "exploration_focuses"
+    assert payload["focuses"][0]["id"] == "focus_landscape_top_leads"
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py::test_explore_focuses_writes_focuses_from_landscape
+```
+
+Commit:
+
+```bash
+git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py gaia/lkm_explorer/client/cli.py tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py
+git commit -m "feat(lkm-explorer): add focuses artifact command"
+```
+
+## Task 4: Add `artifact` envelope
+
+**Files:**
+- Modify: `gaia/lkm_explorer/engine/artifacts.py`
+- Modify: `gaia/lkm_explorer/client/verbs.py`
+- Modify: `gaia/lkm_explorer/client/cli.py`
+- Test: `tests/lkm_explorer/test_artifacts.py`
+- Test: `tests/lkm_explorer/test_cli_explore.py`
+
+- [ ] **Step 1: Write failing test for missing optional files**
+
+Add:
+
+```python
+from gaia.lkm_explorer.engine.artifacts import build_exploration_artifact
+
+
+def test_build_exploration_artifact_records_missing_optional_files(tmp_path):
+    pkg = tmp_path / "pkg"
+    (pkg / ".gaia" / "exploration").mkdir(parents=True)
+
+    payload = build_exploration_artifact(pkg, map_round=0, map_version=1)
+
+    assert payload["kind"] == "lkm_exploration"
+    assert payload["artifacts"]["scope"] is None
+    assert "missing scope" in payload["audit"]["known_limitations"]
+    assert payload["audit"]["allowed_next_steps"] == ["gate"]
+```
+
+- [ ] **Step 2: Implement `build_exploration_artifact`**
+
+Add:
+
+```python
+def _maybe_rel(pkg: str | Path, path: Path) -> str | None:
+    return rel_artifact_path(pkg, path) if path.exists() else None
+
+
+def build_exploration_artifact(
+    pkg: str | Path,
+    *,
+    map_round: int,
+    map_version: int,
+) -> dict[str, Any]:
+    """Aggregate Explore sidecars into a single handoff envelope."""
+    root = exploration_dir(pkg)
+    scope = root / "scope.json"
+    landscape = latest_landscape_path(pkg)
+    focuses = root / "focuses.json"
+    map_path = root / "map.json"
+    rounds = root / "rounds.jsonl"
+    gaia_dir = Path(pkg).resolve() / ".gaia"
+    ir = gaia_dir / "ir.json"
+    beliefs = gaia_dir / "beliefs.json"
+    limitations = []
+    for label, path in [
+        ("scope", scope),
+        ("landscape", landscape),
+        ("focuses", focuses),
+        ("map", map_path),
+    ]:
+        if path is None or not path.exists():
+            limitations.append(f"missing {label}")
+    return {
+        "schema": SOP_SCHEMA,
+        "kind": "lkm_exploration",
+        "id": artifact_id("explore"),
+        "created_at": utcnow(),
+        "inputs": {"pkg": str(pkg)},
+        "artifacts": {
+            "scope": _maybe_rel(pkg, scope),
+            "landscape": rel_artifact_path(pkg, landscape) if landscape else None,
+            "focuses": _maybe_rel(pkg, focuses),
+            "map": _maybe_rel(pkg, map_path),
+            "rounds": _maybe_rel(pkg, rounds),
+            "gaia_ir": _maybe_rel(pkg, ir),
+            "beliefs": _maybe_rel(pkg, beliefs),
+        },
+        "provenance": {
+            "map_round": map_round,
+            "map_version": map_version,
+        },
+        "audit": {
+            "coverage": {},
+            "known_limitations": limitations,
+            "allowed_next_steps": ["gate"],
+        },
+        "interface": {
+            "assess": {
+                "command": (
+                    "gaia-evidence assess --exploration "
+                    ".gaia/exploration/artifact.json --focus <focus-id>"
+                )
+            }
+        },
+    }
+```
+
+- [ ] **Step 3: Add CLI command and test**
+
+Add `artifact_command` analogous to `focuses_command`:
+
+- load `ExplorationMap`;
+- call `build_exploration_artifact(pkg, map_round=exploration_map.round, map_version=exploration_map.version)`;
+- write `.gaia/exploration/artifact.json`;
+- print output path and limitation count.
+
+Register `app.command(name="artifact")(artifact_command)`.
+
+CLI test:
+
+```python
+def test_explore_artifact_writes_handoff_envelope(galileo_pkg: Path):
+    result = runner.invoke(explore_app, ["artifact", str(galileo_pkg)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "artifact.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["kind"] == "lkm_exploration"
+    assert payload["interface"]["assess"]["command"].startswith("gaia-evidence assess")
+```
+
+- [ ] **Step 4: Run tests and commit**
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py::test_explore_artifact_writes_handoff_envelope
+```
+
+Commit:
+
+```bash
+git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py gaia/lkm_explorer/client/cli.py tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py
+git commit -m "feat(lkm-explorer): add exploration artifact envelope"
+```
+
+## Task 5: Add deterministic Explore gate
+
+**Files:**
+- Modify: `gaia/lkm_explorer/engine/artifacts.py`
+- Modify: `gaia/lkm_explorer/client/verbs.py`
+- Modify: `gaia/lkm_explorer/client/cli.py`
+- Test: `tests/lkm_explorer/test_artifacts.py`
+- Test: `tests/lkm_explorer/test_cli_explore.py`
+
+- [ ] **Step 1: Write failing gate tests**
+
+Add:
+
+```python
+from gaia.lkm_explorer.engine.artifacts import build_gate_report
+
+
+def test_gate_blocks_without_focuses():
+    artifact = {
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": None,
+            "map": ".gaia/exploration/map.json",
+        },
+    }
+
+    report = build_gate_report(artifact, focuses=None)
+
+    assert report["verdict"] == "block"
+    assert "assess" not in report["allowed_next_steps"]
+
+
+def test_gate_passes_with_evidence_backed_focus():
+    artifact = {
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+        },
+    }
+    focuses = {"focuses": [{"id": "f1", "evidence_refs": [{"kind": "x"}]}]}
+
+    report = build_gate_report(artifact, focuses=focuses)
+
+    assert report["verdict"] == "pass"
+    assert report["allowed_next_steps"] == ["assess"]
+```
+
+- [ ] **Step 2: Implement `build_gate_report`**
+
+Add:
+
+```python
+def _check(status: str, check_id: str, finding: str) -> dict[str, str]:
+    return {"id": check_id, "status": status, "finding": finding}
+
+
+def build_gate_report(
+    artifact: dict[str, Any],
+    *,
+    focuses: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Check whether an Explore artifact is structurally ready for Assess."""
+    checks = []
+    artifacts = artifact.get("artifacts", {}) if isinstance(artifact, dict) else {}
+    for key in ["scope", "landscape", "focuses", "map"]:
+        present = bool(artifacts.get(key))
+        checks.append(_check("pass" if present else "fail", f"{key}_present", f"{key} {'present' if present else 'missing'}"))
+    focus_rows = []
+    if isinstance(focuses, dict) and isinstance(focuses.get("focuses"), list):
+        focus_rows = [f for f in focuses["focuses"] if isinstance(f, dict)]
+    checks.append(
+        _check(
+            "pass" if focus_rows else "fail",
+            "has_assessable_focus",
+            f"{len(focus_rows)} focus(es) available.",
+        )
+    )
+    missing_refs = [f.get("id", "<unknown>") for f in focus_rows if not f.get("evidence_refs")]
+    checks.append(
+        _check(
+            "pass" if not missing_refs and focus_rows else "fail",
+            "focuses_have_evidence_refs",
+            "All focuses include evidence_refs." if not missing_refs and focus_rows else f"Missing refs: {missing_refs}",
+        )
+    )
+    failed = [c for c in checks if c["status"] == "fail"]
+    verdict = "pass" if not failed else "block"
+    return {
+        "schema": SOP_SCHEMA,
+        "kind": "quality_gate_report",
+        "id": artifact_id("explore-gate"),
+        "created_at": utcnow(),
+        "target_kind": "lkm_exploration",
+        "target": ".gaia/exploration/artifact.json",
+        "verdict": verdict,
+        "checks": checks,
+        "required_changes": [c["finding"] for c in failed],
+        "allowed_next_steps": ["assess"] if verdict == "pass" else [],
+    }
+```
+
+- [ ] **Step 3: Add CLI command**
+
+Add `gate_command`:
+
+- read `.gaia/exploration/artifact.json`, or build and write it if missing;
+- read `.gaia/exploration/focuses.json` when present;
+- call `build_gate_report`;
+- write `.gaia/exploration/gate_report.json`;
+- print `Gate: pass|block`.
+
+Register:
+
+```python
+app.command(name="gate")(gate_command)
+```
+
+- [ ] **Step 4: Add CLI test**
+
+Add:
+
+```python
+def test_explore_gate_blocks_without_focuses(galileo_pkg: Path):
+    runner.invoke(explore_app, ["artifact", str(galileo_pkg)])
+
+    result = runner.invoke(explore_app, ["gate", str(galileo_pkg)])
+
+    assert result.exit_code == 1
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["verdict"] == "block"
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py::test_explore_gate_blocks_without_focuses
+```
+
+Commit:
+
+```bash
+git add gaia/lkm_explorer/engine/artifacts.py gaia/lkm_explorer/client/verbs.py gaia/lkm_explorer/client/cli.py tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_cli_explore.py
+git commit -m "feat(lkm-explorer): add explore gate report"
+```
+
+## Task 6: Backward compatibility and help surface
+
+**Files:**
+- Modify: `tests/lkm_explorer/test_cli_explore.py`
+- Modify: `gaia/lkm_explorer/client/cli.py`
+
+- [ ] **Step 1: Add CLI help test**
+
+Add:
+
+```python
+def test_explore_cli_lists_artifact_mvp_commands():
+    result = runner.invoke(explore_app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "scope" in result.output
+    assert "focuses" in result.output
+    assert "artifact" in result.output
+    assert "gate" in result.output
+    assert "turn" in result.output
+```
+
+- [ ] **Step 2: Ensure command registration order is readable**
+
+In `client/cli.py`, register commands in this order:
+
+```python
+app.command(name="init")(init_command)
+app.command(name="scope")(scope_command)
+app.command(name="observe")(observe_command)
+app.command(name="landscape")(landscape_command)
+app.command(name="focuses")(focuses_command)
+app.command(name="artifact")(artifact_command)
+app.command(name="gate")(gate_command)
+app.command(name="frontier")(frontier_command)
+app.command(name="round")(round_command)
+app.command(name="status")(status_command)
+app.command(name="render")(render_command)
+```
+
+Keep `turn` registered below as it is today.
+
+- [ ] **Step 3: Run compatibility tests**
+
+Run:
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_landscape.py tests/lkm_explorer/test_cli_explore.py tests/lkm_explorer/test_frontier.py tests/lkm_explorer/test_orchestrator.py
+```
+
+Expected: all pass. Existing `landscape`, `frontier`, and `turn` behavior still works.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gaia/lkm_explorer/client/cli.py tests/lkm_explorer/test_cli_explore.py
+git commit -m "test(lkm-explorer): cover artifact mvp cli surface"
+```
+
+## Task 7: Final verification
+
+**Files:**
+- No new code unless verification reveals a bug.
+
+- [ ] **Step 1: Run targeted Explore tests**
+
+```bash
+uv run python -m pytest -q tests/lkm_explorer/test_artifacts.py tests/lkm_explorer/test_landscape.py tests/lkm_explorer/test_cli_explore.py tests/lkm_explorer/test_frontier.py tests/lkm_explorer/test_orchestrator.py tests/lkm_explorer/test_promote.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run PR gate**
+
+```bash
+uv run python -m pytest -q -m "pr_gate and not slow"
+```
+
+Expected: all pass. Use `uv run python -m pytest`, not `uv run pytest`, because
+the latter may resolve to an external conda pytest in this workspace.
+
+- [ ] **Step 3: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Update docs if command help differs from the spec**
+
+If the implemented command names or paths differ from
+`docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md`, update the spec in
+the same PR before final review.
+
+- [ ] **Step 5: Final commit if needed**
+
+```bash
+git add docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
+git commit -m "docs(lkm): add explore artifact mvp plan"
+```

--- a/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
+++ b/docs/plans/2026-05-26-lkm-explore-artifact-mvp.md
@@ -1,6 +1,9 @@
 # LKM Explore Artifact MVP Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For implementers:** Execute this plan task-by-task. Steps use checkbox
+> (`- [ ]`) syntax for tracking. Keep the implementation test-driven, make
+> small commits, and preserve backward compatibility for the existing
+> `gaia-lkm-explore` commands.
 
 **Goal:** Add typed Explore sidecar artifacts to `gaia-lkm-explore`: `scope`, `focuses`, `artifact`, and `gate`, without breaking the existing frontier-driven exploration loop.
 
@@ -11,6 +14,14 @@
 **Spec reference:** `docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md`
 
 ---
+
+## Plan Code Policy
+
+Code snippets in this plan are illustrative implementation sketches, not a
+requirement to paste verbatim. The tests, artifact contracts, command names,
+paths, side effects, and compatibility rules are normative. If production code
+diverges from a snippet while satisfying the tests and contracts, prefer the
+cleaner production code.
 
 ## File Structure
 
@@ -242,7 +253,7 @@ def build_scope_artifact(
         "id": artifact_id("scope"),
         "created_at": utcnow(),
         "inputs": {
-            "pkg": str(pkg),
+            "pkg": str(Path(pkg).resolve()),
             "seeds": list(seeds),
             "profile": profile,
             "dimensions": dimensions,
@@ -308,6 +319,7 @@ Expected: fail because command is not registered.
 In `client/verbs.py`, import:
 
 ```python
+from gaia.engine.packaging import write_text_atomic
 from gaia.lkm_explorer.engine.artifacts import (
     build_scope_artifact,
     parse_dimensions,
@@ -507,7 +519,7 @@ def build_focuses_artifact(
         "id": artifact_id("focuses"),
         "created_at": utcnow(),
         "inputs": {
-            "pkg": str(pkg),
+            "pkg": str(Path(pkg).resolve()),
             "scope": rel_artifact_path(pkg, scope_path),
             "landscape": rel_artifact_path(pkg, landscape_path),
         },
@@ -674,7 +686,7 @@ def build_exploration_artifact(
         "kind": "lkm_exploration",
         "id": artifact_id("explore"),
         "created_at": utcnow(),
-        "inputs": {"pkg": str(pkg)},
+        "inputs": {"pkg": str(Path(pkg).resolve())},
         "artifacts": {
             "scope": _maybe_rel(pkg, scope),
             "landscape": rel_artifact_path(pkg, landscape) if landscape else None,
@@ -765,12 +777,14 @@ from gaia.lkm_explorer.engine.artifacts import build_gate_report
 
 def test_gate_blocks_without_focuses():
     artifact = {
+        "schema": "gaia.sop.artifact.v1",
         "kind": "lkm_exploration",
         "artifacts": {
             "scope": ".gaia/exploration/scope.json",
             "landscape": ".gaia/exploration/landscape-0.json",
             "focuses": None,
             "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
         },
     }
 
@@ -782,12 +796,17 @@ def test_gate_blocks_without_focuses():
 
 def test_gate_passes_with_evidence_backed_focus():
     artifact = {
+        "schema": "gaia.sop.artifact.v1",
         "kind": "lkm_exploration",
         "artifacts": {
             "scope": ".gaia/exploration/scope.json",
             "landscape": ".gaia/exploration/landscape-0.json",
             "focuses": ".gaia/exploration/focuses.json",
             "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": ".gaia/ir.json",
+            "beliefs": ".gaia/beliefs.json",
+            "rounds": ".gaia/exploration/rounds.jsonl",
         },
     }
     focuses = {"focuses": [{"id": "f1", "evidence_refs": [{"kind": "x"}]}]}
@@ -796,6 +815,33 @@ def test_gate_passes_with_evidence_backed_focus():
 
     assert report["verdict"] == "pass"
     assert report["allowed_next_steps"] == ["assess"]
+
+
+def test_gate_revises_when_optional_graph_artifacts_are_missing():
+    artifact = {
+        "schema": "gaia.sop.artifact.v1",
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": None,
+            "beliefs": None,
+            "rounds": None,
+        },
+    }
+    focuses = {"focuses": [{"id": "f1", "evidence_refs": [{"kind": "x"}]}]}
+
+    report = build_gate_report(artifact, focuses=focuses)
+
+    assert report["verdict"] == "revise"
+    assert report["allowed_next_steps"] == []
+    assert any(
+        c["id"] == "compiled_ir_present" and c["status"] == "warn"
+        for c in report["checks"]
+    )
 ```
 
 - [ ] **Step 2: Implement `build_gate_report`**
@@ -815,9 +861,42 @@ def build_gate_report(
     """Check whether an Explore artifact is structurally ready for Assess."""
     checks = []
     artifacts = artifact.get("artifacts", {}) if isinstance(artifact, dict) else {}
-    for key in ["scope", "landscape", "focuses", "map"]:
+
+    schema_ok = artifact.get("schema") == SOP_SCHEMA
+    checks.append(
+        _check(
+            "pass" if schema_ok else "fail",
+            "schema_versions_supported",
+            "schema supported"
+            if schema_ok
+            else f"unsupported schema: {artifact.get('schema')!r}",
+        )
+    )
+
+    for key in ["scope", "landscape", "focuses", "map", "artifact"]:
         present = bool(artifacts.get(key))
-        checks.append(_check("pass" if present else "fail", f"{key}_present", f"{key} {'present' if present else 'missing'}"))
+        checks.append(
+            _check(
+                "pass" if present else "fail",
+                f"{key}_present",
+                f"{key} {'present' if present else 'missing'}",
+            )
+        )
+
+    for key, check_id in [
+        ("gaia_ir", "compiled_ir_present"),
+        ("beliefs", "beliefs_present"),
+        ("rounds", "rounds_present"),
+    ]:
+        present = bool(artifacts.get(key))
+        checks.append(
+            _check(
+                "pass" if present else "warn",
+                check_id,
+                f"{key} {'present' if present else 'missing'}",
+            )
+        )
+
     focus_rows = []
     if isinstance(focuses, dict) and isinstance(focuses.get("focuses"), list):
         focus_rows = [f for f in focuses["focuses"] if isinstance(f, dict)]
@@ -831,13 +910,19 @@ def build_gate_report(
     missing_refs = [f.get("id", "<unknown>") for f in focus_rows if not f.get("evidence_refs")]
     checks.append(
         _check(
-            "pass" if not missing_refs and focus_rows else "fail",
+            "pass" if not missing_refs and focus_rows else "warn",
             "focuses_have_evidence_refs",
             "All focuses include evidence_refs." if not missing_refs and focus_rows else f"Missing refs: {missing_refs}",
         )
     )
     failed = [c for c in checks if c["status"] == "fail"]
-    verdict = "pass" if not failed else "block"
+    warned = [c for c in checks if c["status"] == "warn"]
+    if failed:
+        verdict = "block"
+    elif warned:
+        verdict = "revise"
+    else:
+        verdict = "pass"
     return {
         "schema": SOP_SCHEMA,
         "kind": "quality_gate_report",
@@ -860,7 +945,9 @@ Add `gate_command`:
 - read `.gaia/exploration/focuses.json` when present;
 - call `build_gate_report`;
 - write `.gaia/exploration/gate_report.json`;
-- print `Gate: pass|block`.
+- print `Gate: pass|revise|block`;
+- return exit code 0 for `pass` and `revise`;
+- raise `typer.Exit(1)` when verdict is `block`.
 
 Register:
 

--- a/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
+++ b/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
@@ -1,0 +1,689 @@
+# Gaia LKM Explore and Evidence Assess Design
+
+> **Status:** Draft
+>
+> **Date:** 2026-05-25
+>
+> **Scope:** `gaia-lkm-explore`, its handoff to `gaia-evidence assess`,
+> and the first two stages of the larger Gaia research loop:
+> `Explore -> Assess -> Propose -> Discover -> Merge`.
+
+## Proposal: 细化 Gaia 研究闭环中的 Explore 与 Assess
+
+这份 proposal 的定位需要说清楚：它不是要替代更大的 Gaia 研究闭环，而是细化其中前两个模块。
+
+大闭环来自现有设计文档：
+
+```text
+Explore -> Assess -> Propose -> Discover -> Merge
+```
+
+完整语义是：
+
+```text
+探索领域
+  -> 找到问题
+  -> 分析已有研究
+  -> 提出下一步研究
+  -> 执行并得到结果
+  -> 更新 Gaia 图和 belief
+  -> 回传 LKM / knowledge base
+```
+
+这份 proposal 只聚焦前两步：
+
+```text
+Explore -> Assess
+```
+
+也就是回答：
+
+- `gaia-lkm-explore` 到底应该负责什么？
+- Evidence assessment 应该从哪里接手？
+- Explore 和 Assess 之间的 typed artifact 应该长什么样？
+- 这两步如何给后面的 `Propose -> Discover -> Merge` 提供干净输入？
+
+## 1. 为什么需要重新拆前两步
+
+这次用 `gaia-lkm-explore` 跑「阿司匹林对一级预防心血管疾病的作用」时，流程能跑通，但暴露了一个职责混杂问题。
+
+当前实际流程接近：
+
+```text
+seed
+  -> search
+  -> observe
+  -> frontier
+  -> pull paper
+  -> formalize claims
+  -> compile / infer
+  -> checkpoint
+```
+
+这个流程的问题不是没有能力，而是太早进入局部深挖：
+
+- 第一轮容易被某篇局部相关论文带偏，而不是先建立全局 evidence landscape。
+- pull 一篇 paper 后会爆出大量 claim/question contacts，frontier 很快被细节淹没。
+- 系统能扩图，但不清楚「为什么扩这个」「扩到什么时候停」「哪些 claim 值得评估」。
+- Evidence assessment 没有干净输入，只能在一堆 raw hits、claims、frontier 里再整理上下文。
+
+所以需要把前两步拆清楚：
+
+```text
+Explore: 建立领域地图，暴露问题
+Assess: 分析已有研究与矛盾，判断哪些 gap 值得变成下一步研究
+```
+
+## 2. 核心哲学
+
+前两步的哲学是：
+
+> Explore 不给最终答案，Assess 不做开放探索。
+
+更具体地说：
+
+```text
+Explore 负责 breadth-first，看见版图。
+Assess 负责 depth-selective，解释矛盾。
+```
+
+Explore 的问题是：
+
+```text
+这个领域/问题的证据版图长什么样？
+有哪些主要证据族、模型族、材料族？
+哪里有冲突、空洞、未履行义务？
+哪些区域值得 Assess？
+```
+
+Assess 的问题是：
+
+```text
+围绕一个 focus，已有证据到底说明了什么？
+矛盾来自数据、模型、方法、population、systematics，还是概念混淆？
+哪些 gap 是真实 gap？
+下一步最小判别测试是什么？
+```
+
+它们的边界要靠 typed artifact 固定下来，而不是靠 prompt 约定。
+
+## 3. 建议的前两步内部分解
+
+我建议把大闭环里的前两步细化成下面几个子阶段。
+
+注意：这些不是新的主链步骤，而是 Explore/Assess 内部的可实现模块。
+
+```text
+Explore
+  1. Scope Adapter
+  2. Landscape Builder
+  3. Frontier / Obligation Mapper
+  4. Explore Gate
+
+Assess
+  5. Assessment Context Builder
+  6. Evidence Diagnosis
+  7. Gap / Next-Test Mapper
+  8. Assess Gate
+```
+
+这样既不破坏大闭环的五步结构，又能让前两步真正可实现、可审计。
+
+## 4. Explore 应该怎么拆
+
+### 4.1 Scope Adapter
+
+职责：把 seed question / seed claim / topic 变成探索规格。
+
+它不是单独主链模块，而是 Explore 的输入适配层。
+
+输入：
+
+```text
+阿司匹林对一级预防心血管疾病的作用
+```
+
+输出：
+
+```json
+{
+  "kind": "exploration_scope",
+  "question": "Aspirin for primary prevention of cardiovascular disease",
+  "population": ["adults without established CVD"],
+  "intervention_or_object": "aspirin",
+  "comparators": ["placebo", "usual care", "no aspirin"],
+  "outcomes": ["MI", "stroke", "mortality", "major bleeding"],
+  "subgroups": ["older adults", "diabetes", "high ASCVD risk"],
+  "decision_context": "clinical net benefit"
+}
+```
+
+对哈勃常数张力，scope 会变成：
+
+```json
+{
+  "kind": "exploration_scope",
+  "quantity": "H0",
+  "early_universe_inference": ["Planck CMB under Lambda-CDM", "BAO + BBN"],
+  "late_universe_measurement": ["SH0ES", "TRGB", "strong lensing", "standard sirens"],
+  "model_families": ["Lambda-CDM", "early dark energy", "modified gravity"],
+  "assessment_dimensions": ["systematics", "model dependence", "global fit", "parameter degeneracy"]
+}
+```
+
+### 4.2 Landscape Builder
+
+职责：breadth-first 建立领域地图。
+
+它应该做：
+
+- query planning；
+- 多 query 检索；
+- 去重；
+- paper / artifact-level 聚类；
+- evidence family / model family 标注；
+- 代表性材料排序；
+- coverage map。
+
+阿司匹林例子里，landscape 不应该一上来 pull 某篇 paper 的全部 claims，而应该先形成：
+
+```json
+{
+  "kind": "landscape",
+  "clusters": [
+    {"type": "major_rct", "items": ["ASPREE", "ARRIVE", "ASCEND"]},
+    {"type": "meta_analysis", "items": ["updated primary prevention meta-analysis"]},
+    {"type": "guideline", "items": ["USPSTF", "ACC/AHA", "ESC"]},
+    {"type": "subgroup", "items": ["diabetes", "older adults", "high ASCVD risk"]}
+  ],
+  "coverage": ["benefit", "harm", "mortality", "subgroups", "guidelines"]
+}
+```
+
+哈勃张力例子里，landscape 应该是：
+
+```json
+{
+  "kind": "landscape",
+  "evidence_families": [
+    "Planck CMB",
+    "ACT/SPT",
+    "BAO+BBN",
+    "SH0ES Cepheids+SNe",
+    "TRGB",
+    "strong lensing",
+    "standard sirens"
+  ],
+  "model_families": [
+    "Lambda-CDM",
+    "early dark energy",
+    "modified gravity",
+    "extra relativistic species"
+  ]
+}
+```
+
+### 4.3 Frontier / Obligation Mapper
+
+职责：从 landscape 和当前 Gaia graph 中找值得后续分析的区域。
+
+它输出的不是最终结论，而是 candidate focus：
+
+```json
+{
+  "candidate_foci": [
+    {
+      "kind": "tension",
+      "text": "MI risk reduction vs no clear mortality benefit",
+      "why_it_matters": "benefit signal may not translate into clinically decisive outcome"
+    },
+    {
+      "kind": "tension",
+      "text": "ischemic benefit vs major bleeding harm",
+      "why_it_matters": "central benefit-harm tradeoff"
+    },
+    {
+      "kind": "gap",
+      "text": "individual net benefit depends on baseline CVD and bleeding risk",
+      "why_it_matters": "bridges population evidence to recommendation"
+    }
+  ]
+}
+```
+
+这一步是 `gaia-lkm-explore` 现有 frontier 的升级版：从 claim-level frontier 变成 landscape-aware frontier。
+
+### 4.4 Explore Gate
+
+Explore 结束时要过一个 gate，判断它是否适合交给 Assess。
+
+Gate 不问“结论对不对”，只问：
+
+- 是否覆盖主要 evidence/model family？
+- candidate foci 是否有 provenance？
+- 是否区分了 paper-level landscape 和 claim-level details？
+- 是否暴露了 candidate contradictions / gaps / obligations？
+- 是否避免把 retrieval score 当作 confidence？
+
+## 5. Explore 的 typed artifact
+
+建议 `gaia-lkm-explore` 的输出不要只是 `.gaia/exploration/map.json`，而是补一个更清楚的 artifact：
+
+```json
+{
+  "schema": "gaia.sop.artifact.v1",
+  "kind": "lkm_exploration",
+  "id": "explore-001",
+  "inputs": {
+    "seed": "...",
+    "scope": {}
+  },
+  "artifacts": {
+    "landscape": {},
+    "candidate_foci": [],
+    "exploration_graph": ".gaia/exploration/map.json",
+    "gaia_ir": ".gaia/ir.json",
+    "beliefs": ".gaia/beliefs.json"
+  },
+  "audit": {
+    "coverage": {},
+    "known_limitations": [],
+    "allowed_next_steps": ["assess"]
+  }
+}
+```
+
+这个 artifact 是 Explore 交给 Assess 的正式接口。
+
+## 6. Assess 应该怎么接
+
+Assess 不应该重新从自然语言问题开始，也不应该直接吞完整 raw frontier。
+
+它应该接收一个 focus：
+
+```bash
+gaia-evidence assess \
+  --exploration ./topic-gaia/.gaia/exploration/artifact.json \
+  --focus tension:<id> \
+  --world graph-plus-lkm \
+  --out ./runs/assess-001
+```
+
+也可以保留大文档里定义的 graph 入口：
+
+```bash
+gaia-evidence assess \
+  --graph ./topic-gaia \
+  --focus contradiction:<id> \
+  --world graph-plus-lkm \
+  --out ./runs/assess-001
+```
+
+关键是两种入口进入统一 context：
+
+```json
+{
+  "origin": "lkm_exploration | seed_question | gaia_graph",
+  "focus": {
+    "kind": "claim | question | contradiction | gap | tension | graph_region",
+    "id": "...",
+    "text": "..."
+  },
+  "known_claims": [],
+  "known_relations": [],
+  "candidate_evidence": [],
+  "open_obligations": [],
+  "retrieval_boundary": {},
+  "world_mode": "graph_only | graph_plus_lkm"
+}
+```
+
+## 7. Assess 的职责边界
+
+Assess 负责：
+
+- 判断矛盾成因；
+- 区分 support / oppose / limit / conditional / insufficient evidence；
+- 识别 evidence coverage；
+- 诊断 remaining gaps；
+- 形成 next tests；
+- 为 Propose 提供可执行的 gap。
+
+Assess 不负责：
+
+- 大规模开放探索；
+- 直接执行实验；
+- 直接回写 LKM；
+- 把所有 raw claims 都 formalize 成 Gaia graph。
+
+Assess 输出：
+
+```json
+{
+  "kind": "evidence_assessment",
+  "origin": "lkm_exploration",
+  "focus": {},
+  "evidence_pool": [],
+  "contradiction_diagnosis": [],
+  "gap_map": [],
+  "next_tests": [],
+  "promotion_suggestions": [],
+  "audit": {}
+}
+```
+
+这个输出正好进入大闭环的下一步：
+
+```text
+Assess -> Propose
+```
+
+## 8. 和 Propose / Discover / Merge 如何整合
+
+前两步的目标不是直接产生 research proposal，而是给 `gaia-propose` 一个干净输入。
+
+### Assess 到 Propose
+
+`gaia-propose direction` 应该吃 assessment artifact：
+
+```bash
+gaia-propose direction \
+  --assessment ./runs/assess-001 \
+  --out ./runs/proposal-001
+```
+
+它关注：
+
+- 哪个 gap 最值得研究；
+- 最小判别实验 / 计算 / 分析是什么；
+- 结果 A/B/C 分别会更新哪些 belief；
+- stop condition 是什么。
+
+### Propose 到 Discover
+
+`gaia-discovery run` 执行 proposal：
+
+```bash
+gaia-discovery run \
+  --proposal ./runs/proposal-001 \
+  --mode manual-result | script-result | literature-result \
+  --out ./runs/discovery-001
+```
+
+Explore/Assess 在这里的作用是减少无意义 proposal：proposal 必须来自被证据评估过的 gap。
+
+### Discover 到 Merge
+
+Discovery 产出的 result claims 经审计后 promote 回 Gaia：
+
+```bash
+gaia-discovery promote \
+  --discovery ./runs/discovery-001 \
+  --to-gaia ./topic-gaia
+
+gaia-lkm-merge prepare \
+  --package ./topic-gaia \
+  --out ./runs/merge-001
+```
+
+Merge 的职责是更新 belief，并准备 LKM 回灌。Explore/Assess 只提供上游上下文，不直接 submit。
+
+## 9. gaia-lkm-explore 具体如何改
+
+我建议不要把 `gaia-lkm-explore` 改成大而全的 workbench。它仍然只负责 Explore，但 Explore 内部要更结构化。
+
+### 保留现有能力
+
+现有命令仍然有价值：
+
+```bash
+gaia-lkm-explore init
+gaia-lkm-explore observe
+gaia-lkm-explore frontier
+gaia-lkm-explore turn
+gaia-lkm-explore render
+gaia-lkm-explore status
+```
+
+但 `turn` 不应永远是默认的第一动作。它更适合成为 targeted deep dive 的一种策略。
+
+### 新增 Explore 层命令
+
+建议新增：
+
+```bash
+gaia-lkm-explore scope ./topic-gaia --seed "..."
+gaia-lkm-explore landscape ./topic-gaia --from-scope scope.json
+gaia-lkm-explore foci ./topic-gaia --from-landscape landscape.json
+gaia-lkm-explore artifact ./topic-gaia
+gaia-lkm-explore gate ./topic-gaia
+```
+
+语义：
+
+- `scope`：生成或修订 exploration scope。
+- `landscape`：breadth-first 建 evidence/model landscape。
+- `foci`：生成 candidate tensions / gaps / obligations。
+- `artifact`：导出标准 `lkm_exploration` artifact。
+- `gate`：检查是否可以交给 `gaia-evidence assess`。
+
+### 现有 frontier 如何融入
+
+当前 frontier 不废弃，而是下沉为：
+
+```bash
+gaia-lkm-explore turn ./topic-gaia --focus <focus-id>
+```
+
+也就是：
+
+```text
+landscape-aware foci
+  -> selected focus
+  -> targeted frontier expansion
+  -> materialize relevant claims
+```
+
+这样 frontier expansion 不再盲目扩张，而是服务某个 focus。
+
+## 10. 应用场景
+
+### 医学证据综合：阿司匹林一级预防
+
+Explore 建 landscape：
+
+- RCT：ASPREE、ARRIVE、ASCEND；
+- meta-analysis；
+- guideline：USPSTF、ACC/AHA、ESC；
+- subgroup：older adults、diabetes、高 ASCVD risk；
+- benefit-harm model。
+
+Explore 输出 foci：
+
+- MI 下降 vs mortality no clear benefit；
+- ischemic benefit vs major bleeding harm；
+- older adults harm signal vs selected subgroup benefit；
+- population-level recommendation vs individualized net benefit。
+
+Assess 接手其中一个 focus，例如：
+
+```text
+ischemic benefit vs major bleeding harm
+```
+
+Assess 输出：
+
+- 证据是否一致；
+- 哪些人群适用；
+- harm/benefit magnitude；
+- 剩余 gap；
+- 是否需要个体化 benefit-harm model。
+
+然后 Propose 才提出下一步研究任务。
+
+### 数学物理理论问题：哈勃常数张力
+
+Explore 建 landscape：
+
+- early universe: Planck CMB、ACT/SPT、BAO+BBN；
+- late universe: SH0ES、TRGB、strong lensing、standard sirens；
+- model families: Lambda-CDM、early dark energy、modified gravity、N_eff。
+
+Explore 输出 foci：
+
+- Planck inferred H0 vs SH0ES local H0；
+- Cepheid ladder vs TRGB ladder；
+- new physics vs local systematics；
+- H0 improvement vs S8/BAO/CMB side effects。
+
+Assess 接手其中一个 focus，例如：
+
+```text
+early dark energy can reduce H0 tension without degrading global fit
+```
+
+Assess 评估：
+
+- fit improvement；
+- Bayesian evidence；
+- BAO/SNe compatibility；
+- S8 side effects；
+- parameter degeneracy；
+- fine-tuning；
+- independent predictions。
+
+### 工程技术选型
+
+Explore 建 landscape：
+
+- docs；
+- benchmarks；
+- GitHub issues；
+- case studies；
+- pricing；
+- integration constraints。
+
+Explore 输出 foci：
+
+- latency vs cost；
+- maturity vs flexibility；
+- cloud lock-in vs self-hosting；
+- feature richness vs operational complexity。
+
+Assess 评估具体 focus，例如：
+
+```text
+self-hosted option reduces vendor lock-in but increases operational burden
+```
+
+然后 Propose 可以产出最小 PoC 或 benchmark plan。
+
+## 11. 最小实现路线
+
+### Phase 0: Instrument 当前 explore
+
+先补齐当前流程记录：
+
+- query plan；
+- raw hits；
+- unique papers；
+- pulled papers；
+- generated claims；
+- selected root claims；
+- frontier size；
+- active time；
+- user decisions；
+- failure / timeout。
+
+目的：量化检索效率、claim 转化率、frontier 噪声。
+
+### Phase 1: 定义 Explore artifact schema
+
+先实现：
+
+```text
+exploration_scope.json
+landscape.json
+candidate_foci.json
+lkm_exploration.artifact.json
+explore_gate_report.json
+```
+
+这些 contract 比算法更重要。
+
+### Phase 2: 做 breadth-first landscape
+
+实现：
+
+- 从 scope 生成 query plan；
+- 每个 query 拉 top-k；
+- paper/artifact 去重；
+- evidence/model family 分类；
+- 输出 landscape；
+- 暂时不 deep pull。
+
+### Phase 3: 做 foci / obligation mapper
+
+从 landscape 和已有 Gaia graph 生成：
+
+- candidate tensions；
+- gaps；
+- open obligations；
+- recommended assess foci。
+
+初期可以 LLM-assisted，后面加 domain templates。
+
+### Phase 4: 打通 Assess handoff
+
+让 `gaia-evidence assess` 能吃：
+
+```bash
+--exploration lkm_exploration.artifact.json
+--focus <focus-id>
+```
+
+并生成标准 assessment context。
+
+### Phase 5: 把现有 turn 改成 focus-aware
+
+支持：
+
+```bash
+gaia-lkm-explore turn ./topic-gaia --focus <focus-id>
+```
+
+这样 deep dive 服务某个 focus，而不是在全局 frontier 里漂移。
+
+## 12. MVP
+
+最小版本不要一次做完整闭环。
+
+只做前两步的接口打通：
+
+```text
+gaia-lkm-explore landscape
+gaia-lkm-explore foci
+gaia-lkm-explore artifact
+gaia-evidence assess --exploration ... --focus ...
+```
+
+验收标准：
+
+- Explore 能生成 paper/artifact-level landscape。
+- Explore 能暴露 candidate tensions/gaps。
+- Assess 能消费 focus，而不是从头搜。
+- Assess 能输出 gap_map / next_tests，供 Propose 使用。
+
+## 13. 一句话定位
+
+这份 proposal 是大闭环：
+
+```text
+Explore -> Assess -> Propose -> Discover -> Merge
+```
+
+中前两步的细化设计。
+
+它建议把 `gaia-lkm-explore` 定位为真正的 Explore 模块：负责建立 landscape、暴露 foci、生成 typed exploration artifact；把 Evidence Assessment 定位为第二步：负责围绕 focus 诊断证据、解释矛盾、生成 gap_map 和 next_tests。
+
+这样后面的 Propose / Discover / Merge 就不再面对散乱搜索结果，而是面对经过 Explore 和 Assess 整理过的、可审计的研究问题。

--- a/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
+++ b/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
@@ -4,9 +4,13 @@
 >
 > **Date:** 2026-05-25
 >
+> **Updated:** 2026-05-26
+>
 > **Scope:** `gaia-lkm-explore`, its handoff to `gaia-evidence assess`,
 > and the first two stages of the larger Gaia research loop:
-> `Explore -> Assess -> Propose -> Discover -> Merge`.
+> `Explore -> Assess -> Propose -> Discover -> Merge`. This revision also
+> defines the Gaia-side independent MVP that can later be wrapped by an
+> external Scientific Agent CLI/TUI harness.
 
 ## Proposal: 细化 Gaia 研究闭环中的 Explore 与 Assess
 
@@ -42,6 +46,45 @@ Explore -> Assess
 - Evidence assessment 应该从哪里接手？
 - Explore 和 Assess 之间的 typed artifact 应该长什么样？
 - 这两步如何给后面的 `Propose -> Discover -> Merge` 提供干净输入？
+- Gaia 这边应该先独立开发哪一层，才能以后被外部 agent harness 稳定调用？
+
+## 0. Gaia-side 独立推进定位
+
+近期讨论里出现了一个相邻但不同的产品方向：建设一个可分发的
+Scientific Agent CLI/TUI，让 agent 通过本地安装、登录认证、dry run、权限
+gate、telemetry、审计日志和轨迹回放，主动把实验室环境改造成 agent-ready
+CLI。这个方向很重要，但它不应该成为 Gaia 第一阶段的开发范围。
+
+Gaia 这边第一阶段要独立做的是 **Research Loop Core**：
+
+```text
+agent / human / future TUI
+  -> calls Gaia/LKM commands
+  -> exchanges typed artifacts
+  -> receives auditable research next steps
+```
+
+也就是说，Gaia 暂时不做外层 agent 产品，不做 TUI，不做公司级账号、遥测、
+灰度发布或真实实验室设备接入。Gaia 负责提供稳定的科研语义内核：
+
+- 把开放研究问题变成 evidence landscape 和 candidate foci；
+- 对某个 focus 做 evidence assessment，诊断矛盾与 gap；
+- 产出可审计的 artifact，供下一步 proposal / discovery / merge 使用；
+- 让外部 agent 只需要按 contract 读写 artifact、调用 CLI，就能接入 Gaia。
+
+这个边界能让 Gaia 和未来的 Scientific Agent CLI/TUI 互补：
+
+```text
+Scientific Agent harness:
+  Plan / Edit / Execute / Review UI, auth, telemetry, operational gates,
+  environment refactoring, Lab CLI scaffold.
+
+Gaia Research Loop Core:
+  research semantics, LKM retrieval, evidence landscape, assessment,
+  belief updates, audit artifacts, registry / LKM handoff.
+```
+
+因此本 spec 的 MVP 不包含 agent harness 本体，而是把 Gaia/LKM 的后端协议先做稳。
 
 ## 1. 为什么需要重新拆前两步
 
@@ -295,6 +338,21 @@ Gate 不问“结论对不对”，只问：
 
 这个 artifact 是 Explore 交给 Assess 的正式接口。
 
+它同时是外部 agent harness 接 Gaia 的第一层稳定接口。外部 harness 可以负责
+把用户目标、实验日志、Lab CLI 输出或人工决策整理成输入；Gaia 只承诺消费和
+生产 typed artifacts。第一版必须优先稳定下面这些字段，而不是追求 retrieval
+或 classification 算法一步到位：
+
+- `schema` / `kind` / `id`：让外部系统能做版本判断和路由。
+- `inputs`：记录 seed、scope、调用参数和上游来源。
+- `artifacts`：只放可复现路径或结构化 payload，不放 prompt-only 状态。
+- `provenance`：记录 query、LKM result、paper/artifact id、Gaia graph source。
+- `audit`：记录 coverage、known limitations、gate status、allowed next steps。
+- `interface`：记录下游可调用命令，例如 `gaia-evidence assess --exploration ...`。
+
+因此第一版 artifact 可以比最终 schema 小，但不能是临时日志；它必须能被
+`gaia-evidence assess`、脚本和未来 TUI 作为同一个 contract 使用。
+
 ## 6. Assess 应该怎么接
 
 Assess 不应该重新从自然语言问题开始，也不应该直接吞完整 raw frontier。
@@ -360,7 +418,9 @@ Assess 输出：
 
 ```json
 {
+  "schema": "gaia.sop.artifact.v1",
   "kind": "evidence_assessment",
+  "id": "assess-001",
   "origin": "lkm_exploration",
   "focus": {},
   "evidence_pool": [],
@@ -368,7 +428,11 @@ Assess 输出：
   "gap_map": [],
   "next_tests": [],
   "promotion_suggestions": [],
-  "audit": {}
+  "audit": {
+    "coverage": {},
+    "known_limitations": [],
+    "allowed_next_steps": ["propose"]
+  }
 }
 ```
 
@@ -578,11 +642,81 @@ self-hosted option reduces vendor lock-in but increases operational burden
 
 然后 Propose 可以产出最小 PoC 或 benchmark plan。
 
-## 11. 最小实现路线
+## 11. Gaia Research Loop Core MVP
 
-### Phase 0: Instrument 当前 explore
+最小版本不要一次做完整闭环，也不要先做外层 agent 产品。第一阶段只做
+Gaia/LKM 后端协议和前两步能力，让外部 agent 或人类用户能按同一条命令链调用。
 
-先补齐当前流程记录：
+MVP 名称：
+
+```text
+Gaia Explore/Assess Artifact MVP
+```
+
+MVP 命令链：
+
+```bash
+gaia-lkm-explore scope ./topic-gaia --seed "..."
+gaia-lkm-explore landscape ./topic-gaia
+gaia-lkm-explore foci ./topic-gaia
+gaia-lkm-explore artifact ./topic-gaia
+gaia-lkm-explore gate ./topic-gaia
+
+gaia-evidence assess \
+  --exploration ./topic-gaia/.gaia/exploration/artifact.json \
+  --focus tension:<id> \
+  --out ./runs/assess-001
+```
+
+MVP 交付物：
+
+- `exploration_scope.json`
+- `landscape.json`
+- `candidate_foci.json`
+- `lkm_exploration.artifact.json`
+- `explore_gate_report.json`
+- `assessment_context.json`
+- `evidence_assessment.artifact.json`
+- 一份 “external agent integration” 文档，说明外部 harness 只需调用哪些命令、读写哪些 artifact。
+
+不在 MVP 范围内：
+
+- 自研 TUI / desktop / VSCode plugin；
+- 公司级 auth、telemetry、灰度发布和发包系统；
+- Lab CLI scaffold 和真实实验设备接入；
+- 自动执行实验或自动回写 LKM；
+- 完整的 `Propose -> Discover -> Merge` 实现。
+
+这些能力属于 Scientific Agent harness 或后续 Gaia 阶段。MVP 只保证：一个
+agent 可以把 Gaia 当作 research loop backend 调用。
+
+## 12. 实现路线
+
+### Phase 0: 固定 artifact contract
+
+先实现 schema 和读写位置，不追求算法完美：
+
+```text
+.gaia/exploration/scope.json
+.gaia/exploration/landscape.json
+.gaia/exploration/foci.json
+.gaia/exploration/artifact.json
+.gaia/exploration/gate_report.json
+runs/<id>/assessment_context.json
+runs/<id>/assessment.artifact.json
+```
+
+contract 必须包含：
+
+- `schema` / `kind` / `id`；
+- `inputs` / `provenance`；
+- `artifacts`；
+- `audit.coverage` / `audit.known_limitations` / `audit.allowed_next_steps`；
+- gate status 和人类可读的 failure reasons。
+
+### Phase 1: Instrument 当前 explore
+
+在现有 `gaia-lkm-explore` 上补齐可复现记录：
 
 - query plan；
 - raw hits；
@@ -595,21 +729,8 @@ self-hosted option reduces vendor lock-in but increases operational burden
 - user decisions；
 - failure / timeout。
 
-目的：量化检索效率、claim 转化率、frontier 噪声。
-
-### Phase 1: 定义 Explore artifact schema
-
-先实现：
-
-```text
-exploration_scope.json
-landscape.json
-candidate_foci.json
-lkm_exploration.artifact.json
-explore_gate_report.json
-```
-
-这些 contract 比算法更重要。
+目的：让 artifact 的 provenance 有真实来源，也量化检索效率、claim 转化率和
+frontier 噪声。
 
 ### Phase 2: 做 breadth-first landscape
 
@@ -622,6 +743,8 @@ explore_gate_report.json
 - 输出 landscape；
 - 暂时不 deep pull。
 
+这一步的成功标准是 paper/artifact-level landscape，而不是 claim-level 深挖。
+
 ### Phase 3: 做 foci / obligation mapper
 
 从 landscape 和已有 Gaia graph 生成：
@@ -631,7 +754,8 @@ explore_gate_report.json
 - open obligations；
 - recommended assess foci。
 
-初期可以 LLM-assisted，后面加 domain templates。
+初期可以 LLM-assisted，后面加 domain templates。每个 focus 必须带 provenance，
+不能只是自然语言猜测。
 
 ### Phase 4: 打通 Assess handoff
 
@@ -642,7 +766,9 @@ explore_gate_report.json
 --focus <focus-id>
 ```
 
-并生成标准 assessment context。
+并生成标准 assessment context，再输出 `evidence_assessment.artifact.json`。
+第一版 assessment 可以是 conservative summary + gap/next-test mapper，不需要
+一次完成完整 scientific reviewer。
 
 ### Phase 5: 把现有 turn 改成 focus-aware
 
@@ -654,27 +780,16 @@ gaia-lkm-explore turn ./topic-gaia --focus <focus-id>
 
 这样 deep dive 服务某个 focus，而不是在全局 frontier 里漂移。
 
-## 12. MVP
-
-最小版本不要一次做完整闭环。
-
-只做前两步的接口打通：
-
-```text
-gaia-lkm-explore landscape
-gaia-lkm-explore foci
-gaia-lkm-explore artifact
-gaia-evidence assess --exploration ... --focus ...
-```
-
-验收标准：
+## 13. MVP 验收标准
 
 - Explore 能生成 paper/artifact-level landscape。
-- Explore 能暴露 candidate tensions/gaps。
+- Explore 能暴露 candidate tensions/gaps，并为每个 focus 记录 provenance。
+- `gaia-lkm-explore gate` 能判断 artifact 是否足够交给 Assess。
 - Assess 能消费 focus，而不是从头搜。
-- Assess 能输出 gap_map / next_tests，供 Propose 使用。
+- Assess 能输出 `gap_map` / `next_tests`，供 Propose 使用。
+- 外部 agent 可以只靠命令链和 artifact contract 接入，不需要理解 Gaia 内部数据结构。
 
-## 13. 一句话定位
+## 14. 一句话定位
 
 这份 proposal 是大闭环：
 
@@ -682,8 +797,8 @@ gaia-evidence assess --exploration ... --focus ...
 Explore -> Assess -> Propose -> Discover -> Merge
 ```
 
-中前两步的细化设计。
+中前两步的细化设计，也是 Gaia 侧可独立开发的 Research Loop Core MVP。
 
 它建议把 `gaia-lkm-explore` 定位为真正的 Explore 模块：负责建立 landscape、暴露 foci、生成 typed exploration artifact；把 Evidence Assessment 定位为第二步：负责围绕 focus 诊断证据、解释矛盾、生成 gap_map 和 next_tests。
 
-这样后面的 Propose / Discover / Merge 就不再面对散乱搜索结果，而是面对经过 Explore 和 Assess 整理过的、可审计的研究问题。
+这样后面的 Propose / Discover / Merge 就不再面对散乱搜索结果，而是面对经过 Explore 和 Assess 整理过的、可审计的研究问题；未来外部 Scientific Agent CLI/TUI 也可以把 Gaia 当作稳定 research backend，而不是侵入 Gaia 内部实现。

--- a/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
+++ b/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
@@ -48,6 +48,38 @@ Explore -> Assess
 - 这两步如何给后面的 `Propose -> Discover -> Merge` 提供干净输入？
 - Gaia 这边应该先独立开发哪一层，才能以后被外部 agent harness 稳定调用？
 
+## Current main baseline, 2026-05-26
+
+After merging the latest `origin/main`, part of this proposal is no longer
+purely future-facing. The current baseline already includes:
+
+- a unified sibling CLI entrypoint, `gaia-lkm-explore`, under
+  `gaia.lkm_explorer.client`;
+- deterministic engine verbs including `init`, `observe`, `landscape`,
+  `frontier`, `round`, `status`, and `render`;
+- a neutral paper-level `landscape` command that aggregates saved
+  `gaia search lkm` result envelopes before deep pulls;
+- MapHealth connectivity, orphan/island detection, ratified separations, and
+  consolidate-oriented readouts;
+- pulled-paper claim triage metadata and `frontier --triage-pulled`;
+- checkpoint-time promotion of pulled-paper `depends_on` scaffolds into live
+  `derive` strategies for exploration inference.
+
+The remaining proposal should therefore be read as the next layer on top of
+that baseline, not as a replacement for it. The main missing pieces are:
+
+- a first-class `scope` artifact rather than ad hoc seed text;
+- a `foci` / obligation artifact that turns landscape findings into assessment
+  targets;
+- a standard `lkm_exploration` artifact envelope with provenance and gate
+  status;
+- an explicit Explore gate that decides whether the artifact is ready for
+  assessment;
+- a `gaia-evidence assess --exploration ... --focus ...` handoff and matching
+  assessment context schema;
+- focus-aware deep-dive turns, so frontier expansion serves a chosen focus
+  rather than only the global open frontier.
+
 ## 0. Gaia-side 独立推进定位
 
 近期讨论里出现了一个相邻但不同的产品方向：建设一个可分发的

--- a/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
+++ b/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
@@ -69,7 +69,7 @@ The remaining proposal should therefore be read as the next layer on top of
 that baseline, not as a replacement for it. The main missing pieces are:
 
 - a first-class `scope` artifact rather than ad hoc seed text;
-- a `foci` / obligation artifact that turns landscape findings into assessment
+- a `focuses` / obligation artifact that turns landscape findings into assessment
   targets;
 - a standard `lkm_exploration` artifact envelope with provenance and gate
   status;
@@ -99,7 +99,7 @@ agent / human / future TUI
 也就是说，Gaia 暂时不做外层 agent 产品，不做 TUI，不做公司级账号、遥测、
 灰度发布或真实实验室设备接入。Gaia 负责提供稳定的科研语义内核：
 
-- 把开放研究问题变成 evidence landscape 和 candidate foci；
+- 把开放研究问题变成 evidence landscape 和 candidate focuses（候选分析焦点）；
 - 对某个 focus 做 evidence assessment，诊断矛盾与 gap；
 - 产出可审计的 artifact，供下一步 proposal / discovery / merge 使用；
 - 让外部 agent 只需要按 contract 读写 artifact、调用 CLI，就能接入 Gaia。
@@ -306,7 +306,7 @@ Assess
 
 ```json
 {
-  "candidate_foci": [
+  "candidate_focuses": [
     {
       "kind": "tension",
       "text": "MI risk reduction vs no clear mortality benefit",
@@ -335,7 +335,7 @@ Explore 结束时要过一个 gate，判断它是否适合交给 Assess。
 Gate 不问“结论对不对”，只问：
 
 - 是否覆盖主要 evidence/model family？
-- candidate foci 是否有 provenance？
+- candidate focuses 是否有 provenance？
 - 是否区分了 paper-level landscape 和 claim-level details？
 - 是否暴露了 candidate contradictions / gaps / obligations？
 - 是否避免把 retrieval score 当作 confidence？
@@ -355,7 +355,7 @@ Gate 不问“结论对不对”，只问：
   },
   "artifacts": {
     "landscape": {},
-    "candidate_foci": [],
+    "candidate_focuses": [],
     "exploration_graph": ".gaia/exploration/map.json",
     "gaia_ir": ".gaia/ir.json",
     "beliefs": ".gaia/beliefs.json"
@@ -550,7 +550,7 @@ gaia-lkm-explore status
 ```bash
 gaia-lkm-explore scope ./topic-gaia --seed "..."
 gaia-lkm-explore landscape ./topic-gaia --from-scope scope.json
-gaia-lkm-explore foci ./topic-gaia --from-landscape landscape.json
+gaia-lkm-explore focuses ./topic-gaia --from-landscape landscape.json
 gaia-lkm-explore artifact ./topic-gaia
 gaia-lkm-explore gate ./topic-gaia
 ```
@@ -559,7 +559,7 @@ gaia-lkm-explore gate ./topic-gaia
 
 - `scope`：生成或修订 exploration scope。
 - `landscape`：breadth-first 建 evidence/model landscape。
-- `foci`：生成 candidate tensions / gaps / obligations。
+- `focuses`：生成 candidate tensions / gaps / obligations as assessment focuses。
 - `artifact`：导出标准 `lkm_exploration` artifact。
 - `gate`：检查是否可以交给 `gaia-evidence assess`。
 
@@ -574,7 +574,7 @@ gaia-lkm-explore turn ./topic-gaia --focus <focus-id>
 也就是：
 
 ```text
-landscape-aware foci
+landscape-aware focuses
   -> selected focus
   -> targeted frontier expansion
   -> materialize relevant claims
@@ -594,7 +594,7 @@ Explore 建 landscape：
 - subgroup：older adults、diabetes、高 ASCVD risk；
 - benefit-harm model。
 
-Explore 输出 foci：
+Explore 输出 focuses：
 
 - MI 下降 vs mortality no clear benefit；
 - ischemic benefit vs major bleeding harm；
@@ -625,7 +625,7 @@ Explore 建 landscape：
 - late universe: SH0ES、TRGB、strong lensing、standard sirens；
 - model families: Lambda-CDM、early dark energy、modified gravity、N_eff。
 
-Explore 输出 foci：
+Explore 输出 focuses：
 
 - Planck inferred H0 vs SH0ES local H0；
 - Cepheid ladder vs TRGB ladder；
@@ -659,7 +659,7 @@ Explore 建 landscape：
 - pricing；
 - integration constraints。
 
-Explore 输出 foci：
+Explore 输出 focuses：
 
 - latency vs cost；
 - maturity vs flexibility；
@@ -690,7 +690,7 @@ MVP 命令链：
 ```bash
 gaia-lkm-explore scope ./topic-gaia --seed "..."
 gaia-lkm-explore landscape ./topic-gaia
-gaia-lkm-explore foci ./topic-gaia
+gaia-lkm-explore focuses ./topic-gaia
 gaia-lkm-explore artifact ./topic-gaia
 gaia-lkm-explore gate ./topic-gaia
 
@@ -704,7 +704,7 @@ MVP 交付物：
 
 - `exploration_scope.json`
 - `landscape.json`
-- `candidate_foci.json`
+- `candidate_focuses.json`
 - `lkm_exploration.artifact.json`
 - `explore_gate_report.json`
 - `assessment_context.json`
@@ -731,7 +731,7 @@ agent 可以把 Gaia 当作 research loop backend 调用。
 ```text
 .gaia/exploration/scope.json
 .gaia/exploration/landscape.json
-.gaia/exploration/foci.json
+.gaia/exploration/focuses.json
 .gaia/exploration/artifact.json
 .gaia/exploration/gate_report.json
 runs/<id>/assessment_context.json
@@ -777,14 +777,14 @@ frontier 噪声。
 
 这一步的成功标准是 paper/artifact-level landscape，而不是 claim-level 深挖。
 
-### Phase 3: 做 foci / obligation mapper
+### Phase 3: 做 focuses / obligation mapper
 
 从 landscape 和已有 Gaia graph 生成：
 
 - candidate tensions；
 - gaps；
 - open obligations；
-- recommended assess foci。
+- recommended assessment focuses。
 
 初期可以 LLM-assisted，后面加 domain templates。每个 focus 必须带 provenance，
 不能只是自然语言猜测。
@@ -831,6 +831,6 @@ Explore -> Assess -> Propose -> Discover -> Merge
 
 中前两步的细化设计，也是 Gaia 侧可独立开发的 Research Loop Core MVP。
 
-它建议把 `gaia-lkm-explore` 定位为真正的 Explore 模块：负责建立 landscape、暴露 foci、生成 typed exploration artifact；把 Evidence Assessment 定位为第二步：负责围绕 focus 诊断证据、解释矛盾、生成 gap_map 和 next_tests。
+它建议把 `gaia-lkm-explore` 定位为真正的 Explore 模块：负责建立 landscape、暴露 focuses（分析焦点）、生成 typed exploration artifact；把 Evidence Assessment 定位为第二步：负责围绕 focus 诊断证据、解释矛盾、生成 gap_map 和 next_tests。
 
 这样后面的 Propose / Discover / Merge 就不再面对散乱搜索结果，而是面对经过 Explore 和 Assess 整理过的、可审计的研究问题；未来外部 Scientific Agent CLI/TUI 也可以把 Gaia 当作稳定 research backend，而不是侵入 Gaia 内部实现。

--- a/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
+++ b/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
@@ -80,6 +80,11 @@ that baseline, not as a replacement for it. The main missing pieces are:
 - focus-aware deep-dive turns, so frontier expansion serves a chosen focus
   rather than only the global open frontier.
 
+The first implementation slice is specified in
+[LKM Explore Artifact MVP Design](2026-05-26-lkm-explore-artifact-mvp-design.md).
+It covers the additive Explore-side artifacts (`scope`, `focuses`, `artifact`,
+and `gate`) and leaves `gaia-evidence assess` for a later spec.
+
 ## 0. Gaia-side 独立推进定位
 
 近期讨论里出现了一个相邻但不同的产品方向：建设一个可分发的

--- a/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
+++ b/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
@@ -381,7 +381,6 @@ Required checks:
 - `focuses_present`
 - `has_assessable_focus`
 - `focuses_have_evidence_refs`
-- `artifact_present`
 - `schema_versions_supported`
 
 Optional warning checks:
@@ -389,6 +388,10 @@ Optional warning checks:
 - `compiled_ir_present`
 - `beliefs_present`
 - `rounds_present`
+
+`gate` loads the existing Explore artifact envelope or generates it before
+building the report, so artifact envelope availability is a command invariant
+rather than a separate report check.
 
 ### 10.4 Verdicts
 

--- a/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
+++ b/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
@@ -1,0 +1,488 @@
+# LKM Explore Artifact MVP Design
+
+> **Status:** Draft
+>
+> **Date:** 2026-05-26
+>
+> **Parent spec:** [Gaia LKM Explore and Evidence Assess Design](2026-05-25-gaia-lkm-explore-assess-design.md)
+>
+> **Scope:** The first implementation slice of the parent spec: make
+> `gaia-lkm-explore` produce typed Explore artifacts (`scope`, `focuses`,
+> `artifact`, and `gate`) while preserving the existing frontier-driven
+> exploration loop.
+
+## 1. Goal
+
+This sub-spec defines the first concrete Explore-side change set. It does not
+implement `gaia-evidence assess`, `gaia-propose`, `gaia-discovery`, or LKM merge.
+It only makes the output of `gaia-lkm-explore` suitable for a later Assess
+handoff.
+
+The MVP goal is:
+
+```text
+existing exploration map + optional saved search landscapes
+  -> typed scope artifact
+  -> candidate assessment focuses
+  -> standard exploration artifact envelope
+  -> deterministic Explore gate report
+```
+
+After this MVP, an external human, agent, or future `gaia-evidence assess`
+command can consume one stable file:
+
+```text
+<pkg>/.gaia/exploration/artifact.json
+```
+
+and select a focus from:
+
+```text
+<pkg>/.gaia/exploration/focuses.json
+```
+
+## 2. Non-goals
+
+This MVP deliberately does not:
+
+- replace `gaia-lkm-explore turn`;
+- change `map.json`, `rounds.jsonl`, or existing `turn-*.task/result.json`
+  semantics;
+- call LKM directly from new commands;
+- require LLM access inside the engine;
+- perform evidence assessment;
+- generate research proposals;
+- make `turn` focus-aware;
+- auto-write Gaia DSL source;
+- submit anything back to LKM.
+
+All new artifacts are additive sidecars under `.gaia/exploration/`.
+
+## 3. Current baseline
+
+Latest `main` already has:
+
+- `gaia-lkm-explore init`;
+- `gaia-lkm-explore observe`;
+- `gaia-lkm-explore landscape`;
+- `gaia-lkm-explore frontier`;
+- `gaia-lkm-explore round`;
+- `gaia-lkm-explore status`;
+- `gaia-lkm-explore render`;
+- `gaia-lkm-explore turn`;
+- `frontier --triage-pulled`;
+- MapHealth and consolidate-oriented connectivity;
+- checkpoint-time promotion of pulled-paper `depends_on` scaffolds into live
+  `derive` strategies.
+
+This MVP adds a stable artifact layer on top of that baseline.
+
+## 4. Proposed command surface
+
+Add four deterministic engine verbs to the existing `gaia-lkm-explore` CLI:
+
+```bash
+gaia-lkm-explore scope ./topic-gaia --seed "..." [--profile medical]
+gaia-lkm-explore focuses ./topic-gaia [--landscape .gaia/exploration/landscape-0.json]
+gaia-lkm-explore artifact ./topic-gaia
+gaia-lkm-explore gate ./topic-gaia
+```
+
+These commands do not mutate the existing exploration map, except that `scope`
+may read seeds from `map.json` when `--seed` is omitted.
+
+## 5. Artifact paths
+
+Canonical sidecar files:
+
+```text
+<pkg>/.gaia/exploration/scope.json
+<pkg>/.gaia/exploration/focuses.json
+<pkg>/.gaia/exploration/artifact.json
+<pkg>/.gaia/exploration/gate_report.json
+```
+
+The existing `landscape` command currently writes round-numbered files such as:
+
+```text
+<pkg>/.gaia/exploration/landscape-0.json
+```
+
+The MVP should not change that behavior. `focuses` and `artifact` may discover
+the latest landscape file by default, but they should also accept an explicit
+`--landscape` path.
+
+## 6. Schema conventions
+
+Every new artifact uses the same envelope fields:
+
+```json
+{
+  "schema": "gaia.sop.artifact.v1",
+  "kind": "...",
+  "id": "...",
+  "created_at": "...",
+  "inputs": {},
+  "artifacts": {},
+  "provenance": {},
+  "audit": {}
+}
+```
+
+Rules:
+
+- `schema` is always `"gaia.sop.artifact.v1"` for this MVP.
+- `kind` is one of:
+  - `exploration_scope`
+  - `exploration_focuses`
+  - `lkm_exploration`
+  - `quality_gate_report`
+- `created_at` is UTC ISO-8601 with a trailing `Z`.
+- `id` is deterministic enough for tests and readable enough for humans. A
+  timestamp-based id is acceptable in v1.
+- `inputs` records user inputs, paths, and derived seeds.
+- `artifacts` records paths to produced or consumed artifacts.
+- `provenance` records source files, landscape ids, map version, and round.
+- `audit` records limitations and allowed next steps.
+
+## 7. Scope artifact
+
+### 7.1 Command
+
+```bash
+gaia-lkm-explore scope ./topic-gaia \
+  --seed "阿司匹林对一级预防心血管疾病的作用" \
+  --profile medical \
+  --dimension population="adults without established CVD" \
+  --dimension outcome="myocardial infarction" \
+  --dimension outcome="major bleeding"
+```
+
+### 7.2 Inputs
+
+- `pkg`: package path.
+- `--seed`: repeatable. If omitted, read existing `map.json` seeds.
+- `--profile`: optional free string, such as `medical`, `cosmology`,
+  `engineering`, or `ml-review`.
+- `--dimension`: repeatable `key=value` pair. Multiple values under the same key
+  are stored as an array.
+- `--out`: optional output path, default `.gaia/exploration/scope.json`.
+- `--json`: print the payload after writing.
+
+### 7.3 Output
+
+```json
+{
+  "schema": "gaia.sop.artifact.v1",
+  "kind": "exploration_scope",
+  "id": "scope-20260526T030000Z",
+  "created_at": "2026-05-26T03:00:00Z",
+  "inputs": {
+    "pkg": "./topic-gaia",
+    "seeds": ["阿司匹林对一级预防心血管疾病的作用"],
+    "profile": "medical",
+    "dimensions": {
+      "population": ["adults without established CVD"],
+      "outcome": ["myocardial infarction", "major bleeding"]
+    }
+  },
+  "artifacts": {
+    "map": ".gaia/exploration/map.json"
+  },
+  "provenance": {
+    "seed_source": "cli",
+    "map_round": 0
+  },
+  "audit": {
+    "known_limitations": [
+      "Scope is user-authored; no automatic domain validation is performed."
+    ],
+    "allowed_next_steps": ["landscape", "focuses", "artifact", "gate"]
+  }
+}
+```
+
+### 7.4 Human / LLM boundary
+
+The command is deterministic. It records scope supplied by a human or external
+agent. If an LLM suggests PICO fields, model families, or dimensions, that
+suggestion happens outside this command and must be passed in explicitly.
+
+## 8. Focuses artifact
+
+### 8.1 Command
+
+```bash
+gaia-lkm-explore focuses ./topic-gaia \
+  --landscape .gaia/exploration/landscape-0.json
+```
+
+### 8.2 Purpose
+
+`focuses` turns an Explore landscape into assessment candidates. It does not
+assess evidence. It produces conservative, provenance-backed candidate focuses.
+
+Initial focus sources:
+
+- landscape paper leads;
+- repeated query clusters;
+- existing open obligations from inquiry state;
+- MapHealth orphan / fragmentation readouts;
+- pulled-paper triage contacts when a compiled graph exists.
+
+The MVP may produce simple focuses. For example:
+
+- `paper_lead_cluster`: multiple high-ranked leads from the same query family;
+- `coverage_gap`: a scope dimension has no landscape evidence;
+- `map_fragment`: MapHealth reports orphan islands;
+- `open_obligation`: existing obligations need targeted exploration.
+
+It should not invent unsupported scientific tensions without source refs.
+
+### 8.3 Output
+
+```json
+{
+  "schema": "gaia.sop.artifact.v1",
+  "kind": "exploration_focuses",
+  "id": "focuses-20260526T030500Z",
+  "created_at": "2026-05-26T03:05:00Z",
+  "inputs": {
+    "pkg": "./topic-gaia",
+    "scope": ".gaia/exploration/scope.json",
+    "landscape": ".gaia/exploration/landscape-0.json"
+  },
+  "artifacts": {
+    "map": ".gaia/exploration/map.json",
+    "landscape": ".gaia/exploration/landscape-0.json"
+  },
+  "focuses": [
+    {
+      "id": "focus_landscape_top_leads",
+      "kind": "paper_lead_cluster",
+      "text": "Top unpulled paper leads from the current landscape",
+      "why_it_matters": "These papers are the highest-ranked breadth-first leads and should be considered before local claim-level expansion.",
+      "evidence_refs": [
+        {
+          "kind": "landscape_paper_lead",
+          "path": ".gaia/exploration/landscape-0.json",
+          "paper_id": "812734295629103105"
+        }
+      ],
+      "recommended_next": "assess",
+      "confidence": "structural"
+    }
+  ],
+  "provenance": {
+    "generation": "deterministic",
+    "map_round": 0
+  },
+  "audit": {
+    "known_limitations": [
+      "MVP focuses are structural and provenance-backed; domain-specific tension naming is external or future work."
+    ],
+    "allowed_next_steps": ["artifact", "gate"]
+  }
+}
+```
+
+### 8.4 Human / LLM boundary
+
+The MVP `focuses` command is deterministic and conservative. A future
+LLM-assisted agent may edit or add focuses, but any edited focus must preserve:
+
+- `id`;
+- `kind`;
+- `text`;
+- `why_it_matters`;
+- `evidence_refs`;
+- `recommended_next`.
+
+The engine gate treats focuses without `evidence_refs` as warnings or failures.
+
+## 9. Exploration artifact envelope
+
+### 9.1 Command
+
+```bash
+gaia-lkm-explore artifact ./topic-gaia
+```
+
+### 9.2 Purpose
+
+`artifact` aggregates the current Explore state into a single handoff file. It
+does not validate quality. It only records what exists and where it lives.
+
+### 9.3 Output
+
+```json
+{
+  "schema": "gaia.sop.artifact.v1",
+  "kind": "lkm_exploration",
+  "id": "explore-20260526T031000Z",
+  "created_at": "2026-05-26T03:10:00Z",
+  "inputs": {
+    "pkg": "./topic-gaia"
+  },
+  "artifacts": {
+    "scope": ".gaia/exploration/scope.json",
+    "landscape": ".gaia/exploration/landscape-0.json",
+    "focuses": ".gaia/exploration/focuses.json",
+    "map": ".gaia/exploration/map.json",
+    "rounds": ".gaia/exploration/rounds.jsonl",
+    "gaia_ir": ".gaia/ir.json",
+    "beliefs": ".gaia/beliefs.json"
+  },
+  "provenance": {
+    "map_round": 0,
+    "map_version": 1
+  },
+  "audit": {
+    "coverage": {},
+    "known_limitations": [],
+    "allowed_next_steps": ["gate"]
+  },
+  "interface": {
+    "assess": {
+      "command": "gaia-evidence assess --exploration .gaia/exploration/artifact.json --focus <focus-id>"
+    }
+  }
+}
+```
+
+If optional files are missing, record `null` and a limitation instead of
+crashing. The `gate` command decides whether missing files block handoff.
+
+## 10. Explore gate
+
+### 10.1 Command
+
+```bash
+gaia-lkm-explore gate ./topic-gaia
+```
+
+### 10.2 Purpose
+
+`gate` checks whether the Explore artifact is structurally ready for Assess. It
+does not decide whether a scientific conclusion is correct.
+
+### 10.3 Checks
+
+Required checks:
+
+- `scope_present`
+- `map_present`
+- `landscape_present`
+- `focuses_present`
+- `has_assessable_focus`
+- `focuses_have_evidence_refs`
+- `artifact_present`
+- `schema_versions_supported`
+
+Optional warning checks:
+
+- `compiled_ir_present`
+- `beliefs_present`
+- `rounds_present`
+
+### 10.4 Verdicts
+
+- `pass`: allowed next step includes `assess`.
+- `revise`: artifact can be reviewed, but Assess should wait for missing or weak
+  fields.
+- `block`: no assessable focus or core artifact is missing.
+
+### 10.5 Output
+
+```json
+{
+  "schema": "gaia.sop.artifact.v1",
+  "kind": "quality_gate_report",
+  "id": "explore-gate-20260526T031500Z",
+  "created_at": "2026-05-26T03:15:00Z",
+  "target_kind": "lkm_exploration",
+  "target": ".gaia/exploration/artifact.json",
+  "verdict": "pass",
+  "checks": [
+    {
+      "id": "focuses_have_evidence_refs",
+      "status": "pass",
+      "finding": "All 1 focuses include evidence_refs."
+    }
+  ],
+  "required_changes": [],
+  "allowed_next_steps": ["assess"]
+}
+```
+
+## 11. Backward compatibility
+
+The old path remains supported:
+
+```bash
+gaia-lkm-explore init ./pkg --seed "..."
+gaia-lkm-explore observe ./pkg --search-json leads.json
+gaia-lkm-explore turn ./pkg
+```
+
+New commands are opt-in sidecars:
+
+```bash
+gaia-lkm-explore scope ./pkg --seed "..."
+gaia-lkm-explore landscape ./pkg --search-json leads.json
+gaia-lkm-explore focuses ./pkg
+gaia-lkm-explore artifact ./pkg
+gaia-lkm-explore gate ./pkg
+```
+
+Compatibility rules:
+
+- no existing command changes required arguments;
+- no existing artifact is renamed;
+- `landscape` keeps its current saved-search aggregator behavior;
+- `artifact` and `gate` do not mutate `map.json`;
+- `turn` behavior is unchanged in this MVP.
+
+## 12. Testing requirements
+
+Unit tests:
+
+- schema payload serialization;
+- scope dimension parsing;
+- latest landscape discovery;
+- focus generation from a minimal landscape;
+- artifact envelope with present and missing optional files;
+- gate verdicts for pass, revise, and block.
+
+CLI tests:
+
+- `gaia-lkm-explore scope --help`;
+- `gaia-lkm-explore focuses --help`;
+- `gaia-lkm-explore artifact --help`;
+- `gaia-lkm-explore gate --help`;
+- smoke test for the additive path on a temporary package.
+
+Regression tests:
+
+- existing `tests/lkm_explorer/*` still pass;
+- `gaia-lkm-explore landscape` current behavior remains unchanged;
+- `gaia-lkm-explore turn` current behavior remains unchanged.
+
+## 13. Open questions
+
+1. Should `scope` be created automatically by `init`, or only by an explicit
+   command?
+   - MVP recommendation: explicit command only. Auto-create can be added later.
+
+2. Should `landscape` also write a stable `.gaia/exploration/landscape.json`
+   alias?
+   - MVP recommendation: no. Keep round-numbered output and let `artifact`
+     select the latest landscape.
+
+3. Should domain-specific focuses be generated inside Gaia?
+   - MVP recommendation: no. Gaia generates structural focuses only; domain
+     profiles can layer on later.
+
+4. Should `gate` fail when there is no compiled IR?
+   - MVP recommendation: warn, not fail. Breadth-first exploration can be useful
+     before compilation, but graph-aware Assess may later require IR.

--- a/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
+++ b/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
@@ -91,6 +91,11 @@ gaia-lkm-explore gate ./topic-gaia
 These commands do not mutate the existing exploration map, except that `scope`
 may read seeds from `map.json` when `--seed` is omitted.
 
+All four artifact commands support the common artifact-output flags:
+
+- `--out <path>` when the command writes a primary artifact;
+- `--json` to print the payload after writing it.
+
 ## 5. Artifact paths
 
 Canonical sidecar files:

--- a/gaia/lkm_explorer/client/cli.py
+++ b/gaia/lkm_explorer/client/cli.py
@@ -4,8 +4,9 @@ A **sibling console_scripts entrypoint** to ``gaia`` and, as of build 7
 (CLIENT.md "Unified surface"), the *single* user-facing surface for exploration.
 It carries both halves of the turn loop:
 
-* the deterministic **engine verbs** (``init`` / ``observe`` / ``landscape`` /
-  ``frontier`` / ``round`` / ``status`` / ``render``), migrated here from the now-removed
+* the deterministic **engine verbs** (``init`` / ``scope`` / ``observe`` /
+  ``landscape`` / ``focuses`` / ``artifact`` / ``gate`` / ``frontier`` /
+  ``round`` / ``status`` / ``render``), migrated here from the now-removed
   ``gaia explore`` sub-app — thin wrappers over :mod:`gaia.lkm_explorer.engine`
   (the library / SDK, which stays in gaia); and
 * the **orchestrator** phase-aware step ``turn`` — the turn state machine that
@@ -52,9 +53,10 @@ app = typer.Typer(
     name="gaia-lkm-explore",
     help=(
         "Gaia LKM Explore — fog-of-war exploration of a knowledge package. "
-        "Deterministic engine verbs (init / observe / landscape / frontier / round / "
-        "status / render) plus the orchestrator turn state machine (turn), which hands the "
-        "fuzzy survey to an agent through a self-contained task envelope."
+        "Deterministic engine verbs (init / scope / observe / landscape / focuses / "
+        "artifact / gate / frontier / round / status / render) plus the orchestrator "
+        "turn state machine (turn), which hands the fuzzy survey to an agent through a "
+        "self-contained task envelope."
     ),
     no_args_is_help=True,
 )

--- a/gaia/lkm_explorer/client/cli.py
+++ b/gaia/lkm_explorer/client/cli.py
@@ -41,6 +41,7 @@ from gaia.lkm_explorer.client.verbs import (
     observe_command,
     render_command,
     round_command,
+    scope_command,
     status_command,
 )
 
@@ -59,6 +60,7 @@ app = typer.Typer(
 # wrap `gaia.lkm_explorer.engine` (the library / SDK) and are pure + deterministic
 # — no LKM call, no `gaia author` orchestration; those are the agent's survey.
 app.command(name="init")(init_command)
+app.command(name="scope")(scope_command)
 app.command(name="observe")(observe_command)
 app.command(name="landscape")(landscape_command)
 app.command(name="frontier")(frontier_command)

--- a/gaia/lkm_explorer/client/cli.py
+++ b/gaia/lkm_explorer/client/cli.py
@@ -35,6 +35,7 @@ from gaia.lkm_explorer.client.orchestrator import (
     run_turn,
 )
 from gaia.lkm_explorer.client.verbs import (
+    focuses_command,
     frontier_command,
     init_command,
     landscape_command,
@@ -63,6 +64,7 @@ app.command(name="init")(init_command)
 app.command(name="scope")(scope_command)
 app.command(name="observe")(observe_command)
 app.command(name="landscape")(landscape_command)
+app.command(name="focuses")(focuses_command)
 app.command(name="frontier")(frontier_command)
 app.command(name="round")(round_command)
 app.command(name="status")(status_command)

--- a/gaia/lkm_explorer/client/cli.py
+++ b/gaia/lkm_explorer/client/cli.py
@@ -38,6 +38,7 @@ from gaia.lkm_explorer.client.verbs import (
     artifact_command,
     focuses_command,
     frontier_command,
+    gate_command,
     init_command,
     landscape_command,
     observe_command,
@@ -67,6 +68,7 @@ app.command(name="observe")(observe_command)
 app.command(name="landscape")(landscape_command)
 app.command(name="focuses")(focuses_command)
 app.command(name="artifact")(artifact_command)
+app.command(name="gate")(gate_command)
 app.command(name="frontier")(frontier_command)
 app.command(name="round")(round_command)
 app.command(name="status")(status_command)

--- a/gaia/lkm_explorer/client/cli.py
+++ b/gaia/lkm_explorer/client/cli.py
@@ -35,6 +35,7 @@ from gaia.lkm_explorer.client.orchestrator import (
     run_turn,
 )
 from gaia.lkm_explorer.client.verbs import (
+    artifact_command,
     focuses_command,
     frontier_command,
     init_command,
@@ -65,6 +66,7 @@ app.command(name="scope")(scope_command)
 app.command(name="observe")(observe_command)
 app.command(name="landscape")(landscape_command)
 app.command(name="focuses")(focuses_command)
+app.command(name="artifact")(artifact_command)
 app.command(name="frontier")(frontier_command)
 app.command(name="round")(round_command)
 app.command(name="status")(status_command)

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -801,11 +801,14 @@ def scope_command(
         seeds = [s.strip() for s in seed if s.strip()]
         seed_source = "cli"
     else:
-        seeds = [
-            str(item.get("qid") or item.get("text"))
-            for item in exploration_map.seeds
-            if item.get("qid") or item.get("text")
-        ]
+        seeds = []
+        for item in exploration_map.seeds:
+            qid = item.get("qid")
+            text = item.get("text")
+            if qid:
+                seeds.append(str(qid))
+            elif text:
+                seeds.append(str(text))
         seed_source = "map"
     payload = build_scope_artifact(
         pkg,

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -816,15 +816,12 @@ def scope_command(
         map_round=exploration_map.round,
     )
 
-    output_path = (
-        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "scope.json"
-    )
+    output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "scope.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
 
     typer.echo(
-        f"Scope: {len(seeds)} seed(s), {len(dimensions)} dimension group(s)"
-        f" ({seed_source} seeds)."
+        f"Scope: {len(seeds)} seed(s), {len(dimensions)} dimension group(s) ({seed_source} seeds)."
     )
     typer.echo(f"Output: {output_path}")
     if json_out:
@@ -1079,9 +1076,7 @@ def focuses_command(
         landscape=_read_json_object(landscape_path),
         map_round=load_map(pkg).round,
     )
-    output_path = (
-        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "focuses.json"
-    )
+    output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "focuses.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
 
@@ -1111,9 +1106,7 @@ def artifact_command(
         raise typer.Exit(1)
 
     exploration_map = load_map(pkg)
-    output_path = (
-        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "artifact.json"
-    )
+    output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "artifact.json"
     payload = build_exploration_artifact(
         pkg,
         map_round=exploration_map.round,

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -55,6 +55,10 @@ from gaia.cli.commands._stellaris_svg import post_process_stellaris_svg
 from gaia.engine.inquiry.focus import resolve_focus_target
 from gaia.engine.inquiry.review import resolve_graph
 from gaia.engine.packaging import write_text_atomic
+from gaia.lkm_explorer.engine.artifacts import (
+    build_scope_artifact,
+    parse_dimensions,
+)
 from gaia.lkm_explorer.engine.discoveries import compute_discoveries
 from gaia.lkm_explorer.engine.frontier import (
     JointView,
@@ -161,6 +165,26 @@ _LANDSCAPE_JSON_OPT = typer.Option(
     False,
     "--json",
     help="Print the landscape artifact JSON to stdout after writing it.",
+)
+_SCOPE_SEED_OPT = typer.Option(
+    None,
+    "--seed",
+    help="Scope seed text or QID (repeatable; defaults to map seeds).",
+)
+_SCOPE_PROFILE_OPT = typer.Option(
+    None,
+    "--profile",
+    help="Optional exploration profile name.",
+)
+_SCOPE_DIMENSION_OPT = typer.Option(
+    None,
+    "--dimension",
+    help="Exploration dimension as key=value (repeatable).",
+)
+_SCOPE_OUT_OPT = typer.Option(
+    None,
+    "--out",
+    help="Output JSON path (default <pkg>/.gaia/exploration/scope.json).",
 )
 _OBSERVE_SOURCE_OPT = typer.Option(
     None,
@@ -712,6 +736,74 @@ def init_command(
         f"({len(seeds)} seed(s), {resolved} resolved; doctrine {doctrine}, budget_k={budget_k})."
     )
     typer.echo(f"Output: {_gaia_dir(pkg) / 'exploration' / 'map.json'}")
+
+
+# --------------------------------------------------------------------------- #
+# scope                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def scope_command(
+    pkg: str = _PKG_ARG,
+    seed: list[str] | None = _SCOPE_SEED_OPT,
+    profile: str | None = _SCOPE_PROFILE_OPT,
+    dimension: list[str] | None = _SCOPE_DIMENSION_OPT,
+    out: str | None = _SCOPE_OUT_OPT,
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    r"""Write the explicit Explore scope sidecar.
+
+    The scope artifact captures the broad exploration setup — seeds, optional
+    profile, and user-supplied dimensions — so later landscape/focus/gate steps
+    can be audited without guessing the user's intent from the map alone.
+    """
+    map_path = _gaia_dir(pkg) / "exploration" / "map.json"
+    if not map_path.exists():
+        typer.echo(
+            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    try:
+        dimensions = parse_dimensions(dimension)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    exploration_map = load_map(pkg)
+    if seed:
+        seeds = [s.strip() for s in seed if s.strip()]
+        seed_source = "cli"
+    else:
+        seeds = [
+            str(item.get("qid") or item.get("text"))
+            for item in exploration_map.seeds
+            if item.get("qid") or item.get("text")
+        ]
+        seed_source = "map"
+    payload = build_scope_artifact(
+        pkg,
+        seeds=seeds,
+        profile=profile,
+        dimensions=dimensions,
+        seed_source=seed_source,
+        map_round=exploration_map.round,
+    )
+
+    output_path = (
+        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "scope.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    typer.echo(
+        f"Scope: {len(seeds)} seed(s), {len(dimensions)} dimension group(s)"
+        f" ({seed_source} seeds)."
+    )
+    typer.echo(f"Output: {output_path}")
+    if json_out:
+        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 
 
 # --------------------------------------------------------------------------- #

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -58,6 +58,7 @@ from gaia.engine.packaging import write_text_atomic
 from gaia.lkm_explorer.engine.artifacts import (
     build_exploration_artifact,
     build_focuses_artifact,
+    build_gate_report,
     build_scope_artifact,
     latest_landscape_path,
     parse_dimensions,
@@ -204,6 +205,11 @@ _ARTIFACT_OUT_OPT = typer.Option(
     None,
     "--out",
     help="Output JSON path (default <pkg>/.gaia/exploration/artifact.json).",
+)
+_GATE_OUT_OPT = typer.Option(
+    None,
+    "--out",
+    help="Output JSON path (default <pkg>/.gaia/exploration/gate_report.json).",
 )
 _OBSERVE_SOURCE_OPT = typer.Option(
     None,
@@ -1123,6 +1129,71 @@ def artifact_command(
     typer.echo(f"Assess: {payload['interface']['assess']['command']}")
     if json_out:
         typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# gate                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def _build_and_write_exploration_artifact(pkg: str, output_path: Path) -> dict[str, Any]:
+    exploration_map = load_map(pkg)
+    payload = build_exploration_artifact(
+        pkg,
+        map_round=exploration_map.round,
+        map_version=exploration_map.version,
+    )
+    payload["artifacts"]["artifact"] = rel_artifact_path(pkg, output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+    return payload
+
+
+def _resolve_pkg_artifact_path(pkg: str, ref: Any) -> Path | None:
+    if not isinstance(ref, str) or not ref:
+        return None
+    path = Path(ref)
+    return path if path.is_absolute() else Path(pkg).resolve() / path
+
+
+def gate_command(
+    pkg: str = _PKG_ARG,
+    out: str | None = _GATE_OUT_OPT,
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    r"""Check whether Explore artifacts are ready for evidence assessment."""
+    map_path = _gaia_dir(pkg) / "exploration" / "map.json"
+    if not map_path.exists():
+        typer.echo(
+            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    artifact_path = _gaia_dir(pkg) / "exploration" / "artifact.json"
+    if artifact_path.exists():
+        artifact = _read_json_object(artifact_path)
+    else:
+        artifact = _build_and_write_exploration_artifact(pkg, artifact_path)
+
+    focuses_path = _resolve_pkg_artifact_path(pkg, artifact.get("artifacts", {}).get("focuses"))
+    if focuses_path is None:
+        focuses_path = _gaia_dir(pkg) / "exploration" / "focuses.json"
+    focuses = _read_json_object(focuses_path) if focuses_path.exists() else None
+
+    report = build_gate_report(artifact, focuses)
+    output_path = (
+        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "gate_report.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(report, ensure_ascii=False, indent=2))
+
+    typer.echo(f"Gate: {report['verdict']}")
+    typer.echo(f"Output: {output_path}")
+    if json_out:
+        typer.echo(json.dumps(report, ensure_ascii=False, indent=2))
+    if report["verdict"] == "block":
+        raise typer.Exit(1)
 
 
 # --------------------------------------------------------------------------- #

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -56,7 +56,9 @@ from gaia.engine.inquiry.focus import resolve_focus_target
 from gaia.engine.inquiry.review import resolve_graph
 from gaia.engine.packaging import write_text_atomic
 from gaia.lkm_explorer.engine.artifacts import (
+    build_focuses_artifact,
     build_scope_artifact,
+    latest_landscape_path,
     parse_dimensions,
 )
 from gaia.lkm_explorer.engine.discoveries import compute_discoveries
@@ -185,6 +187,16 @@ _SCOPE_OUT_OPT = typer.Option(
     None,
     "--out",
     help="Output JSON path (default <pkg>/.gaia/exploration/scope.json).",
+)
+_FOCUSES_LANDSCAPE_OPT = typer.Option(
+    None,
+    "--landscape",
+    help="Landscape JSON path (default latest <pkg>/.gaia/exploration/landscape-*.json).",
+)
+_FOCUSES_OUT_OPT = typer.Option(
+    None,
+    "--out",
+    help="Output JSON path (default <pkg>/.gaia/exploration/focuses.json).",
 )
 _OBSERVE_SOURCE_OPT = typer.Option(
     None,
@@ -1013,6 +1025,55 @@ def landscape_command(
     else:
         typer.echo("  (no unpulled paper leads)")
 
+    if json_out:
+        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# focuses                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def focuses_command(
+    pkg: str = _PKG_ARG,
+    landscape: str | None = _FOCUSES_LANDSCAPE_OPT,
+    out: str | None = _FOCUSES_OUT_OPT,
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    r"""Create deterministic Explore focuses from a landscape artifact."""
+    map_path = _gaia_dir(pkg) / "exploration" / "map.json"
+    if not map_path.exists():
+        typer.echo(
+            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    landscape_path = Path(landscape) if landscape is not None else latest_landscape_path(pkg)
+    if landscape_path is None or not landscape_path.exists():
+        typer.echo(
+            "Error: no landscape artifact found; run `gaia-lkm-explore landscape` first "
+            "or pass --landscape.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    scope_path = _gaia_dir(pkg) / "exploration" / "scope.json"
+    payload = build_focuses_artifact(
+        pkg,
+        scope_path=scope_path if scope_path.exists() else None,
+        landscape_path=landscape_path,
+        landscape=_read_json_object(landscape_path),
+        map_round=load_map(pkg).round,
+    )
+    output_path = (
+        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "focuses.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    typer.echo(f"Focuses: {len(payload['focuses'])} focus(es) from {landscape_path}.")
+    typer.echo(f"Output: {output_path}")
     if json_out:
         typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -56,10 +56,12 @@ from gaia.engine.inquiry.focus import resolve_focus_target
 from gaia.engine.inquiry.review import resolve_graph
 from gaia.engine.packaging import write_text_atomic
 from gaia.lkm_explorer.engine.artifacts import (
+    build_exploration_artifact,
     build_focuses_artifact,
     build_scope_artifact,
     latest_landscape_path,
     parse_dimensions,
+    rel_artifact_path,
 )
 from gaia.lkm_explorer.engine.discoveries import compute_discoveries
 from gaia.lkm_explorer.engine.frontier import (
@@ -197,6 +199,11 @@ _FOCUSES_OUT_OPT = typer.Option(
     None,
     "--out",
     help="Output JSON path (default <pkg>/.gaia/exploration/focuses.json).",
+)
+_ARTIFACT_OUT_OPT = typer.Option(
+    None,
+    "--out",
+    help="Output JSON path (default <pkg>/.gaia/exploration/artifact.json).",
 )
 _OBSERVE_SOURCE_OPT = typer.Option(
     None,
@@ -1074,6 +1081,46 @@ def focuses_command(
 
     typer.echo(f"Focuses: {len(payload['focuses'])} focus(es) from {landscape_path}.")
     typer.echo(f"Output: {output_path}")
+    if json_out:
+        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# artifact                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def artifact_command(
+    pkg: str = _PKG_ARG,
+    out: str | None = _ARTIFACT_OUT_OPT,
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    r"""Write the Explore handoff envelope for downstream evidence assessment."""
+    map_path = _gaia_dir(pkg) / "exploration" / "map.json"
+    if not map_path.exists():
+        typer.echo(
+            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    exploration_map = load_map(pkg)
+    output_path = (
+        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "artifact.json"
+    )
+    payload = build_exploration_artifact(
+        pkg,
+        map_round=exploration_map.round,
+        map_version=exploration_map.version,
+    )
+    payload["artifacts"]["artifact"] = rel_artifact_path(pkg, output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    limitations = payload["audit"]["known_limitations"]
+    typer.echo(f"Artifact: {len(limitations)} known limitation(s).")
+    typer.echo(f"Output: {output_path}")
+    typer.echo(f"Assess: {payload['interface']['assess']['command']}")
     if json_out:
         typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -46,12 +46,20 @@ def exploration_dir(pkg: str | Path) -> Path:
 
 
 def latest_landscape_path(pkg: str | Path) -> Path | None:
-    """Return the lexically latest ``landscape-*.json`` sidecar, if any."""
+    """Return the highest-round ``landscape-*.json`` sidecar, if any."""
     exp = exploration_dir(pkg)
     if not exp.exists():
         return None
-    matches = sorted(exp.glob("landscape-*.json"))
+    matches = sorted(exp.glob("landscape-*.json"), key=_landscape_sort_key)
     return matches[-1] if matches else None
+
+
+def _landscape_sort_key(path: Path) -> tuple[int, str]:
+    suffix = path.stem.removeprefix("landscape-")
+    try:
+        return (int(suffix), "")
+    except ValueError:
+        return (-1, suffix)
 
 
 def rel_artifact_path(pkg: str | Path, path: Path | None) -> str | None:
@@ -286,12 +294,14 @@ def build_gate_report(
             "at least one focus recommends assess",
         ),
         "focuses_have_evidence_refs": _check(
-            "pass" if assessable and len(assessable_with_refs) == len(assessable) else "fail",
-            "assessable focuses carry evidence refs",
-        ),
-        "artifact_present": _check(
-            "pass" if _artifact_ref(artifact, "artifact") else "fail",
-            "exploration artifact envelope reference is present",
+            "skip"
+            if not assessable
+            else "pass"
+            if len(assessable_with_refs) == len(assessable)
+            else "fail",
+            "assessable focuses carry evidence refs"
+            if assessable
+            else "no assessable focus to check for evidence refs",
         ),
         "schema_versions_supported": _check(
             "pass"
@@ -324,7 +334,6 @@ def build_gate_report(
         "focuses_present",
         "has_assessable_focus",
         "focuses_have_evidence_refs",
-        "artifact_present",
         "schema_versions_supported",
     ]
     warnings = [

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -118,9 +118,7 @@ def build_focuses_artifact(
     map_round: int,
 ) -> dict[str, Any]:
     """Build deterministic focus suggestions from a paper-level landscape."""
-    paper_leads = [
-        lead for lead in landscape.get("paper_leads", []) if isinstance(lead, dict)
-    ]
+    paper_leads = [lead for lead in landscape.get("paper_leads", []) if isinstance(lead, dict)]
     focuses: list[dict[str, Any]] = []
     if paper_leads:
         evidence_refs: list[dict[str, str]] = []
@@ -207,9 +205,7 @@ def build_exploration_artifact(
         "focuses": "focuses.json",
         "map": "map.json",
     }
-    limitations = [
-        f"missing {name}" for key, name in core_names.items() if artifacts[key] is None
-    ]
+    limitations = [f"missing {name}" for key, name in core_names.items() if artifacts[key] is None]
     return {
         "schema": SOP_SCHEMA,
         "kind": "lkm_exploration",
@@ -266,8 +262,7 @@ def build_gate_report(
         if isinstance(row.get("evidence_refs"), list) and bool(row["evidence_refs"])
     ]
     all_focuses_have_refs = all(
-        isinstance(row.get("evidence_refs"), list) and bool(row["evidence_refs"])
-        for row in rows
+        isinstance(row.get("evidence_refs"), list) and bool(row["evidence_refs"]) for row in rows
     )
     checks = {
         "scope_present": _check(

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -1,0 +1,372 @@
+"""Deterministic Explore SOP sidecar artifacts.
+
+This module is intentionally pure: it builds typed JSON-compatible payloads and
+does filesystem discovery for already-written sidecars, but it does not write
+files, call LKM, invoke an LLM, or mutate the exploration map.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SOP_SCHEMA = "gaia.sop.artifact.v1"
+
+
+def utcnow() -> str:
+    """Return the current UTC timestamp as a compact JSON-friendly string."""
+    return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def artifact_id(prefix: str) -> str:
+    """Create a deterministic-shape artifact id with a UTC suffix."""
+    safe_prefix = prefix.strip().replace(" ", "_") or "artifact"
+    return f"{safe_prefix}_{utcnow()}"
+
+
+def parse_dimensions(items: list[str] | None) -> dict[str, list[str]]:
+    """Parse repeated ``key=value`` CLI options into grouped dimension lists."""
+    dimensions: dict[str, list[str]] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise ValueError(f"dimension must be key=value, got {item!r}")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"dimension must be key=value, got {item!r}")
+        dimensions.setdefault(key, []).append(value)
+    return dimensions
+
+
+def exploration_dir(pkg: str | Path) -> Path:
+    """Return ``<pkg>/.gaia/exploration`` as an absolute path."""
+    return Path(pkg).resolve() / ".gaia" / "exploration"
+
+
+def latest_landscape_path(pkg: str | Path) -> Path | None:
+    """Return the lexically latest ``landscape-*.json`` sidecar, if any."""
+    exp = exploration_dir(pkg)
+    if not exp.exists():
+        return None
+    matches = sorted(exp.glob("landscape-*.json"))
+    return matches[-1] if matches else None
+
+
+def rel_artifact_path(pkg: str | Path, path: Path | None) -> str | None:
+    """Render artifact paths package-relative when they live under ``pkg``."""
+    if path is None:
+        return None
+    resolved_pkg = Path(pkg).resolve()
+    resolved_path = Path(path).resolve()
+    try:
+        return resolved_path.relative_to(resolved_pkg).as_posix()
+    except ValueError:
+        return str(resolved_path)
+
+
+def build_scope_artifact(
+    pkg: str | Path,
+    *,
+    seeds: list[str],
+    profile: str | None,
+    dimensions: dict[str, list[str]],
+    seed_source: str,
+    map_round: int,
+) -> dict[str, Any]:
+    """Build an ``exploration_scope`` artifact from explicit or map-derived seeds."""
+    payload: dict[str, Any] = {
+        "schema": SOP_SCHEMA,
+        "kind": "exploration_scope",
+        "id": artifact_id("scope"),
+        "created_at": utcnow(),
+        "inputs": {
+            "pkg": str(Path(pkg).resolve()),
+            "seeds": list(seeds),
+            "profile": profile,
+            "dimensions": {k: list(v) for k, v in dimensions.items()},
+        },
+        "provenance": {
+            "seed_source": seed_source,
+            "map_round": map_round,
+        },
+        "audit": {
+            "allowed_next_steps": ["landscape", "focuses", "artifact", "gate"],
+        },
+    }
+    return payload
+
+
+def _lead_evidence_refs(lead: dict[str, Any]) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    paper_id = lead.get("paper_id")
+    if isinstance(paper_id, str) and paper_id:
+        refs.append({"kind": "paper", "id": paper_id})
+    for node_id in lead.get("lkm_node_ids", []) or []:
+        if isinstance(node_id, str) and node_id:
+            refs.append({"kind": "lkm_node", "id": node_id})
+    return refs
+
+
+def build_focuses_artifact(
+    pkg: str | Path,
+    *,
+    scope_path: Path | None,
+    landscape_path: Path | None,
+    landscape: dict[str, Any],
+    map_round: int,
+) -> dict[str, Any]:
+    """Build deterministic focus suggestions from a paper-level landscape."""
+    paper_leads = [
+        lead for lead in landscape.get("paper_leads", []) if isinstance(lead, dict)
+    ]
+    focuses: list[dict[str, Any]] = []
+    if paper_leads:
+        evidence_refs: list[dict[str, str]] = []
+        paper_ids: list[str] = []
+        titles: list[str] = []
+        queries: list[str] = []
+        for lead in paper_leads:
+            paper_id = lead.get("paper_id")
+            if isinstance(paper_id, str) and paper_id:
+                paper_ids.append(paper_id)
+            title = lead.get("title")
+            if isinstance(title, str) and title:
+                titles.append(title)
+            for query in lead.get("queries", []) or []:
+                if isinstance(query, str) and query and query not in queries:
+                    queries.append(query)
+            for ref in _lead_evidence_refs(lead):
+                if ref not in evidence_refs:
+                    evidence_refs.append(ref)
+        label = ", ".join(paper_ids[:3]) or f"{len(paper_leads)} paper lead(s)"
+        text = f"Assess the paper-lead cluster surfaced by the landscape pass: {label}."
+        focuses.append(
+            {
+                "id": artifact_id("focus"),
+                "kind": "paper_lead_cluster",
+                "text": text,
+                "why_it_matters": (
+                    "Landscape paper leads are the breadth-first bridge from Explore "
+                    "into evidence assessment."
+                ),
+                "evidence_refs": evidence_refs,
+                "recommended_next": "assess",
+                "confidence": "medium",
+                "provenance": {
+                    "paper_ids": paper_ids,
+                    "titles": titles[:5],
+                    "queries": queries,
+                },
+            }
+        )
+
+    return {
+        "schema": SOP_SCHEMA,
+        "kind": "exploration_focuses",
+        "id": artifact_id("focuses"),
+        "created_at": utcnow(),
+        "inputs": {
+            "pkg": str(Path(pkg).resolve()),
+            "scope": rel_artifact_path(pkg, scope_path),
+            "landscape": rel_artifact_path(pkg, landscape_path),
+        },
+        "provenance": {"map_round": map_round},
+        "focuses": focuses,
+        "audit": {"allowed_next_steps": ["artifact", "gate", "assess"]},
+    }
+
+
+def _optional_artifact(pkg: str | Path, path: Path) -> str | None:
+    return rel_artifact_path(pkg, path) if path.exists() else None
+
+
+def build_exploration_artifact(
+    pkg: str | Path,
+    *,
+    map_round: int,
+    map_version: int,
+) -> dict[str, Any]:
+    """Build the handoff envelope that links Explore sidecars together."""
+    exp = exploration_dir(pkg)
+    gaia_dir = Path(pkg).resolve() / ".gaia"
+    artifacts = {
+        "scope": _optional_artifact(pkg, exp / "scope.json"),
+        "landscape": rel_artifact_path(pkg, latest_landscape_path(pkg)),
+        "focuses": _optional_artifact(pkg, exp / "focuses.json"),
+        "map": _optional_artifact(pkg, exp / "map.json"),
+        "artifact": _optional_artifact(pkg, exp / "artifact.json"),
+        "rounds": _optional_artifact(pkg, exp / "rounds.jsonl"),
+        "gaia_ir": _optional_artifact(pkg, gaia_dir / "ir.json"),
+        "beliefs": _optional_artifact(pkg, gaia_dir / "beliefs.json"),
+    }
+    core_names = {
+        "scope": "scope.json",
+        "landscape": "landscape-*.json",
+        "focuses": "focuses.json",
+        "map": "map.json",
+    }
+    limitations = [
+        f"missing {name}" for key, name in core_names.items() if artifacts[key] is None
+    ]
+    return {
+        "schema": SOP_SCHEMA,
+        "kind": "lkm_exploration",
+        "id": artifact_id("exploration"),
+        "created_at": utcnow(),
+        "inputs": {
+            "pkg": str(Path(pkg).resolve()),
+            "map_round": map_round,
+            "map_version": map_version,
+        },
+        "artifacts": artifacts,
+        "audit": {
+            "known_limitations": limitations,
+            "allowed_next_steps": ["gate"],
+        },
+        "interface": {
+            "assess": {
+                "command": "gaia-evidence assess --exploration .gaia/exploration/artifact.json"
+            }
+        },
+    }
+
+
+def _check(status: str, detail: str) -> dict[str, str]:
+    return {"status": status, "detail": detail}
+
+
+def _artifact_ref(artifact: dict[str, Any], name: str) -> Any:
+    artifacts = artifact.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return None
+    return artifacts.get(name)
+
+
+def _focus_list(focuses: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(focuses, dict):
+        return []
+    rows = focuses.get("focuses")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def build_gate_report(
+    artifact: dict[str, Any],
+    focuses: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build a deterministic pass/revise/block report for Assess handoff."""
+    rows = _focus_list(focuses)
+    assessable = [row for row in rows if row.get("recommended_next") == "assess"]
+    assessable_with_refs = [
+        row
+        for row in assessable
+        if isinstance(row.get("evidence_refs"), list) and bool(row["evidence_refs"])
+    ]
+    all_focuses_have_refs = all(
+        isinstance(row.get("evidence_refs"), list) and bool(row["evidence_refs"])
+        for row in rows
+    )
+    checks = {
+        "scope_present": _check(
+            "pass" if _artifact_ref(artifact, "scope") else "fail",
+            "scope artifact reference is present",
+        ),
+        "map_present": _check(
+            "pass" if _artifact_ref(artifact, "map") else "fail",
+            "exploration map reference is present",
+        ),
+        "landscape_present": _check(
+            "pass" if _artifact_ref(artifact, "landscape") else "fail",
+            "landscape artifact reference is present",
+        ),
+        "focuses_present": _check(
+            "pass" if _artifact_ref(artifact, "focuses") and focuses else "fail",
+            "focuses artifact is present and readable",
+        ),
+        "has_assessable_focus": _check(
+            "pass" if assessable else "fail",
+            "at least one focus recommends assess",
+        ),
+        "focuses_have_evidence_refs": _check(
+            "pass" if assessable and len(assessable_with_refs) == len(assessable) else "fail",
+            "assessable focuses carry evidence refs",
+        ),
+        "artifact_present": _check(
+            "pass" if _artifact_ref(artifact, "artifact") else "fail",
+            "exploration artifact envelope reference is present",
+        ),
+        "schema_versions_supported": _check(
+            "pass"
+            if artifact.get("schema") == SOP_SCHEMA
+            and (focuses is None or focuses.get("schema") == SOP_SCHEMA)
+            else "fail",
+            f"supported schema is {SOP_SCHEMA}",
+        ),
+        "compiled_ir_present": _check(
+            "pass" if _artifact_ref(artifact, "gaia_ir") else "warn",
+            "compiled IR is available for downstream assessment context",
+        ),
+        "beliefs_present": _check(
+            "pass" if _artifact_ref(artifact, "beliefs") else "warn",
+            "beliefs sidecar is available for downstream assessment context",
+        ),
+        "rounds_present": _check(
+            "pass" if _artifact_ref(artifact, "rounds") else "warn",
+            "round history is available for provenance",
+        ),
+        "all_focuses_have_evidence_refs": _check(
+            "pass" if all_focuses_have_refs else "warn",
+            "all focus rows carry evidence refs",
+        ),
+    }
+    required = [
+        "scope_present",
+        "map_present",
+        "landscape_present",
+        "focuses_present",
+        "has_assessable_focus",
+        "focuses_have_evidence_refs",
+        "artifact_present",
+        "schema_versions_supported",
+    ]
+    warnings = [
+        "compiled_ir_present",
+        "beliefs_present",
+        "rounds_present",
+        "all_focuses_have_evidence_refs",
+    ]
+    if any(checks[name]["status"] == "fail" for name in required):
+        verdict = "block"
+    elif any(checks[name]["status"] == "warn" for name in warnings):
+        verdict = "revise"
+    else:
+        verdict = "pass"
+    return {
+        "schema": SOP_SCHEMA,
+        "kind": "exploration_gate_report",
+        "id": artifact_id("gate"),
+        "created_at": utcnow(),
+        "verdict": verdict,
+        "checks": checks,
+        "audit": {
+            "allowed_next_steps": ["assess"] if verdict == "pass" else [],
+        },
+    }
+
+
+__all__ = [
+    "SOP_SCHEMA",
+    "artifact_id",
+    "build_exploration_artifact",
+    "build_focuses_artifact",
+    "build_gate_report",
+    "build_scope_artifact",
+    "exploration_dir",
+    "latest_landscape_path",
+    "parse_dimensions",
+    "rel_artifact_path",
+    "utcnow",
+]

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -39,10 +39,16 @@ def test_artifact_id_includes_prefix_and_utc_suffix() -> None:
 def test_latest_landscape_path_returns_highest_sorted(tmp_path: Path) -> None:
     exp = tmp_path / ".gaia" / "exploration"
     exp.mkdir(parents=True)
-    for name in ["landscape-0.json", "landscape-2.json", "landscape-1.json"]:
+    for name in [
+        "landscape-0.json",
+        "landscape-2.json",
+        "landscape-1.json",
+        "landscape-9.json",
+        "landscape-10.json",
+    ]:
         (exp / name).write_text("{}", encoding="utf-8")
 
-    assert latest_landscape_path(tmp_path) == exp / "landscape-2.json"
+    assert latest_landscape_path(tmp_path) == exp / "landscape-10.json"
 
 
 def test_rel_artifact_path_prefers_package_relative_paths(tmp_path: Path) -> None:
@@ -151,6 +157,8 @@ def test_build_gate_report_blocks_without_focuses() -> None:
     assert report["kind"] == "exploration_gate_report"
     assert report["verdict"] == "block"
     assert report["checks"]["focuses_present"]["status"] == "fail"
+    assert report["checks"]["focuses_have_evidence_refs"]["status"] == "skip"
+    assert "artifact_present" not in report["checks"]
     assert report["audit"]["allowed_next_steps"] == []
 
 

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaia.lkm_explorer.engine.artifacts import (
+    SOP_SCHEMA,
+    artifact_id,
+    build_exploration_artifact,
+    build_focuses_artifact,
+    build_gate_report,
+    build_scope_artifact,
+    latest_landscape_path,
+    parse_dimensions,
+    rel_artifact_path,
+)
+
+
+def test_parse_dimensions_groups_repeated_keys() -> None:
+    assert parse_dimensions(["population=adults", "population=elderly", "endpoint=mi"]) == {
+        "population": ["adults", "elderly"],
+        "endpoint": ["mi"],
+    }
+
+
+def test_parse_dimensions_rejects_malformed_items() -> None:
+    with pytest.raises(ValueError, match="key=value"):
+        parse_dimensions(["population"])
+
+
+def test_artifact_id_includes_prefix_and_utc_suffix() -> None:
+    generated = artifact_id("scope")
+    assert generated.startswith("scope_")
+    assert generated.endswith("Z")
+
+
+def test_latest_landscape_path_returns_highest_sorted(tmp_path: Path) -> None:
+    exp = tmp_path / ".gaia" / "exploration"
+    exp.mkdir(parents=True)
+    for name in ["landscape-0.json", "landscape-2.json", "landscape-1.json"]:
+        (exp / name).write_text("{}", encoding="utf-8")
+
+    assert latest_landscape_path(tmp_path) == exp / "landscape-2.json"
+
+
+def test_rel_artifact_path_prefers_package_relative_paths(tmp_path: Path) -> None:
+    path = tmp_path / ".gaia" / "exploration" / "scope.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{}", encoding="utf-8")
+
+    assert rel_artifact_path(tmp_path, path) == ".gaia/exploration/scope.json"
+    assert rel_artifact_path(tmp_path, None) is None
+
+
+def test_build_scope_artifact_records_contract(tmp_path: Path) -> None:
+    artifact = build_scope_artifact(
+        tmp_path,
+        seeds=["aspirin primary prevention"],
+        profile="clinical",
+        dimensions={"population": ["older adults"]},
+        seed_source="cli",
+        map_round=3,
+    )
+
+    assert artifact["schema"] == SOP_SCHEMA
+    assert artifact["kind"] == "exploration_scope"
+    assert artifact["inputs"]["pkg"] == str(tmp_path.resolve())
+    assert artifact["inputs"]["seeds"] == ["aspirin primary prevention"]
+    assert artifact["inputs"]["profile"] == "clinical"
+    assert artifact["inputs"]["dimensions"] == {"population": ["older adults"]}
+    assert artifact["provenance"]["seed_source"] == "cli"
+    assert artifact["provenance"]["map_round"] == 3
+    assert artifact["audit"]["allowed_next_steps"] == [
+        "landscape",
+        "focuses",
+        "artifact",
+        "gate",
+    ]
+
+
+def test_build_focuses_artifact_uses_landscape_paper_leads(tmp_path: Path) -> None:
+    landscape = {
+        "kind": "exploration_landscape",
+        "paper_leads": [
+            {
+                "paper_id": "P1",
+                "title": "Aspirin for primary prevention",
+                "queries": ["aspirin primary prevention"],
+                "lkm_node_ids": ["lkm:1", "lkm:2"],
+            }
+        ],
+    }
+    artifact = build_focuses_artifact(
+        tmp_path,
+        scope_path=tmp_path / ".gaia" / "exploration" / "scope.json",
+        landscape_path=tmp_path / ".gaia" / "exploration" / "landscape-0.json",
+        landscape=landscape,
+        map_round=0,
+    )
+
+    assert artifact["kind"] == "exploration_focuses"
+    assert artifact["focuses"]
+    focus = artifact["focuses"][0]
+    assert focus["kind"] == "paper_lead_cluster"
+    assert focus["recommended_next"] == "assess"
+    assert focus["evidence_refs"] == [
+        {"kind": "paper", "id": "P1"},
+        {"kind": "lkm_node", "id": "lkm:1"},
+        {"kind": "lkm_node", "id": "lkm:2"},
+    ]
+
+
+def test_build_exploration_artifact_records_present_and_missing_sidecars(tmp_path: Path) -> None:
+    exp = tmp_path / ".gaia" / "exploration"
+    exp.mkdir(parents=True)
+    (exp / "scope.json").write_text("{}", encoding="utf-8")
+    (exp / "landscape-0.json").write_text("{}", encoding="utf-8")
+    (exp / "map.json").write_text("{}", encoding="utf-8")
+
+    artifact = build_exploration_artifact(tmp_path, map_round=0, map_version=1)
+
+    assert artifact["kind"] == "lkm_exploration"
+    assert artifact["artifacts"]["scope"] == ".gaia/exploration/scope.json"
+    assert artifact["artifacts"]["landscape"] == ".gaia/exploration/landscape-0.json"
+    assert artifact["artifacts"]["focuses"] is None
+    assert "missing focuses.json" in artifact["audit"]["known_limitations"]
+    assert artifact["audit"]["allowed_next_steps"] == ["gate"]
+    assert "gaia-evidence assess" in artifact["interface"]["assess"]["command"]
+
+
+def test_build_gate_report_blocks_without_focuses() -> None:
+    artifact = {
+        "schema": SOP_SCHEMA,
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": None,
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": ".gaia/ir.json",
+            "beliefs": ".gaia/beliefs.json",
+            "rounds": ".gaia/exploration/rounds.jsonl",
+        },
+    }
+
+    report = build_gate_report(artifact, focuses=None)
+
+    assert report["kind"] == "exploration_gate_report"
+    assert report["verdict"] == "block"
+    assert report["checks"]["focuses_present"]["status"] == "fail"
+    assert report["audit"]["allowed_next_steps"] == []
+
+
+def test_build_gate_report_passes_with_supported_schema_and_backed_focus() -> None:
+    artifact = {
+        "schema": SOP_SCHEMA,
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": ".gaia/ir.json",
+            "beliefs": ".gaia/beliefs.json",
+            "rounds": ".gaia/exploration/rounds.jsonl",
+        },
+    }
+    focuses = {
+        "schema": SOP_SCHEMA,
+        "focuses": [
+            {
+                "id": "focus_1",
+                "recommended_next": "assess",
+                "evidence_refs": [{"kind": "paper", "id": "P1"}],
+            }
+        ],
+    }
+
+    report = build_gate_report(artifact, focuses)
+
+    assert report["verdict"] == "pass"
+    assert report["audit"]["allowed_next_steps"] == ["assess"]
+
+
+def test_build_gate_report_revises_when_warning_artifacts_are_missing() -> None:
+    artifact = {
+        "schema": SOP_SCHEMA,
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": None,
+            "beliefs": None,
+            "rounds": None,
+        },
+    }
+    focuses = {
+        "schema": SOP_SCHEMA,
+        "focuses": [
+            {
+                "id": "focus_1",
+                "recommended_next": "assess",
+                "evidence_refs": [{"kind": "paper", "id": "P1"}],
+            }
+        ],
+    }
+
+    report = build_gate_report(artifact, focuses)
+
+    assert report["verdict"] == "revise"
+    assert report["checks"]["compiled_ir_present"]["status"] == "warn"
+
+
+def test_build_gate_report_blocks_unsupported_schema() -> None:
+    artifact = {
+        "schema": "future.schema",
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": ".gaia/ir.json",
+            "beliefs": ".gaia/beliefs.json",
+            "rounds": ".gaia/exploration/rounds.jsonl",
+        },
+    }
+    focuses = {"schema": SOP_SCHEMA, "focuses": []}
+
+    report = build_gate_report(artifact, focuses)
+
+    assert report["verdict"] == "block"
+    assert report["checks"]["schema_versions_supported"]["status"] == "fail"
+
+
+def test_gate_report_is_json_serializable() -> None:
+    report = build_gate_report(
+        {
+            "schema": SOP_SCHEMA,
+            "kind": "lkm_exploration",
+            "artifacts": {},
+        },
+        focuses=None,
+    )
+
+    json.dumps(report)

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -562,6 +562,79 @@ def test_explore_landscape_writes_neutral_paper_leads(galileo_pkg: Path):
     assert "evidence_hierarchy" not in first
 
 
+def test_explore_scope_writes_scope_artifact(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "scope",
+            str(galileo_pkg),
+            "--seed",
+            "aspirin primary prevention",
+            "--profile",
+            "clinical",
+            "--dimension",
+            "population=adults",
+            "--dimension",
+            "endpoint=mi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Scope:" in result.output
+
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "scope.json").read_text(encoding="utf-8")
+    )
+    assert payload["kind"] == "exploration_scope"
+    assert payload["inputs"]["seeds"] == ["aspirin primary prevention"]
+    assert payload["inputs"]["profile"] == "clinical"
+    assert payload["inputs"]["dimensions"] == {
+        "population": ["adults"],
+        "endpoint": ["mi"],
+    }
+    assert payload["provenance"]["seed_source"] == "cli"
+
+
+def test_explore_scope_derives_seeds_from_map(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+
+    result = runner.invoke(app, ["scope", str(galileo_pkg)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "scope.json").read_text(encoding="utf-8")
+    )
+    assert payload["inputs"]["seeds"] == [_galileo_qid("aristotle_model")]
+    assert payload["provenance"]["seed_source"] == "map"
+
+
+def test_explore_scope_rejects_invalid_dimension(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+
+    result = runner.invoke(app, ["scope", str(galileo_pkg), "--dimension", "population"])
+
+    assert result.exit_code == 2
+    assert "key=value" in result.output
+
+
+def test_explore_scope_help_lists_options():
+    result = runner.invoke(app, ["scope", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--seed" in result.output
+    assert "--profile" in result.output
+    assert "--dimension" in result.output
+
+
 def test_explore_observe_dedups_and_skips_materialized(galileo_pkg: Path):
     runner.invoke(
         app,

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -453,7 +453,20 @@ def test_explore_help_lists_all_verbs():
     # alongside the orchestrator `turn` (CLIENT.md "Unified surface", build 7).
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    for verb in ("init", "observe", "frontier", "round", "status", "render", "turn"):
+    for verb in (
+        "init",
+        "scope",
+        "observe",
+        "landscape",
+        "focuses",
+        "artifact",
+        "gate",
+        "frontier",
+        "round",
+        "status",
+        "render",
+        "turn",
+    ):
         assert verb in result.output
 
 

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -35,6 +35,18 @@ def _galileo_qid(label: str) -> str:
     return f"{GALILEO_NS}:{GALILEO_PKG}::{label}"
 
 
+def _trailing_json_object(output: str) -> dict[str, object]:
+    start = output.rfind("\n{")
+    if start == -1:
+        start = output.find("{")
+    else:
+        start += 1
+    assert start != -1, output
+    payload = json.loads(output[start:])
+    assert isinstance(payload, dict)
+    return payload
+
+
 def _example_root() -> Path:
     # tests/exploration/ -> repo root -> examples/galileo-v0-5-gaia
     return Path(__file__).resolve().parents[2] / "examples" / "galileo-v0-5-gaia"
@@ -593,6 +605,7 @@ def test_explore_scope_writes_scope_artifact(galileo_pkg: Path):
             "population=adults",
             "--dimension",
             "endpoint=mi",
+            "--json",
         ],
     )
     assert result.exit_code == 0, result.output
@@ -609,6 +622,9 @@ def test_explore_scope_writes_scope_artifact(galileo_pkg: Path):
         "endpoint": ["mi"],
     }
     assert payload["provenance"]["seed_source"] == "cli"
+    stdout_payload = _trailing_json_object(result.output)
+    assert stdout_payload["kind"] == "exploration_scope"
+    assert stdout_payload["inputs"] == payload["inputs"]
 
 
 def test_explore_scope_derives_seeds_from_map(galileo_pkg: Path):

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -639,7 +639,7 @@ def test_explore_scope_rejects_invalid_dimension(galileo_pkg: Path):
     assert "key=value" in result.output
 
 
-def test_explore_scope_help_lists_options():
+def test_explore_scope_help_is_available():
     result = runner.invoke(
         app,
         ["scope", "--help"],
@@ -648,9 +648,7 @@ def test_explore_scope_help_lists_options():
     )
 
     assert result.exit_code == 0, result.output
-    assert "--seed" in result.output
-    assert "--profile" in result.output
-    assert "--dimension" in result.output
+    assert "Write the explicit Explore scope sidecar" in result.output
 
 
 def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -664,9 +664,7 @@ def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):
     assert result.exit_code == 0, result.output
     assert "Focuses:" in result.output
     payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(
-            encoding="utf-8"
-        )
+        (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(encoding="utf-8")
     )
     assert payload["kind"] == "exploration_focuses"
     assert payload["focuses"]
@@ -703,9 +701,7 @@ def test_explore_artifact_writes_handoff_envelope(galileo_pkg: Path):
     assert "Artifact:" in result.output
     assert "gaia-evidence assess" in result.output
     payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "artifact.json").read_text(
-            encoding="utf-8"
-        )
+        (galileo_pkg / ".gaia" / "exploration" / "artifact.json").read_text(encoding="utf-8")
     )
     assert payload["kind"] == "lkm_exploration"
     assert payload["artifacts"]["scope"] == ".gaia/exploration/scope.json"
@@ -728,9 +724,7 @@ def test_explore_gate_blocks_without_focuses(galileo_pkg: Path):
     assert result.exit_code == 1
     assert "Gate: block" in result.output
     payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(
-            encoding="utf-8"
-        )
+        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(encoding="utf-8")
     )
     assert payload["verdict"] == "block"
     assert payload["checks"]["focuses_present"]["status"] == "fail"
@@ -744,9 +738,7 @@ def test_explore_gate_passes_with_complete_assessable_artifacts(galileo_pkg: Pat
     runner.invoke(app, ["scope", str(galileo_pkg)])
     runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
     runner.invoke(app, ["focuses", str(galileo_pkg)])
-    (galileo_pkg / ".gaia" / "exploration" / "rounds.jsonl").write_text(
-        "{}\n", encoding="utf-8"
-    )
+    (galileo_pkg / ".gaia" / "exploration" / "rounds.jsonl").write_text("{}\n", encoding="utf-8")
     runner.invoke(app, ["artifact", str(galileo_pkg)])
 
     result = runner.invoke(app, ["gate", str(galileo_pkg)])
@@ -754,9 +746,7 @@ def test_explore_gate_passes_with_complete_assessable_artifacts(galileo_pkg: Pat
     assert result.exit_code == 0, result.output
     assert "Gate: pass" in result.output
     payload = json.loads(
-        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(
-            encoding="utf-8"
-        )
+        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(encoding="utf-8")
     )
     assert payload["verdict"] == "pass"
     assert payload["audit"]["allowed_next_steps"] == ["assess"]

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -635,6 +635,46 @@ def test_explore_scope_help_lists_options():
     assert "--dimension" in result.output
 
 
+def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    landscape_result = runner.invoke(
+        app,
+        ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)],
+    )
+    assert landscape_result.exit_code == 0, landscape_result.output
+
+    result = runner.invoke(app, ["focuses", str(galileo_pkg)])
+
+    assert result.exit_code == 0, result.output
+    assert "Focuses:" in result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["kind"] == "exploration_focuses"
+    assert payload["focuses"]
+    focus = payload["focuses"][0]
+    assert focus["kind"] == "paper_lead_cluster"
+    assert focus["recommended_next"] == "assess"
+    assert focus["evidence_refs"]
+
+
+def test_explore_focuses_requires_landscape(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+
+    result = runner.invoke(app, ["focuses", str(galileo_pkg)])
+
+    assert result.exit_code == 2
+    assert "no landscape" in result.output
+
+
 def test_explore_observe_dedups_and_skips_materialized(galileo_pkg: Path):
     runner.invoke(
         app,

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -701,6 +701,54 @@ def test_explore_artifact_writes_handoff_envelope(galileo_pkg: Path):
     assert payload["interface"]["assess"]["command"].startswith("gaia-evidence assess")
 
 
+def test_explore_gate_blocks_without_focuses(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    runner.invoke(app, ["scope", str(galileo_pkg)])
+    runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
+    runner.invoke(app, ["artifact", str(galileo_pkg)])
+
+    result = runner.invoke(app, ["gate", str(galileo_pkg)])
+
+    assert result.exit_code == 1
+    assert "Gate: block" in result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["verdict"] == "block"
+    assert payload["checks"]["focuses_present"]["status"] == "fail"
+
+
+def test_explore_gate_passes_with_complete_assessable_artifacts(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    runner.invoke(app, ["scope", str(galileo_pkg)])
+    runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
+    runner.invoke(app, ["focuses", str(galileo_pkg)])
+    (galileo_pkg / ".gaia" / "exploration" / "rounds.jsonl").write_text(
+        "{}\n", encoding="utf-8"
+    )
+    runner.invoke(app, ["artifact", str(galileo_pkg)])
+
+    result = runner.invoke(app, ["gate", str(galileo_pkg)])
+
+    assert result.exit_code == 0, result.output
+    assert "Gate: pass" in result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["verdict"] == "pass"
+    assert payload["audit"]["allowed_next_steps"] == ["assess"]
+
+
 def test_explore_observe_dedups_and_skips_materialized(galileo_pkg: Path):
     runner.invoke(
         app,

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -675,6 +675,32 @@ def test_explore_focuses_requires_landscape(galileo_pkg: Path):
     assert "no landscape" in result.output
 
 
+def test_explore_artifact_writes_handoff_envelope(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    runner.invoke(app, ["scope", str(galileo_pkg)])
+    runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
+    runner.invoke(app, ["focuses", str(galileo_pkg)])
+
+    result = runner.invoke(app, ["artifact", str(galileo_pkg)])
+
+    assert result.exit_code == 0, result.output
+    assert "Artifact:" in result.output
+    assert "gaia-evidence assess" in result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "artifact.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["kind"] == "lkm_exploration"
+    assert payload["artifacts"]["scope"] == ".gaia/exploration/scope.json"
+    assert payload["artifacts"]["focuses"] == ".gaia/exploration/focuses.json"
+    assert payload["artifacts"]["artifact"] == ".gaia/exploration/artifact.json"
+    assert payload["interface"]["assess"]["command"].startswith("gaia-evidence assess")
+
+
 def test_explore_observe_dedups_and_skips_materialized(galileo_pkg: Path):
     runner.invoke(
         app,

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -640,7 +640,12 @@ def test_explore_scope_rejects_invalid_dimension(galileo_pkg: Path):
 
 
 def test_explore_scope_help_lists_options():
-    result = runner.invoke(app, ["scope", "--help"])
+    result = runner.invoke(
+        app,
+        ["scope", "--help"],
+        color=False,
+        terminal_width=200,
+    )
 
     assert result.exit_code == 0, result.output
     assert "--seed" in result.output


### PR DESCRIPTION
## Summary
- Add a draft design spec for positioning `gaia-lkm-explore` as the Explore stage in the Gaia research loop.
- Define the Explore-to-Assess handoff via typed artifacts, foci, gates, and assessment contexts.
- Document the `docs/specs/` directory in the docs README.

## Test Plan
- [x] `git diff --cached --check`
- [x] Commit hooks completed during `git commit`

## Notes
- Sent the repository spec Markdown to the 大知识模型中的涌现 Feishu group for discussion.