### PR TITLE
docs(bayes): document point vs composite hypothesis distinction and Lindley–Jeffreys trap

### DIFF
--- a/docs/for-users/bayes-hypothesis-types.md
+++ b/docs/for-users/bayes-hypothesis-types.md
@@ -1,5 +1,8 @@
 # Bayes hypothesis types
 
+> **Status:** Current user guide for authoring `bayes.compare` model
+> distributions.
+
 This guide explains the two kinds of hypothesis you can model with
 `bayes.compare`, why the choice matters, and how to avoid the
 Lindley–Jeffreys trap that produces over-confident posteriors.
@@ -69,7 +72,10 @@ mass near one value.
 If the observation is even slightly off the point's predicted value, the
 point model assigns it very low probability while the diffuse model assigns
 it ordinary probability. The Bayes factor against the point hypothesis
-explodes — often 10²–10⁵ from a single observation.
+explodes — often 10²–10⁵ from a single Gaia observation claim. For a
+`Binomial(n=...)` observation, that claim may itself summarize many
+underlying trials; "single observation" here means one `observe(...)` input
+to `bayes.compare`, not one Bernoulli trial.
 
 This is mathematically correct: a sharp prediction that misses is strong
 evidence against the sharp prediction. But the same data may still
@@ -148,8 +154,8 @@ For most empirical hypotheses, both sides should be composite.
    not, are you intentionally invoking parsimony?
 3. **Spread realism**: does each compound distribution allow values that the
    hypothesis would not contradict?
-4. **Single-observation log-LR**: does the resulting `|log LR|` per
-   observation exceed roughly 3? If so, sanity-check that the distributions
-   are not over-precise.
+4. **Single-observation-claim log-LR**: does the resulting `|log LR|` per
+   Gaia observation claim exceed roughly 3? If so, sanity-check that the
+   distributions are not over-precise.
 
 If check 4 fires, return to check 1.

