### PR TITLE
feat(bayes): add Lindley-Jeffreys diagnostic to bayes.compare lowering

### DIFF
--- a/gaia/engine/bayes/compiler/lower.py
+++ b/gaia/engine/bayes/compiler/lower.py
@@ -29,8 +29,17 @@ from __future__ import annotations
 
 import hashlib
 import math
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
+
+# Per-observation |log LR| above which `bayes.compare` warns about a possible
+# Lindley-Jeffreys mismatch (point hypothesis vs diffuse alternative producing
+# very large Bayes factors from data only slightly off the point). The number
+# is the standard "decisive" threshold from Kass & Raftery (1995, Table 1).
+# Authors can suppress the warning via `warnings.filterwarnings(...)` or by
+# matching commitment levels on both compared models.
+LINDLEY_PER_OBS_LOG_LR_THRESHOLD = 5.0
 
 from gaia.engine.bayes.distributions.base import _is_deferred_reference
 from gaia.engine.bayes.runtime import Model, ModelCompare, PrecomputedLikelihoods
@@ -197,6 +206,31 @@ def _comparison_hypotheses(action: ModelCompare) -> tuple[Claim, ...]:
     return tuple(h for h in hypotheses if h is not None)
 
 
+def _has_diffuse_uniform_alternative(model_actions: tuple[Model, ...]) -> bool:
+    """Return True if any compared model uses ``BetaBinomial(n, alpha=1, beta=1)``.
+
+    This is the canonical "diffuse uniform" alternative used in the Mendel
+    example and in the cheat sheet. Pairing it with a sharp point hypothesis
+    is the classical Lindley-Jeffreys setup, where the diffuse model wins by
+    default for any data slightly off the point's predicted mode.
+    """
+    for action in model_actions:
+        dist = getattr(action, "distribution", None)
+        if dist is None:
+            continue
+        if getattr(dist, "kind", None) != "betabinomial":
+            continue
+        params = getattr(dist, "params", None) or {}
+        alpha = params.get("alpha")
+        beta = params.get("beta")
+        try:
+            if alpha is not None and beta is not None and float(alpha) == 1.0 and float(beta) == 1.0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 def _lower_comparison(
     action: ModelCompare,
     *,
@@ -223,6 +257,25 @@ def _lower_comparison(
             "predictive distribution support, or use precomputed likelihoods."
         )
 
+    # Lindley-Jeffreys diagnostic. Compute per-observation |log LR| and flag
+    # when a large LR combines with the structural signature of the trap:
+    # at least one compared model is the canonical "diffuse uniform"
+    # alternative (BetaBinomial(n, alpha=1, beta=1)). Point-vs-point and
+    # composite-vs-composite comparisons can also produce large LRs but are
+    # not the Lindley trap. See docs/for-users/bayes-hypothesis-types.md.
+    finite_logl = [v for v in likelihoods.values() if math.isfinite(v)]
+    n_obs = max(1, len(action.data))
+    if len(finite_logl) >= 2:
+        max_pairwise_log_lr = max(finite_logl) - min(finite_logl)
+    else:
+        max_pairwise_log_lr = 0.0
+    per_observation_log_lr = max_pairwise_log_lr / n_obs
+    lindley_signature = _has_diffuse_uniform_alternative(model_actions)
+    lindley_warning = (
+        per_observation_log_lr > LINDLEY_PER_OBS_LOG_LR_THRESHOLD
+        and lindley_signature
+    )
+
     comparison_metadata = {
         "kind": "comparison",
         "exclusivity": action.exclusivity,
@@ -230,7 +283,28 @@ def _lower_comparison(
         "data": data_ids,
         "models": model_ids,
         "hypotheses": [knowledge_map[id(h)] for h in hypotheses],
+        "max_pairwise_log_lr": max_pairwise_log_lr,
+        "per_observation_log_lr": per_observation_log_lr,
+        "lindley_threshold": LINDLEY_PER_OBS_LOG_LR_THRESHOLD,
+        "lindley_signature": lindley_signature,
+        "lindley_warning": lindley_warning,
     }
+
+    if lindley_warning:
+        label_repr = action.label or action.helper.content
+        warnings.warn(
+            f"bayes.compare ({label_repr!r}): per-observation |log LR| = "
+            f"{per_observation_log_lr:.2f} > threshold {LINDLEY_PER_OBS_LOG_LR_THRESHOLD}. "
+            "Extreme single-observation Bayes factors often indicate the "
+            "Lindley-Jeffreys trap: a point hypothesis vs a diffuse alternative "
+            "produces very large likelihood ratios for data only slightly off "
+            "the point, even when the data are qualitatively consistent with "
+            "the broader hypothesis. Consider using compound distributions "
+            "(e.g. BetaBinomial) on both sides. "
+            "See docs/for-users/bayes-hypothesis-types.md.",
+            UserWarning,
+            stacklevel=2,
+        )
     if isinstance(action.precomputed, PrecomputedLikelihoods):
         comparison_metadata["precomputed_source"] = knowledge_map[id(action.precomputed)]
 

--- a/gaia/engine/bayes/compiler/lower.py
+++ b/gaia/engine/bayes/compiler/lower.py
@@ -33,14 +33,6 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
-# Per-observation |log LR| above which `bayes.compare` warns about a possible
-# Lindley-Jeffreys mismatch (point hypothesis vs diffuse alternative producing
-# very large Bayes factors from data only slightly off the point). The number
-# is the standard "decisive" threshold from Kass & Raftery (1995, Table 1).
-# Authors can suppress the warning via `warnings.filterwarnings(...)` or by
-# matching commitment levels on both compared models.
-LINDLEY_PER_OBS_LOG_LR_THRESHOLD = 5.0
-
 from gaia.engine.bayes.distributions.base import _is_deferred_reference
 from gaia.engine.bayes.runtime import Model, ModelCompare, PrecomputedLikelihoods
 from gaia.engine.bp.factor_graph import CROMWELL_EPS
@@ -55,6 +47,14 @@ from gaia.engine.lang.formula.predicate import Equals
 from gaia.engine.lang.formula.primitives import PrimitiveType
 from gaia.engine.lang.formula.term import Constant
 from gaia.engine.lang.runtime import Claim, Distribution, Domain, Knowledge, Variable
+
+# Per-observation |log LR| above which `bayes.compare` warns about a possible
+# Lindley-Jeffreys mismatch (point hypothesis vs diffuse alternative producing
+# very large Bayes factors from data only slightly off the point). The number
+# is the standard "decisive" threshold from Kass & Raftery (1995, Table 1).
+# Authors can suppress the warning via `warnings.filterwarnings(...)` or by
+# matching commitment levels on both compared models.
+LINDLEY_PER_OBS_LOG_LR_THRESHOLD = 5.0
 
 
 @dataclass(frozen=True)
@@ -215,16 +215,24 @@ def _has_diffuse_uniform_alternative(model_actions: tuple[Model, ...]) -> bool:
     default for any data slightly off the point's predicted mode.
     """
     for action in model_actions:
-        dist = getattr(action, "distribution", None)
-        if dist is None:
+        if action.distribution is None or action.hypothesis is None:
             continue
-        if getattr(dist, "kind", None) != "betabinomial":
+        try:
+            impl = _bind_distribution_impl(action.distribution, action.hypothesis)
+        except ValueError:
             continue
-        params = getattr(dist, "params", None) or {}
+        if getattr(impl, "kind", None) != "betabinomial":
+            continue
+        params = getattr(impl, "params", None) or {}
         alpha = params.get("alpha")
         beta = params.get("beta")
         try:
-            if alpha is not None and beta is not None and float(alpha) == 1.0 and float(beta) == 1.0:
+            if (
+                alpha is not None
+                and beta is not None
+                and float(alpha) == 1.0
+                and float(beta) == 1.0
+            ):
                 return True
         except (TypeError, ValueError):
             continue
@@ -262,18 +270,15 @@ def _lower_comparison(
     # at least one compared model is the canonical "diffuse uniform"
     # alternative (BetaBinomial(n, alpha=1, beta=1)). Point-vs-point and
     # composite-vs-composite comparisons can also produce large LRs but are
-    # not the Lindley trap. See docs/for-users/bayes-hypothesis-types.md.
+    # not the Lindley trap. See the Bayes Hypothesis Types user guide
+    # (docs/for-users/bayes-hypothesis-types.md).
     finite_logl = [v for v in likelihoods.values() if math.isfinite(v)]
     n_obs = max(1, len(action.data))
-    if len(finite_logl) >= 2:
-        max_pairwise_log_lr = max(finite_logl) - min(finite_logl)
-    else:
-        max_pairwise_log_lr = 0.0
+    max_pairwise_log_lr = max(finite_logl) - min(finite_logl) if len(finite_logl) >= 2 else 0.0
     per_observation_log_lr = max_pairwise_log_lr / n_obs
     lindley_signature = _has_diffuse_uniform_alternative(model_actions)
     lindley_warning = (
-        per_observation_log_lr > LINDLEY_PER_OBS_LOG_LR_THRESHOLD
-        and lindley_signature
+        per_observation_log_lr > LINDLEY_PER_OBS_LOG_LR_THRESHOLD and lindley_signature
     )
 
     comparison_metadata = {
@@ -301,7 +306,8 @@ def _lower_comparison(
             "the point, even when the data are qualitatively consistent with "
             "the broader hypothesis. Consider using compound distributions "
             "(e.g. BetaBinomial) on both sides. "
-            "See docs/for-users/bayes-hypothesis-types.md.",
+            "See the Bayes Hypothesis Types user guide "
+            "(docs/for-users/bayes-hypothesis-types.md).",
             UserWarning,
             stacklevel=2,
         )

--- a/gaia/engine/bayes/dsl/compare.py
+++ b/gaia/engine/bayes/dsl/compare.py
@@ -372,6 +372,21 @@ def compare(
     ``metadata["comparison"]`` describing the exclusivity contract and,
     after compilation, the per-hypothesis log-likelihood table.
 
+    Point vs composite hypotheses
+    -----------------------------
+    Use a point distribution such as ``Binomial(n, p=v)`` only when the
+    hypothesis really fixes the parameter value. If the hypothesis
+    commits to a direction or region instead, use a compound
+    distribution such as ``BetaBinomial(n, alpha, beta)``.
+
+    Comparing a point hypothesis with a diffuse alternative such as
+    ``BetaBinomial(n, alpha=1, beta=1)`` can produce extreme Bayes
+    factors from one Gaia observation claim when the data are only
+    slightly off the point. Run ``gaia sdk`` for the local SDK reference
+    and cheat sheet; see the Bayes Hypothesis Types guide in the Gaia
+    docs (``docs/for-users/bayes-hypothesis-types.md``) for the full
+    treatment.
+
     Exclusivity contracts
     ---------------------
     ``exclusivity`` controls what structural-action relationship Gaia

--- a/tests/gaia/bayes/test_runtime_and_lowering.py
+++ b/tests/gaia/bayes/test_runtime_and_lowering.py
@@ -16,6 +16,7 @@ from gaia.engine.bp.lowering import lower_local_graph
 from gaia.engine.ir.operator import OperatorType
 from gaia.engine.ir.parameterization import CROMWELL_EPS
 from gaia.engine.lang import (
+    BetaBinomial,
     Binomial,
     Domain,
     Nat,
@@ -1123,3 +1124,147 @@ def test_three_model_pairwise_contradiction_remains_supported():
     }
     assert contradict_pairs == expected_pairs
     assert cmp_result.metadata["comparison"]["exclusivity"] == "pairwise_contradiction"
+
+
+# -----------------------------------------------------------------------------
+# Lindley-Jeffreys diagnostic
+# -----------------------------------------------------------------------------
+
+
+def _compile_lindley_setup(*, k_observed: int, alpha: float, beta: float):
+    """Build a point-Binomial(p=0.10) vs BetaBinomial(α, β) comparison."""
+    pkg = CollectedPackage(name="bayes_lindley_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        theta = Variable(symbol="theta", domain=Probability)
+        k = Variable(symbol="k", domain=Nat, value=k_observed)
+        n = 244
+
+        h_path = parameter(theta, 0.10, content="theta = 0.10.", prior=0.5, label="h_path")
+        h_alt = parameter(theta, 0.5, content="theta diffuse.", prior=0.5, label="h_alt")
+        data = observe(k, value=k_observed, label="data", rationale=f"k = {k_observed}.")
+        model_path = bayes.model(
+            h_path,
+            observable=k,
+            distribution=Binomial("k under p=0.10", n=n, p=theta),
+            label="model_path",
+        )
+        model_alt = bayes.model(
+            h_alt,
+            observable=k,
+            distribution=BetaBinomial("k under diffuse", n=n, alpha=alpha, beta=beta),
+            label="model_alt",
+        )
+        cmp_result = bayes.compare(
+            data,
+            models=[model_path, model_alt],
+            label="cmp_lindley",
+        )
+    finally:
+        _current_package.reset(token)
+    return pkg, cmp_result
+
+
+def _ir_comparison_metadata(compiled, cmp_result):
+    """Pull the comparison helper's IR-side metadata."""
+    cmp_id = compiled.knowledge_ids_by_object[id(cmp_result)]
+    cmp_ir = next(k for k in compiled.graph.knowledges if k.id == cmp_id)
+    return cmp_ir.metadata["comparison"]
+
+
+def test_compare_emits_lindley_diagnostic_for_point_vs_diffuse_uniform_extreme():
+    """k=4 vs Binomial(244, 0.10) (mean 24.4) hits the Lindley trap; warning fires."""
+    pkg, cmp_result = _compile_lindley_setup(k_observed=4, alpha=1, beta=1)
+
+    with pytest.warns(UserWarning, match="Lindley-Jeffreys trap"):
+        compiled = compile_package_artifact(pkg)
+
+    cmp_md = _ir_comparison_metadata(compiled, cmp_result)
+    assert cmp_md["lindley_signature"] is True
+    assert cmp_md["lindley_warning"] is True
+    assert cmp_md["per_observation_log_lr"] > 5.0
+    assert cmp_md["lindley_threshold"] == 5.0
+    assert cmp_md["max_pairwise_log_lr"] == pytest.approx(
+        cmp_md["per_observation_log_lr"], rel=1e-9
+    )
+
+
+def test_compare_lindley_quiet_for_point_vs_point_extreme():
+    """Mendel-style point-vs-point comparison with extreme LR: no Lindley warning."""
+    import warnings as _w
+
+    pkg, _h_31, _h_null, _data, _model_31, _model_null, cmp_result = _compiled_mendel_bayes()
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        compiled = compile_package_artifact(pkg)
+
+    lindley = [w for w in caught if "Lindley" in str(w.message)]
+    assert lindley == [], f"unexpected Lindley warning(s): {[str(w.message) for w in lindley]}"
+
+    cmp_md = _ir_comparison_metadata(compiled, cmp_result)
+    assert cmp_md["lindley_signature"] is False
+    assert cmp_md["lindley_warning"] is False
+    # Per-obs log-LR can still be large; only the structural signature
+    # gates the warning.
+    assert cmp_md["per_observation_log_lr"] > 5.0
+
+
+def test_compare_lindley_quiet_for_composite_vs_composite():
+    """Two non-degenerate BetaBinomials (no uniform diffuse): no Lindley warning."""
+    import warnings as _w
+
+    pkg = CollectedPackage(name="bayes_composite_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        theta = Variable(symbol="theta", domain=Probability)
+        k = Variable(symbol="k", domain=Nat, value=10)
+        n = 100
+
+        h_elev = parameter(theta, 0.20, content="elevated.", prior=0.5, label="h_elev")
+        h_base = parameter(theta, 0.05, content="baseline.", prior=0.5, label="h_base")
+        data = observe(k, value=10, label="data", rationale="k = 10.")
+        model_elev = bayes.model(
+            h_elev,
+            observable=k,
+            distribution=BetaBinomial("elevated", n=n, alpha=10, beta=40),
+            label="model_elev",
+        )
+        model_base = bayes.model(
+            h_base,
+            observable=k,
+            distribution=BetaBinomial("baseline", n=n, alpha=1, beta=20),
+            label="model_base",
+        )
+        cmp_result = bayes.compare(
+            data,
+            models=[model_elev, model_base],
+            label="cmp_composite",
+        )
+    finally:
+        _current_package.reset(token)
+
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        compiled = compile_package_artifact(pkg)
+
+    lindley = [w for w in caught if "Lindley" in str(w.message)]
+    assert lindley == [], f"unexpected Lindley warning(s): {[str(w.message) for w in lindley]}"
+
+    cmp_md = _ir_comparison_metadata(compiled, cmp_result)
+    assert cmp_md["lindley_signature"] is False
+    assert cmp_md["lindley_warning"] is False
+
+
+def test_compare_metadata_always_exposes_diagnostic_fields():
+    """The diagnostic numbers are present on every comparison."""
+    pkg, cmp_result = _compile_lindley_setup(k_observed=24, alpha=1, beta=1)
+    # k=24 is at the Binomial mode: log-LR is small; no warning, but fields exist
+    compiled = compile_package_artifact(pkg)
+
+    cmp_md = _ir_comparison_metadata(compiled, cmp_result)
+    assert "max_pairwise_log_lr" in cmp_md
+    assert "per_observation_log_lr" in cmp_md
+    assert "lindley_threshold" in cmp_md
+    assert "lindley_signature" in cmp_md
+    assert "lindley_warning" in cmp_md
+    assert cmp_md["lindley_warning"] is False

--- a/tests/gaia/bayes/test_runtime_and_lowering.py
+++ b/tests/gaia/bayes/test_runtime_and_lowering.py
@@ -18,13 +18,17 @@ from gaia.engine.ir.parameterization import CROMWELL_EPS
 from gaia.engine.lang import (
     BetaBinomial,
     Binomial,
+    Constant,
     Domain,
     Nat,
     Normal,
     Probability,
     Real,
     Variable,
+    claim,
     contradict,
+    equals,
+    land,
     observe,
     parameter,
 )
@@ -1187,6 +1191,53 @@ def test_compare_emits_lindley_diagnostic_for_point_vs_diffuse_uniform_extreme()
     assert cmp_md["max_pairwise_log_lr"] == pytest.approx(
         cmp_md["per_observation_log_lr"], rel=1e-9
     )
+
+
+def test_compare_lindley_diagnostic_resolves_deferred_betabinomial_parameters():
+    """A deferred BetaBinomial(alpha=1, beta=1) still carries the Lindley signature."""
+    pkg = CollectedPackage(name="bayes_lindley_deferred_pkg", namespace="t")
+    token = _current_package.set(pkg)
+    try:
+        theta = Variable(symbol="theta", domain=Probability)
+        alpha = Variable(symbol="alpha", domain=Real)
+        beta = Variable(symbol="beta", domain=Real)
+        k = Variable(symbol="k", domain=Nat, value=4)
+        n = 244
+
+        h_path = parameter(theta, 0.10, content="theta = 0.10.", prior=0.5, label="h_path")
+        h_alt = claim(
+            "Diffuse alternative sets alpha = 1 and beta = 1.",
+            formula=land(equals(alpha, Constant(1.0, Real)), equals(beta, Constant(1.0, Real))),
+            prior=0.5,
+        )
+        h_alt.label = "h_alt"
+        data = observe(k, value=4, label="data", rationale="k = 4.")
+        model_path = bayes.model(
+            h_path,
+            observable=k,
+            distribution=Binomial("k under p=0.10", n=n, p=theta),
+            label="model_path",
+        )
+        model_alt = bayes.model(
+            h_alt,
+            observable=k,
+            distribution=BetaBinomial("k under diffuse", n=n, alpha=alpha, beta=beta),
+            label="model_alt",
+        )
+        cmp_result = bayes.compare(
+            data,
+            models=[model_path, model_alt],
+            label="cmp_lindley_deferred",
+        )
+    finally:
+        _current_package.reset(token)
+
+    with pytest.warns(UserWarning, match="Lindley-Jeffreys trap"):
+        compiled = compile_package_artifact(pkg)
+
+    cmp_md = _ir_comparison_metadata(compiled, cmp_result)
+    assert cmp_md["lindley_signature"] is True
+    assert cmp_md["lindley_warning"] is True
 
 
 def test_compare_lindley_quiet_for_point_vs_point_extreme():


### PR DESCRIPTION
## Motivation

`bayes.compare` currently surfaces only per-hypothesis log-likelihoods in IR metadata. Users authoring composite ("directional") hypotheses can hit the **Lindley-Jeffreys trap** — pair a point `Binomial(n, p=v)` for H with `BetaBinomial(n, 1, 1)` as the diffuse alternative (the canonical Mendel template), then commit `v` too sharply for an empirical claim that only entails a direction — and get posteriors of `> 0.999` or `< 0.001` from one observation. The math is correct; the user just wrote a too-sharp distribution. There is no surfaced signal that this is happening.

The companion docs PR (#710) introduces the point-vs-composite distinction in the cheat sheet and adds a long-form guide at `docs/for-users/bayes-hypothesis-types.md`. This PR adds the engine-side counterpart: a lightweight, structurally-gated diagnostic computed during lowering.

## What changes

`gaia/engine/bayes/compiler/lower.py` (`_lower_comparison`) now writes five additional fields to the comparison helper's IR metadata:

| Field | Meaning |
|---|---|
| `max_pairwise_log_lr` | largest `\|log L_i − log L_j\|` across compared hypotheses |
| `per_observation_log_lr` | the above divided by `len(action.data)` |
| `lindley_threshold` | `|log LR|` above which we consider the diagnostic to fire (`5.0`, Kass–Raftery "decisive") |
| `lindley_signature` | `True` iff any compared model uses `BetaBinomial(n, alpha=1, beta=1)` — the canonical diffuse-uniform alternative |
| `lindley_warning` | `True` iff `per_observation_log_lr > lindley_threshold` **and** `lindley_signature` |

When `lindley_warning` is `True`, lowering emits a `UserWarning` pointing at `docs/for-users/bayes-hypothesis-types.md` for the remediation pattern (switch to BetaBinomial on both sides with different concentrations).

### Why structurally gate the warning

A naive `|log LR| > 5` warning misfires on legitimate strong evidence from point-vs-point comparisons. Mendel-style `Binomial(395, p=3/4)` vs `Binomial(395, p=0.5)` on observed `k=295` gives per-observation log-LR ≈ 50 — that is not a Lindley trap, it is exactly the kind of decisive Bayesian model selection the framework should let through silently.

The structural gate (`lindley_signature`) restricts the warning to comparisons where **at least one model is the canonical diffuse-uniform alternative**. The empirical pattern that produces the trap is "sharp point H vs `BetaBinomial(n, 1, 1)`"; matching commitments on both sides (point-vs-point, composite-vs-composite) silences the warning.

## Scope

- No public API change: `bayes.compare` signature unchanged; only the helper claim's IR metadata gains five new fields.
- No semantic change to posteriors: the diagnostic is purely advisory.
- Standard `warnings.filterwarnings(...)` suppresses the message if a user prefers metadata-only inspection.

## Test plan

Four new tests in `tests/gaia/bayes/test_runtime_and_lowering.py`:

- [x] Point Binomial(244, 0.10) vs BetaBinomial(244, 1, 1), observed k=4: warning fires; `lindley_signature` and `lindley_warning` are `True`; `per_observation_log_lr > 5`.
- [x] Mendel point-vs-point (Binomial vs Binomial) on the extreme `k=295`: no warning emitted; `lindley_signature` is `False`; per-obs log-LR > 5 but gated by the structural check.
- [x] Composite vs composite (`BetaBinomial(10, 40)` vs `BetaBinomial(1, 20)`): no warning; `lindley_signature` is `False`.
- [x] Quiet case (k at the Binomial mode): warning does not fire, but the five diagnostic fields are still present.

All 108 existing bayes tests continue to pass.

## Related

- Companion docs PR: #710 (cheat sheet + `docs/for-users/bayes-hypothesis-types.md`).
- Prior cheat-sheet PR: #705 (verb-level semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
