### PR TITLE
docs(skills): sharpen hedge rule for inferential conclusions

### DIFF
--- a/gaia/_skills/_shared/formalize-extract-conclusions.md
+++ b/gaia/_skills/_shared/formalize-extract-conclusions.md
@@ -38,6 +38,20 @@ The paper text is the only source of truth. While extracting:
   it undefined and surface the gap.
 - Preserve the authors' epistemic hedging exactly: regimes, error bars,
   speculative qualifiers, modal force ("suggests" stays "suggests").
+- **Inferential conclusions inherit the paper's hedge, never a stronger one.**
+  When a conclusion is a synthesis or inference *from* the paper's observations
+  — a mechanism, a cause, a cross-case generalization — rather than a direct
+  restatement of one paper sentence, its modal force must not exceed the paper's
+  strongest claim about that inference. If the paper only *observes* X and
+  *suggests* mechanism M, the conclusion is "X is observed; the authors
+  attribute it to M", not "M causes X". Two recurring traps:
+  - **Observation upgraded to a property the data only partially supports** —
+    e.g. "the loci amplified" becomes "the loci are polymorphic" when some of
+    them are monomorphic in the reported table. State only the property the
+    data actually shows.
+  - **Attributed mechanism stated as established fact** — e.g. the authors
+    write "we attribute the effect to surface area"; the conclusion must keep
+    the attribution framing, not assert the mechanism outright.
 
 ## Write every claim self-contained
 


### PR DESCRIPTION
## Summary

Sharpens the shared `formalize-extract-conclusions.md` hedge rule to catch a specific overclaim mode the generic rule misses.

The doc already says *"preserve the authors' epistemic hedging exactly … 'suggests' stays 'suggests'"*. But a 3-paper faithfulness audit (skill conclusions vs source paper, DeepSeek auditing Claude's output) found **2/20 conclusions still overclaimed — both inferential**, not direct measurements:

| Paper | Conclusion | Overclaim |
|---|---|---|
| Patella (microsatellites) | cross-amplification | "the loci amplified" → "the loci are **polymorphic**", when Table 2 shows 3 of them are monomorphic (Na=1) for that species |
| γ-Mg(BH4)2 dehydrogenation | diborane evolution | authors *attribute* it to surface area; conclusion stated the mechanism as established fact |

Direct-measurement conclusions had 0 overclaims; the tendency is concentrated on **synthesis / mechanism / generalization** conclusions.

## Change

Adds an explicit sub-rule under "Fidelity to the paper": an inferential conclusion's modal force must not exceed the paper's strongest claim about that inference, with the two recurring traps spelled out (observation→property upgrade; attributed mechanism→fact). Shared by `gaia-formalize-coarse` + `gaia-formalize-fine`.

## Test plan

- [x] Pre-commit + pre-push gates pass (docs-only change)
- [ ] Re-run the Patella + γ-Mg formalizations post-merge; confirm the c5 "polymorphic" overclaim and c7 mechanism overclaim no longer appear in the faithfulness audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)