--- a/docs/for-users/bayes-hypothesis-types.md
+++ b/docs/for-users/bayes-hypothesis-types.md
@@ -1,0 +1,155 @@
+# Bayes hypothesis types
+
+This guide explains the two kinds of hypothesis you can model with
+`bayes.compare`, why the choice matters, and how to avoid the
+Lindley–Jeffreys trap that produces over-confident posteriors.
+
+## The mechanism
+
+`bayes.compare(observation, models=[m_1, m_2, ...])` is exact Bayesian
+model comparison:
+
+```
+posterior(M_i | data) ∝ prior(M_i) × P(data | M_i)
+```
+
+where `P(data | M_i)` is the marginal likelihood of the observation under the
+predictive distribution attached to `M_i`. The engine does nothing but
+evaluate the user-provided distributions at the observation and renormalise.
+
+The choice of distribution is therefore a load-bearing epistemological
+commitment, not a matter of taste. A wrong distribution produces a
+mathematically correct but practically misleading posterior.
+
+## Two kinds of hypothesis
+
+### Point hypothesis
+
+The theory uniquely determines the value of the parameter. Classic example:
+Mendel's segregation model entails `P(dominant) = 3/4` for a single-factor
+cross.
+
+Model with a distribution that pins the parameter to its theoretical value:
+
+```python
+Binomial("Mendel 3:1", n=395, p=3/4)
+```
+
+### Composite hypothesis
+
+The theory commits only to a direction or to a region of parameter space.
+"Drug X reduces mortality" entails some `p_X < p_control` without specifying
+which `p_X`. "Marker M is associated with outcome" entails some non-trivial
+dependence without specifying its strength.
+
+Model with a compound distribution that integrates over the region the
+hypothesis allows:
+
+```python
+BetaBinomial("elevated rate", n=N, alpha=10, beta=40)
+# Equivalent to: p ~ Beta(10, 40); mean = 20%, with mass over roughly 5–40%
+```
+
+For each composite hypothesis you pick `α` and `β` (or the analogous
+parameters for non-Binomial models) to reflect two things:
+
+- the **central tendency** the hypothesis predicts — encoded in the mean
+- the **spread** the hypothesis allows — encoded in the concentration
+
+A wider spread makes the model robust to choosing the "wrong" central value,
+at the cost of weaker evidence even when the hypothesis is correct.
+
+## The Lindley–Jeffreys trap
+
+When you compare a **point** hypothesis against a **diffuse** alternative
+(e.g. `BetaBinomial(n, 1, 1)`), the diffuse model spreads probability mass
+uniformly across all possible counts. The point model concentrates all its
+mass near one value.
+
+If the observation is even slightly off the point's predicted value, the
+point model assigns it very low probability while the diffuse model assigns
+it ordinary probability. The Bayes factor against the point hypothesis
+explodes — often 10²–10⁵ from a single observation.
+
+This is mathematically correct: a sharp prediction that misses is strong
+evidence against the sharp prediction. But the same data may still
+qualitatively support the broader hypothesis the user actually meant — they
+just wrote a too-sharp distribution.
+
+### Symptom
+
+A single observation produces:
+
+- posterior on the hypothesis > 0.99, or
+- posterior on the hypothesis < 0.01
+
+If this surprises you given the data, you have likely committed too strongly.
+
+### Diagnosis
+
+Ask: does my theory really predict this exact parameter value, or only this
+direction / region?
+
+If the theory only predicts direction (most empirical hypotheses), the point
+distribution is wrong. Switch to a compound distribution.
+
+### Fix
+
+Use compound distributions on **both** sides of the comparison:
+
+```python
+m_elevated = bayes.model(H_elevated, observable=k,
+    distribution=BetaBinomial("elevated", n=N, alpha=10, beta=40),
+    rationale="H entails p above baseline ~5%, central ~20%.")
+m_baseline = bayes.model(H_no_effect, observable=k,
+    distribution=BetaBinomial("baseline", n=N, alpha=1, beta=20),
+    rationale="Without H, p matches baseline.")
+```
+
+The `α / β` choices must reflect what each hypothesis honestly predicts.
+A useful sanity check: simulate from each distribution and verify the
+simulated data look like what the hypothesis would expect to see.
+
+## Choosing α and β for a BetaBinomial
+
+For a directional composite hypothesis where the theory predicts "rate is
+elevated":
+
+- **Mean rate**: `α / (α + β)` should equal your best estimate of the rate
+  under the hypothesis.
+- **Concentration**: `α + β` controls spread. Higher concentration means a
+  sharper distribution. Recommended ranges:
+  - `α + β ≈ 10` for vague directional hypotheses
+  - `α + β ≈ 50–100` when theory or prior data narrows the range
+  - `α + β ≈ 1000` only with strong prior data
+
+If unsure, prefer lower concentration. Over-precise priors trip the Lindley
+trap from the prior side.
+
+## When point-vs-diffuse IS the right setup
+
+The Mendel-vs-blending comparison in the example packages is genuinely
+point-vs-diffuse, and the math behaves as intended:
+
+- `H_Mendel`: `Binomial(395, p=3/4)`. Mendel's theory gives this point.
+- `H_blending`: `BetaBinomial(395, 1, 1)`. The alternative is genuinely
+  diffuse — blending inheritance does not predict any particular ratio.
+
+This setup is appropriate **only when** the theoretical prediction is a
+parsimony commitment: you want to reward the theory for being specific and
+right, and penalise it for being specific and wrong.
+
+For most empirical hypotheses, both sides should be composite.
+
+## Diagnostic checklist before calling `bayes.compare`
+
+1. **Hypothesis kind**: is each model a point or a composite hypothesis?
+2. **Matched commitment**: if one side is point, is the other also point? If
+   not, are you intentionally invoking parsimony?
+3. **Spread realism**: does each compound distribution allow values that the
+   hypothesis would not contradict?
+4. **Single-observation log-LR**: does the resulting `|log LR|` per
+   observation exceed roughly 3? If so, sanity-check that the distributions
+   are not over-precise.
+
+If check 4 fires, return to check 1.

