### PR TITLE
Improve exploration feedback UX and landscape staging

### DIFF
--- a/gaia/cli/commands/infer.py
+++ b/gaia/cli/commands/infer.py
@@ -22,11 +22,12 @@ from gaia.engine.packaging import (
     gaia_lang_version,
     load_dependency_compiled_graphs,
     load_gaia_package,
+    write_text_atomic,
 )
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    write_text_atomic(path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
 
 
 def _load_inference_inputs(path: str) -> tuple[Any, Any]:

--- a/gaia/engine/_stale_check.py
+++ b/gaia/engine/_stale_check.py
@@ -10,6 +10,7 @@ diagnostics). This module owns the detection; callers own the reporting.
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -49,6 +50,8 @@ def check_compiled_artifacts(
     *,
     ir_hash: str,
     compiled_payload: dict[str, Any] | None = None,
+    retries: int = 3,
+    retry_delay_s: float = 0.05,
 ) -> ArtifactStaleness:
     """Compare persisted ``.gaia/ir_hash`` / ``.gaia/ir.json`` against a fresh compile.
 
@@ -56,6 +59,25 @@ def check_compiled_artifacts(
     compares the persisted ``ir.json`` byte-payload against it (the
     ``infer`` flow needs this; ``check`` does not).
     """
+    for attempt in range(retries + 1):
+        result = _check_compiled_artifacts_once(
+            pkg_path,
+            ir_hash=ir_hash,
+            compiled_payload=compiled_payload,
+        )
+        if not result.is_stale or attempt == retries:
+            return result
+        time.sleep(retry_delay_s)
+    raise AssertionError("unreachable")
+
+
+def _check_compiled_artifacts_once(
+    pkg_path: Path,
+    *,
+    ir_hash: str,
+    compiled_payload: dict[str, Any] | None = None,
+) -> ArtifactStaleness:
+    """Single-read implementation for :func:`check_compiled_artifacts`."""
     ir_hash_path = pkg_path / ".gaia" / "ir_hash"
     ir_json_path = pkg_path / ".gaia" / "ir.json"
     result = ArtifactStaleness(

--- a/gaia/engine/exploration/frontier.py
+++ b/gaia/engine/exploration/frontier.py
@@ -89,6 +89,35 @@ def _pulled_claim_title(text: str, *, limit: int = 90) -> str:
     return collapsed[: limit - 1] + "…" if len(collapsed) > limit else collapsed
 
 
+def _pulled_claim_triage_meta(qid: str, edges: list[tuple[str, list[str]]]) -> dict[str, Any]:
+    """Classify a pulled dependency claim for display-level triage.
+
+    LKM materialization labels paper conclusions as ``conclusion_*``. Those are
+    the first items a human usually wants to wire into the root graph. Other
+    pulled claims that participate in dependency edges are still load-bearing;
+    isolated claims are supporting context. This metadata does not affect the
+    scorer. It only lets the CLI list pulled-paper worklists in a human triage
+    order.
+    """
+    label = qid.rsplit("::", 1)[1] if "::" in qid else qid
+    edge_degree = sum(1 for _kind, refs in edges if qid in refs)
+    lowered = label.lower()
+    if lowered.startswith("conclusion"):
+        role = "conclusion"
+        priority = 0
+    elif edge_degree > 0:
+        role = "load-bearing"
+        priority = 1
+    else:
+        role = "supporting"
+        priority = 2
+    return {
+        "triage_role": role,
+        "triage_priority": priority,
+        "triage_edge_degree": edge_degree,
+    }
+
+
 def _iter_operators(ir: LocalCanonicalGraph) -> list[Any]:
     """Yield every Operator the IR carries: standalone + inside FormalStrategy.
 
@@ -572,6 +601,7 @@ class JointView:
             meta = dict(prior.meta) if prior is not None else {}
             meta["pulled_unformalized"] = True
             meta["title"] = _pulled_claim_title(texts.get(qid, "")) or label
+            meta.update(_pulled_claim_triage_meta(qid, self.edges))
             contacts.append(
                 Contact(
                     id=prior.id if prior is not None else mint_contact_id(),

--- a/gaia/engine/exploration/landscape.py
+++ b/gaia/engine/exploration/landscape.py
@@ -1,0 +1,231 @@
+"""Paper-level landscape staging for LKM exploration.
+
+The normal frontier loop expands one ranked contact at a time. A landscape pass
+is deliberately shallower: it consumes one or more already-run ``gaia search lkm``
+JSON envelopes, deduplicates them to paper-level leads, and produces a neutral
+pull-order artifact. It does not call LKM, author Gaia source, or encode any
+field-specific schema such as PICO, evidence hierarchy, or endpoint categories.
+Those belong in optional tactics layered above this generic paper-lead table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from gaia.engine.exploration.observe import distill_paper_leads
+from gaia.engine.exploration.state import Contact, ExplorationMap
+
+LANDSCAPE_SCHEMA_VERSION = 1
+
+
+def _utcnow() -> str:
+    return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _query_text(search_results: dict[str, Any], fallback: str | None = None) -> str | None:
+    """Return explicit query text, else the normalized envelope query."""
+    if isinstance(fallback, str) and fallback.strip():
+        return fallback.strip()
+    query = search_results.get("query")
+    if isinstance(query, dict):
+        text = query.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return None
+
+
+def _result_count(search_results: dict[str, Any]) -> int:
+    results = search_results.get("results")
+    return len(results) if isinstance(results, list) else 0
+
+
+@dataclass
+class LandscapeBatch:
+    """One saved LKM search envelope supplied to a landscape pass."""
+
+    search_results: dict[str, Any]
+    query: str | None = None
+    source_qid: str | None = None
+    path: str | None = None
+
+
+@dataclass
+class LandscapeLead:
+    """One deduplicated unpulled paper lead in a landscape artifact."""
+
+    paper_id: str
+    title: str | None = None
+    doi: str | None = None
+    index_id: str | None = None
+    best_rank: float | None = None
+    queries: list[str] = field(default_factory=list)
+    source_qids: list[str] = field(default_factory=list)
+    lkm_node_ids: list[str] = field(default_factory=list)
+    result_count: int = 0
+    existing_contact_id: str | None = None
+    existing_contact_status: str | None = None
+
+    def merge_query(self, query: str | None) -> None:
+        """Record a surfacing query once, preserving first-seen order."""
+        if query and query not in self.queries:
+            self.queries.append(query)
+
+    def merge_source(self, source_qid: str | None) -> None:
+        """Record a survey source once, preserving first-seen order."""
+        if source_qid and source_qid not in self.source_qids:
+            self.source_qids.append(source_qid)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-compatible representation."""
+        payload: dict[str, Any] = {
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "doi": self.doi,
+            "index_id": self.index_id,
+            "best_rank": self.best_rank,
+            "queries": list(self.queries),
+            "source_qids": list(self.source_qids),
+            "lkm_node_ids": list(self.lkm_node_ids),
+            "result_count": self.result_count,
+        }
+        if self.existing_contact_id is not None:
+            payload["existing_contact_id"] = self.existing_contact_id
+            payload["existing_contact_status"] = self.existing_contact_status
+        return payload
+
+
+@dataclass
+class Landscape:
+    """A neutral, paper-level view of multiple LKM search batches."""
+
+    created_at: str
+    queries: list[dict[str, Any]]
+    paper_leads: list[LandscapeLead]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-compatible artifact."""
+        paper_leads = [lead.to_dict() for lead in self.paper_leads]
+        return {
+            "schema_version": LANDSCAPE_SCHEMA_VERSION,
+            "kind": "exploration_landscape",
+            "created_at": self.created_at,
+            "queries": [dict(q) for q in self.queries],
+            "stats": {
+                "query_batches": len(self.queries),
+                "raw_results": sum(int(q.get("raw_results", 0)) for q in self.queries),
+                "paper_leads": len(paper_leads),
+            },
+            "paper_leads": paper_leads,
+            "recommended_pull_order": [lead.paper_id for lead in self.paper_leads],
+            "notes": [
+                "Paper leads are topic-neutral and schema-neutral.",
+                "Domain-specific classifications should be added by an optional tactic/profile.",
+            ],
+        }
+
+
+def _existing_lkm_contacts(exploration_map: ExplorationMap | None) -> dict[str, Contact]:
+    if exploration_map is None:
+        return {}
+    out: dict[str, Contact] = {}
+    for contact in exploration_map.frontier:
+        if contact.ref.get("kind") != "lkm":
+            continue
+        paper_id = str(contact.ref.get("value"))
+        if paper_id:
+            out[paper_id] = contact
+    return out
+
+
+def build_landscape(
+    batches: list[LandscapeBatch],
+    *,
+    materialized: set[str],
+    materialized_paper_ids: set[str] | None = None,
+    exploration_map: ExplorationMap | None = None,
+) -> Landscape:
+    """Build a deduplicated paper-lead landscape from saved LKM search results.
+
+    Args:
+        batches: Search envelopes to aggregate. They should be normalized
+            ``gaia-json`` results from ``gaia search lkm``.
+        materialized: Joint materialized QID set. Results already materialized as
+            Gaia QIDs are skipped.
+        materialized_paper_ids: Paper IDs already pulled into the joint view.
+        exploration_map: Optional current map used only to annotate whether a
+            paper already has a frontier contact.
+
+    Returns:
+        A :class:`Landscape` ordered by neutral pull priority: best retrieval
+        rank, then number of surfacing result rows, then paper id.
+    """
+    leads_by_paper: dict[str, LandscapeLead] = {}
+    queries: list[dict[str, Any]] = []
+    existing_contacts = _existing_lkm_contacts(exploration_map)
+
+    for index, batch in enumerate(batches):
+        query = _query_text(batch.search_results, batch.query)
+        raw_results = _result_count(batch.search_results)
+        distilled = distill_paper_leads(
+            batch.search_results,
+            materialized=materialized,
+            materialized_paper_ids=materialized_paper_ids,
+        )
+        queries.append(
+            {
+                "index": index,
+                "query": query,
+                "source_qid": batch.source_qid,
+                "path": batch.path,
+                "raw_results": raw_results,
+                "paper_leads": len(distilled),
+            }
+        )
+        for paper in distilled:
+            lead = leads_by_paper.get(paper.paper_id)
+            if lead is None:
+                contact = existing_contacts.get(paper.paper_id)
+                lead = LandscapeLead(
+                    paper_id=paper.paper_id,
+                    title=paper.title,
+                    doi=paper.doi,
+                    index_id=paper.index_id,
+                    existing_contact_id=contact.id if contact is not None else None,
+                    existing_contact_status=contact.status if contact is not None else None,
+                )
+                leads_by_paper[paper.paper_id] = lead
+            if lead.title is None and paper.title:
+                lead.title = paper.title
+            if lead.doi is None and paper.doi:
+                lead.doi = paper.doi
+            if lead.index_id is None and paper.index_id:
+                lead.index_id = paper.index_id
+            if paper.rank is not None and (lead.best_rank is None or paper.rank > lead.best_rank):
+                lead.best_rank = paper.rank
+            lead.merge_query(query)
+            lead.merge_source(batch.source_qid)
+            for node_id in paper.lkm_node_ids or []:
+                if node_id not in lead.lkm_node_ids:
+                    lead.lkm_node_ids.append(node_id)
+            lead.result_count += len(paper.lkm_node_ids or [])
+
+    paper_leads = sorted(
+        leads_by_paper.values(),
+        key=lambda lead: (
+            -(lead.best_rank or 0.0),
+            -lead.result_count,
+            lead.paper_id,
+        ),
+    )
+    return Landscape(created_at=_utcnow(), queries=queries, paper_leads=paper_leads)
+
+
+__all__ = [
+    "LANDSCAPE_SCHEMA_VERSION",
+    "Landscape",
+    "LandscapeBatch",
+    "LandscapeLead",
+    "build_landscape",
+]

--- a/gaia/engine/exploration/state.py
+++ b/gaia/engine/exploration/state.py
@@ -586,16 +586,22 @@ def load_map(pkg_path: str | Path) -> ExplorationMap:
 def save_map(pkg_path: str | Path, exploration_map: ExplorationMap) -> None:
     """Persist the exploration map atomically to ``.gaia/exploration/map.json``.
 
-    Refreshes ``updated_at`` and writes via ``map.json.tmp`` then
+    Refreshes ``updated_at`` and writes via a per-save temp file before
     ``tmp.replace(path)`` (the ``snapshot.py`` atomic-write pattern) so a reader
-    never observes a half-written file.
+    never observes a half-written file. The temp name is unique per process/save,
+    so two read-only frontier/status probes do not collide on one shared
+    ``map.json.tmp`` scratch path.
     """
     p = _map_path(pkg_path)
     exploration_map.updated_at = _utcnow()
     payload = exploration_map.to_dict()
-    tmp = p.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp.replace(p)
+    tmp = p.with_name(f"{p.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(p)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
 
 
 def append_round(

--- a/gaia/engine/packaging.py
+++ b/gaia/engine/packaging.py
@@ -12,6 +12,7 @@ import importlib
 import json
 import subprocess
 import sys
+import uuid
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -58,6 +59,7 @@ __all__ = [
     "ensure_package_env",
     "load_dependency_compiled_graphs",
     "load_gaia_package",
+    "write_text_atomic",
 ]
 
 
@@ -1506,6 +1508,18 @@ def _render_compile_metadata(ir_hash: str) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
 
 
+def write_text_atomic(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Write text via a unique temp file and atomic replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        tmp.write_text(text, encoding=encoding)
+        tmp.replace(path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
 def write_compiled_artifacts(
     pkg_path: Path,
     ir: dict[str, Any],
@@ -1517,16 +1531,17 @@ def write_compiled_artifacts(
     gaia_dir = pkg_path / ".gaia"
     gaia_dir.mkdir(exist_ok=True)
     ir_json = json.dumps(ir, ensure_ascii=False, indent=2, sort_keys=True)
-    (gaia_dir / "ir.json").write_text(ir_json)
-    (gaia_dir / "ir_hash").write_text(ir["ir_hash"])
-    (gaia_dir / "compile_metadata.json").write_text(_render_compile_metadata(ir["ir_hash"]))
+    write_text_atomic(gaia_dir / "ir.json", ir_json)
+    write_text_atomic(gaia_dir / "ir_hash", ir["ir_hash"])
+    write_text_atomic(gaia_dir / "compile_metadata.json", _render_compile_metadata(ir["ir_hash"]))
     if formalization_manifest is not None:
-        (gaia_dir / "formalization_manifest.json").write_text(
-            render_manifest_json(formalization_manifest)
+        write_text_atomic(
+            gaia_dir / "formalization_manifest.json",
+            render_manifest_json(formalization_manifest),
         )
     if manifests:
         manifests_dir = gaia_dir / "manifests"
         manifests_dir.mkdir(exist_ok=True)
         for filename, payload in manifests.items():
-            (manifests_dir / filename).write_text(render_manifest_json(payload))
+            write_text_atomic(manifests_dir / filename, render_manifest_json(payload))
     return gaia_dir

--- a/gaia/explore_client/cli.py
+++ b/gaia/explore_client/cli.py
@@ -4,8 +4,8 @@ A **sibling console_scripts entrypoint** to ``gaia`` and, as of build 7
 (CLIENT.md "Unified surface"), the *single* user-facing surface for exploration.
 It carries both halves of the turn loop:
 
-* the deterministic **engine verbs** (``init`` / ``observe`` / ``frontier`` /
-  ``round`` / ``status`` / ``render``), migrated here from the now-removed
+* the deterministic **engine verbs** (``init`` / ``observe`` / ``landscape`` /
+  ``frontier`` / ``round`` / ``status`` / ``render``), migrated here from the now-removed
   ``gaia explore`` sub-app — thin wrappers over :mod:`gaia.engine.exploration`
   (the library / SDK, which stays in gaia); and
 * the **orchestrator** phase-aware step ``turn`` — the turn state machine that
@@ -37,6 +37,7 @@ from gaia.explore_client.orchestrator import (
 from gaia.explore_client.verbs import (
     frontier_command,
     init_command,
+    landscape_command,
     observe_command,
     render_command,
     round_command,
@@ -47,8 +48,8 @@ app = typer.Typer(
     name="gaia-lkm-explore",
     help=(
         "Gaia LKM Explore — fog-of-war exploration of a knowledge package. "
-        "Deterministic engine verbs (init / observe / frontier / round / status / "
-        "render) plus the orchestrator turn state machine (turn), which hands the "
+        "Deterministic engine verbs (init / observe / landscape / frontier / round / "
+        "status / render) plus the orchestrator turn state machine (turn), which hands the "
         "fuzzy survey to an agent through a self-contained task envelope."
     ),
     no_args_is_help=True,
@@ -59,6 +60,7 @@ app = typer.Typer(
 # — no LKM call, no `gaia author` orchestration; those are the agent's survey.
 app.command(name="init")(init_command)
 app.command(name="observe")(observe_command)
+app.command(name="landscape")(landscape_command)
 app.command(name="frontier")(frontier_command)
 app.command(name="round")(round_command)
 app.command(name="status")(status_command)

--- a/gaia/explore_client/instructions.py
+++ b/gaia/explore_client/instructions.py
@@ -142,6 +142,10 @@ You survey the contacts listed in this task (round 0: survey the seed(s) instead
            --query "<query>" --search-json /tmp/leads.json
    Every result whose paper is not materialized becomes an `lkm_related`
    paper-contact, ranked next round. Do this for EVERY survey query.
+   If the original research question is not in English and LKM search metadata
+   hydration times out, KEEP the original seed/question but retry the LKM search
+   with a faithful English equivalent query; record the actual search string in
+   `--query` so the map preserves how the paper frontier was surfaced.
 
 3. PULL the top related paper(s) to open new territory:
        gaia pkg add --lkm-paper <paper_id>
@@ -174,6 +178,15 @@ You survey the contacts listed in this task (round 0: survey the seed(s) instead
    a dependency. Formalize the load-bearing claims (not necessarily all of a
    paper's claims, but the ones that matter to your question) BEFORE moving on to
    the next contact.
+
+   Multi-endpoint papers and meta-analyses need structure, not one giant gate. If
+   a paper reports several independent endpoint conclusions (for example benefit,
+   null-effect, and harm endpoints), do NOT put every pulled conclusion into one
+   all-of `derive` for a single net claim. Author intermediate claims such as
+   benefit signal / null-effect signal / harm signal, support each with its own
+   relevant pulled conclusions, then connect those intermediate claims to the
+   higher-level net-benefit interpretation. This avoids making belief hinge on an
+   overly strict conjunction of unrelated endpoints.
 
 4. AUTHOR remaining evidence from search results — for leads you surfaced via
    `gaia search lkm` but did not pull (or that have no compilable chain),

--- a/gaia/explore_client/orchestrator.py
+++ b/gaia/explore_client/orchestrator.py
@@ -351,6 +351,7 @@ def _compile_and_infer(pkg: str | Path) -> list[str]:
         gaia_lang_version,
         load_gaia_package,
         write_compiled_artifacts,
+        write_text_atomic,
     )
 
     pkg_path = Path(pkg).resolve()
@@ -443,9 +444,9 @@ def _compile_and_infer(pkg: str | Path) -> list[str]:
     }
     gaia_dir = loaded.pkg_path / ".gaia"
     gaia_dir.mkdir(exist_ok=True)
-    (gaia_dir / "beliefs.json").write_text(
+    write_text_atomic(
+        gaia_dir / "beliefs.json",
         json.dumps(beliefs_payload, ensure_ascii=False, indent=2, sort_keys=True),
-        encoding="utf-8",
     )
     return notes
 

--- a/gaia/explore_client/verbs.py
+++ b/gaia/explore_client/verbs.py
@@ -17,6 +17,8 @@ Commands (SCHEMA.md §7c / §7f):
   read ``gaia search lkm`` JSON (file/stdin) and record each unpulled related
   paper as an ``lkm_related`` paper-contact (SCHEMA.md §7f — the primary frontier
   source). This is the step the agent calls after each LKM survey.
+* ``landscape <pkg> --search-json <file> ...`` — aggregate saved LKM search JSON
+  into a neutral paper-level landscape artifact before deep pulls.
 * ``frontier <pkg>`` — load map + IR + manifest + beliefs, build the joint view,
   promote any now-materialized ``lkm`` contacts, run ``extract_frontier`` →
   ``reconcile_frontier`` → ``score_frontier``, save, and print the ranked top-k
@@ -58,6 +60,7 @@ from gaia.engine.exploration.frontier import (
     resolve_freetext_seed_qid,
 )
 from gaia.engine.exploration.health import MapHealth, compute_map_health
+from gaia.engine.exploration.landscape import LandscapeBatch, build_landscape
 from gaia.engine.exploration.observe import (
     materialized_paper_ids_from_roots,
     observe_lkm_results,
@@ -92,6 +95,7 @@ from gaia.engine.exploration.state import (
 )
 from gaia.engine.inquiry.focus import resolve_focus_target
 from gaia.engine.inquiry.review import resolve_graph
+from gaia.engine.packaging import write_text_atomic
 
 # Module-level option singletons — Typer needs ``typer.Option`` objects as the
 # parameter defaults, but ruff B008 forbids the call literally in the signature,
@@ -129,6 +133,34 @@ _SEARCH_JSON_OPT = typer.Option(
     None,
     "--search-json",
     help="Path to a `gaia search lkm` result JSON file (omit to read from stdin).",
+)
+_LANDSCAPE_SEARCH_JSON_OPT = typer.Option(
+    None,
+    "--search-json",
+    help="Path to a saved `gaia search lkm` result JSON file (repeatable).",
+)
+_LANDSCAPE_QUERY_OPT = typer.Option(
+    None,
+    "--query",
+    help=(
+        "Query text for the matching --search-json file (repeatable; defaults to "
+        "the normalized search envelope's query text)."
+    ),
+)
+_LANDSCAPE_SOURCE_OPT = typer.Option(
+    None,
+    "--source",
+    help="Survey source QID for the matching --search-json file (repeatable, optional).",
+)
+_LANDSCAPE_OUT_OPT = typer.Option(
+    None,
+    "--out",
+    help="Output JSON path (default <pkg>/.gaia/exploration/landscape-<round>.json).",
+)
+_LANDSCAPE_JSON_OPT = typer.Option(
+    False,
+    "--json",
+    help="Print the landscape artifact JSON to stdout after writing it.",
 )
 _OBSERVE_SOURCE_OPT = typer.Option(
     None,
@@ -239,6 +271,22 @@ def _load_ir_dict(pkg: str) -> dict[str, Any] | None:
         return dict(json.loads(p.read_text(encoding="utf-8")))
     except json.JSONDecodeError:
         return None
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    """Read a JSON object from ``path`` or exit with a CLI error."""
+    if not path.exists():
+        typer.echo(f"Error: file not found: {path}", err=True)
+        raise typer.Exit(1)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Error: {path} is not valid JSON: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    if not isinstance(raw, dict):
+        typer.echo(f"Error: {path} must contain a JSON object.", err=True)
+        raise typer.Exit(1)
+    return raw
 
 
 def _require_graph(pkg: str) -> Any:
@@ -768,6 +816,113 @@ def observe_command(
     typer.echo(
         "Next: `gaia-lkm-explore frontier` to rank them; pull the top via `pkg add --lkm-paper`."
     )
+
+
+# --------------------------------------------------------------------------- #
+# landscape                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def landscape_command(
+    pkg: str = _PKG_ARG,
+    search_json: list[str] | None = _LANDSCAPE_SEARCH_JSON_OPT,
+    query: list[str] | None = _LANDSCAPE_QUERY_OPT,
+    source: list[str] | None = _LANDSCAPE_SOURCE_OPT,
+    out: str | None = _LANDSCAPE_OUT_OPT,
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    r"""Aggregate saved LKM searches into a paper-level landscape artifact.
+
+    This is a breadth-first staging pass before deep pulls. It reads one or more
+    normalized ``gaia search lkm`` JSON files, deduplicates their results by
+    paper, skips already materialized papers when the package is compiled, and
+    writes a generic ``exploration_landscape`` JSON artifact. It does **not** call
+    LKM, mutate the map, pull papers, author Gaia source, or encode any
+    field-specific evidence schema.
+
+    Example:
+
+    .. code-block:: bash
+
+        gaia search lkm knowledge "free fall" > leads-a.json
+        gaia search lkm knowledge "falling bodies Galileo" > leads-b.json
+        gaia-lkm-explore landscape ./pkg \
+            --search-json leads-a.json --search-json leads-b.json
+    """
+    if not (_gaia_dir(pkg) / "exploration" / "map.json").exists():
+        typer.echo(
+            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    search_paths = [Path(p) for p in search_json or []]
+    if not search_paths:
+        typer.echo("Error: provide at least one --search-json file.", err=True)
+        raise typer.Exit(2)
+
+    queries = list(query or [])
+    sources = list(source or [])
+    batches = [
+        LandscapeBatch(
+            search_results=_read_json_object(path),
+            query=queries[i] if i < len(queries) else None,
+            source_qid=sources[i] if i < len(sources) else None,
+            path=str(path),
+        )
+        for i, path in enumerate(search_paths)
+    ]
+
+    exploration_map = load_map(pkg)
+    materialized: set[str] = set()
+    materialized_papers: set[str] = set()
+    graph = resolve_graph(pkg)
+    if graph is not None:
+        view = _require_joint_view(pkg, graph)
+        materialized = set(view.materialized)
+        materialized_papers = set(view.materialized_paper_ids) | materialized_paper_ids_from_roots(
+            view.package_roots
+        )
+    else:
+        typer.echo(
+            "(no compiled IR yet — landscape cannot skip already-pulled papers by joint view)",
+            err=True,
+        )
+
+    landscape = build_landscape(
+        batches,
+        materialized=materialized,
+        materialized_paper_ids=materialized_papers,
+        exploration_map=exploration_map,
+    )
+    payload = landscape.to_dict()
+
+    output_path = (
+        Path(out)
+        if out is not None
+        else _gaia_dir(pkg) / "exploration" / f"landscape-{exploration_map.round}.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    stats = payload["stats"]
+    typer.echo(
+        f"Landscape: {stats['query_batches']} query batch(es), "
+        f"{stats['raw_results']} raw result(s), {stats['paper_leads']} paper lead(s)."
+    )
+    typer.echo(f"Output: {output_path}")
+    top = landscape.paper_leads[: exploration_map.policy.budget_k]
+    if top:
+        typer.echo(f"Top paper lead(s) (budget_k={exploration_map.policy.budget_k}):")
+        for rank, lead in enumerate(top, start=1):
+            title = f' "{lead.title}"' if lead.title else ""
+            rank_text = f", rank={lead.best_rank:.4g}" if lead.best_rank is not None else ""
+            typer.echo(f"  {rank}. paper:{lead.paper_id}{title}{rank_text}")
+    else:
+        typer.echo("  (no unpulled paper leads)")
+
+    if json_out:
+        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 
 
 # --------------------------------------------------------------------------- #

--- a/gaia/explore_client/verbs.py
+++ b/gaia/explore_client/verbs.py
@@ -112,6 +112,14 @@ _DOCTRINE_OPT = typer.Option(
 )
 _BUDGET_K_OPT = typer.Option(5, "--budget-k", help="Top-k contacts to survey per round.")
 _FRONTIER_JSON_OPT = typer.Option(False, "--json", help="Emit the ranked contacts as JSON.")
+_FRONTIER_TRIAGE_PULLED_OPT = typer.Option(
+    False,
+    "--triage-pulled",
+    help=(
+        "Show pulled-paper claim contacts first, ordered for paper triage "
+        "(conclusion, load-bearing, then supporting)."
+    ),
+)
 _SURVEYED_OPT = typer.Option(
     None,
     "--surveyed",
@@ -381,6 +389,63 @@ def _ranked_open_contacts(exploration_map: ExplorationMap) -> list[Contact]:
     )
 
 
+def _triaged_pulled_contacts(ranked: list[Contact]) -> list[Contact]:
+    """Pulled-paper claim contacts ordered for a human paper-triage pass.
+
+    This is a display/worklist mode, not a scorer change: it filters to the
+    existing pulled-but-unformalized contacts and orders them by metadata emitted
+    by the joint frontier view, with the stored rank as a stable tie-breaker.
+    """
+    pulled = [c for c in ranked if c.meta.get("pulled_unformalized")]
+    return sorted(
+        pulled,
+        key=lambda c: (
+            int(c.meta.get("triage_priority", 99)),
+            -(c.score or 0.0),
+            str(c.ref.get("value")),
+        ),
+    )
+
+
+def _recommendation_reason(contact: Contact) -> str:
+    """Human-readable frontier rationale from agent-visible signals.
+
+    The numeric score and belief-derived terms stay hidden (build 11 steer 4).
+    This explains the rank using non-belief facets plus contact type/triage
+    metadata so the next action is legible without exposing BP internals.
+    """
+    features = sanitize_score_features(contact.score_features)
+    reasons: list[str] = []
+    if contact.ref.get("kind") == "lkm":
+        reasons.append("unpulled related paper")
+        if float(features.get("new_territory", 0.0) or 0.0) >= 0.5:
+            reasons.append("opens fresh paper territory")
+        if float(features.get("closeness_to_seed", 0.0) or 0.0) > 0.0:
+            reasons.append("matches the seed/query context")
+        if float(features.get("survey_cost", 0.0) or 0.0) > 1.0:
+            reasons.append("requires a full paper pull")
+    elif contact.meta.get("pulled_unformalized"):
+        role = str(contact.meta.get("triage_role") or "pulled claim")
+        if role == "conclusion":
+            reasons.append("pulled paper conclusion not wired into the root graph")
+        elif role == "load-bearing":
+            reasons.append("pulled paper load-bearing claim")
+        else:
+            reasons.append("pulled paper supporting claim")
+        degree = int(contact.meta.get("triage_edge_degree", 0) or 0)
+        if degree:
+            reasons.append(f"appears in {degree} dependency edge(s)")
+    else:
+        reasons.append("referenced claim/question not materialized yet")
+        edge_kinds = sorted({str(s.get("edge")) for s in contact.sources if s.get("edge")})
+        if edge_kinds:
+            reasons.append(f"reached via {', '.join(edge_kinds)}")
+
+    if float(features.get("obligation_pressure", 0.0) or 0.0) > 0.0:
+        reasons.append("discharges an open obligation")
+    return "; ".join(reasons)
+
+
 def _is_paper_contact(contact: Contact) -> bool:
     """True iff the contact is an unpulled-paper (``lkm_related``) contact.
 
@@ -438,6 +503,88 @@ def _refresh_obligation_pressure(
         if graph is not None:
             edges = _require_joint_view(pkg, graph).edges
     recompute_obligation_pressure(exploration_map, obligations=obligations, edges=edges)
+
+
+def _frontier_json_rows(contacts: list[Contact]) -> list[dict[str, Any]]:
+    """Agent-facing frontier JSON rows, with belief-derived fields hidden."""
+    return [
+        {
+            "id": c.id,
+            "ref": c.ref,
+            "score_features": sanitize_score_features(c.score_features),
+            "sources": c.sources,
+            "recommendation": _recommendation_reason(c),
+        }
+        for c in contacts
+    ]
+
+
+def _echo_frontier_contact(
+    rank: int,
+    contact: Contact,
+    *,
+    obligation_contents: list[str],
+) -> None:
+    """Print one human-readable frontier contact row."""
+    ref = str(contact.ref.get("value"))
+    srcs = ", ".join(f"{s['qid']}[{s['edge']}]" for s in contact.sources) or "(no sources)"
+    if contact.ref.get("kind") == "lkm":
+        title = contact.meta.get("title")
+        label = f"paper:{ref}"
+        if isinstance(title, str) and title:
+            label = f'{label}  "{title}"'
+        index_id = contact.meta.get("index_id")
+        idx_arg = f" --lkm-index {index_id}" if isinstance(index_id, str) else ""
+        typer.echo(f"  {rank}. [lkm] {label}")
+        typer.echo(f"       pull: gaia pkg add{idx_arg} --lkm-paper {ref}")
+    else:
+        typer.echo(f"  {rank}. {ref}")
+    typer.echo(f"       via: {srcs}")
+    typer.echo(f"       why: {_recommendation_reason(contact)}")
+    if contact.meta.get("pulled_unformalized"):
+        role = contact.meta.get("triage_role", "pulled claim")
+        degree = contact.meta.get("triage_edge_degree", 0)
+        typer.echo(f"       triage: {role} (dependency edges: {degree})")
+    # (theme 006) Surface that this contact discharges an open obligation —
+    # set by the scorer's ref/source OR one-hop-adjacency match.
+    if _is_obligation_pressed(contact) and obligation_contents:
+        typer.echo(f"       discharges open obligation: {'; '.join(obligation_contents[:2])}")
+
+
+def _echo_frontier_text(
+    ranked: list[Contact],
+    top_k: list[Contact],
+    exploration_map: ExplorationMap,
+    *,
+    triage_pulled: bool,
+    obligations: list[Any],
+) -> None:
+    """Print the human frontier/triage surface."""
+    if triage_pulled:
+        typer.echo(
+            f"Frontier triage: {len(top_k)} pulled-paper claim contact(s) shown "
+            f"from {len(ranked)} open contact(s); top {len(top_k)} "
+            f"(budget_k={exploration_map.policy.budget_k}, "
+            f"doctrine {exploration_map.policy.doctrine}):"
+        )
+    else:
+        n_lkm = sum(1 for c in ranked if c.ref.get("kind") == "lkm")
+        typer.echo(
+            f"Frontier: {len(ranked)} open contact(s) ({n_lkm} lkm_related); "
+            f"top {len(top_k)} (budget_k={exploration_map.policy.budget_k}, "
+            f"doctrine {exploration_map.policy.doctrine}):"
+        )
+    if not top_k:
+        msg = (
+            "  (no pulled-paper claim contacts to triage)"
+            if triage_pulled
+            else "  (frontier empty — every referenced node is materialized)"
+        )
+        typer.echo(msg)
+        return
+    obligation_contents = _obligation_contents(obligations)
+    for rank, contact in enumerate(top_k, start=1):
+        _echo_frontier_contact(rank, contact, obligation_contents=obligation_contents)
 
 
 # --------------------------------------------------------------------------- #
@@ -631,6 +778,7 @@ def observe_command(
 def frontier_command(
     pkg: str = _PKG_ARG,
     json_out: bool = _FRONTIER_JSON_OPT,
+    triage_pulled: bool = _FRONTIER_TRIAGE_PULLED_OPT,
 ) -> None:
     r"""Extract, score, and rank the exploration frontier.
 
@@ -648,6 +796,7 @@ def frontier_command(
 
         gaia-lkm-explore frontier ./pkg
         gaia-lkm-explore frontier ./pkg --json
+        gaia-lkm-explore frontier ./pkg --triage-pulled
     """
     if not (_gaia_dir(pkg) / "exploration" / "map.json").exists():
         typer.echo(
@@ -698,7 +847,8 @@ def frontier_command(
     save_map(pkg, exploration_map)
 
     ranked = _ranked_open_contacts(exploration_map)
-    top_k = ranked[: exploration_map.policy.budget_k]
+    display_contacts = _triaged_pulled_contacts(ranked) if triage_pulled else ranked
+    top_k = display_contacts[: exploration_map.policy.budget_k]
 
     if json_out:
         # Build 11 steer 4 (Jaynes' robot): the engine ranks by belief
@@ -706,15 +856,7 @@ def frontier_command(
         # surfaces the belief math. ``top_k`` is already belief-ordered; here we
         # drop the belief-derived ``belief_entropy`` feature and the raw
         # belief-weighted ``score`` from each emitted row. Ordering is preserved.
-        rows = [
-            {
-                "id": c.id,
-                "ref": c.ref,
-                "score_features": sanitize_score_features(c.score_features),
-                "sources": c.sources,
-            }
-            for c in top_k
-        ]
+        rows = _frontier_json_rows(top_k)
         typer.echo(json.dumps(rows, ensure_ascii=False, indent=2))
         return
 
@@ -725,38 +867,15 @@ def frontier_command(
             f"Promoted {len(promoted_papers)} lkm_related contact(s) "
             f"(paper(s) now materialized): {', '.join(promoted_papers)}"
         )
-    # ``ranked`` is already open-only; count the lkm_related share for legibility.
-    n_lkm = sum(1 for c in ranked if c.ref.get("kind") == "lkm")
-    typer.echo(
-        f"Frontier: {len(ranked)} open contact(s) ({n_lkm} lkm_related); "
-        f"top {len(top_k)} (budget_k={exploration_map.policy.budget_k}, "
-        f"doctrine {exploration_map.policy.doctrine}):"
-    )
-    if not top_k:
-        typer.echo("  (frontier empty — every referenced node is materialized)")
-        return
     # Rank order conveys priority; the numeric belief-weighted score is NOT
     # printed (build 11 steer 4 — belief stays internal to the engine).
-    obligation_contents = _obligation_contents(obligations)
-    for rank, c in enumerate(top_k, start=1):
-        ref = str(c.ref.get("value"))
-        srcs = ", ".join(f"{s['qid']}[{s['edge']}]" for s in c.sources) or "(no sources)"
-        if c.ref.get("kind") == "lkm":
-            title = c.meta.get("title")
-            label = f"paper:{ref}"
-            if isinstance(title, str) and title:
-                label = f'{label}  "{title}"'
-            index_id = c.meta.get("index_id")
-            idx_arg = f" --lkm-index {index_id}" if isinstance(index_id, str) else ""
-            typer.echo(f"  {rank}. [lkm] {label}")
-            typer.echo(f"       pull: gaia pkg add{idx_arg} --lkm-paper {ref}")
-        else:
-            typer.echo(f"  {rank}. {ref}")
-        typer.echo(f"       via: {srcs}")
-        # (theme 006) Surface that this contact discharges an open obligation —
-        # set by the scorer's ref/source OR one-hop-adjacency match.
-        if _is_obligation_pressed(c) and obligation_contents:
-            typer.echo(f"       discharges open obligation: {'; '.join(obligation_contents[:2])}")
+    _echo_frontier_text(
+        ranked,
+        top_k,
+        exploration_map,
+        triage_pulled=triage_pulled,
+        obligations=obligations,
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/cli/test_compile.py
+++ b/tests/cli/test_compile.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 from gaia.cli.main import app
 from gaia.engine.ir import LocalCanonicalGraph
 from gaia.engine.ir.validator import validate_local_graph
+from gaia.engine.packaging import write_text_atomic
 
 pytestmark = pytest.mark.pr_gate
 
@@ -71,6 +72,16 @@ def test_compile_creates_ir_json(tmp_path):
     assert premises_manifest["premises"] == []
     assert holes_manifest["holes"] == []
     assert bridges_manifest["bridges"] == []
+
+
+def test_atomic_text_writer_replaces_without_temp_leftovers(tmp_path):
+    path = tmp_path / "artifact.json"
+
+    write_text_atomic(path, '{"version": 1}')
+    write_text_atomic(path, '{"version": 2}')
+
+    assert path.read_text(encoding="utf-8") == '{"version": 2}'
+    assert list(tmp_path.glob("artifact.json.*.tmp")) == []
 
 
 def test_compile_no_pyproject(tmp_path):

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -1,0 +1,52 @@
+"""Tests for compiled artifact freshness checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gaia.engine._stale_check import check_compiled_artifacts
+
+pytestmark = pytest.mark.pr_gate
+
+
+def test_check_compiled_artifacts_retries_transient_invalid_ir_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gaia_dir = tmp_path / ".gaia"
+    gaia_dir.mkdir()
+    (gaia_dir / "ir_hash").write_text("abc", encoding="utf-8")
+    (gaia_dir / "ir.json").write_text(json.dumps({"ir_hash": "abc"}), encoding="utf-8")
+
+    original_read_text = Path.read_text
+    calls = 0
+
+    def flaky_read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+        nonlocal calls
+        if path.name == "ir.json" and calls == 0:
+            calls += 1
+            return "{"
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+    result = check_compiled_artifacts(tmp_path, ir_hash="abc", retries=1, retry_delay_s=0)
+
+    assert not result.is_stale
+    assert calls == 1
+
+
+def test_check_compiled_artifacts_reports_persistent_invalid_ir_json(tmp_path: Path) -> None:
+    gaia_dir = tmp_path / ".gaia"
+    gaia_dir.mkdir()
+    (gaia_dir / "ir_hash").write_text("abc", encoding="utf-8")
+    (gaia_dir / "ir.json").write_text("{", encoding="utf-8")
+
+    result = check_compiled_artifacts(tmp_path, ir_hash="abc", retries=1, retry_delay_s=0)
+
+    assert result.is_stale
+    assert result.ir_json_invalid_reason is not None

--- a/tests/exploration/test_cli_explore.py
+++ b/tests/exploration/test_cli_explore.py
@@ -145,6 +145,7 @@ def test_explore_frontier_ranks_contacts(galileo_pkg: Path):
     assert result.exit_code == 0, result.output
     assert "Frontier:" in result.output
     assert contact_qid in result.output
+    assert "why:" in result.output
 
     m = load_map(galileo_pkg)
     contacts = [c for c in m.frontier if c.ref["value"] == contact_qid]
@@ -171,9 +172,10 @@ def test_explore_frontier_json_output(galileo_pkg: Path):
         # Build 11 steer 4: the agent-facing frontier JSON keeps the non-belief
         # surface but hides the belief math — no raw ``score`` row key, and no
         # ``belief_entropy`` inside ``score_features``.
-        assert {"id", "ref", "score_features", "sources"} <= set(row)
+        assert {"id", "ref", "score_features", "sources", "recommendation"} <= set(row)
         assert "score" not in row
         assert "belief_entropy" not in row["score_features"]
+        assert row["recommendation"]
 
 
 def test_explore_frontier_applies_obligations_like_turn(galileo_pkg: Path):

--- a/tests/exploration/test_cli_explore.py
+++ b/tests/exploration/test_cli_explore.py
@@ -520,6 +520,48 @@ def test_explore_observe_reads_stdin(galileo_pkg: Path):
     assert len([c for c in m.frontier if c.ref["kind"] == "lkm"]) == 5
 
 
+def test_explore_landscape_writes_neutral_paper_leads(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    out = galileo_pkg / ".gaia" / "exploration" / "custom-landscape.json"
+    result = runner.invoke(
+        app,
+        [
+            "landscape",
+            str(galileo_pkg),
+            "--search-json",
+            str(_FIXTURE),
+            "--search-json",
+            str(_FIXTURE),
+            "--source",
+            _galileo_qid("aristotle_model"),
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "2 query batch(es)" in result.output
+    assert "5 paper lead(s)" in result.output
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["kind"] == "exploration_landscape"
+    assert payload["stats"]["query_batches"] == 2
+    assert payload["stats"]["raw_results"] == 10
+    assert payload["stats"]["paper_leads"] == 5
+    assert len(payload["recommended_pull_order"]) == 5
+    assert "Paper leads are topic-neutral" in payload["notes"][0]
+
+    # Landscape is a staging artifact, not observe: it does not mutate the map
+    # frontier or import field-specific paper classifications.
+    assert load_map(galileo_pkg).frontier == []
+    first = payload["paper_leads"][0]
+    assert {"paper_id", "best_rank", "queries", "lkm_node_ids"} <= set(first)
+    assert "pico" not in first
+    assert "evidence_hierarchy" not in first
+
+
 def test_explore_observe_dedups_and_skips_materialized(galileo_pkg: Path):
     runner.invoke(
         app,

--- a/tests/exploration/test_frontier.py
+++ b/tests/exploration/test_frontier.py
@@ -493,6 +493,28 @@ def test_pulled_dep_claims_surface_as_unformalized_contacts(tmp_path):
     assert all(not v.startswith(NS) for v in pulled)
 
 
+def test_pulled_dep_claims_carry_triage_metadata(tmp_path):
+    root = make_graph(knowledges=[claim("seed")])
+    dep = dep_graph(
+        [
+            Knowledge(id=dep_qid("conclusion_3"), type="claim", content="main result"),
+            Knowledge(id=dep_qid("evidence_1"), type="claim", content="supporting evidence"),
+            Knowledge(id=dep_qid("context_1"), type="claim", content="background context"),
+        ]
+    )
+    view = _joint_view(root, dep, root_path=tmp_path / "root", dep_path=tmp_path / "dep")
+    view.edges.append(("depends_on", [dep_qid("evidence_1"), dep_qid("conclusion_3")]))
+
+    pulled = {c.ref["value"]: c for c in view.extract() if c.meta.get("pulled_unformalized")}
+
+    assert pulled[dep_qid("conclusion_3")].meta["triage_role"] == "conclusion"
+    assert pulled[dep_qid("conclusion_3")].meta["triage_priority"] == 0
+    assert pulled[dep_qid("evidence_1")].meta["triage_role"] == "load-bearing"
+    assert pulled[dep_qid("evidence_1")].meta["triage_priority"] == 1
+    assert pulled[dep_qid("context_1")].meta["triage_role"] == "supporting"
+    assert pulled[dep_qid("context_1")].meta["triage_priority"] == 2
+
+
 def test_formalized_dep_claim_is_not_surfaced(tmp_path):
     # A root edge referencing a dep claim = it's formalized into the reasoning
     # graph -> it must NOT appear as a pulled-unformalized contact (p2 still does).

--- a/tests/exploration/test_landscape.py
+++ b/tests/exploration/test_landscape.py
@@ -1,0 +1,115 @@
+"""Unit tests for neutral paper-level landscape staging."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gaia.engine.exploration.landscape import LandscapeBatch, build_landscape
+from gaia.engine.exploration.state import Contact, ExplorationMap
+
+
+def _search(query: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "query": {"text": query, "provider": "lkm", "kind": "knowledge"},
+        "results": rows,
+    }
+
+
+def _row(
+    paper_id: str,
+    node_id: str,
+    rank: float,
+    *,
+    title: str | None = None,
+    qid: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": node_id,
+        "title": title,
+        "gaia": {"qid": qid},
+        "source": {"paper_id": paper_id, "index_id": "bohrium"},
+        "rank": {"score": rank},
+    }
+
+
+def test_landscape_dedupes_paper_leads_across_query_batches():
+    landscape = build_landscape(
+        [
+            LandscapeBatch(
+                _search(
+                    "seed query",
+                    [
+                        _row("P1", "n1", 0.2, title="Paper One"),
+                        _row("P2", "n2", 0.5, title="Paper Two"),
+                    ],
+                ),
+                source_qid="example:pkg::seed",
+                path="a.json",
+            ),
+            LandscapeBatch(
+                _search(
+                    "alternate query",
+                    [
+                        _row("P1", "n3", 0.9, title="Paper One"),
+                        _row("P3", "n4", 0.1, title="Paper Three"),
+                    ],
+                ),
+                source_qid="example:pkg::seed",
+                path="b.json",
+            ),
+        ],
+        materialized=set(),
+    )
+
+    payload = landscape.to_dict()
+    assert payload["kind"] == "exploration_landscape"
+    assert payload["stats"] == {
+        "query_batches": 2,
+        "raw_results": 4,
+        "paper_leads": 3,
+    }
+    assert payload["recommended_pull_order"] == ["P1", "P2", "P3"]
+
+    p1 = payload["paper_leads"][0]
+    assert p1["paper_id"] == "P1"
+    assert p1["best_rank"] == 0.9
+    assert p1["queries"] == ["seed query", "alternate query"]
+    assert p1["source_qids"] == ["example:pkg::seed"]
+    assert set(p1["lkm_node_ids"]) == {"n1", "n3"}
+    assert p1["result_count"] == 2
+
+
+def test_landscape_skips_materialized_and_annotates_existing_contacts():
+    exploration_map = ExplorationMap()
+    exploration_map.frontier.append(
+        Contact(
+            id="ct_p2",
+            ref={"kind": "lkm", "value": "P2"},
+            status="open",
+            meta={"paper_id": "P2"},
+        )
+    )
+
+    landscape = build_landscape(
+        [
+            LandscapeBatch(
+                _search(
+                    "q",
+                    [
+                        _row("P1", "n1", 0.8, qid="example:pkg::already"),
+                        _row("P2", "n2", 0.7),
+                        _row("P3", "n3", 0.6),
+                    ],
+                )
+            )
+        ],
+        materialized=set(),
+        materialized_paper_ids={"P3"},
+        exploration_map=exploration_map,
+    )
+
+    payload = landscape.to_dict()
+    assert [lead["paper_id"] for lead in payload["paper_leads"]] == ["P2"]
+    assert payload["paper_leads"][0]["existing_contact_id"] == "ct_p2"
+    assert payload["paper_leads"][0]["existing_contact_status"] == "open"


### PR DESCRIPTION
## Summary
- harden exploration map and compile/infer artifact writes against concurrent reader/writer races
- make frontier output more legible with recommendation reasons and pulled-paper triage metadata
- add a neutral `gaia-lkm-explore landscape` staging command for breadth-first paper-lead aggregation from saved LKM search JSON

## Validation
- pre-push hook passed: ruff, format, IR schema check, pr_gate pytest slice
- focused: `uv run pytest tests/exploration/test_landscape.py tests/exploration/test_cli_explore.py tests/exploration/test_observe.py -q`
- focused lint/type: `ruff check`, `ruff format --check`, `mypy --strict` on touched files

## Notes
- landscape output is topic/schema neutral; domain-specific evidence classifications belong in optional tactics/profiles, not core explorer state