--- a/gaia/cli/commands/sdk/_cheatsheet.py
+++ b/gaia/cli/commands/sdk/_cheatsheet.py
@@ -57,7 +57,7 @@ from gaia.engine.lang import (
     compose, composition,                                   # Action composition
     register_prior,                                         # External prior records
     Normal, LogNormal, Beta, Gamma, StudentT,               # Distribution factories
-    Cauchy, ChiSquared, Binomial, Poisson,
+    Cauchy, ChiSquared, Binomial, BetaBinomial, Poisson,
 )
 import gaia.engine.bayes as bayes                           # Bayes hypothesis comparison
 ```
@@ -194,22 +194,56 @@ StudentT("heavy tails", nu=3.0, mu=0.0, sigma=1.0)
 Cauchy("location", x0=0.0, gamma=1.0)
 ChiSquared("variance", k=2.0)
 Binomial("F2 dominant count", n=395, p=3/4)
+BetaBinomial("diffuse F2 count", n=395, alpha=1, beta=1)
 Poisson("event count", lam=4.0)
 ```
 
 ## Bayes: hypothesis vs data
 
+`bayes.compare` evaluates each model's predictive distribution at the
+observation and combines with the model's prior to give posteriors. The math is
+`posterior ∝ prior × likelihood`; what matters is whether your distribution
+captures what the hypothesis actually predicts.
+
+Two kinds of hypothesis, modelled differently:
+
+| Kind | Theory says | Distribution to use |
+|---|---|---|
+| **Point** | parameter equals a specific value | distribution with that value fixed (e.g. `Binomial(n, p=v)`) |
+| **Composite** | parameter lies in a region (elevated, depressed, above baseline) | compound distribution integrating over the region (e.g. `BetaBinomial(n, α, β)`) |
+
+### Point hypothesis (Mendel's 3:1)
+
 ```python
 import gaia.engine.bayes as bayes
 
-m1 = bayes.model(mendel_model, observable=k_dominant,
-                 distribution=Binomial("Mendel 3:1", n=395, p=3/4),
-                 rationale="...")
-m2 = bayes.model(diffuse_model, observable=k_dominant,
-                 distribution=Binomial("diffuse", n=395, p=0.5),
-                 rationale="...")
-bayes.compare(count_observation, models=[m1, m2], rationale="...")
+m_mendel = bayes.model(mendel_model, observable=k_dominant,
+    distribution=Binomial("Mendel 3:1", n=395, p=3/4),
+    rationale="Segregation predicts dominant count ~ Binomial(N, 3/4).")
+m_diffuse = bayes.model(diffuse_model, observable=k_dominant,
+    distribution=BetaBinomial("diffuse", n=395, alpha=1, beta=1),
+    rationale="No theoretical commitment; any rate equally plausible.")
+bayes.compare(count_observation, models=[m_mendel, m_diffuse], rationale="...")
 ```
+
+### Composite hypothesis (directional, no point value)
+
+```python
+m_elevated = bayes.model(H_elevated, observable=k,
+    distribution=BetaBinomial("elevated", n=N, alpha=10, beta=40),
+    rationale="H entails p>baseline; mean ~20%, spread allows 5–40%.")
+m_baseline = bayes.model(H_no_effect, observable=k,
+    distribution=BetaBinomial("baseline", n=N, alpha=1, beta=20),
+    rationale="Without H, p ~ baseline (~5%, allows lower).")
+bayes.compare(observation, models=[m_elevated, m_baseline], rationale="...")
+```
+
+**Lindley–Jeffreys trap.** A point H against a diffuse alternative produces
+Bayes factors 10²–10⁵ against H even for data only slightly off the point.
+Symptom: a single observation gives posterior > 0.99 or < 0.01. Match the
+level of commitment on both sides — point-vs-point or composite-vs-composite —
+unless the theory genuinely demands a point.
+See `docs/for-users/bayes-hypothesis-types.md` for the full treatment.
 
 ---
 

--- a/gaia/cli/commands/sdk/_cheatsheet.py
+++ b/gaia/cli/commands/sdk/_cheatsheet.py
@@ -207,10 +207,10 @@ captures what the hypothesis actually predicts.
 
 Two kinds of hypothesis, modelled differently:
 
-| Kind | Theory says | Distribution to use |
+| Kind | Theory says | Use |
 |---|---|---|
-| **Point** | parameter equals a specific value | distribution with that value fixed (e.g. `Binomial(n, p=v)`) |
-| **Composite** | parameter lies in a region (elevated, depressed, above baseline) | compound distribution integrating over the region (e.g. `BetaBinomial(n, α, β)`) |
+| **Point** | parameter equals a specific value | fixed-value distribution |
+| **Composite** | parameter lies in a region | compound distribution |
 
 ### Point hypothesis (Mendel's 3:1)
 
@@ -243,7 +243,8 @@ Bayes factors 10²–10⁵ against H even for data only slightly off the point.
 Symptom: a single observation gives posterior > 0.99 or < 0.01. Match the
 level of commitment on both sides — point-vs-point or composite-vs-composite —
 unless the theory genuinely demands a point.
-See `docs/for-users/bayes-hypothesis-types.md` for the full treatment.
+See the Bayes Hypothesis Types guide in the Gaia docs
+(`docs/for-users/bayes-hypothesis-types.md`) for the full treatment.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
   - User Reference:
       - Language Reference: for-users/language-reference.md
       - CLI Commands: for-users/cli-commands.md
+      - Bayes Hypothesis Types: for-users/bayes-hypothesis-types.md
   - Release Notes:
       - v0.5.0a1 Alpha: releases/0.5.0a1.md
   - Foundational Docs:


### PR DESCRIPTION
## Motivation

The cheat sheet's Bayes section currently shows only one usage pattern — Mendel-style point `Binomial(n, p=v)` under H vs diffuse `BetaBinomial(n, 1, 1)` as the alternative. Users authoring empirical hypotheses (which describe directions or regions of parameter space, not theory-derived point values) follow that template verbatim, write a point Binomial under their H, and then hit the **Lindley–Jeffreys trap**: any single observation even slightly off the chosen `p` produces Bayes factors 10²–10⁵ against H — mathematically correct, but practically misleading because the data may still be qualitatively consistent with the broader hypothesis.

The engine is fine — `posterior ∝ prior × likelihood` evaluated at the user-provided distribution is exact Bayesian model comparison. The fix is documentation: distinguish point hypotheses from composite/directional ones, and show users when to use each distribution shape.

## Changes

### `CHEATSHEET.md` (generated by `gaia sdk`)

- Bayes section rewritten with a 2-row taxonomy table: **Point** (theory pins a value, use point distribution) vs **Composite** (theory pins direction/region, use compound distribution).
- Point example kept (Mendel 3:1) but the diffuse alternative switched to `BetaBinomial(n, 1, 1)` to align with the example packages.
- New **composite-hypothesis** example showing `BetaBinomial(n, α, β)` on both sides with different concentrations encoding the directional prediction.
- Short **Lindley–Jeffreys** warning with the symptom users should recognise (single observation → posterior > 0.99 or < 0.01).
- `BetaBinomial` added to the Imports block and the Distributions section (was already used in example packages but not surfaced in the cheat sheet).

### New `docs/for-users/bayes-hypothesis-types.md`

Long-form companion covering what the cheat sheet only summarises:

- **The mechanism** — what `bayes.compare` does, why the distribution choice is load-bearing.
- **Point vs composite** with concrete distribution choices.
- **The Lindley–Jeffreys trap** — intuition (point = needle, diffuse = haystack), symptom, diagnosis, fix.
- **Choosing α and β** for `BetaBinomial` under composite hypotheses (mean, concentration, recommended ranges).
- **When point-vs-diffuse IS the right setup** (parsimony commitment — Mendel-style).
- **Diagnostic checklist** to run before calling `bayes.compare`.

### `mkdocs.yml`

- New doc added under **User Reference**.

## Scope

Documentation only. No engine change, no API change. Engine math is correct as-is.

## Test plan

- [x] `tests/cli/test_sdk.py` — 5/5 pass locally. The per-symbol reference's API-surface assertions still hold (the imports block change adds `BetaBinomial`, which is already in `gaia.engine.lang`).
- [x] `gaia sdk --out /tmp/check-sdk` regenerates without error; CHEATSHEET.md renders the new Bayes section correctly.

## Follow-ups (out of scope here)

An engine-level diagnostic — e.g. flagging `|log LR| > 5` from a single observation as a Lindley-risk symptom — could help users recognise the trap automatically. Not included in this PR; happy to file separately if maintainers want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
