### PR TITLE
feat(research-loop): complete explore assess loop

### DIFF
--- a/docs/plans/2026-05-28-gaia-research-loop-agent-protocol.md
+++ b/docs/plans/2026-05-28-gaia-research-loop-agent-protocol.md
@@ -1,0 +1,1953 @@
+# Gaia Research Loop Agent Protocol Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the MVP `gaia-research-loop` CLI and protocol so a generic agent can run an Explore -> Assess loop through self-contained task envelopes, validated candidate JSON, durable artifacts, and repairable state.
+
+**Architecture:** Add a new `gaia.research_loop` package that owns protocol schemas, storage, event logging, state rebuild, task generation, candidate validation, and the `gaia-research-loop` Typer app. Reuse `gaia.lkm_explorer` landscape/focus helpers where possible, but keep the new loop storage under `.gaia/research_loop/` and keep `gaia-lkm-explore` backward-compatible.
+
+**Tech Stack:** Python 3.12, Typer, Pydantic v2, pytest, ruff, mypy strict, existing `uv` workflow.
+
+---
+
+## Implementation Strategy
+
+This plan intentionally builds the protocol in thin, testable layers:
+
+1. Shared schema and storage.
+2. `status` and state rebuild.
+3. `next` task emission.
+4. `submit` validation and repair context.
+5. Query planning and mechanical search execution.
+6. LKM landscape adaptation under the new storage layout.
+7. Focus synthesis and Explore gate.
+8. Assessment context, evidence diagnosis, and Assess gate.
+9. Thin in-repo skill template and final verification.
+
+Every intelligent step is represented as a task envelope. Gaia validates shape,
+grounding, and state transitions; the external agent supplies semantic judgment.
+
+## File Structure
+
+Create:
+
+- `gaia/research_loop/__init__.py`  
+  Public package marker and CLI-facing exports.
+- `gaia/research_loop/schemas.py`  
+  Pydantic models and constants for task, candidate, artifact, gate, state, refs,
+  events, query plans, focuses, and assessment outputs.
+- `gaia/research_loop/storage.py`  
+  Canonical path helpers, directory initialization, JSON read/write, state rebuild,
+  and event log append/read helpers.
+- `gaia/research_loop/tasks.py`  
+  Task envelope builders for scope, query planning, search execution, focus
+  synthesis, assessment context, and evidence diagnosis.
+- `gaia/research_loop/engine.py`  
+  State machine orchestration for `status`, `next`, `submit`, and `gate`.
+- `gaia/research_loop/lkm_adapter.py`  
+  LKM-specific parsing and reuse of `gaia.lkm_explorer` landscape/focus helpers.
+- `gaia/research_loop/cli.py`  
+  Typer app for `gaia-research-loop`.
+- `tests/research_loop/__init__.py`
+- `tests/research_loop/test_schemas.py`
+- `tests/research_loop/test_storage.py`
+- `tests/research_loop/test_cli_status.py`
+- `tests/research_loop/test_next_submit.py`
+- `tests/research_loop/test_lkm_adapter.py`
+- `tests/research_loop/test_explore_gate.py`
+- `tests/research_loop/test_assess_gate.py`
+- `gaia/_skills/gaia-research-loop/SKILL.md`
+
+Modify:
+
+- `pyproject.toml`  
+  Add the `gaia-research-loop` console script.
+- `tests/baseline/__snapshots__/test_help_snapshots/` if the existing help
+  snapshot suite discovers console scripts automatically. If it does not,
+  leave snapshots untouched.
+
+Do not modify:
+
+- `gaia/lkm_explorer/client/verbs.py` unless a small exported helper is needed.
+  It is already large; new loop orchestration belongs in `gaia/research_loop/`.
+- Existing `.gaia/exploration/` artifact paths. The new canonical path is
+  `.gaia/research_loop/`.
+
+---
+
+## Task 1: Schema Models
+
+**Files:**
+
+- Create: `gaia/research_loop/__init__.py`
+- Create: `gaia/research_loop/schemas.py`
+- Create: `tests/research_loop/__init__.py`
+- Test: `tests/research_loop/test_schemas.py`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Create `tests/research_loop/test_schemas.py` with tests that establish the
+contract before implementation:
+
+```python
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gaia.research_loop.schemas import (
+    CandidateEnvelope,
+    EvidenceRef,
+    ResearchLoopTask,
+    TaskKind,
+)
+
+
+def test_task_embeds_contract_and_minimal_example() -> None:
+    task = ResearchLoopTask(
+        task_id="task-query-plan-1",
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        objective="Plan the next LKM searches.",
+        inputs={"scope": {"seed": "aspirin primary prevention"}},
+        instructions=["Return two focused queries."],
+        allowed_actions=["submit_query_plan", "stop"],
+        recommended_action="submit_query_plan",
+        output_contract={"type": "object", "required": ["queries"]},
+        allowed_refs=[EvidenceRef(kind="scope", id="scope-1")],
+        minimal_example={"queries": [{"query": "example query", "purpose": "shape only"}]},
+        submit_command="gaia-research-loop submit /tmp/pkg candidate.json",
+    )
+
+    assert task.schema == "gaia.research_loop.task.v1"
+    assert task.stage == "explore"
+    assert task.kind == TaskKind.QUERY_PLAN
+    assert task.repair_context is None
+
+
+def test_candidate_selected_action_must_be_allowed_or_recommended() -> None:
+    candidate = CandidateEnvelope(
+        task_id="task-query-plan-1",
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        selected_action="stop",
+        override_rationale="Budget exhausted.",
+        payload={"reason": "No more searches."},
+    )
+
+    candidate.validate_against_actions(
+        recommended_action="submit_query_plan",
+        allowed_actions=["submit_query_plan", "stop"],
+    )
+
+
+def test_candidate_override_requires_rationale() -> None:
+    candidate = CandidateEnvelope(
+        task_id="task-query-plan-1",
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        selected_action="stop",
+        payload={"reason": "No more searches."},
+    )
+
+    with pytest.raises(ValueError, match="override_rationale"):
+        candidate.validate_against_actions(
+            recommended_action="submit_query_plan",
+            allowed_actions=["submit_query_plan", "stop"],
+        )
+
+
+def test_extra_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResearchLoopTask(
+            task_id="task-query-plan-1",
+            stage="explore",
+            kind=TaskKind.QUERY_PLAN,
+            objective="Plan.",
+            inputs={},
+            instructions=[],
+            allowed_actions=["submit_query_plan"],
+            recommended_action="submit_query_plan",
+            output_contract={},
+            allowed_refs=[],
+            minimal_example={},
+            submit_command="gaia-research-loop submit /tmp/pkg candidate.json",
+            unexpected=True,
+        )
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_schemas.py -q
+```
+
+Expected: fail with `ModuleNotFoundError: No module named 'gaia.research_loop'`.
+
+- [ ] **Step 3: Implement schema models**
+
+Create `gaia/research_loop/__init__.py`:
+
+```python
+"""Agent-facing Gaia research loop protocol."""
+```
+
+Create `gaia/research_loop/schemas.py` with:
+
+```python
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TASK_SCHEMA = "gaia.research_loop.task.v1"
+CANDIDATE_SCHEMA = "gaia.research_loop.candidate.v1"
+ARTIFACT_SCHEMA = "gaia.research_loop.artifact.v1"
+GATE_SCHEMA = "gaia.research_loop.gate.v1"
+
+Stage = Literal["explore", "assess"]
+
+
+class TaskKind(StrEnum):
+    SCOPE = "scope"
+    QUERY_PLAN = "query_plan"
+    SEARCH_EXECUTION = "search_execution"
+    FOCUS_SYNTHESIS = "focus_synthesis"
+    EXPLORE_GATE = "explore_gate"
+    ASSESSMENT_CONTEXT = "assessment_context"
+    EVIDENCE_DIAGNOSIS = "evidence_diagnosis"
+    ASSESS_GATE = "assess_gate"
+
+
+class EvidenceRef(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    id: str
+    role: str | None = None
+
+
+class RepairContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    failed_candidate_path: str
+    errors: list[dict[str, Any]]
+    instruction: str
+    preserved_fields: dict[str, Any] = Field(default_factory=dict)
+
+
+class ResearchLoopTask(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal["gaia.research_loop.task.v1"] = TASK_SCHEMA
+    task_id: str
+    stage: Stage
+    kind: TaskKind
+    objective: str
+    inputs: dict[str, Any]
+    instructions: list[str]
+    allowed_actions: list[str]
+    recommended_action: str
+    output_contract: dict[str, Any]
+    allowed_refs: list[EvidenceRef] = Field(default_factory=list)
+    minimal_example: dict[str, Any]
+    submit_command: str
+    validation: dict[str, Any] = Field(default_factory=dict)
+    repair_context: RepairContext | None = None
+
+
+class CandidateEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal["gaia.research_loop.candidate.v1"] = CANDIDATE_SCHEMA
+    task_id: str
+    stage: Stage
+    kind: TaskKind
+    selected_action: str
+    override_rationale: str | None = None
+    payload: dict[str, Any]
+
+    def validate_against_actions(
+        self,
+        *,
+        recommended_action: str,
+        allowed_actions: list[str],
+    ) -> None:
+        if self.selected_action not in allowed_actions:
+            raise ValueError(f"selected_action {self.selected_action!r} is not allowed")
+        if (
+            self.selected_action != recommended_action
+            and not self.override_rationale
+        ):
+            raise ValueError("override_rationale is required when overriding recommendation")
+```
+
+- [ ] **Step 4: Verify schema tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_schemas.py -q
+```
+
+Expected: `4 passed`.
+
+- [ ] **Step 5: Type and lint the new module**
+
+Run:
+
+```bash
+uv run mypy gaia/research_loop tests/research_loop
+uv run ruff check gaia/research_loop tests/research_loop
+uv run ruff format --check gaia/research_loop tests/research_loop
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/research_loop/__init__.py gaia/research_loop/schemas.py tests/research_loop/__init__.py tests/research_loop/test_schemas.py
+git commit -m "feat(research-loop): add protocol schemas"
+```
+
+---
+
+## Task 2: Storage, Event Log, and State Rebuild
+
+**Files:**
+
+- Modify: `gaia/research_loop/schemas.py`
+- Create: `gaia/research_loop/storage.py`
+- Test: `tests/research_loop/test_storage.py`
+
+- [ ] **Step 1: Write failing storage tests**
+
+Create tests for canonical layout, event append, and rebuild:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from gaia.research_loop.storage import (
+    append_event,
+    ensure_loop_dirs,
+    load_events,
+    rebuild_state,
+    write_json,
+)
+
+
+def test_ensure_loop_dirs_creates_canonical_layout(tmp_path: Path) -> None:
+    paths = ensure_loop_dirs(tmp_path)
+
+    assert paths.root == tmp_path / ".gaia" / "research_loop"
+    for stage in ["explore", "assess"]:
+        for leaf in ["tasks", "candidates", "artifacts"]:
+            assert (paths.root / stage / leaf).is_dir()
+
+
+def test_append_event_writes_jsonl(tmp_path: Path) -> None:
+    paths = ensure_loop_dirs(tmp_path)
+    append_event(paths, event_type="task_emitted", stage="explore", data={"task_id": "t1"})
+
+    events = load_events(paths)
+    assert len(events) == 1
+    assert events[0].event_type == "task_emitted"
+    assert events[0].stage == "explore"
+    assert events[0].data == {"task_id": "t1"}
+
+
+def test_rebuild_state_indexes_latest_task_and_artifact(tmp_path: Path) -> None:
+    paths = ensure_loop_dirs(tmp_path)
+    write_json(paths.explore_tasks / "task-1.json", {"task_id": "task-1", "kind": "scope"})
+    write_json(paths.explore_artifacts / "scope.json", {"kind": "scope", "id": "scope-1"})
+
+    state = rebuild_state(paths)
+
+    assert state.schema == "gaia.research_loop.state.v1"
+    assert state.latest_task_by_stage["explore"].endswith("task-1.json")
+    assert state.latest_artifact_by_stage["explore"].endswith("scope.json")
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_storage.py -q
+```
+
+Expected: fail because `storage.py` and `ResearchLoopEvent` do not exist.
+
+- [ ] **Step 3: Add state and event schemas**
+
+Extend `gaia/research_loop/schemas.py` with:
+
+```python
+from datetime import UTC, datetime
+
+STATE_SCHEMA = "gaia.research_loop.state.v1"
+
+
+def utcnow() -> str:
+    return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+class ResearchLoopEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal["gaia.research_loop.event.v1"] = "gaia.research_loop.event.v1"
+    created_at: str = Field(default_factory=utcnow)
+    event_type: str
+    stage: Stage | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ResearchLoopState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal["gaia.research_loop.state.v1"] = STATE_SCHEMA
+    phase: str = "idle"
+    latest_task_by_stage: dict[str, str] = Field(default_factory=dict)
+    latest_artifact_by_stage: dict[str, str] = Field(default_factory=dict)
+    last_validation_error: dict[str, Any] | None = None
+```
+
+- [ ] **Step 4: Implement storage helpers**
+
+Create `gaia/research_loop/storage.py` with path helpers:
+
+```python
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gaia.research_loop.schemas import ResearchLoopEvent, ResearchLoopState, Stage
+
+
+@dataclass(frozen=True)
+class ResearchLoopPaths:
+    pkg: Path
+    root: Path
+    state: Path
+    events: Path
+    explore_tasks: Path
+    explore_candidates: Path
+    explore_artifacts: Path
+    assess_tasks: Path
+    assess_candidates: Path
+    assess_artifacts: Path
+
+
+def loop_paths(pkg: str | Path) -> ResearchLoopPaths:
+    pkg_path = Path(pkg).resolve()
+    root = pkg_path / ".gaia" / "research_loop"
+    return ResearchLoopPaths(
+        pkg=pkg_path,
+        root=root,
+        state=root / "state.json",
+        events=root / "events.jsonl",
+        explore_tasks=root / "explore" / "tasks",
+        explore_candidates=root / "explore" / "candidates",
+        explore_artifacts=root / "explore" / "artifacts",
+        assess_tasks=root / "assess" / "tasks",
+        assess_candidates=root / "assess" / "candidates",
+        assess_artifacts=root / "assess" / "artifacts",
+    )
+
+
+def ensure_loop_dirs(pkg: str | Path) -> ResearchLoopPaths:
+    paths = loop_paths(pkg)
+    for directory in [
+        paths.explore_tasks,
+        paths.explore_candidates,
+        paths.explore_artifacts,
+        paths.assess_tasks,
+        paths.assess_candidates,
+        paths.assess_artifacts,
+    ]:
+        directory.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def append_event(
+    paths: ResearchLoopPaths,
+    *,
+    event_type: str,
+    stage: Stage | None,
+    data: dict[str, Any],
+) -> ResearchLoopEvent:
+    event = ResearchLoopEvent(event_type=event_type, stage=stage, data=data)
+    paths.events.parent.mkdir(parents=True, exist_ok=True)
+    with paths.events.open("a", encoding="utf-8") as handle:
+        handle.write(event.model_dump_json() + "\n")
+    return event
+
+
+def load_events(paths: ResearchLoopPaths) -> list[ResearchLoopEvent]:
+    if not paths.events.exists():
+        return []
+    return [
+        ResearchLoopEvent.model_validate_json(line)
+        for line in paths.events.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _latest_json_path(directory: Path) -> str | None:
+    matches = sorted(directory.glob("*.json"), key=lambda path: path.stat().st_mtime)
+    return str(matches[-1]) if matches else None
+
+
+def rebuild_state(paths: ResearchLoopPaths) -> ResearchLoopState:
+    state = ResearchLoopState(
+        latest_task_by_stage={
+            stage: path
+            for stage, path in {
+                "explore": _latest_json_path(paths.explore_tasks),
+                "assess": _latest_json_path(paths.assess_tasks),
+            }.items()
+            if path is not None
+        },
+        latest_artifact_by_stage={
+            stage: path
+            for stage, path in {
+                "explore": _latest_json_path(paths.explore_artifacts),
+                "assess": _latest_json_path(paths.assess_artifacts),
+            }.items()
+            if path is not None
+        },
+    )
+    write_json(paths.state, state.model_dump(mode="json"))
+    return state
+```
+
+- [ ] **Step 5: Verify storage tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_storage.py -q
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 6: Run schema and storage tests together**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_schemas.py tests/research_loop/test_storage.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/research_loop/schemas.py gaia/research_loop/storage.py tests/research_loop/test_storage.py
+git commit -m "feat(research-loop): add storage and event log"
+```
+
+---
+
+## Task 3: `gaia-research-loop status`
+
+**Files:**
+
+- Create: `gaia/research_loop/engine.py`
+- Create: `gaia/research_loop/cli.py`
+- Modify: `pyproject.toml`
+- Test: `tests/research_loop/test_cli_status.py`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Create `tests/research_loop/test_cli_status.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_status_initializes_empty_loop(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["status", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    assert '"phase": "idle"' in result.stdout
+    assert (tmp_path / ".gaia" / "research_loop" / "state.json").exists()
+
+
+def test_status_human_output_names_next_command(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["status", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Research loop: idle" in result.stdout
+    assert "Next: gaia-research-loop next" in result.stdout
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_cli_status.py -q
+```
+
+Expected: fail because `gaia.research_loop.cli` does not exist.
+
+- [ ] **Step 3: Implement engine status**
+
+Create `gaia/research_loop/engine.py` with:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from gaia.research_loop.storage import ensure_loop_dirs, load_events, rebuild_state
+
+
+def status_payload(pkg: str | Path) -> dict[str, Any]:
+    paths = ensure_loop_dirs(pkg)
+    state = rebuild_state(paths)
+    events = load_events(paths)
+    return {
+        "schema": state.schema,
+        "phase": state.phase,
+        "root": str(paths.root),
+        "latest_task_by_stage": state.latest_task_by_stage,
+        "latest_artifact_by_stage": state.latest_artifact_by_stage,
+        "event_count": len(events),
+        "recommended_next": "gaia-research-loop next",
+    }
+```
+
+- [ ] **Step 4: Implement CLI and console script**
+
+Create `gaia/research_loop/cli.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+import typer
+
+from gaia.research_loop.engine import status_payload
+
+app = typer.Typer(
+    name="gaia-research-loop",
+    help="Gaia Research Loop — agent-facing Explore -> Assess protocol.",
+    no_args_is_help=True,
+)
+
+_PKG_ARG = typer.Argument(..., help="Knowledge-package path.")
+_JSON_OPT = typer.Option(False, "--json", help="Emit JSON.")
+
+
+@app.command("status")
+def status_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Show or rebuild research loop state."""
+    payload = status_payload(pkg)
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"Research loop: {payload['phase']}")
+    typer.echo(f"Root: {payload['root']}")
+    typer.echo(f"Events: {payload['event_count']}")
+    typer.echo(f"Next: {payload['recommended_next']} {pkg}")
+```
+
+Modify `pyproject.toml`:
+
+```toml
+[project.scripts]
+gaia = "gaia.cli.main:app"
+gaia-lkm-explore = "gaia.lkm_explorer.client.cli:app"
+gaia-research-loop = "gaia.research_loop.cli:app"
+```
+
+- [ ] **Step 5: Verify CLI tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_cli_status.py -q
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 6: Verify installed script help**
+
+Run:
+
+```bash
+uv run gaia-research-loop --help
+uv run gaia-research-loop status /tmp/gaia-research-loop-smoke --json
+```
+
+Expected: help lists `status`; JSON output contains `"phase": "idle"`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml gaia/research_loop/engine.py gaia/research_loop/cli.py tests/research_loop/test_cli_status.py
+git commit -m "feat(research-loop): add status cli"
+```
+
+---
+
+## Task 4: `next` for Scope and Query Planning
+
+**Files:**
+
+- Modify: `gaia/research_loop/schemas.py`
+- Create: `gaia/research_loop/tasks.py`
+- Modify: `gaia/research_loop/engine.py`
+- Modify: `gaia/research_loop/cli.py`
+- Test: `tests/research_loop/test_next_submit.py`
+
+- [ ] **Step 1: Write failing `next` tests**
+
+Add to `tests/research_loop/test_next_submit.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_next_emits_scope_task_for_empty_loop(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["recommended_action"] == "submit_scope"
+    task_path = Path(payload["task_path"])
+    assert task_path.exists()
+    task = json.loads(task_path.read_text(encoding="utf-8"))
+    assert task["kind"] == "scope"
+    assert task["output_contract"]["title"] == "ScopeCandidatePayload"
+    assert task["submit_command"].startswith("gaia-research-loop submit")
+
+
+def test_next_emits_query_plan_after_scope_artifact(tmp_path: Path) -> None:
+    runner = CliRunner()
+    scope_dir = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "scope.json").write_text(
+        json.dumps({"kind": "scope", "seed_question": "aspirin primary prevention"}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["recommended_action"] == "submit_query_plan"
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "query_plan"
+    assert "Plan the next LKM searches" in task["objective"]
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py -q
+```
+
+Expected: fail because `next` command and task builders do not exist.
+
+- [ ] **Step 3: Add payload schemas**
+
+Extend `schemas.py` with `ScopeCandidatePayload` and `QueryPlanCandidatePayload`:
+
+```python
+class ScopeCandidatePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    seed_question: str
+    domain_profile: str | None = None
+    scope_dimensions: dict[str, list[str]] = Field(default_factory=dict)
+    search_budget: int = 5
+
+
+class PlannedQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    query: str
+    purpose: str
+    expected_evidence_family: str | None = None
+    source_ref: EvidenceRef | None = None
+
+
+class QueryPlanCandidatePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    queries: list[PlannedQuery]
+    rationale: str
+```
+
+- [ ] **Step 4: Implement task builders**
+
+Create `gaia/research_loop/tasks.py` with:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from gaia.research_loop.schemas import (
+    EvidenceRef,
+    QueryPlanCandidatePayload,
+    ResearchLoopTask,
+    ScopeCandidatePayload,
+    TaskKind,
+)
+from gaia.research_loop.storage import ResearchLoopPaths, write_json
+
+
+def _task_path(paths: ResearchLoopPaths, task_id: str) -> Path:
+    return paths.explore_tasks / f"{task_id}.json"
+
+
+def build_scope_task(paths: ResearchLoopPaths) -> tuple[ResearchLoopTask, Path]:
+    task_id = "task-scope-0001"
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="explore",
+        kind=TaskKind.SCOPE,
+        objective="Turn the seed research question into a structured exploration scope.",
+        inputs={"pkg": str(paths.pkg)},
+        instructions=[
+            "Identify the seed question and any obvious scope dimensions.",
+            "Keep this lightweight; do not assess evidence yet.",
+        ],
+        allowed_actions=["submit_scope", "stop"],
+        recommended_action="submit_scope",
+        output_contract=ScopeCandidatePayload.model_json_schema(),
+        allowed_refs=[],
+        minimal_example={
+            "task_id": task_id,
+            "stage": "explore",
+            "kind": "scope",
+            "selected_action": "submit_scope",
+            "payload": {"seed_question": "example topic", "search_budget": 3},
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _task_path(paths, task_id)
+
+
+def build_query_plan_task(paths: ResearchLoopPaths, scope: dict[str, Any]) -> tuple[ResearchLoopTask, Path]:
+    task_id = "task-query-plan-0001"
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        objective="Plan the next LKM searches from the current scope and coverage.",
+        inputs={"scope": scope},
+        instructions=[
+            "Propose a small set of LKM search queries.",
+            "Prefer breadth-first coverage over deep paper analysis.",
+        ],
+        allowed_actions=["submit_query_plan", "stop"],
+        recommended_action="submit_query_plan",
+        output_contract=QueryPlanCandidatePayload.model_json_schema(),
+        allowed_refs=[EvidenceRef(kind="scope", id="scope")],
+        minimal_example={
+            "task_id": task_id,
+            "stage": "explore",
+            "kind": "query_plan",
+            "selected_action": "submit_query_plan",
+            "payload": {
+                "queries": [{"query": "example query", "purpose": "cover one evidence family"}],
+                "rationale": "Tiny shape example only.",
+            },
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _task_path(paths, task_id)
+
+
+def write_task(task: ResearchLoopTask, path: Path) -> None:
+    write_json(path, task.model_dump(mode="json"))
+```
+
+- [ ] **Step 5: Implement `next` engine and CLI**
+
+Add `next_payload` to `engine.py`:
+
+```python
+from gaia.research_loop.storage import read_json, write_json
+from gaia.research_loop.tasks import build_query_plan_task, build_scope_task, write_task
+
+
+def next_payload(pkg: str | Path) -> dict[str, Any]:
+    paths = ensure_loop_dirs(pkg)
+    scope_path = paths.explore_artifacts / "scope.json"
+    if scope_path.exists():
+        task, task_path = build_query_plan_task(paths, read_json(scope_path))
+    else:
+        task, task_path = build_scope_task(paths)
+    write_task(task, task_path)
+    append_event(
+        paths,
+        event_type="task_emitted",
+        stage=task.stage,
+        data={"task_id": task.task_id, "kind": task.kind.value, "task_path": str(task_path)},
+    )
+    rebuild_state(paths)
+    return {
+        "recommended_action": task.recommended_action,
+        "allowed_actions": task.allowed_actions,
+        "task_path": str(task_path),
+        "submit_command": task.submit_command,
+        "rationale": task.objective,
+    }
+```
+
+Add CLI command:
+
+```python
+from gaia.research_loop.engine import next_payload, status_payload
+
+
+@app.command("next")
+def next_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit the next task envelope."""
+    payload = next_payload(pkg)
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"Recommended: {payload['recommended_action']}")
+    typer.echo(f"Task: {payload['task_path']}")
+    typer.echo(f"Submit: {payload['submit_command']}")
+```
+
+- [ ] **Step 6: Verify `next` tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py -q
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/research_loop/schemas.py gaia/research_loop/tasks.py gaia/research_loop/engine.py gaia/research_loop/cli.py tests/research_loop/test_next_submit.py
+git commit -m "feat(research-loop): emit scope and query tasks"
+```
+
+---
+
+## Task 5: `submit` Validation and Repair Context
+
+**Files:**
+
+- Modify: `gaia/research_loop/schemas.py`
+- Modify: `gaia/research_loop/storage.py`
+- Modify: `gaia/research_loop/engine.py`
+- Modify: `gaia/research_loop/cli.py`
+- Test: `tests/research_loop/test_next_submit.py`
+
+- [ ] **Step 1: Add failing submit tests**
+
+Append:
+
+```python
+def test_submit_scope_writes_scope_artifact(tmp_path: Path) -> None:
+    runner = CliRunner()
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task_path = Path(json.loads(next_result.stdout)["task_path"])
+    task = json.loads(task_path.read_text(encoding="utf-8"))
+    candidate_path = tmp_path / "scope-candidate.json"
+    candidate_path.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {
+                    "seed_question": "aspirin primary prevention",
+                    "domain_profile": "clinical",
+                    "scope_dimensions": {"outcome": ["MI", "major bleeding"]},
+                    "search_budget": 4,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["submit", str(tmp_path), str(candidate_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "accepted"
+    scope_artifact = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts" / "scope.json"
+    assert json.loads(scope_artifact.read_text(encoding="utf-8"))["seed_question"] == (
+        "aspirin primary prevention"
+    )
+
+
+def test_submit_invalid_candidate_records_repair_context(tmp_path: Path) -> None:
+    runner = CliRunner()
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task_path = Path(json.loads(next_result.stdout)["task_path"])
+    task = json.loads(task_path.read_text(encoding="utf-8"))
+    bad_candidate = tmp_path / "bad.json"
+    bad_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {"search_budget": 4},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["submit", str(tmp_path), str(bad_candidate), "--json"])
+    assert result.exit_code == 1
+
+    repair_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    repair_task = json.loads(Path(json.loads(repair_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    assert repair_task["repair_context"]["failed_candidate_path"].endswith("bad.json")
+    assert "seed_question" in json.dumps(repair_task["repair_context"]["errors"])
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py -q
+```
+
+Expected: fail because `submit` does not exist.
+
+- [ ] **Step 3: Implement task lookup and candidate persistence**
+
+Add helpers in `storage.py`:
+
+```python
+def find_task(paths: ResearchLoopPaths, task_id: str) -> Path:
+    for directory in [paths.explore_tasks, paths.assess_tasks]:
+        candidate = directory / f"{task_id}.json"
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"No task envelope found for {task_id}")
+
+
+def candidate_destination(paths: ResearchLoopPaths, stage: str, candidate_path: Path) -> Path:
+    directory = paths.explore_candidates if stage == "explore" else paths.assess_candidates
+    return directory / candidate_path.name
+```
+
+- [ ] **Step 4: Implement validation and artifact writing**
+
+Add `submit_candidate` to `engine.py`:
+
+```python
+from pydantic import ValidationError
+
+from gaia.research_loop.schemas import (
+    CandidateEnvelope,
+    QueryPlanCandidatePayload,
+    ResearchLoopTask,
+    ScopeCandidatePayload,
+    TaskKind,
+)
+from gaia.research_loop.storage import candidate_destination, find_task
+
+
+def _payload_model_for(kind: TaskKind) -> type[ScopeCandidatePayload] | type[QueryPlanCandidatePayload]:
+    if kind == TaskKind.SCOPE:
+        return ScopeCandidatePayload
+    if kind == TaskKind.QUERY_PLAN:
+        return QueryPlanCandidatePayload
+    raise ValueError(f"No payload validator for {kind.value}")
+
+
+def submit_candidate(pkg: str | Path, candidate_path: str | Path) -> dict[str, Any]:
+    paths = ensure_loop_dirs(pkg)
+    source_path = Path(candidate_path).resolve()
+    try:
+        candidate = CandidateEnvelope.model_validate_json(source_path.read_text(encoding="utf-8"))
+        task_path = find_task(paths, candidate.task_id)
+        task = ResearchLoopTask.model_validate_json(task_path.read_text(encoding="utf-8"))
+        if candidate.stage != task.stage or candidate.kind != task.kind:
+            raise ValueError("candidate stage/kind does not match task")
+        candidate.validate_against_actions(
+            recommended_action=task.recommended_action,
+            allowed_actions=task.allowed_actions,
+        )
+        payload_model = _payload_model_for(task.kind)
+        payload = payload_model.model_validate(candidate.payload)
+    except (ValidationError, ValueError, FileNotFoundError) as exc:
+        errors = exc.errors() if isinstance(exc, ValidationError) else [{"msg": str(exc)}]
+        _record_validation_failure(paths, source_path, errors)
+        raise
+
+    copied_candidate = candidate_destination(paths, candidate.stage, source_path)
+    write_json(copied_candidate, candidate.model_dump(mode="json"))
+    if task.kind == TaskKind.SCOPE:
+        artifact_path = paths.explore_artifacts / "scope.json"
+        write_json(artifact_path, payload.model_dump(mode="json"))
+    elif task.kind == TaskKind.QUERY_PLAN:
+        artifact_path = paths.explore_artifacts / "query_plan.json"
+        write_json(artifact_path, payload.model_dump(mode="json"))
+    append_event(
+        paths,
+        event_type="candidate_submitted",
+        stage=candidate.stage,
+        data={"task_id": candidate.task_id, "candidate_path": str(copied_candidate)},
+    )
+    rebuild_state(paths)
+    return {"status": "accepted", "artifact_path": str(artifact_path)}
+```
+
+Add `_record_validation_failure`:
+
+```python
+def _record_validation_failure(
+    paths: ResearchLoopPaths,
+    failed_candidate_path: Path,
+    errors: list[dict[str, Any]],
+) -> None:
+    state = rebuild_state(paths)
+    state.last_validation_error = {
+        "failed_candidate_path": str(failed_candidate_path),
+        "errors": errors,
+        "instruction": "Repair the candidate JSON so it satisfies the same task contract.",
+    }
+    write_json(paths.state, state.model_dump(mode="json"))
+    append_event(
+        paths,
+        event_type="validation_failed",
+        stage=None,
+        data=state.last_validation_error,
+    )
+```
+
+Modify `next_payload` so when `state.last_validation_error` exists, it re-emits
+the same task with `repair_context` populated instead of advancing.
+
+- [ ] **Step 5: Add CLI command**
+
+In `cli.py`:
+
+```python
+from gaia.research_loop.engine import next_payload, status_payload, submit_candidate
+
+
+@app.command("submit")
+def submit_command(
+    pkg: str = _PKG_ARG,
+    candidate: str = typer.Argument(..., help="Candidate JSON path."),
+    json_out: bool = _JSON_OPT,
+) -> None:
+    """Validate and submit a candidate JSON file."""
+    try:
+        payload = submit_candidate(pkg, candidate)
+    except Exception as exc:
+        if json_out:
+            typer.echo(json.dumps({"status": "rejected", "error": str(exc)}, indent=2))
+        else:
+            typer.echo(f"Rejected: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"Accepted: {payload['artifact_path']}")
+```
+
+- [ ] **Step 6: Verify submit and repair tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py -q
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/research_loop tests/research_loop/test_next_submit.py
+git commit -m "feat(research-loop): validate candidate submission"
+```
+
+---
+
+## Task 6: Query Plan to Mechanical Search Execution Task
+
+**Files:**
+
+- Modify: `gaia/research_loop/schemas.py`
+- Modify: `gaia/research_loop/tasks.py`
+- Modify: `gaia/research_loop/engine.py`
+- Test: `tests/research_loop/test_next_submit.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```python
+def test_next_after_query_plan_emits_search_execution(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    scope_candidate = tmp_path / "scope.json"
+    scope_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-scope-0001",
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {"seed_question": "aspirin primary prevention", "search_budget": 2},
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner.invoke(app, ["submit", str(tmp_path), str(scope_candidate), "--json"])
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    query_candidate = tmp_path / "query-plan.json"
+    query_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-query-plan-0001",
+                "stage": "explore",
+                "kind": "query_plan",
+                "selected_action": "submit_query_plan",
+                "payload": {
+                    "queries": [{"query": "aspirin primary prevention bleeding", "purpose": "harms"}],
+                    "rationale": "Need harm evidence.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner.invoke(app, ["submit", str(tmp_path), str(query_candidate), "--json"])
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "search_execution"
+    assert "gaia search lkm knowledge" in task["inputs"]["commands"][0]["command"]
+    assert task["inputs"]["commands"][0]["output_path"].endswith(".json")
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py::test_next_after_query_plan_emits_search_execution -q
+```
+
+Expected: fail because `next` does not advance past query plan.
+
+- [ ] **Step 3: Add search execution payload schema**
+
+In `schemas.py`:
+
+```python
+class SearchResultPath(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    query: str
+    path: str
+
+
+class SearchExecutionCandidatePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    results: list[SearchResultPath]
+```
+
+- [ ] **Step 4: Add task builder**
+
+In `tasks.py`, add `build_search_execution_task(paths, query_plan)` that creates
+commands such as:
+
+```python
+command = f"gaia search lkm knowledge {query_text!r} --json > {output_path}"
+```
+
+The task input item should include:
+
+```json
+{
+  "query": "aspirin primary prevention bleeding",
+  "command": "gaia search lkm knowledge 'aspirin primary prevention bleeding' --json > ...",
+  "output_path": ".gaia/research_loop/explore/artifacts/raw-search-0001-0.json"
+}
+```
+
+- [ ] **Step 5: Update `next` routing**
+
+Routing order:
+
+```text
+if last_validation_error: repair same task
+elif no scope artifact: scope
+elif no query_plan artifact: query_plan
+elif landscape artifact exists and no focuses artifact: focus_synthesis
+elif no raw_search_manifest artifact: search_execution
+else: landscape
+```
+
+- [ ] **Step 6: Verify targeted test passes**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py::test_next_after_query_plan_emits_search_execution -q
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/research_loop tests/research_loop/test_next_submit.py
+git commit -m "feat(research-loop): emit search execution tasks"
+```
+
+---
+
+## Task 7: LKM Landscape Artifact Under Research Loop
+
+**Files:**
+
+- Create: `gaia/research_loop/lkm_adapter.py`
+- Modify: `gaia/research_loop/engine.py`
+- Test: `tests/research_loop/test_lkm_adapter.py`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Create fixture-based tests using `tests/lkm_explorer/fixtures/lkm_search_free_fall.json`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from gaia.research_loop.lkm_adapter import build_landscape_from_raw_results
+
+
+def test_build_landscape_from_raw_results_extracts_paper_leads(tmp_path: Path) -> None:
+    fixture = Path("tests/lkm_explorer/fixtures/lkm_search_free_fall.json")
+
+    artifact = build_landscape_from_raw_results(
+        pkg=tmp_path,
+        raw_results=[("free fall", fixture)],
+        round_number=0,
+    )
+
+    assert artifact["schema"] == "gaia.research_loop.artifact.v1"
+    assert artifact["kind"] == "landscape"
+    assert artifact["round"] == 0
+    assert artifact["raw_results"][0]["query"] == "free fall"
+    assert isinstance(artifact["paper_leads"], list)
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_lkm_adapter.py -q
+```
+
+Expected: fail because adapter does not exist.
+
+- [ ] **Step 3: Implement adapter**
+
+Create `lkm_adapter.py` with a small adapter around existing landscape parser.
+If `gaia.lkm_explorer.engine.landscape.build_landscape` accepts the raw fixture
+shape directly, use it. If not, implement only the minimal extraction needed for
+saved LKM search envelopes and keep the function pure.
+
+Required output shape:
+
+```python
+{
+    "schema": "gaia.research_loop.artifact.v1",
+    "kind": "landscape",
+    "round": round_number,
+    "raw_results": [{"query": query, "path": str(path)}],
+    "paper_leads": [...],
+    "coverage": {"paper_count": len(paper_leads)},
+}
+```
+
+- [ ] **Step 4: Add submit path for search execution**
+
+When a valid `SearchExecutionCandidatePayload` is submitted:
+
+1. Validate every `path` exists.
+2. Write `raw_search_manifest.json`.
+3. Build and write `landscape-0000.json`.
+4. Append `artifact_written`.
+
+- [ ] **Step 5: Verify adapter and CLI path**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_lkm_adapter.py tests/research_loop/test_next_submit.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/research_loop/lkm_adapter.py gaia/research_loop/engine.py tests/research_loop/test_lkm_adapter.py tests/research_loop/test_next_submit.py
+git commit -m "feat(research-loop): build lkm landscape artifacts"
+```
+
+---
+
+## Task 8: Focus Synthesis Task and Explore Gate
+
+**Files:**
+
+- Modify: `gaia/research_loop/schemas.py`
+- Modify: `gaia/research_loop/tasks.py`
+- Modify: `gaia/research_loop/engine.py`
+- Test: `tests/research_loop/test_explore_gate.py`
+
+- [ ] **Step 1: Write failing focus and gate tests**
+
+Create `tests/research_loop/test_explore_gate.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_focus_synthesis_candidate_writes_focuses(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "scope.json").write_text(json.dumps({"seed_question": "aspirin"}), encoding="utf-8")
+    (artifacts / "query_plan.json").write_text(json.dumps({"queries": []}), encoding="utf-8")
+    (artifacts / "landscape-0000.json").write_text(
+        json.dumps(
+            {
+                "kind": "landscape",
+                "paper_leads": [{"paper_id": "P1", "title": "Aspirin trial"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "focus_synthesis"
+    candidate = tmp_path / "focuses.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "focus_synthesis",
+                "selected_action": "submit_focuses",
+                "payload": {
+                    "focuses": [
+                        {
+                            "focus_id": "focus-net-benefit",
+                            "research_question": "Does benefit outweigh bleeding risk?",
+                            "why_it_matters": "It determines clinical recommendation.",
+                            "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                            "coverage_status": "ready_for_assess",
+                            "ready_for_assess": True,
+                            "recommended_assess_mode": "evidence_table",
+                        }
+                    ],
+                    "selection": {
+                        "selected_focus_ids": ["focus-net-benefit"],
+                        "selection_rationale": "Ready and grounded.",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(candidate), "--json"])
+    assert submit.exit_code == 0
+    focuses = json.loads((artifacts / "focuses.json").read_text(encoding="utf-8"))
+    assert focuses["focuses"][0]["focus_id"] == "focus-net-benefit"
+
+
+def test_gate_passes_when_selected_focus_ready(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "focuses.json").write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "focus_id": "focus-net-benefit",
+                        "ready_for_assess": True,
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ],
+                "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["gate", str(tmp_path), "--stage", "explore", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "pass"
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_explore_gate.py -q
+```
+
+Expected: fail because focus payloads and gate are not implemented.
+
+- [ ] **Step 3: Implement focus schemas and task**
+
+Add `FocusCandidatePayload`, `FocusRecord`, and `FocusSelection` models.
+Build a `focus_synthesis` task whose `allowed_refs` come from `landscape`
+paper leads and LKM node ids.
+
+- [ ] **Step 4: Implement Explore gate**
+
+Gate status:
+
+```text
+pass   = selected ready focus has at least one grounded evidence ref
+revise = no selected focus, no ready focus, or ungrounded refs
+```
+
+Write gate report to:
+
+```text
+.gaia/research_loop/explore/artifacts/explore_gate.json
+```
+
+- [ ] **Step 5: Verify Explore gate tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_explore_gate.py -q
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gaia/research_loop tests/research_loop/test_explore_gate.py
+git commit -m "feat(research-loop): add focus synthesis gate"
+```
+
+---
+
+## Task 9: Assessment Context, Evidence Diagnosis, and Assess Gate
+
+**Files:**
+
+- Modify: `gaia/research_loop/schemas.py`
+- Modify: `gaia/research_loop/tasks.py`
+- Modify: `gaia/research_loop/engine.py`
+- Test: `tests/research_loop/test_assess_gate.py`
+
+- [ ] **Step 1: Write failing assess tests**
+
+Create `tests/research_loop/test_assess_gate.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_next_after_explore_gate_emits_assessment_context(tmp_path: Path) -> None:
+    runner = CliRunner()
+    explore = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    explore.mkdir(parents=True)
+    (explore / "focuses.json").write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "focus_id": "focus-net-benefit",
+                        "research_question": "Does benefit outweigh bleeding risk?",
+                        "ready_for_assess": True,
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ],
+                "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (explore / "explore_gate.json").write_text(json.dumps({"status": "pass"}), encoding="utf-8")
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    task = json.loads(Path(json.loads(result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    assert task["stage"] == "assess"
+    assert task["kind"] == "assessment_context"
+
+
+def test_assess_gate_passes_grounded_evidence_diagnosis(tmp_path: Path) -> None:
+    runner = CliRunner()
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    assess.mkdir(parents=True)
+    (assess / "evidence_diagnosis.json").write_text(
+        json.dumps(
+            {
+                "focus_id": "focus-net-benefit",
+                "evidence_items": [{"id": "e1", "refs": [{"kind": "paper", "id": "P1"}]}],
+                "contradictions_or_tensions": [],
+                "limitations": ["Sparse example."],
+                "gap_map": [{"gap_id": "g1", "description": "Need subgroup evidence."}],
+                "next_tests": [{"gap_id": "g1", "test": "Search subgroup RCTs."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["gate", str(tmp_path), "--stage", "assess", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["status"] == "pass"
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_assess_gate.py -q
+```
+
+Expected: fail because Assess routing and gate are not implemented.
+
+- [ ] **Step 3: Implement assess schemas**
+
+Add:
+
+- `AssessmentContextPayload`
+- `EvidenceItem`
+- `EvidenceDiagnosisPayload`
+- `GapMapEntry`
+- `NextTest`
+
+Require refs on evidence items and require `next_tests[].gap_id` to refer to an
+existing gap.
+
+- [ ] **Step 4: Implement assess task routing**
+
+After Explore gate pass:
+
+```text
+if no assessment_context artifact: emit assessment_context task
+elif no evidence_diagnosis artifact: emit evidence_diagnosis task
+else: recommend assess_gate
+```
+
+- [ ] **Step 5: Implement Assess gate**
+
+Gate status:
+
+```text
+pass   = diagnosis has evidence items, limitations, gap map, and next tests tied to gaps
+revise = missing refs, missing gaps, missing limitations, or dangling next_tests
+```
+
+- [ ] **Step 6: Verify assess tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_assess_gate.py -q
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/research_loop tests/research_loop/test_assess_gate.py
+git commit -m "feat(research-loop): add assessment loop gate"
+```
+
+---
+
+## Task 10: Thin Skill Template
+
+**Files:**
+
+- Create: `gaia/_skills/gaia-research-loop/SKILL.md`
+- Test: `tests/research_loop/test_cli_status.py`
+
+- [ ] **Step 1: Add test that skill exists and stays thin**
+
+Append:
+
+```python
+def test_research_loop_skill_exists_and_is_thin() -> None:
+    path = Path("gaia/_skills/gaia-research-loop/SKILL.md")
+
+    text = path.read_text(encoding="utf-8")
+
+    assert "gaia-research-loop next" in text
+    assert "output_contract" in text
+    assert "Do not hardcode" in text
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_cli_status.py::test_research_loop_skill_exists_and_is_thin -q
+```
+
+Expected: fail because the skill file does not exist.
+
+- [ ] **Step 3: Create skill**
+
+Create `gaia/_skills/gaia-research-loop/SKILL.md`:
+
+```markdown
+---
+name: gaia-research-loop
+description: Run Gaia's agent-facing Explore -> Assess research loop through self-contained task envelopes.
+---
+
+# Gaia Research Loop
+
+Use this when a user asks to run or continue a Gaia research loop.
+
+1. Run `gaia-research-loop next <pkg> --json`.
+2. Open the returned task envelope.
+3. Follow the task's `instructions`.
+4. If the task requires reasoning, use your own model.
+5. Write candidate JSON matching `output_contract`.
+6. Run the task's `submit_command`.
+7. If validation fails, run `gaia-research-loop next <pkg> --json` and repair
+   the same task using `repair_context`.
+8. Repeat until `gaia-research-loop status <pkg>` or `gaia-research-loop gate`
+   reports that the loop is done.
+
+Do not hardcode query planning, focus synthesis, or assessment schemas. The task
+envelope is the contract.
+```
+
+- [ ] **Step 4: Verify skill test passes**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_cli_status.py::test_research_loop_skill_exists_and_is_thin -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gaia/_skills/gaia-research-loop/SKILL.md tests/research_loop/test_cli_status.py
+git commit -m "docs(research-loop): add thin agent skill"
+```
+
+---
+
+## Task 11: End-to-End Smoke and Final Gates
+
+**Files:**
+
+- Test-only changes if needed: `tests/research_loop/test_next_submit.py`
+- No production files unless smoke reveals a bug.
+
+- [ ] **Step 1: Add a tiny E2E smoke test**
+
+Add one test that runs:
+
+```text
+status -> next(scope) -> submit(scope) -> next(query_plan) -> submit(query_plan)
+-> next(search_execution)
+```
+
+Use a saved raw fixture instead of live network for the landscape transition.
+
+- [ ] **Step 2: Run research loop test suite**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run lkm explorer regression slice**
+
+Run:
+
+```bash
+uv run pytest tests/lkm_explorer -q
+```
+
+Expected: all tests pass; this verifies new code did not break the existing
+Explore engine.
+
+- [ ] **Step 4: Run typecheck and lint**
+
+Run:
+
+```bash
+uv run mypy gaia tests
+uv run ruff check gaia tests
+uv run ruff format --check gaia tests
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Run CLI smoke manually**
+
+Run:
+
+```bash
+uv run gaia-research-loop --help
+uv run gaia-research-loop status /tmp/gaia-research-loop-smoke --json
+uv run gaia-research-loop next /tmp/gaia-research-loop-smoke --json
+```
+
+Expected:
+
+- help lists `status`, `next`, `submit`, and `gate`;
+- status initializes `.gaia/research_loop`;
+- next emits a task envelope path and a submit command.
+
+- [ ] **Step 6: Run PR-gate slice**
+
+Run:
+
+```bash
+uv run pytest -n auto -v -m "pr_gate and not slow"
+```
+
+Expected: pass. If failures are unrelated to this branch, record them with
+exact test names and output before deciding whether to fix or defer.
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git add gaia tests pyproject.toml
+git commit -m "test(research-loop): cover agent protocol smoke"
+```
+
+---
+
+## Verification Matrix
+
+| Requirement | Verification |
+| --- | --- |
+| New `gaia-research-loop` CLI exists | `uv run gaia-research-loop --help` |
+| Canonical `.gaia/research_loop/` layout | `tests/research_loop/test_storage.py` |
+| `state.json` rebuilds from artifacts | `test_rebuild_state_indexes_latest_task_and_artifact` |
+| `events.jsonl` records actions | `test_append_event_writes_jsonl` |
+| Task envelope has output contract and example | `test_task_embeds_contract_and_minimal_example` |
+| Candidate validates selected action and override rationale | `test_candidate_selected_action_must_be_allowed_or_recommended`, `test_candidate_override_requires_rationale` |
+| `next` emits first task | `test_next_emits_scope_task_for_empty_loop` |
+| Scope submission writes artifact | `test_submit_scope_writes_scope_artifact` |
+| Validation failure returns repairable same task | `test_submit_invalid_candidate_records_repair_context` |
+| Query planning is agent task | `test_next_emits_query_plan_after_scope_artifact` |
+| Search execution is mechanical | `test_next_after_query_plan_emits_search_execution` |
+| Raw LKM results become landscape | `test_build_landscape_from_raw_results_extracts_paper_leads` |
+| Focus synthesis is agent task | `test_focus_synthesis_candidate_writes_focuses` |
+| Explore gate passes selected ready focus | `test_gate_passes_when_selected_focus_ready` |
+| Assess context starts from selected focus | `test_next_after_explore_gate_emits_assessment_context` |
+| Assess gate checks diagnosis/gaps/tests | `test_assess_gate_passes_grounded_evidence_diagnosis` |
+| Thin skill does not hardcode schemas | `test_research_loop_skill_exists_and_is_thin` |
+
+## Self-Review Notes
+
+- Spec coverage: This plan covers the CLI, canonical storage, state/event
+  model, task envelope, repair context, query planning, search execution,
+  landscape, focus synthesis, Explore gate, assessment context, evidence
+  diagnosis, Assess gate, thin skill, and verification.
+- Scope boundary: The plan stops before `Propose`, `Discover`, `Merge`, live LKM
+  networking, built-in LLM providers, and claim merge.
+- Risk: The exact LKM raw search fixture shape may require a small adapter
+  adjustment in Task 7. The test requires only the stable output contract, not a
+  specific internal parser.

--- a/docs/plans/2026-05-28-gaia-research-loop-agent-protocol.md
+++ b/docs/plans/2026-05-28-gaia-research-loop-agent-protocol.md
@@ -16,13 +16,14 @@ This plan intentionally builds the protocol in thin, testable layers:
 
 1. Shared schema and storage.
 2. `status` and state rebuild.
-3. `next` task emission.
-4. `submit` validation and repair context.
-5. Query planning and mechanical search execution.
-6. LKM landscape adaptation under the new storage layout.
-7. Focus synthesis and Explore gate.
-8. Assessment context, evidence diagnosis, and Assess gate.
-9. Thin in-repo skill template and final verification.
+3. Pure task-builder primitives and a `task` CLI group.
+4. `next` task emission on top of the primitives.
+5. `submit` validation and repair context.
+6. Query planning and mechanical search execution.
+7. LKM landscape adaptation under the new storage layout.
+8. Focus synthesis and Explore gate.
+9. Assessment context, evidence diagnosis, and Assess gate.
+10. Thin in-repo skill template and final verification.
 
 Every intelligent step is represented as a task envelope. Gaia validates shape,
 grounding, and state transitions; the external agent supplies semantic judgment.
@@ -47,7 +48,8 @@ Create:
 - `gaia/research_loop/lkm_adapter.py`  
   LKM-specific parsing and reuse of `gaia.lkm_explorer` landscape/focus helpers.
 - `gaia/research_loop/cli.py`  
-  Typer app for `gaia-research-loop`.
+  Typer app for `gaia-research-loop`, including orchestration commands and a
+  `task` sub-app for independently callable primitives.
 - `tests/research_loop/__init__.py`
 - `tests/research_loop/test_schemas.py`
 - `tests/research_loop/test_storage.py`
@@ -978,6 +980,157 @@ Expected: `2 passed`.
 ```bash
 git add gaia/research_loop/schemas.py gaia/research_loop/tasks.py gaia/research_loop/engine.py gaia/research_loop/cli.py tests/research_loop/test_next_submit.py
 git commit -m "feat(research-loop): emit scope and query tasks"
+```
+
+---
+
+## Task 4A: Independently Callable Task Primitives
+
+**Files:**
+
+- Modify: `gaia/research_loop/cli.py`
+- Modify: `gaia/research_loop/tasks.py`
+- Test: `tests/research_loop/test_next_submit.py`
+
+- [ ] **Step 1: Add failing primitive CLI tests**
+
+Append to `tests/research_loop/test_next_submit.py`:
+
+```python
+def test_task_scope_primitive_writes_scope_task(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["task", "scope", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["recommended_action"] == "submit_scope"
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "scope"
+    assert task["submit_command"].startswith("gaia-research-loop submit")
+
+
+def test_task_query_plan_primitive_uses_existing_scope(tmp_path: Path) -> None:
+    runner = CliRunner()
+    scope_dir = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "scope.json").write_text(
+        json.dumps({"seed_question": "aspirin primary prevention"}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "query-plan", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "query_plan"
+    assert task["inputs"]["scope"]["seed_question"] == "aspirin primary prevention"
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py::test_task_scope_primitive_writes_scope_task tests/research_loop/test_next_submit.py::test_task_query_plan_primitive_uses_existing_scope -q
+```
+
+Expected: fail because the `task` CLI group does not exist.
+
+- [ ] **Step 3: Add primitive engine helper**
+
+Add a helper in `engine.py`:
+
+```python
+def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
+    paths = ensure_loop_dirs(pkg)
+    if kind == TaskKind.SCOPE:
+        task, task_path = build_scope_task(paths)
+    elif kind == TaskKind.QUERY_PLAN:
+        scope_path = paths.explore_artifacts / "scope.json"
+        if not scope_path.exists():
+            raise FileNotFoundError("scope.json is required for query-plan task")
+        task, task_path = build_query_plan_task(paths, read_json(scope_path))
+    else:
+        raise ValueError(f"Primitive task {kind.value} is not implemented yet")
+    write_task(task, task_path)
+    append_event(
+        paths,
+        event_type="task_emitted",
+        stage=task.stage,
+        data={"task_id": task.task_id, "kind": task.kind.value, "task_path": str(task_path)},
+    )
+    rebuild_state(paths)
+    return {
+        "recommended_action": task.recommended_action,
+        "allowed_actions": task.allowed_actions,
+        "task_path": str(task_path),
+        "submit_command": task.submit_command,
+        "rationale": task.objective,
+    }
+```
+
+Change `next_payload` to call `emit_task` instead of duplicating task emission
+logic.
+
+- [ ] **Step 4: Add `task` sub-app**
+
+In `cli.py`:
+
+```python
+from gaia.research_loop.schemas import TaskKind
+
+task_app = typer.Typer(help="Emit one task envelope without running the full loop.")
+app.add_typer(task_app, name="task")
+
+
+def _echo_task_payload(payload: dict[str, Any], json_out: bool) -> None:
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"Recommended: {payload['recommended_action']}")
+    typer.echo(f"Task: {payload['task_path']}")
+    typer.echo(f"Submit: {payload['submit_command']}")
+
+
+@task_app.command("scope")
+def task_scope_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit a scope task envelope without consulting loop state."""
+    _echo_task_payload(emit_task(pkg, kind=TaskKind.SCOPE), json_out)
+
+
+@task_app.command("query-plan")
+def task_query_plan_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit a query planning task envelope from the current scope artifact."""
+    _echo_task_payload(emit_task(pkg, kind=TaskKind.QUERY_PLAN), json_out)
+```
+
+- [ ] **Step 5: Verify primitive tests pass**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py::test_task_scope_primitive_writes_scope_task tests/research_loop/test_next_submit.py::test_task_query_plan_primitive_uses_existing_scope -q
+```
+
+Expected: both pass.
+
+- [ ] **Step 6: Verify orchestration still works**
+
+Run:
+
+```bash
+uv run pytest tests/research_loop/test_next_submit.py::test_next_emits_scope_task_for_empty_loop tests/research_loop/test_next_submit.py::test_next_emits_query_plan_after_scope_artifact -q
+```
+
+Expected: both pass; `next` and primitive commands share the same task builders.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gaia/research_loop/cli.py gaia/research_loop/engine.py tests/research_loop/test_next_submit.py
+git commit -m "feat(research-loop): expose task primitives"
 ```
 
 ---
@@ -1929,6 +2082,7 @@ git commit -m "test(research-loop): cover agent protocol smoke"
 | Task envelope has output contract and example | `test_task_embeds_contract_and_minimal_example` |
 | Candidate validates selected action and override rationale | `test_candidate_selected_action_must_be_allowed_or_recommended`, `test_candidate_override_requires_rationale` |
 | `next` emits first task | `test_next_emits_scope_task_for_empty_loop` |
+| Task primitives can be called without full loop orchestration | `test_task_scope_primitive_writes_scope_task`, `test_task_query_plan_primitive_uses_existing_scope` |
 | Scope submission writes artifact | `test_submit_scope_writes_scope_artifact` |
 | Validation failure returns repairable same task | `test_submit_invalid_candidate_records_repair_context` |
 | Query planning is agent task | `test_next_emits_query_plan_after_scope_artifact` |
@@ -1942,10 +2096,11 @@ git commit -m "test(research-loop): cover agent protocol smoke"
 
 ## Self-Review Notes
 
-- Spec coverage: This plan covers the CLI, canonical storage, state/event
-  model, task envelope, repair context, query planning, search execution,
-  landscape, focus synthesis, Explore gate, assessment context, evidence
-  diagnosis, Assess gate, thin skill, and verification.
+- Spec coverage: This plan covers the CLI, independently callable task
+  primitives, canonical storage, state/event model, task envelope, repair
+  context, query planning, search execution, landscape, focus synthesis,
+  Explore gate, assessment context, evidence diagnosis, Assess gate, thin skill,
+  and verification.
 - Scope boundary: The plan stops before `Propose`, `Discover`, `Merge`, live LKM
   networking, built-in LLM providers, and claim merge.
 - Risk: The exact LKM raw search fixture shape may require a small adapter

--- a/docs/specs/2026-05-28-gaia-research-loop-agent-protocol-design.md
+++ b/docs/specs/2026-05-28-gaia-research-loop-agent-protocol-design.md
@@ -32,6 +32,11 @@ gaia-research-loop gate <pkg>
 gaia-research-loop status <pkg>
 ```
 
+This CLI is the orchestrator surface, not the only way to use the underlying
+capabilities. Each loop step should also be exposed as an independently callable
+primitive, either through a CLI subcommand or a Python API, so an agent can use
+only the part of the loop it needs.
+
 The MVP is LKM-backed, but the name deliberately does not include `explore`.
 Explore is one stage inside the loop, not the whole loop.
 
@@ -130,6 +135,34 @@ should be able to rebuild it by scanning artifacts.
 - `state_rebuilt`
 
 ## 5. CLI Semantics
+
+The CLI has two layers:
+
+```text
+orchestration:
+  gaia-research-loop next / submit / status / gate
+
+primitives:
+  gaia-research-loop task scope
+  gaia-research-loop task query-plan
+  gaia-research-loop task search-execution
+  gaia-research-loop task focus-synthesis
+  gaia-research-loop task assessment-context
+  gaia-research-loop task evidence-diagnosis
+```
+
+The orchestration layer chooses the next step from package state. The primitive
+layer creates or validates one specific task or artifact without requiring the
+whole loop to be active. This lets an agent:
+
+- generate a focus synthesis task from an already prepared landscape;
+- build an assessment context from hand-selected focuses;
+- validate an evidence diagnosis without running Explore;
+- embed Gaia task builders inside a separate agent harness;
+- recover or rerun one step without replaying the full loop.
+
+Both layers use the same task envelope and candidate contracts. There should not
+be a second schema for primitive use.
 
 ### 5.1 `next`
 
@@ -507,14 +540,15 @@ Suggested implementation order:
 
 1. Add shared research-loop storage, event log, and schema models.
 2. Add `gaia-research-loop status` and state rebuild.
-3. Add `next` for `scope` and `query_plan`.
-4. Add `submit` validation and repair context.
-5. Add mechanical `search_execution` tasks from accepted query plans.
-6. Reuse or adapt LKM landscape generation under `.gaia/research_loop/explore`.
-7. Add LLM/agent `focus_synthesis` task envelopes and validators.
-8. Add Explore gate and focus selection.
-9. Add Assess context and `evidence_diagnosis` task envelopes.
-10. Add Assess gate and final loop status.
+3. Add pure task-builder primitives and the `gaia-research-loop task` CLI group.
+4. Add `next` for `scope` and `query_plan` on top of those primitives.
+5. Add `submit` validation and repair context.
+6. Add mechanical `search_execution` tasks from accepted query plans.
+7. Reuse or adapt LKM landscape generation under `.gaia/research_loop/explore`.
+8. Add LLM/agent `focus_synthesis` task envelopes and validators.
+9. Add Explore gate and focus selection.
+10. Add Assess context and `evidence_diagnosis` task envelopes.
+11. Add Assess gate and final loop status.
 
 This order preserves the central idea: every intelligent step is mediated by a
 self-contained task envelope, and every transition is validated by Gaia.

--- a/docs/specs/2026-05-28-gaia-research-loop-agent-protocol-design.md
+++ b/docs/specs/2026-05-28-gaia-research-loop-agent-protocol-design.md
@@ -1,0 +1,520 @@
+# Gaia Research Loop Agent Protocol Design
+
+> **Status:** Draft
+>
+> **Date:** 2026-05-28
+>
+> **Related specs:**
+>
+> - [Gaia LKM Explore and Evidence Assess Design](2026-05-25-gaia-lkm-explore-assess-design.md)
+> - [LKM Explore Artifact MVP Design](2026-05-26-lkm-explore-artifact-mvp-design.md)
+> - [LKM Explore Iterative Landscape Design](2026-05-27-lkm-explore-iterative-landscape-design.md)
+>
+> **Scope:** Define a unified agent-facing protocol and CLI for the first two
+> stages of the larger Gaia research loop: `Explore -> Assess`. The protocol
+> lets a generic coding agent run the loop with a thin in-repo skill, a CLI, and
+> self-contained task envelopes.
+
+## 1. Goal
+
+The current `gaia-lkm-explore` work has established the right research method:
+start with a breadth-first paper landscape, synthesize assessment focuses, then
+enter evidence assessment only for selected focuses. The missing layer is a
+single protocol that tells an external agent what to do next, what output shape
+to produce, how to submit it, and how to recover from validation failures.
+
+This spec proposes a new top-level CLI:
+
+```bash
+gaia-research-loop next <pkg>
+gaia-research-loop submit <pkg> <candidate.json>
+gaia-research-loop gate <pkg>
+gaia-research-loop status <pkg>
+```
+
+The MVP is LKM-backed, but the name deliberately does not include `explore`.
+Explore is one stage inside the loop, not the whole loop.
+
+The protocol boundary is:
+
+```text
+agent / LLM:
+  research judgment, query planning, focus synthesis, evidence diagnosis
+
+Gaia kernel:
+  task envelopes, contracts, validation, persistence, gates, next-step routing
+```
+
+Gaia does not need an embedded LLM provider in the MVP. The agent uses its own
+model and reasoning, reads a task envelope, writes a candidate JSON file, and
+submits it through the CLI.
+
+## 2. Non-goals
+
+This spec does not:
+
+- replace the full future loop `Explore -> Assess -> Propose -> Discover ->
+  Merge`;
+- implement `Propose`, `Discover`, `Merge`, wet-lab execution, or experiment
+  automation;
+- require a Gaia-hosted LLM client;
+- require automatic installation of a Codex/Claude/Cursor skill;
+- require backward compatibility with `.gaia/exploration/` as the canonical
+  storage location;
+- formalize every retrieved paper into claims during Explore;
+- adjudicate final truth during Assess;
+- merge assessed claims back into Gaia or LKM.
+
+The MVP should keep old `gaia-lkm-explore` artifacts readable where practical,
+but new protocol artifacts should use the canonical `research_loop` layout
+defined below.
+
+## 3. Research Model
+
+The loop has two implemented stages in the MVP:
+
+```text
+Explore:
+  build and iterate a paper-level landscape until useful focuses emerge
+
+Assess:
+  diagnose the evidence around one selected focus and map remaining gaps
+```
+
+The important separation is:
+
+```text
+Paper level  ->  Focus level  ->  Claim level
+landscape        questions       propositions and evidence relations
+```
+
+Explore operates primarily at paper and focus level. It should not eagerly turn
+every paper into a global claim frontier. Assess starts from one or more
+selected focuses and may then read, pull, or formalize evidence more deeply.
+
+Explore-to-Assess handoff happens at the focus level, not at the whole-domain
+level. A broad landscape may contain many focuses; only ready selected focuses
+enter Assess.
+
+## 4. Canonical Layout
+
+New loop state lives under:
+
+```text
+<pkg>/.gaia/research_loop/
+  state.json
+  events.jsonl
+  explore/
+    tasks/
+    candidates/
+    artifacts/
+  assess/
+    tasks/
+    candidates/
+    artifacts/
+```
+
+`state.json` is a navigation index and cache, not the source of truth. The
+source of truth is the set of task, candidate, artifact, gate, and event files.
+If `state.json` is missing or stale, `gaia-research-loop status` and `next`
+should be able to rebuild it by scanning artifacts.
+
+`events.jsonl` records append-only audit events such as:
+
+- `task_emitted`
+- `candidate_submitted`
+- `validation_failed`
+- `artifact_written`
+- `gate_passed`
+- `gate_revised`
+- `state_rebuilt`
+
+## 5. CLI Semantics
+
+### 5.1 `next`
+
+`next` inspects the package and emits the next recommended task envelope. It
+also writes that envelope to the appropriate `tasks/` directory.
+
+It returns:
+
+- `recommended_action`: the Gaia kernel's preferred next action;
+- `allowed_actions`: a small set of legal alternatives;
+- `task_path`: the written task envelope path;
+- `submit_command`: the exact command the agent should run after producing a
+  candidate;
+- `rationale`: why the kernel recommends this action.
+
+The agent may choose an allowed alternative, but must record an override
+rationale in its submitted candidate.
+
+### 5.2 `submit`
+
+`submit` validates a candidate JSON against its task envelope. The candidate
+must include `task_id`; Gaia uses that id to load the matching task from the
+stage `tasks/` directory. On success it writes or updates the corresponding
+artifact. On failure it records the validation error and leaves the loop on the
+same task.
+
+Validation checks include:
+
+- JSON schema validity;
+- required fields;
+- allowed action membership;
+- allowed reference grounding;
+- candidate/task id match;
+- stage-specific invariants.
+
+### 5.3 `gate`
+
+`gate` validates the current stage boundary. For Explore it checks whether at
+least one selected focus is ready for assessment, or whether the loop has a
+valid reason to continue landscape expansion or stop. For Assess it checks that
+the evidence diagnosis, gap map, and next tests are grounded and complete enough
+for downstream proposal work.
+
+### 5.4 `status`
+
+`status` summarizes current state, latest tasks, latest artifacts, validation
+failures, available focuses, and recommended next actions. It should be useful
+to both humans and agents.
+
+## 6. Task Envelope
+
+Every semantic agent step is represented by a self-contained task envelope.
+The envelope is the main protocol object.
+
+Required fields:
+
+```json
+{
+  "schema": "gaia.research_loop.task.v1",
+  "task_id": "task-...",
+  "stage": "explore",
+  "kind": "query_plan",
+  "objective": "...",
+  "inputs": {},
+  "instructions": [],
+  "allowed_actions": [],
+  "recommended_action": "...",
+  "output_contract": {},
+  "allowed_refs": [],
+  "minimal_example": {},
+  "submit_command": "gaia-research-loop submit ...",
+  "validation": {},
+  "repair_context": null
+}
+```
+
+The task envelope must be sufficient for a generic coding agent to proceed
+without reading implementation code. It should not depend on hidden prompt
+state.
+
+Every candidate submitted for a task must include the matching `task_id`,
+`stage`, `kind`, and `selected_action`. `selected_action` must equal the
+recommended action or one of the task's allowed alternatives. If it differs from
+the recommendation, the candidate must include `override_rationale`.
+
+`minimal_example` is intentionally tiny. It demonstrates JSON shape and
+reference syntax, but must not contain realistic domain content that would tempt
+the agent to copy it.
+
+`output_contract` is the authoritative machine-readable JSON schema. The
+example is illustrative only.
+
+## 7. Repair Loop
+
+Validation failure does not create a separate repair task. Instead, `next`
+returns the same task with `repair_context` populated.
+
+`repair_context` includes:
+
+- the failed candidate path;
+- structured validation errors;
+- a short repair instruction;
+- any fields that passed validation and can be preserved;
+- the same `submit_command`.
+
+This keeps the agent loop simple:
+
+```text
+read task -> write candidate -> submit
+  if valid: advance
+  if invalid: next returns same task with repair_context
+```
+
+## 8. State Flow
+
+The MVP state flow is:
+
+```text
+scope
+-> query_plan
+-> search_execution
+-> landscape
+-> focus_synthesis
+-> explore_gate
+-> assessment_context
+-> evidence_diagnosis
+-> assess_gate
+-> done
+```
+
+The Explore portion is iterative:
+
+```text
+query_plan -> search_execution -> landscape -> focus_synthesis -> explore_gate
+       ^                                                       |
+       |                                                       |
+       +------------- needs_more_landscape --------------------+
+```
+
+Stop conditions include:
+
+- at least one selected focus is ready for assessment;
+- search budget is exhausted;
+- no materially new papers or evidence families are found;
+- required scope dimensions are sufficiently covered;
+- the agent chooses an allowed stop action with rationale;
+- a human stops the run.
+
+## 9. Explore Tasks
+
+### 9.1 Scope
+
+`scope` turns a seed question into a structured exploration scope. In the MVP,
+scope may be user-authored or agent-authored, but the submitted scope must be
+validated and persisted.
+
+Typical fields:
+
+- seed question;
+- domain profile;
+- population, system, material, model, or regime dimensions;
+- outcomes or observables;
+- comparators or alternative explanations;
+- decision context;
+- search budget.
+
+### 9.2 Query Planning
+
+`query_plan` is an LLM/agent task. It is not a fixed deterministic recipe.
+
+Inputs include:
+
+- current scope;
+- prior landscape summaries;
+- existing focuses;
+- coverage gaps;
+- remaining budget;
+- allowed LKM search command template.
+
+Output includes a small set of planned queries with purpose, source focus or
+gap, expected evidence family, and budget. Gaia validates mechanical properties
+such as non-empty query strings, duplicate removal, budget bounds, and valid
+source references.
+
+### 9.3 Search Execution
+
+`search_execution` is a mechanical agent task. Gaia emits exact commands and
+expected output paths. The agent runs those commands, saves raw LKM JSON, and
+submits the paths.
+
+The agent should not transform raw LKM output into paper leads. Gaia parses raw
+search envelopes into landscape artifacts so the process remains reproducible.
+
+### 9.4 Landscape
+
+`landscape` is a Gaia artifact produced from raw search results. It contains:
+
+- search provenance;
+- paper leads;
+- LKM node refs when available;
+- evidence families;
+- deduplicated contacts;
+- coarse coverage of scope dimensions;
+- missing or weakly covered dimensions.
+
+### 9.5 Focus Synthesis
+
+`focus_synthesis` is an LLM/agent task. Deterministic rules may assemble
+grounding packets, but the scientific focus itself is semantic and should be
+generated by an LLM-assisted or human research agent.
+
+Each focus should include:
+
+- `focus_id`;
+- `research_question`;
+- `why_it_matters`;
+- supporting refs;
+- conflicting, limiting, or missing refs;
+- covered scope dimensions;
+- missing dimensions;
+- `coverage_status`;
+- `ready_for_assess`;
+- recommended assessment mode;
+- next landscape queries if more coverage is needed.
+
+A paper cluster is not automatically a focus. It is grounding material from
+which the agent may synthesize one or more focuses.
+
+### 9.6 Explore Gate
+
+The Explore gate checks whether the loop can enter Assess. It should pass when
+there is at least one selected focus with enough grounded evidence for
+assessment. It should revise when the loop needs more landscape, has no selected
+focus, or has ungrounded references.
+
+Focus selection is hybrid:
+
+- Gaia recommends focuses;
+- the agent may select one or more recommended focuses;
+- the agent may choose to continue landscape expansion;
+- overrides require `selection_rationale`.
+
+## 10. Assess Tasks
+
+### 10.1 Assessment Context
+
+`assessment_context` packages the selected focus for deeper evaluation. It
+should include:
+
+- selected focus;
+- supporting and opposing refs;
+- relevant paper leads;
+- relevant LKM nodes or claims;
+- scope dimensions;
+- known gaps;
+- assessment mode;
+- allowed evidence refs.
+
+### 10.2 Evidence Diagnosis
+
+`evidence_diagnosis` is an LLM/agent task. The MVP output is an evidence table
+and gap map, not final adjudication.
+
+Output includes:
+
+- evidence items;
+- candidate claims;
+- contradictions or tensions;
+- limitations;
+- missing evidence;
+- gap map;
+- next tests or next searches;
+- confidence notes;
+- provenance refs.
+
+Gaia validates schema and grounding. It does not decide whether the scientific
+conclusion is true.
+
+### 10.3 Assess Gate
+
+The Assess gate passes when the evidence diagnosis is coherent, grounded, and
+useful as input to future `Propose`. It should check:
+
+- each evidence item has allowed refs;
+- each contradiction links at least two evidence items or claims;
+- limitations are explicit;
+- gap map entries identify what evidence would reduce uncertainty;
+- next tests are tied to gaps;
+- selected focus id is preserved.
+
+## 11. Thin Skill Contract
+
+The in-repo skill should be thin. It should teach a generic agent the loop
+algorithm, not encode scientific schemas.
+
+The skill should say:
+
+```text
+1. Run `gaia-research-loop next <pkg>`.
+2. Open the returned task envelope.
+3. Follow `instructions`.
+4. If the task requires reasoning, use your own model.
+5. Write candidate JSON matching `output_contract`.
+6. Run `submit_command`.
+7. If validation fails, run `next` again and repair the same task.
+8. Repeat until `status` or `gate` reports done.
+```
+
+The skill must not hardcode query planning, focus synthesis, or assessment
+schemas. Those belong in task envelopes.
+
+## 12. Relationship to Existing `gaia-lkm-explore`
+
+The existing `gaia-lkm-explore` implementation remains valuable as an Explore
+stage engine. The new protocol should initially reuse its internals where that
+reduces risk:
+
+- landscape parsing;
+- focus context generation;
+- focus validation;
+- artifact and gate logic;
+- provenance checks.
+
+Conceptually, however, `gaia-research-loop` is the parent interface:
+
+```text
+gaia-research-loop
+  explore stage
+    may call or reuse lkm explorer internals
+  assess stage
+    will add evidence diagnosis artifacts
+```
+
+The new canonical storage is `.gaia/research_loop/`. A later migration may copy
+or index old `.gaia/exploration/` artifacts, but the MVP does not need to keep
+writing new artifacts there.
+
+## 13. Schema and Validation
+
+All task, candidate, artifact, and gate objects should have versioned schemas:
+
+```text
+gaia.research_loop.task.v1
+gaia.research_loop.candidate.v1
+gaia.research_loop.artifact.v1
+gaia.research_loop.gate.v1
+```
+
+Pydantic models should be the Python source of truth. Task envelopes should
+embed the JSON schema for the expected candidate output.
+
+Grounding rules are stage-specific, but the common rule is:
+
+```text
+Any evidence or source reference in a candidate must appear in the task's
+allowed_refs or in an artifact explicitly listed by the task inputs.
+```
+
+## 14. Testing Strategy
+
+The implementation should be driven by tests at three levels:
+
+- model tests for task/candidate schema validation;
+- CLI tests for `next`, `submit`, `status`, and `gate`;
+- smoke tests with a tiny synthetic package and one realistic saved LKM search
+  fixture.
+
+PR-gate tests should cover user-facing CLI behavior and schema compatibility.
+Lower-level helper tests can remain in the nightly slice unless they protect a
+public artifact contract.
+
+## 15. Open Implementation Slices
+
+Suggested implementation order:
+
+1. Add shared research-loop storage, event log, and schema models.
+2. Add `gaia-research-loop status` and state rebuild.
+3. Add `next` for `scope` and `query_plan`.
+4. Add `submit` validation and repair context.
+5. Add mechanical `search_execution` tasks from accepted query plans.
+6. Reuse or adapt LKM landscape generation under `.gaia/research_loop/explore`.
+7. Add LLM/agent `focus_synthesis` task envelopes and validators.
+8. Add Explore gate and focus selection.
+9. Add Assess context and `evidence_diagnosis` task envelopes.
+10. Add Assess gate and final loop status.
+
+This order preserves the central idea: every intelligent step is mediated by a
+self-contained task envelope, and every transition is validated by Gaia.

--- a/gaia/_skills/gaia-research-loop/SKILL.md
+++ b/gaia/_skills/gaia-research-loop/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: gaia-research-loop
+description: Run Gaia's agent-facing Explore -> Assess research loop through self-contained task envelopes.
+---
+
+# Gaia Research Loop
+
+Use this when a user asks to run or continue a Gaia research loop.
+
+1. Run `gaia-research-loop next <pkg> --json`.
+2. Open the returned task envelope.
+3. Follow the task's `instructions`.
+4. If the task requires reasoning, use your own model.
+5. Write candidate JSON matching `output_contract`.
+6. Run the task's `submit_command`.
+7. If validation fails, run `gaia-research-loop next <pkg> --json` and repair
+   the same task using `repair_context`.
+8. Repeat until `gaia-research-loop status <pkg>` or `gaia-research-loop gate`
+   reports that the loop is done.
+
+Do not hardcode query planning, focus synthesis, or assessment schemas. The task
+envelope is the contract.

--- a/gaia/lkm_explorer/client/cli.py
+++ b/gaia/lkm_explorer/client/cli.py
@@ -37,6 +37,7 @@ from gaia.lkm_explorer.client.orchestrator import (
 )
 from gaia.lkm_explorer.client.verbs import (
     artifact_command,
+    focus_context_command,
     focuses_command,
     frontier_command,
     gate_command,
@@ -68,6 +69,7 @@ app.command(name="init")(init_command)
 app.command(name="scope")(scope_command)
 app.command(name="observe")(observe_command)
 app.command(name="landscape")(landscape_command)
+app.command(name="focus-context")(focus_context_command)
 app.command(name="focuses")(focuses_command)
 app.command(name="artifact")(artifact_command)
 app.command(name="gate")(gate_command)

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -38,6 +38,7 @@ gracefully with an actionable message.
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -59,6 +60,7 @@ from gaia.lkm_explorer.engine.artifacts import (
     build_exploration_artifact,
     build_focus_context_artifact,
     build_focuses_artifact,
+    build_focuses_artifact_from_candidates,
     build_gate_report,
     build_scope_artifact,
     collect_landscape_grounding_refs,
@@ -203,6 +205,23 @@ _FOCUSES_OUT_OPT = typer.Option(
     None,
     "--out",
     help="Output JSON path (default <pkg>/.gaia/exploration/focuses.json).",
+)
+_FOCUSES_CONTEXT_OPT = typer.Option(
+    None,
+    "--from-context",
+    help="Focus synthesis context JSON path (default <pkg>/.gaia/exploration/focus_context.json).",
+)
+_FOCUSES_CANDIDATES_OPT = typer.Option(
+    None,
+    "--candidate-focuses",
+    help="Candidate focuses JSON produced by an LLM/human agent.",
+)
+_FOCUSES_LLM_COMMAND_OPT = typer.Option(
+    None,
+    "--llm-command",
+    help=(
+        "External command that reads focus_context JSON on stdin and writes candidate focuses JSON."
+    ),
 )
 _FOCUS_CONTEXT_OUT_OPT = typer.Option(
     None,
@@ -1112,10 +1131,13 @@ def focus_context_command(
 def focuses_command(
     pkg: str = _PKG_ARG,
     landscape: str | None = _FOCUSES_LANDSCAPE_OPT,
+    from_context: str | None = _FOCUSES_CONTEXT_OPT,
+    candidate_focuses: str | None = _FOCUSES_CANDIDATES_OPT,
+    llm_command: str | None = _FOCUSES_LLM_COMMAND_OPT,
     out: str | None = _FOCUSES_OUT_OPT,
     json_out: bool = _LANDSCAPE_JSON_OPT,
 ) -> None:
-    r"""Create deterministic Explore focuses from a landscape artifact."""
+    r"""Create Explore focuses from deterministic rules or validated LLM candidates."""
     map_path = _gaia_dir(pkg) / "exploration" / "map.json"
     if not map_path.exists():
         typer.echo(
@@ -1123,6 +1145,27 @@ def focuses_command(
             err=True,
         )
         raise typer.Exit(1)
+
+    output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "focuses.json"
+    if from_context is not None or candidate_focuses is not None or llm_command is not None:
+        payload = _build_focuses_from_agent_candidates(
+            pkg,
+            context_path=Path(from_context)
+            if from_context is not None
+            else _gaia_dir(pkg) / "exploration" / "focus_context.json",
+            candidate_focuses=Path(candidate_focuses) if candidate_focuses is not None else None,
+            llm_command=llm_command,
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+        typer.echo(
+            f"Focuses: {len(payload['focuses'])} validated candidate focus(es) "
+            f"from {payload['provenance']['generation']}."
+        )
+        typer.echo(f"Output: {output_path}")
+        if json_out:
+            typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
 
     landscape_path: Path | None
     if landscape is not None:
@@ -1149,7 +1192,6 @@ def focuses_command(
         landscape_rounds=landscape_rounds,
         map_round=load_map(pkg).round,
     )
-    output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "focuses.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
 
@@ -1160,6 +1202,77 @@ def focuses_command(
     typer.echo(f"Output: {output_path}")
     if json_out:
         typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def _build_focuses_from_agent_candidates(
+    pkg: str,
+    *,
+    context_path: Path,
+    candidate_focuses: Path | None,
+    llm_command: str | None,
+) -> dict[str, Any]:
+    if candidate_focuses is not None and llm_command is not None:
+        typer.echo("Error: pass only one of --candidate-focuses or --llm-command.", err=True)
+        raise typer.Exit(2)
+    if candidate_focuses is None and llm_command is None:
+        typer.echo(
+            "Error: pass --candidate-focuses or --llm-command with --from-context.", err=True
+        )
+        raise typer.Exit(2)
+    if not context_path.exists():
+        typer.echo(
+            "Error: no focus context found; run `gaia-lkm-explore focus-context` first "
+            "or pass --from-context.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    context = _read_json_object(context_path)
+    if candidate_focuses is not None:
+        candidates = _read_json_object(candidate_focuses)
+        generation = "candidate_file"
+    else:
+        candidates = _run_focus_llm_command(str(llm_command), context)
+        generation = "llm_command"
+    try:
+        return build_focuses_artifact_from_candidates(
+            pkg,
+            context_path=context_path,
+            context=context,
+            candidates=candidates,
+            map_round=load_map(pkg).round,
+            generation=generation,
+        )
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+
+def _run_focus_llm_command(command: str, context: dict[str, Any]) -> dict[str, Any]:
+    try:
+        proc = subprocess.run(
+            shlex.split(command),
+            input=json.dumps(context, ensure_ascii=False),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        typer.echo(f"Error: failed to run --llm-command: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit code {proc.returncode}"
+        typer.echo(f"Error: --llm-command failed: {detail}", err=True)
+        raise typer.Exit(2)
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Error: --llm-command did not return valid JSON: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if not isinstance(payload, dict):
+        typer.echo("Error: --llm-command must return a JSON object.", err=True)
+        raise typer.Exit(2)
+    return payload
 
 
 # --------------------------------------------------------------------------- #

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -57,6 +57,7 @@ from gaia.engine.inquiry.review import resolve_graph
 from gaia.engine.packaging import write_text_atomic
 from gaia.lkm_explorer.engine.artifacts import (
     build_exploration_artifact,
+    build_focus_context_artifact,
     build_focuses_artifact,
     build_gate_report,
     build_scope_artifact,
@@ -201,6 +202,11 @@ _FOCUSES_OUT_OPT = typer.Option(
     None,
     "--out",
     help="Output JSON path (default <pkg>/.gaia/exploration/focuses.json).",
+)
+_FOCUS_CONTEXT_OUT_OPT = typer.Option(
+    None,
+    "--out",
+    help="Output JSON path (default <pkg>/.gaia/exploration/focus_context.json).",
 )
 _ARTIFACT_OUT_OPT = typer.Option(
     None,
@@ -1039,6 +1045,60 @@ def landscape_command(
     else:
         typer.echo("  (no unpulled paper leads)")
 
+    if json_out:
+        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# focus-context                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def focus_context_command(
+    pkg: str = _PKG_ARG,
+    out: str | None = _FOCUS_CONTEXT_OUT_OPT,
+    json_out: bool = _LANDSCAPE_JSON_OPT,
+) -> None:
+    r"""Write the grounded packet for LLM/human focus synthesis."""
+    map_path = _gaia_dir(pkg) / "exploration" / "map.json"
+    if not map_path.exists():
+        typer.echo(
+            f"Error: no exploration map at {pkg}; run `gaia-lkm-explore init` first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    round_paths = landscape_round_paths(pkg)
+    if not round_paths:
+        typer.echo(
+            "Error: no landscape artifact found; run `gaia-lkm-explore landscape` first.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    scope_path = _gaia_dir(pkg) / "exploration" / "scope.json"
+    focuses_path = _gaia_dir(pkg) / "exploration" / "focuses.json"
+    landscape_rounds = [(path, _read_json_object(path)) for path in round_paths]
+    payload = build_focus_context_artifact(
+        pkg,
+        scope_path=scope_path if scope_path.exists() else None,
+        scope=_read_json_object(scope_path) if scope_path.exists() else None,
+        landscape_rounds=landscape_rounds,
+        existing_focuses_path=focuses_path if focuses_path.exists() else None,
+        existing_focuses=_read_json_object(focuses_path) if focuses_path.exists() else None,
+        map_round=load_map(pkg).round,
+    )
+    output_path = (
+        Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "focus_context.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    typer.echo(
+        f"Focus context: {len(payload['paper_leads'])} paper lead(s) from "
+        f"{len(payload['landscape_rounds'])} landscape round(s)."
+    )
+    typer.echo(f"Output: {output_path}")
     if json_out:
         typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
 

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -61,6 +61,7 @@ from gaia.lkm_explorer.engine.artifacts import (
     build_focuses_artifact,
     build_gate_report,
     build_scope_artifact,
+    collect_landscape_grounding_refs,
     landscape_round_paths,
     latest_landscape_path,
     parse_dimensions,
@@ -1182,10 +1183,13 @@ def artifact_command(
 
     exploration_map = load_map(pkg)
     output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "artifact.json"
+    focuses_path = _gaia_dir(pkg) / "exploration" / "focuses.json"
+    focuses = _read_json_object(focuses_path) if focuses_path.exists() else None
     payload = build_exploration_artifact(
         pkg,
         map_round=exploration_map.round,
         map_version=exploration_map.version,
+        focuses=focuses,
     )
     payload["artifacts"]["artifact"] = rel_artifact_path(pkg, output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1206,10 +1210,13 @@ def artifact_command(
 
 def _build_and_write_exploration_artifact(pkg: str, output_path: Path) -> dict[str, Any]:
     exploration_map = load_map(pkg)
+    focuses_path = _gaia_dir(pkg) / "exploration" / "focuses.json"
+    focuses = _read_json_object(focuses_path) if focuses_path.exists() else None
     payload = build_exploration_artifact(
         pkg,
         map_round=exploration_map.round,
         map_version=exploration_map.version,
+        focuses=focuses,
     )
     payload["artifacts"]["artifact"] = rel_artifact_path(pkg, output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1222,6 +1229,20 @@ def _resolve_pkg_artifact_path(pkg: str, ref: Any) -> Path | None:
         return None
     path = Path(ref)
     return path if path.is_absolute() else Path(pkg).resolve() / path
+
+
+def _landscape_round_payloads_for_gate(pkg: str, artifact: dict[str, Any]) -> list[dict[str, Any]]:
+    rounds = artifact.get("landscape_rounds")
+    paths: list[Path] = []
+    if isinstance(rounds, list):
+        for row in rounds:
+            if isinstance(row, dict):
+                path = _resolve_pkg_artifact_path(pkg, row.get("path"))
+                if path is not None and path.exists():
+                    paths.append(path)
+    if not paths:
+        paths = landscape_round_paths(pkg)
+    return [_read_json_object(path) for path in paths]
 
 
 def gate_command(
@@ -1249,7 +1270,10 @@ def gate_command(
         focuses_path = _gaia_dir(pkg) / "exploration" / "focuses.json"
     focuses = _read_json_object(focuses_path) if focuses_path.exists() else None
 
-    report = build_gate_report(artifact, focuses)
+    grounding_refs = collect_landscape_grounding_refs(
+        _landscape_round_payloads_for_gate(pkg, artifact)
+    )
+    report = build_gate_report(artifact, focuses, grounding_refs=grounding_refs)
     output_path = (
         Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "gate_report.json"
     )

--- a/gaia/lkm_explorer/client/verbs.py
+++ b/gaia/lkm_explorer/client/verbs.py
@@ -60,6 +60,7 @@ from gaia.lkm_explorer.engine.artifacts import (
     build_focuses_artifact,
     build_gate_report,
     build_scope_artifact,
+    landscape_round_paths,
     latest_landscape_path,
     parse_dimensions,
     rel_artifact_path,
@@ -1062,7 +1063,13 @@ def focuses_command(
         )
         raise typer.Exit(1)
 
-    landscape_path = Path(landscape) if landscape is not None else latest_landscape_path(pkg)
+    landscape_path: Path | None
+    if landscape is not None:
+        landscape_path = Path(landscape)
+        round_paths = [landscape_path]
+    else:
+        landscape_path = latest_landscape_path(pkg)
+        round_paths = landscape_round_paths(pkg)
     if landscape_path is None or not landscape_path.exists():
         typer.echo(
             "Error: no landscape artifact found; run `gaia-lkm-explore landscape` first "
@@ -1070,20 +1077,25 @@ def focuses_command(
             err=True,
         )
         raise typer.Exit(2)
+    landscape_rounds = [(path, _read_json_object(path)) for path in round_paths]
 
     scope_path = _gaia_dir(pkg) / "exploration" / "scope.json"
     payload = build_focuses_artifact(
         pkg,
         scope_path=scope_path if scope_path.exists() else None,
         landscape_path=landscape_path,
-        landscape=_read_json_object(landscape_path),
+        landscape=landscape_rounds[-1][1],
+        landscape_rounds=landscape_rounds,
         map_round=load_map(pkg).round,
     )
     output_path = Path(out) if out is not None else _gaia_dir(pkg) / "exploration" / "focuses.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_text_atomic(output_path, json.dumps(payload, ensure_ascii=False, indent=2))
 
-    typer.echo(f"Focuses: {len(payload['focuses'])} focus(es) from {landscape_path}.")
+    typer.echo(
+        f"Focuses: {len(payload['focuses'])} focus(es) from "
+        f"{len(landscape_rounds)} landscape round(s)."
+    )
     typer.echo(f"Output: {output_path}")
     if json_out:
         typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -47,11 +47,16 @@ def exploration_dir(pkg: str | Path) -> Path:
 
 def latest_landscape_path(pkg: str | Path) -> Path | None:
     """Return the highest-round ``landscape-*.json`` sidecar, if any."""
+    matches = landscape_round_paths(pkg)
+    return matches[-1] if matches else None
+
+
+def landscape_round_paths(pkg: str | Path) -> list[Path]:
+    """Return all ``landscape-*.json`` sidecars sorted by numeric round."""
     exp = exploration_dir(pkg)
     if not exp.exists():
-        return None
-    matches = sorted(exp.glob("landscape-*.json"), key=_landscape_sort_key)
-    return matches[-1] if matches else None
+        return []
+    return sorted(exp.glob("landscape-*.json"), key=_landscape_sort_key)
 
 
 def _landscape_sort_key(path: Path) -> tuple[int, str]:
@@ -207,6 +212,15 @@ def build_exploration_artifact(
         "gaia_ir": _optional_artifact(pkg, gaia_dir / "ir.json"),
         "beliefs": _optional_artifact(pkg, gaia_dir / "beliefs.json"),
     }
+    landscape_rounds = [
+        {
+            "round": round_number,
+            "path": rel_artifact_path(pkg, path),
+            "purpose": "broad_initial_survey" if round_number == 0 else "focus_gap_followup",
+        }
+        for path in landscape_round_paths(pkg)
+        if (round_number := _landscape_round_number(path)) is not None
+    ]
     core_names = {
         "scope": "scope.json",
         "landscape": "landscape-*.json",
@@ -225,6 +239,7 @@ def build_exploration_artifact(
             "map_version": map_version,
         },
         "artifacts": artifacts,
+        "landscape_rounds": landscape_rounds,
         "audit": {
             "known_limitations": limitations,
             "allowed_next_steps": ["gate"],
@@ -235,6 +250,14 @@ def build_exploration_artifact(
             }
         },
     }
+
+
+def _landscape_round_number(path: Path) -> int | None:
+    suffix = path.stem.removeprefix("landscape-")
+    try:
+        return int(suffix)
+    except ValueError:
+        return None
 
 
 def _check(status: str, detail: str) -> dict[str, str]:
@@ -369,6 +392,7 @@ __all__ = [
     "build_gate_report",
     "build_scope_artifact",
     "exploration_dir",
+    "landscape_round_paths",
     "latest_landscape_path",
     "parse_dimensions",
     "rel_artifact_path",

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 SOP_SCHEMA = "gaia.sop.artifact.v1"
 SOP_SCHEMA_V2 = "gaia.sop.artifact.v2"
@@ -22,6 +24,54 @@ FOCUS_SYNTHESIS_INSTRUCTIONS = [
     "Do not state a tension as established unless the refs support it.",
     "For each focus, list missing evidence needed before assessment.",
 ]
+
+FOCUS_STATUSES = {
+    "provisional",
+    "needs_more_landscape",
+    "ready_for_assess",
+    "deferred",
+}
+
+FocusStatus = Literal["provisional", "needs_more_landscape", "ready_for_assess", "deferred"]
+
+
+class FocusEvidenceRef(BaseModel):
+    """One evidence ref an LLM candidate focus is allowed to cite."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    id: str
+    role: str | None = None
+
+
+class CandidateFocus(BaseModel):
+    """Schema for one LLM/human proposed assessment focus."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: str
+    level: Literal["focus"] = "focus"
+    question: str | None = None
+    text: str | None = None
+    why_it_matters: str = ""
+    status: FocusStatus
+    coverage: dict[str, Any]
+    evidence_refs: list[FocusEvidenceRef] = Field(default_factory=list)
+    candidate_claims: list[Any] = Field(default_factory=list)
+    next_landscape_queries: list[str] = Field(default_factory=list)
+    recommended_next: str | None = None
+    confidence: str = "medium"
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
+class CandidateFocuses(BaseModel):
+    """Top-level JSON object expected from a focus synthesis agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    focuses: list[CandidateFocus]
 
 
 def utcnow() -> str:
@@ -258,6 +308,7 @@ def build_focus_context_artifact(
     """Build the grounded packet for LLM/human focus synthesis."""
     round_refs: list[dict[str, Any]] = []
     paper_leads: list[dict[str, Any]] = []
+    allowed_refs: list[dict[str, Any]] = []
     queries: list[dict[str, Any]] = []
     for path, payload in landscape_rounds:
         round_number = _landscape_round_number(path)
@@ -290,6 +341,32 @@ def build_focus_context_artifact(
                     "lkm_node_ids": list(lead.get("lkm_node_ids", []) or []),
                 }
             )
+            paper_id = lead.get("paper_id")
+            title = lead.get("title")
+            if isinstance(paper_id, str) and paper_id:
+                _append_allowed_ref(
+                    allowed_refs,
+                    {
+                        "kind": "paper",
+                        "id": paper_id,
+                        "round": round_number,
+                        "path": rel_path,
+                        "title": title,
+                    },
+                )
+            for node_id in lead.get("lkm_node_ids", []) or []:
+                if isinstance(node_id, str) and node_id:
+                    _append_allowed_ref(
+                        allowed_refs,
+                        {
+                            "kind": "lkm_node",
+                            "id": node_id,
+                            "round": round_number,
+                            "path": rel_path,
+                            "paper_id": paper_id,
+                            "title": title,
+                        },
+                    )
     focus_rows = _focus_list(existing_focuses)
     return {
         "schema": SOP_SCHEMA_V2,
@@ -307,11 +384,187 @@ def build_focus_context_artifact(
         "paper_leads": paper_leads,
         "queries": queries,
         "existing_focuses": focus_rows,
+        "allowed_evidence_refs": allowed_refs,
+        "output_contract": _focus_output_contract(),
         "coverage_gaps": [],
         "instructions": list(FOCUS_SYNTHESIS_INSTRUCTIONS),
         "audit": {
             "allowed_next_steps": ["focuses", "artifact", "gate"],
         },
+    }
+
+
+def _append_allowed_ref(rows: list[dict[str, Any]], ref: dict[str, Any]) -> None:
+    if any(row.get("kind") == ref.get("kind") and row.get("id") == ref.get("id") for row in rows):
+        return
+    rows.append(ref)
+
+
+def _focus_output_contract() -> dict[str, Any]:
+    return {
+        "format": "json",
+        "json_schema": CandidateFocuses.model_json_schema(),
+        "rules": [
+            "Return only a JSON object with a top-level focuses array.",
+            "Every evidence_refs[].id must appear in allowed_evidence_refs.",
+            "Do not output assessment conclusions; output assessment questions.",
+            "ready_for_assess requires at least one evidence ref.",
+            "needs_more_landscape requires coverage.missing_dimensions or next_landscape_queries.",
+        ],
+    }
+
+
+def _context_grounding_refs(context: dict[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    for ref in context.get("allowed_evidence_refs", []) or []:
+        if isinstance(ref, dict) and isinstance(ref.get("id"), str):
+            refs.add(ref["id"])
+    for lead in context.get("paper_leads", []) or []:
+        if not isinstance(lead, dict):
+            continue
+        paper_id = lead.get("paper_id")
+        if isinstance(paper_id, str) and paper_id:
+            refs.add(paper_id)
+        for node_id in lead.get("lkm_node_ids", []) or []:
+            if isinstance(node_id, str) and node_id:
+                refs.add(node_id)
+    return refs
+
+
+def _context_landscape_rounds(context: dict[str, Any]) -> list[dict[str, Any]]:
+    rounds = context.get("landscape_rounds")
+    if not isinstance(rounds, list):
+        return []
+    return [row for row in rounds if isinstance(row, dict)]
+
+
+def _candidate_focus_rows(candidates: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        parsed = CandidateFocuses.model_validate(candidates)
+    except Exception as exc:
+        raise ValueError(f"candidate focuses do not match schema: {exc}") from exc
+    return [row.model_dump(mode="json") for row in parsed.focuses]
+
+
+def _validate_candidate_ref(ref: Any, *, focus_id: str, grounded_refs: set[str]) -> dict[str, Any]:
+    if not isinstance(ref, dict):
+        raise ValueError(f"focus {focus_id} has a non-object evidence ref")
+    ref_id = ref.get("id")
+    ref_kind = ref.get("kind")
+    if not isinstance(ref_id, str) or not ref_id:
+        raise ValueError(f"focus {focus_id} has an evidence ref without id")
+    if not isinstance(ref_kind, str) or not ref_kind:
+        raise ValueError(f"focus {focus_id} has an evidence ref without kind")
+    if ref_id not in grounded_refs:
+        raise ValueError(f"focus {focus_id} has ungrounded evidence refs: {ref_id}")
+    return dict(ref)
+
+
+def _normalize_candidate_focus(
+    row: dict[str, Any],
+    *,
+    context_ref: str | None,
+    grounded_refs: set[str],
+    generation: str,
+) -> dict[str, Any]:
+    focus_id = row.get("id")
+    if not isinstance(focus_id, str) or not focus_id:
+        raise ValueError("candidate focus must include a non-empty id")
+    kind = row.get("kind")
+    if not isinstance(kind, str) or not kind:
+        raise ValueError(f"focus {focus_id} must include a non-empty kind")
+    question = row.get("question") or row.get("text")
+    if not isinstance(question, str) or not question.strip():
+        raise ValueError(f"focus {focus_id} must include question or text")
+    status = row.get("status")
+    if not isinstance(status, str) or status not in FOCUS_STATUSES:
+        raise ValueError(f"focus {focus_id} has invalid status {status!r}")
+    coverage = row.get("coverage")
+    if not isinstance(coverage, dict):
+        raise ValueError(f"focus {focus_id} must include coverage")
+
+    evidence_refs = [
+        _validate_candidate_ref(ref, focus_id=focus_id, grounded_refs=grounded_refs)
+        for ref in row.get("evidence_refs", []) or []
+    ]
+    if status == "ready_for_assess" and not evidence_refs:
+        raise ValueError(f"focus {focus_id} is ready_for_assess but has no evidence refs")
+
+    next_queries = list(row.get("next_landscape_queries", []) or [])
+    missing_dimensions = coverage.get("missing_dimensions")
+    if status == "needs_more_landscape" and not next_queries and not missing_dimensions:
+        raise ValueError(
+            f"focus {focus_id} needs_more_landscape but has no missing dimensions or next queries"
+        )
+
+    provenance_value = row.get("provenance")
+    provenance = dict(provenance_value) if isinstance(provenance_value, dict) else {}
+    provenance.update(
+        {
+            "generation": generation,
+            "focus_context": context_ref,
+            "grounded_ref_count": len({ref["id"] for ref in evidence_refs}),
+        }
+    )
+
+    return {
+        "id": focus_id,
+        "kind": kind,
+        "level": "focus",
+        "text": question.strip(),
+        "question": question.strip(),
+        "why_it_matters": str(row.get("why_it_matters") or "").strip(),
+        "evidence_refs": evidence_refs,
+        "recommended_next": "assess" if status == "ready_for_assess" else "landscape",
+        "status": status,
+        "coverage": dict(coverage),
+        "candidate_claims": list(row.get("candidate_claims", []) or []),
+        "next_landscape_queries": next_queries,
+        "confidence": row.get("confidence") if isinstance(row.get("confidence"), str) else "medium",
+        "provenance": provenance,
+    }
+
+
+def build_focuses_artifact_from_candidates(
+    pkg: str | Path,
+    *,
+    context_path: Path,
+    context: dict[str, Any],
+    candidates: dict[str, Any],
+    map_round: int,
+    generation: str,
+) -> dict[str, Any]:
+    """Build a focuses artifact from LLM/human candidate JSON after validation."""
+    grounded_refs = _context_grounding_refs(context)
+    context_ref = rel_artifact_path(pkg, context_path)
+    focuses = [
+        _normalize_candidate_focus(
+            row,
+            context_ref=context_ref,
+            grounded_refs=grounded_refs,
+            generation=generation,
+        )
+        for row in _candidate_focus_rows(candidates)
+    ]
+    return {
+        "schema": SOP_SCHEMA_V2,
+        "kind": "exploration_focuses",
+        "id": artifact_id("focuses"),
+        "created_at": utcnow(),
+        "inputs": {
+            "pkg": str(Path(pkg).resolve()),
+            "scope": context.get("inputs", {}).get("scope")
+            if isinstance(context.get("inputs"), dict)
+            else None,
+            "focus_context": context_ref,
+            "landscape_rounds": _context_landscape_rounds(context),
+        },
+        "provenance": {
+            "generation": generation,
+            "map_round": map_round,
+        },
+        "focuses": focuses,
+        "audit": {"allowed_next_steps": ["artifact", "gate", "assess"]},
     }
 
 
@@ -665,6 +918,7 @@ __all__ = [
     "build_exploration_artifact",
     "build_focus_context_artifact",
     "build_focuses_artifact",
+    "build_focuses_artifact_from_candidates",
     "build_gate_report",
     "build_scope_artifact",
     "collect_landscape_grounding_refs",

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -132,6 +132,18 @@ def _lead_evidence_refs(lead: dict[str, Any]) -> list[dict[str, str]]:
     return refs
 
 
+def collect_landscape_grounding_refs(landscape_rounds: Sequence[dict[str, Any]]) -> set[str]:
+    """Return paper and LKM node ids that are grounded by landscape rounds."""
+    refs: set[str] = set()
+    for payload in landscape_rounds:
+        for lead in payload.get("paper_leads", []) or []:
+            if not isinstance(lead, dict):
+                continue
+            for ref in _lead_evidence_refs(lead):
+                refs.add(ref["id"])
+    return refs
+
+
 def build_focuses_artifact(
     pkg: str | Path,
     *,
@@ -185,13 +197,28 @@ def build_focuses_artifact(
             {
                 "id": artifact_id("focus"),
                 "kind": "paper_lead_cluster",
+                "level": "focus",
                 "text": text,
+                "question": text,
                 "why_it_matters": (
                     "Landscape paper leads are the breadth-first bridge from Explore "
                     "into evidence assessment."
                 ),
                 "evidence_refs": evidence_refs,
                 "recommended_next": "assess",
+                "status": "ready_for_assess",
+                "coverage": {
+                    "status": "ready_for_assess",
+                    "evidence_families": ["paper_lead"],
+                    "support_refs": len(paper_ids),
+                    "oppose_or_harm_refs": 0,
+                    "limitation_refs": 0,
+                    "missing_dimensions": [],
+                    "grounded_ref_count": len(evidence_refs),
+                    "stop_reason": "paper leads are grounded for downstream assessment",
+                },
+                "candidate_claims": [],
+                "next_landscape_queries": [],
                 "confidence": "medium",
                 "provenance": {
                     "paper_ids": paper_ids,
@@ -202,7 +229,7 @@ def build_focuses_artifact(
         )
 
     return {
-        "schema": SOP_SCHEMA,
+        "schema": SOP_SCHEMA_V2,
         "kind": "exploration_focuses",
         "id": artifact_id("focuses"),
         "created_at": utcnow(),
@@ -292,11 +319,91 @@ def _optional_artifact(pkg: str | Path, path: Path) -> str | None:
     return rel_artifact_path(pkg, path) if path.exists() else None
 
 
+def _focus_list(focuses: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(focuses, dict):
+        return []
+    rows = focuses.get("focuses")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _focus_status(row: dict[str, Any]) -> str:
+    status = row.get("status")
+    if isinstance(status, str) and status:
+        return status
+    if row.get("recommended_next") == "assess":
+        return "ready_for_assess"
+    return "needs_more_landscape"
+
+
+def _focus_ref_ids(row: dict[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    for ref in row.get("evidence_refs", []) or []:
+        if isinstance(ref, dict) and isinstance(ref.get("id"), str):
+            refs.add(ref["id"])
+    return refs
+
+
+def _focus_status_summaries(focuses: dict[str, Any] | None) -> list[dict[str, Any]]:
+    summaries: list[dict[str, Any]] = []
+    for row in _focus_list(focuses):
+        focus_id = row.get("id")
+        if not isinstance(focus_id, str) or not focus_id:
+            continue
+        status = _focus_status(row)
+        summaries.append(
+            {
+                "id": focus_id,
+                "status": status,
+                "recommended_next": "assess" if status == "ready_for_assess" else "landscape",
+                "evidence_refs": len(_focus_ref_ids(row)),
+            }
+        )
+    return summaries
+
+
+def _ready_focus_contract_ok(row: dict[str, Any]) -> bool:
+    has_prompt = isinstance(row.get("question"), str) or isinstance(row.get("text"), str)
+    return (
+        has_prompt
+        and isinstance(row.get("coverage"), dict)
+        and isinstance(row.get("provenance"), dict)
+        and bool(_focus_ref_ids(row))
+    )
+
+
+def _unready_focus_has_next_step(row: dict[str, Any]) -> bool:
+    coverage = row.get("coverage")
+    missing = coverage.get("missing_dimensions") if isinstance(coverage, dict) else None
+    next_queries = row.get("next_landscape_queries")
+    return bool(missing) or bool(next_queries)
+
+
+def _exploration_coverage_summary(artifacts: dict[str, str | None]) -> dict[str, Any]:
+    paper_level_gaps: list[str] = []
+    if artifacts["landscape"] is None:
+        paper_level_gaps.append("landscape missing")
+
+    claim_level_gaps: list[str] = []
+    if artifacts["gaia_ir"] is None:
+        claim_level_gaps.append("compiled IR missing")
+    if artifacts["beliefs"] is None:
+        claim_level_gaps.append("beliefs sidecar missing")
+
+    return {
+        "paper_level_gaps": paper_level_gaps,
+        "claim_level_gaps": claim_level_gaps,
+        "budget_exhaustion": "not_evaluated",
+    }
+
+
 def build_exploration_artifact(
     pkg: str | Path,
     *,
     map_round: int,
     map_version: int,
+    focuses: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the handoff envelope that links Explore sidecars together."""
     exp = exploration_dir(pkg)
@@ -305,6 +412,7 @@ def build_exploration_artifact(
         "scope": _optional_artifact(pkg, exp / "scope.json"),
         "landscape": rel_artifact_path(pkg, latest_landscape_path(pkg)),
         "focuses": _optional_artifact(pkg, exp / "focuses.json"),
+        "focus_context": _optional_artifact(pkg, exp / "focus_context.json"),
         "map": _optional_artifact(pkg, exp / "map.json"),
         "artifact": _optional_artifact(pkg, exp / "artifact.json"),
         "rounds": _optional_artifact(pkg, exp / "rounds.jsonl"),
@@ -327,8 +435,10 @@ def build_exploration_artifact(
         "map": "map.json",
     }
     limitations = [f"missing {name}" for key, name in core_names.items() if artifacts[key] is None]
+    focus_statuses = _focus_status_summaries(focuses)
+    ready_focus_ids = [row["id"] for row in focus_statuses if row["status"] == "ready_for_assess"]
     return {
-        "schema": SOP_SCHEMA,
+        "schema": SOP_SCHEMA_V2,
         "kind": "lkm_exploration",
         "id": artifact_id("exploration"),
         "created_at": utcnow(),
@@ -339,13 +449,20 @@ def build_exploration_artifact(
         },
         "artifacts": artifacts,
         "landscape_rounds": landscape_rounds,
+        "focus_statuses": focus_statuses,
         "audit": {
+            "coverage": _exploration_coverage_summary(artifacts),
             "known_limitations": limitations,
             "allowed_next_steps": ["gate"],
         },
         "interface": {
             "assess": {
-                "command": "gaia-evidence assess --exploration .gaia/exploration/artifact.json"
+                "command": "gaia-evidence assess --exploration .gaia/exploration/artifact.json",
+                "focus_commands": [
+                    "gaia-evidence assess --exploration "
+                    f".gaia/exploration/artifact.json --focus {focus_id}"
+                    for focus_id in ready_focus_ids
+                ],
             }
         },
     }
@@ -370,22 +487,15 @@ def _artifact_ref(artifact: dict[str, Any], name: str) -> Any:
     return artifacts.get(name)
 
 
-def _focus_list(focuses: dict[str, Any] | None) -> list[dict[str, Any]]:
-    if not isinstance(focuses, dict):
-        return []
-    rows = focuses.get("focuses")
-    if not isinstance(rows, list):
-        return []
-    return [row for row in rows if isinstance(row, dict)]
-
-
 def build_gate_report(
     artifact: dict[str, Any],
     focuses: dict[str, Any] | None,
+    *,
+    grounding_refs: set[str] | None = None,
 ) -> dict[str, Any]:
     """Build a deterministic pass/revise/block report for Assess handoff."""
     rows = _focus_list(focuses)
-    assessable = [row for row in rows if row.get("recommended_next") == "assess"]
+    assessable = [row for row in rows if _focus_status(row) == "ready_for_assess"]
     assessable_with_refs = [
         row
         for row in assessable
@@ -393,6 +503,24 @@ def build_gate_report(
     ]
     all_focuses_have_refs = all(
         isinstance(row.get("evidence_refs"), list) and bool(row["evidence_refs"]) for row in rows
+    )
+    unsupported_refs: set[str] = set()
+    if grounding_refs is not None:
+        ready_ref_ids = (
+            set().union(*[_focus_ref_ids(row) for row in assessable]) if assessable else set()
+        )
+        unsupported_refs = ready_ref_ids - grounding_refs
+    supported_schemas = {SOP_SCHEMA, SOP_SCHEMA_V2}
+    ready_focuses_have_contract = all(_ready_focus_contract_ok(row) for row in assessable)
+    unready_focuses = [row for row in rows if _focus_status(row) != "ready_for_assess"]
+    unready_have_next_steps = all(_unready_focus_has_next_step(row) for row in unready_focuses)
+    audit = artifact.get("audit")
+    coverage = audit.get("coverage") if isinstance(audit, dict) else None
+    v2_coverage_budget_recorded = (
+        isinstance(coverage, dict)
+        and isinstance(coverage.get("paper_level_gaps"), list)
+        and isinstance(coverage.get("claim_level_gaps"), list)
+        and coverage.get("budget_exhaustion") is not None
     )
     checks = {
         "scope_present": _check(
@@ -413,7 +541,7 @@ def build_gate_report(
         ),
         "has_assessable_focus": _check(
             "pass" if assessable else "fail",
-            "at least one focus recommends assess",
+            "at least one focus is ready for assess",
         ),
         "focuses_have_evidence_refs": _check(
             "skip"
@@ -425,12 +553,36 @@ def build_gate_report(
             if assessable
             else "no assessable focus to check for evidence refs",
         ),
+        "ready_focuses_have_contract": _check(
+            "skip" if not assessable else "pass" if ready_focuses_have_contract else "fail",
+            "ready focuses carry question/text, coverage, provenance, and evidence refs"
+            if assessable
+            else "no ready focus to check",
+        ),
+        "ready_focus_refs_grounded": _check(
+            "skip"
+            if grounding_refs is None or not assessable
+            else "pass"
+            if not unsupported_refs
+            else "fail",
+            "ready focus evidence refs are grounded in landscape rounds"
+            if grounding_refs is not None and assessable
+            else "no grounding refs or ready focuses to check",
+        ),
         "schema_versions_supported": _check(
             "pass"
-            if artifact.get("schema") == SOP_SCHEMA
-            and (focuses is None or focuses.get("schema") == SOP_SCHEMA)
+            if artifact.get("schema") in supported_schemas
+            and (focuses is None or focuses.get("schema") in supported_schemas)
             else "fail",
-            f"supported schema is {SOP_SCHEMA}",
+            f"supported schemas are {', '.join(sorted(supported_schemas))}",
+        ),
+        "coverage_budget_recorded": _check(
+            "skip"
+            if artifact.get("schema") != SOP_SCHEMA_V2
+            else "pass"
+            if v2_coverage_budget_recorded
+            else "fail",
+            "v2 artifact records paper gaps, claim gaps, and budget exhaustion",
         ),
         "compiled_ir_present": _check(
             "pass" if _artifact_ref(artifact, "gaia_ir") else "warn",
@@ -448,6 +600,10 @@ def build_gate_report(
             "pass" if all_focuses_have_refs else "warn",
             "all focus rows carry evidence refs",
         ),
+        "unready_focuses_have_next_steps": _check(
+            "pass" if not unready_focuses or unready_have_next_steps else "warn",
+            "unready focuses explain missing dimensions or next landscape queries",
+        ),
     }
     required = [
         "scope_present",
@@ -456,13 +612,17 @@ def build_gate_report(
         "focuses_present",
         "has_assessable_focus",
         "focuses_have_evidence_refs",
+        "ready_focuses_have_contract",
+        "ready_focus_refs_grounded",
         "schema_versions_supported",
+        "coverage_budget_recorded",
     ]
     warnings = [
         "compiled_ir_present",
         "beliefs_present",
         "rounds_present",
         "all_focuses_have_evidence_refs",
+        "unready_focuses_have_next_steps",
     ]
     if any(checks[name]["status"] == "fail" for name in required):
         verdict = "block"
@@ -477,6 +637,9 @@ def build_gate_report(
         "created_at": utcnow(),
         "verdict": verdict,
         "checks": checks,
+        "validation": {
+            "ungrounded_refs": sorted(unsupported_refs),
+        },
         "audit": {
             "allowed_next_steps": ["assess"] if verdict == "pass" else [],
         },
@@ -493,6 +656,7 @@ __all__ = [
     "build_focuses_artifact",
     "build_gate_report",
     "build_scope_artifact",
+    "collect_landscape_grounding_refs",
     "exploration_dir",
     "landscape_round_paths",
     "latest_landscape_path",

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -7,6 +7,7 @@ files, call LKM, invoke an LLM, or mutate the exploration map.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -128,10 +129,28 @@ def build_focuses_artifact(
     scope_path: Path | None,
     landscape_path: Path | None,
     landscape: dict[str, Any],
+    landscape_rounds: Sequence[tuple[Path | None, dict[str, Any]]] | None = None,
     map_round: int,
 ) -> dict[str, Any]:
-    """Build deterministic focus suggestions from a paper-level landscape."""
-    paper_leads = [lead for lead in landscape.get("paper_leads", []) if isinstance(lead, dict)]
+    """Build deterministic focus suggestions from paper-level landscape rounds."""
+    rounds = landscape_rounds or [(landscape_path, landscape)]
+    paper_leads = [
+        lead
+        for _, round_payload in rounds
+        for lead in round_payload.get("paper_leads", [])
+        if isinstance(lead, dict)
+    ]
+    round_refs = [
+        {
+            "round": round_number,
+            "path": rel_artifact_path(pkg, path),
+            "paper_leads": len(
+                [lead for lead in payload.get("paper_leads", []) if isinstance(lead, dict)]
+            ),
+        }
+        for path, payload in rounds
+        if path is not None and (round_number := _landscape_round_number(path)) is not None
+    ]
     focuses: list[dict[str, Any]] = []
     if paper_leads:
         evidence_refs: list[dict[str, str]] = []
@@ -140,10 +159,10 @@ def build_focuses_artifact(
         queries: list[str] = []
         for lead in paper_leads:
             paper_id = lead.get("paper_id")
-            if isinstance(paper_id, str) and paper_id:
+            if isinstance(paper_id, str) and paper_id and paper_id not in paper_ids:
                 paper_ids.append(paper_id)
             title = lead.get("title")
-            if isinstance(title, str) and title:
+            if isinstance(title, str) and title and title not in titles:
                 titles.append(title)
             for query in lead.get("queries", []) or []:
                 if isinstance(query, str) and query and query not in queries:
@@ -182,6 +201,7 @@ def build_focuses_artifact(
             "pkg": str(Path(pkg).resolve()),
             "scope": rel_artifact_path(pkg, scope_path),
             "landscape": rel_artifact_path(pkg, landscape_path),
+            "landscape_rounds": round_refs,
         },
         "provenance": {"map_round": map_round},
         "focuses": focuses,

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -487,6 +487,15 @@ def _artifact_ref(artifact: dict[str, Any], name: str) -> Any:
     return artifacts.get(name)
 
 
+def _has_landscape_round_provenance(artifact: dict[str, Any]) -> bool:
+    if artifact.get("schema") != SOP_SCHEMA_V2:
+        return False
+    rounds = artifact.get("landscape_rounds")
+    if not isinstance(rounds, list) or not rounds:
+        return False
+    return all(isinstance(row, dict) and row.get("path") for row in rounds)
+
+
 def build_gate_report(
     artifact: dict[str, Any],
     focuses: dict[str, Any] | None,
@@ -593,8 +602,10 @@ def build_gate_report(
             "beliefs sidecar is available for downstream assessment context",
         ),
         "rounds_present": _check(
-            "pass" if _artifact_ref(artifact, "rounds") else "warn",
-            "round history is available for provenance",
+            "pass"
+            if _artifact_ref(artifact, "rounds") or _has_landscape_round_provenance(artifact)
+            else "warn",
+            "round history or v2 landscape round index is available for provenance",
         ),
         "all_focuses_have_evidence_refs": _check(
             "pass" if all_focuses_have_refs else "warn",

--- a/gaia/lkm_explorer/engine/artifacts.py
+++ b/gaia/lkm_explorer/engine/artifacts.py
@@ -13,6 +13,15 @@ from pathlib import Path
 from typing import Any
 
 SOP_SCHEMA = "gaia.sop.artifact.v1"
+SOP_SCHEMA_V2 = "gaia.sop.artifact.v2"
+
+FOCUS_SYNTHESIS_INSTRUCTIONS = [
+    "Propose only focuses grounded in evidence refs.",
+    "Prefer 2-5 assessment questions.",
+    "Separate paper-level material from claim-level conclusions.",
+    "Do not state a tension as established unless the refs support it.",
+    "For each focus, list missing evidence needed before assessment.",
+]
 
 
 def utcnow() -> str:
@@ -206,6 +215,76 @@ def build_focuses_artifact(
         "provenance": {"map_round": map_round},
         "focuses": focuses,
         "audit": {"allowed_next_steps": ["artifact", "gate", "assess"]},
+    }
+
+
+def build_focus_context_artifact(
+    pkg: str | Path,
+    *,
+    scope_path: Path | None,
+    scope: dict[str, Any] | None,
+    landscape_rounds: Sequence[tuple[Path, dict[str, Any]]],
+    existing_focuses_path: Path | None,
+    existing_focuses: dict[str, Any] | None,
+    map_round: int,
+) -> dict[str, Any]:
+    """Build the grounded packet for LLM/human focus synthesis."""
+    round_refs: list[dict[str, Any]] = []
+    paper_leads: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for path, payload in landscape_rounds:
+        round_number = _landscape_round_number(path)
+        if round_number is None:
+            continue
+        rel_path = rel_artifact_path(pkg, path)
+        leads = [lead for lead in payload.get("paper_leads", []) if isinstance(lead, dict)]
+        round_refs.append(
+            {
+                "round": round_number,
+                "path": rel_path,
+                "purpose": "broad_initial_survey" if round_number == 0 else "focus_gap_followup",
+                "paper_leads": len(leads),
+            }
+        )
+        for query in payload.get("queries", []) or []:
+            if isinstance(query, dict):
+                queries.append({"round": round_number, "path": rel_path, **query})
+        for lead in leads:
+            paper_leads.append(
+                {
+                    "round": round_number,
+                    "path": rel_path,
+                    "paper_id": lead.get("paper_id"),
+                    "title": lead.get("title"),
+                    "doi": lead.get("doi"),
+                    "index_id": lead.get("index_id"),
+                    "best_rank": lead.get("best_rank"),
+                    "queries": list(lead.get("queries", []) or []),
+                    "lkm_node_ids": list(lead.get("lkm_node_ids", []) or []),
+                }
+            )
+    focus_rows = _focus_list(existing_focuses)
+    return {
+        "schema": SOP_SCHEMA_V2,
+        "kind": "focus_synthesis_context",
+        "id": artifact_id("focus_context"),
+        "created_at": utcnow(),
+        "inputs": {
+            "pkg": str(Path(pkg).resolve()),
+            "scope": rel_artifact_path(pkg, scope_path),
+            "existing_focuses": rel_artifact_path(pkg, existing_focuses_path),
+            "map_round": map_round,
+        },
+        "scope": scope or {},
+        "landscape_rounds": round_refs,
+        "paper_leads": paper_leads,
+        "queries": queries,
+        "existing_focuses": focus_rows,
+        "coverage_gaps": [],
+        "instructions": list(FOCUS_SYNTHESIS_INSTRUCTIONS),
+        "audit": {
+            "allowed_next_steps": ["focuses", "artifact", "gate"],
+        },
     }
 
 
@@ -405,9 +484,12 @@ def build_gate_report(
 
 
 __all__ = [
+    "FOCUS_SYNTHESIS_INSTRUCTIONS",
     "SOP_SCHEMA",
+    "SOP_SCHEMA_V2",
     "artifact_id",
     "build_exploration_artifact",
+    "build_focus_context_artifact",
     "build_focuses_artifact",
     "build_gate_report",
     "build_scope_artifact",

--- a/gaia/research_loop/__init__.py
+++ b/gaia/research_loop/__init__.py
@@ -1,0 +1,1 @@
+"""Agent-facing Gaia research loop protocol."""

--- a/gaia/research_loop/cli.py
+++ b/gaia/research_loop/cli.py
@@ -6,7 +6,8 @@ import json
 
 import typer
 
-from gaia.research_loop.engine import next_payload, status_payload
+from gaia.research_loop.engine import emit_task, next_payload, status_payload
+from gaia.research_loop.schemas import TaskKind
 
 app = typer.Typer(
     name="gaia-research-loop",
@@ -16,6 +17,8 @@ app = typer.Typer(
 
 _PKG_ARG = typer.Argument(..., help="Knowledge-package path.")
 _JSON_OPT = typer.Option(False, "--json", help="Emit JSON.")
+task_app = typer.Typer(help="Emit one task envelope without running the full loop.")
+app.add_typer(task_app, name="task")
 
 
 @app.callback()
@@ -40,9 +43,27 @@ def status_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
 def next_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
     """Emit the next task envelope."""
     payload = next_payload(pkg)
+    _echo_task_payload(payload, json_out)
+
+
+def _echo_task_payload(payload: dict[str, object], json_out: bool) -> None:
     if json_out:
         typer.echo(json.dumps(payload, indent=2, sort_keys=True))
         return
     typer.echo(f"Recommended: {payload['recommended_action']}")
     typer.echo(f"Task: {payload['task_path']}")
     typer.echo(f"Submit: {payload['submit_command']}")
+
+
+@task_app.command("scope")
+def task_scope_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit a scope task envelope without consulting loop state."""
+    payload = emit_task(pkg, kind=TaskKind.SCOPE)
+    _echo_task_payload(payload, json_out)
+
+
+@task_app.command("query-plan")
+def task_query_plan_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit a query planning task envelope from the current scope artifact."""
+    payload = emit_task(pkg, kind=TaskKind.QUERY_PLAN)
+    _echo_task_payload(payload, json_out)

--- a/gaia/research_loop/cli.py
+++ b/gaia/research_loop/cli.py
@@ -6,7 +6,7 @@ import json
 
 import typer
 
-from gaia.research_loop.engine import emit_task, next_payload, status_payload
+from gaia.research_loop.engine import emit_task, next_payload, status_payload, submit_candidate
 from gaia.research_loop.schemas import TaskKind
 
 app = typer.Typer(
@@ -44,6 +44,27 @@ def next_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
     """Emit the next task envelope."""
     payload = next_payload(pkg)
     _echo_task_payload(payload, json_out)
+
+
+@app.command("submit")
+def submit_command(
+    pkg: str = _PKG_ARG,
+    candidate: str = typer.Argument(..., help="Candidate JSON path."),
+    json_out: bool = _JSON_OPT,
+) -> None:
+    """Validate and submit a candidate JSON file."""
+    try:
+        payload = submit_candidate(pkg, candidate)
+    except Exception as exc:
+        if json_out:
+            typer.echo(json.dumps({"status": "rejected", "error": str(exc)}, indent=2))
+        else:
+            typer.echo(f"Rejected: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"Accepted: {payload['artifact_path']}")
 
 
 def _echo_task_payload(payload: dict[str, object], json_out: bool) -> None:

--- a/gaia/research_loop/cli.py
+++ b/gaia/research_loop/cli.py
@@ -6,7 +6,7 @@ import json
 
 import typer
 
-from gaia.research_loop.engine import status_payload
+from gaia.research_loop.engine import next_payload, status_payload
 
 app = typer.Typer(
     name="gaia-research-loop",
@@ -34,3 +34,15 @@ def status_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
     typer.echo(f"Root: {payload['root']}")
     typer.echo(f"Events: {payload['event_count']}")
     typer.echo(f"Next: {payload['recommended_next']} {pkg}")
+
+
+@app.command("next")
+def next_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit the next task envelope."""
+    payload = next_payload(pkg)
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"Recommended: {payload['recommended_action']}")
+    typer.echo(f"Task: {payload['task_path']}")
+    typer.echo(f"Submit: {payload['submit_command']}")

--- a/gaia/research_loop/cli.py
+++ b/gaia/research_loop/cli.py
@@ -100,8 +100,10 @@ def _echo_task_payload(payload: dict[str, object], json_out: bool) -> None:
         typer.echo(json.dumps(payload, indent=2, sort_keys=True))
         return
     typer.echo(f"Recommended: {payload['recommended_action']}")
-    typer.echo(f"Task: {payload['task_path']}")
-    typer.echo(f"Submit: {payload['submit_command']}")
+    if payload.get("task_path") is not None:
+        typer.echo(f"Task: {payload['task_path']}")
+    if payload.get("submit_command") is not None:
+        typer.echo(f"Submit: {payload['submit_command']}")
 
 
 @task_app.command("scope")
@@ -115,4 +117,32 @@ def task_scope_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
 def task_query_plan_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
     """Emit a query planning task envelope from the current scope artifact."""
     payload = emit_task(pkg, kind=TaskKind.QUERY_PLAN)
+    _echo_task_payload(payload, json_out)
+
+
+@task_app.command("search-execution")
+def task_search_execution_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit a search execution task envelope from the current query plan."""
+    payload = emit_task(pkg, kind=TaskKind.SEARCH_EXECUTION)
+    _echo_task_payload(payload, json_out)
+
+
+@task_app.command("focus-synthesis")
+def task_focus_synthesis_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit a focus synthesis task envelope from the current landscape."""
+    payload = emit_task(pkg, kind=TaskKind.FOCUS_SYNTHESIS)
+    _echo_task_payload(payload, json_out)
+
+
+@task_app.command("assessment-context")
+def task_assessment_context_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit an assessment context task envelope from selected focuses."""
+    payload = emit_task(pkg, kind=TaskKind.ASSESSMENT_CONTEXT)
+    _echo_task_payload(payload, json_out)
+
+
+@task_app.command("evidence-diagnosis")
+def task_evidence_diagnosis_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Emit an evidence diagnosis task envelope from assessment context."""
+    payload = emit_task(pkg, kind=TaskKind.EVIDENCE_DIAGNOSIS)
     _echo_task_payload(payload, json_out)

--- a/gaia/research_loop/cli.py
+++ b/gaia/research_loop/cli.py
@@ -1,0 +1,36 @@
+"""``gaia-research-loop`` command-line interface."""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from gaia.research_loop.engine import status_payload
+
+app = typer.Typer(
+    name="gaia-research-loop",
+    help="Gaia Research Loop — agent-facing Explore -> Assess protocol.",
+    no_args_is_help=True,
+)
+
+_PKG_ARG = typer.Argument(..., help="Knowledge-package path.")
+_JSON_OPT = typer.Option(False, "--json", help="Emit JSON.")
+
+
+@app.callback()
+def main() -> None:
+    """Run Gaia research loop commands."""
+
+
+@app.command("status")
+def status_command(pkg: str = _PKG_ARG, json_out: bool = _JSON_OPT) -> None:
+    """Show or rebuild research loop state."""
+    payload = status_payload(pkg)
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"Research loop: {payload['phase']}")
+    typer.echo(f"Root: {payload['root']}")
+    typer.echo(f"Events: {payload['event_count']}")
+    typer.echo(f"Next: {payload['recommended_next']} {pkg}")

--- a/gaia/research_loop/cli.py
+++ b/gaia/research_loop/cli.py
@@ -6,7 +6,13 @@ import json
 
 import typer
 
-from gaia.research_loop.engine import emit_task, next_payload, status_payload, submit_candidate
+from gaia.research_loop.engine import (
+    emit_task,
+    gate_payload,
+    next_payload,
+    status_payload,
+    submit_candidate,
+)
 from gaia.research_loop.schemas import TaskKind
 
 app = typer.Typer(
@@ -17,6 +23,7 @@ app = typer.Typer(
 
 _PKG_ARG = typer.Argument(..., help="Knowledge-package path.")
 _JSON_OPT = typer.Option(False, "--json", help="Emit JSON.")
+_STAGE_OPT = typer.Option("explore", "--stage", help="Loop stage to gate.")
 task_app = typer.Typer(help="Emit one task envelope without running the full loop.")
 app.add_typer(task_app, name="task")
 
@@ -65,6 +72,27 @@ def submit_command(
         typer.echo(json.dumps(payload, indent=2, sort_keys=True))
         return
     typer.echo(f"Accepted: {payload['artifact_path']}")
+
+
+@app.command("gate")
+def gate_command(
+    pkg: str = _PKG_ARG,
+    stage: str = _STAGE_OPT,
+    json_out: bool = _JSON_OPT,
+) -> None:
+    """Run a stage gate."""
+    try:
+        payload = gate_payload(pkg, stage=stage)
+    except Exception as exc:
+        if json_out:
+            typer.echo(json.dumps({"status": "error", "error": str(exc)}, indent=2))
+        else:
+            typer.echo(f"Gate error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    if json_out:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    typer.echo(f"{stage}: {payload['status']}")
 
 
 def _echo_task_payload(payload: dict[str, object], json_out: bool) -> None:

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from gaia.research_loop.schemas import TaskKind
 from gaia.research_loop.storage import (
     append_event,
     ensure_loop_dirs,
@@ -36,9 +37,22 @@ def next_payload(pkg: str | Path) -> dict[str, Any]:
     paths = ensure_loop_dirs(pkg)
     scope_path = paths.explore_artifacts / "scope.json"
     if scope_path.exists():
+        return emit_task(pkg, kind=TaskKind.QUERY_PLAN)
+    return emit_task(pkg, kind=TaskKind.SCOPE)
+
+
+def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
+    """Emit one specific task envelope without consulting the full loop router."""
+    paths = ensure_loop_dirs(pkg)
+    if kind == TaskKind.SCOPE:
+        task, task_path = build_scope_task(paths)
+    elif kind == TaskKind.QUERY_PLAN:
+        scope_path = paths.explore_artifacts / "scope.json"
+        if not scope_path.exists():
+            raise FileNotFoundError("scope.json is required for query-plan task")
         task, task_path = build_query_plan_task(paths, read_json(scope_path))
     else:
-        task, task_path = build_scope_task(paths)
+        raise ValueError(f"Primitive task {kind.value} is not implemented yet")
     write_task(task, task_path)
     append_event(
         paths,

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -7,12 +7,14 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from gaia.research_loop.lkm_adapter import build_landscape_from_raw_results
 from gaia.research_loop.schemas import (
     CandidateEnvelope,
     QueryPlanCandidatePayload,
     RepairContext,
     ResearchLoopTask,
     ScopeCandidatePayload,
+    SearchExecutionCandidatePayload,
     TaskKind,
 )
 from gaia.research_loop.storage import (
@@ -150,6 +152,26 @@ def _write_candidate_artifact(
         query_payload = QueryPlanCandidatePayload.model_validate(candidate.payload)
         artifact_path = paths.explore_artifacts / "query_plan.json"
         write_json(artifact_path, query_payload.model_dump(mode="json"))
+        return artifact_path
+    if task.kind == TaskKind.SEARCH_EXECUTION:
+        search_payload = SearchExecutionCandidatePayload.model_validate(candidate.payload)
+        raw_results: list[tuple[str, Path]] = []
+        manifest_results: list[dict[str, str]] = []
+        for result in search_payload.results:
+            raw_path = Path(result.path)
+            if not raw_path.exists():
+                raise FileNotFoundError(f"Search result path does not exist: {raw_path}")
+            raw_results.append((result.query, raw_path))
+            manifest_results.append({"query": result.query, "path": str(raw_path)})
+        manifest_path = paths.explore_artifacts / "raw_search_manifest.json"
+        write_json(manifest_path, {"results": manifest_results})
+        artifact_path = paths.explore_artifacts / "landscape-0000.json"
+        landscape = build_landscape_from_raw_results(
+            paths.pkg,
+            raw_results=raw_results,
+            round_number=0,
+        )
+        write_json(artifact_path, landscape)
         return artifact_path
     raise ValueError(f"No payload validator for {task.kind.value}")
 

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -5,13 +5,27 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from gaia.research_loop.schemas import TaskKind
+from pydantic import ValidationError
+
+from gaia.research_loop.schemas import (
+    CandidateEnvelope,
+    QueryPlanCandidatePayload,
+    RepairContext,
+    ResearchLoopTask,
+    ScopeCandidatePayload,
+    TaskKind,
+)
 from gaia.research_loop.storage import (
+    ResearchLoopPaths,
     append_event,
+    candidate_destination,
     ensure_loop_dirs,
+    find_task,
     load_events,
+    load_state,
     read_json,
     rebuild_state,
+    write_json,
 )
 from gaia.research_loop.tasks import build_query_plan_task, build_scope_task, write_task
 
@@ -35,6 +49,9 @@ def status_payload(pkg: str | Path) -> dict[str, Any]:
 def next_payload(pkg: str | Path) -> dict[str, Any]:
     """Emit the next recommended task envelope."""
     paths = ensure_loop_dirs(pkg)
+    state = load_state(paths)
+    if state.last_validation_error is not None:
+        return _repair_task_payload(paths, state.last_validation_error)
     scope_path = paths.explore_artifacts / "scope.json"
     if scope_path.exists():
         return emit_task(pkg, kind=TaskKind.QUERY_PLAN)
@@ -61,6 +78,104 @@ def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
         data={"task_id": task.task_id, "kind": task.kind.value, "task_path": str(task_path)},
     )
     rebuild_state(paths)
+    return {
+        "recommended_action": task.recommended_action,
+        "allowed_actions": task.allowed_actions,
+        "task_path": str(task_path),
+        "submit_command": task.submit_command,
+        "rationale": task.objective,
+    }
+
+
+def submit_candidate(pkg: str | Path, candidate_path: str | Path) -> dict[str, Any]:
+    """Validate a candidate JSON file and persist the accepted artifact."""
+    paths = ensure_loop_dirs(pkg)
+    source_path = Path(candidate_path).resolve()
+    try:
+        candidate = CandidateEnvelope.model_validate_json(source_path.read_text(encoding="utf-8"))
+        task_path = find_task(paths, candidate.task_id)
+        task = ResearchLoopTask.model_validate_json(task_path.read_text(encoding="utf-8"))
+        if candidate.stage != task.stage or candidate.kind != task.kind:
+            raise ValueError("candidate stage/kind does not match task")
+        candidate.validate_against_actions(
+            recommended_action=task.recommended_action,
+            allowed_actions=task.allowed_actions,
+        )
+        artifact_path = _write_candidate_artifact(paths, task, candidate)
+    except (ValidationError, ValueError, FileNotFoundError, OSError) as exc:
+        errors: list[dict[str, Any]] = (
+            [dict(error) for error in exc.errors()]
+            if isinstance(exc, ValidationError)
+            else [{"msg": str(exc)}]
+        )
+        _record_validation_failure(paths, source_path, errors)
+        raise
+
+    copied_candidate = candidate_destination(paths, candidate.stage, source_path)
+    write_json(copied_candidate, candidate.model_dump(mode="json", by_alias=True))
+    append_event(
+        paths,
+        event_type="candidate_submitted",
+        stage=candidate.stage,
+        data={"task_id": candidate.task_id, "candidate_path": str(copied_candidate)},
+    )
+    rebuild_state(paths)
+    return {"status": "accepted", "artifact_path": str(artifact_path)}
+
+
+def _write_candidate_artifact(
+    paths: ResearchLoopPaths,
+    task: ResearchLoopTask,
+    candidate: CandidateEnvelope,
+) -> Path:
+    if task.kind == TaskKind.SCOPE:
+        scope_payload = ScopeCandidatePayload.model_validate(candidate.payload)
+        artifact_path = paths.explore_artifacts / "scope.json"
+        write_json(artifact_path, scope_payload.model_dump(mode="json"))
+        return artifact_path
+    if task.kind == TaskKind.QUERY_PLAN:
+        query_payload = QueryPlanCandidatePayload.model_validate(candidate.payload)
+        artifact_path = paths.explore_artifacts / "query_plan.json"
+        write_json(artifact_path, query_payload.model_dump(mode="json"))
+        return artifact_path
+    raise ValueError(f"No payload validator for {task.kind.value}")
+
+
+def _record_validation_failure(
+    paths: ResearchLoopPaths,
+    failed_candidate_path: Path,
+    errors: list[dict[str, Any]],
+) -> None:
+    state = rebuild_state(paths)
+    state.last_validation_error = {
+        "failed_candidate_path": str(failed_candidate_path),
+        "errors": errors,
+        "instruction": "Repair the candidate JSON so it satisfies the same task contract.",
+    }
+    write_json(paths.state, state.model_dump(mode="json", by_alias=True))
+    append_event(
+        paths,
+        event_type="validation_failed",
+        stage=None,
+        data=state.last_validation_error,
+    )
+
+
+def _repair_task_payload(
+    paths: ResearchLoopPaths,
+    validation_error: dict[str, Any],
+) -> dict[str, Any]:
+    failed_path = Path(str(validation_error["failed_candidate_path"]))
+    candidate = CandidateEnvelope.model_validate_json(failed_path.read_text(encoding="utf-8"))
+    task_path = find_task(paths, candidate.task_id)
+    task = ResearchLoopTask.model_validate_json(task_path.read_text(encoding="utf-8"))
+    errors = validation_error.get("errors", [])
+    task.repair_context = RepairContext(
+        failed_candidate_path=str(failed_path),
+        errors=errors if isinstance(errors, list) else [{"msg": str(errors)}],
+        instruction=str(validation_error["instruction"]),
+    )
+    write_task(task, task_path)
     return {
         "recommended_action": task.recommended_action,
         "allowed_actions": task.allowed_actions,

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -9,7 +9,9 @@ from pydantic import ValidationError
 
 from gaia.research_loop.lkm_adapter import build_landscape_from_raw_results
 from gaia.research_loop.schemas import (
+    AssessmentContextCandidatePayload,
     CandidateEnvelope,
+    EvidenceDiagnosisCandidatePayload,
     FocusSynthesisCandidatePayload,
     QueryPlanCandidatePayload,
     RepairContext,
@@ -31,6 +33,8 @@ from gaia.research_loop.storage import (
     write_json,
 )
 from gaia.research_loop.tasks import (
+    build_assessment_context_task,
+    build_evidence_diagnosis_task,
     build_focus_synthesis_task,
     build_query_plan_task,
     build_scope_task,
@@ -61,6 +65,14 @@ def next_payload(pkg: str | Path) -> dict[str, Any]:
     state = load_state(paths)
     if state.last_validation_error is not None:
         return _repair_task_payload(paths, state.last_validation_error)
+    explore_gate_path = paths.explore_artifacts / "explore_gate.json"
+    if _gate_passed(explore_gate_path):
+        assessment_context_path = paths.assess_artifacts / "assessment_context.json"
+        evidence_diagnosis_path = paths.assess_artifacts / "evidence_diagnosis.json"
+        if not assessment_context_path.exists():
+            return emit_task(pkg, kind=TaskKind.ASSESSMENT_CONTEXT)
+        if not evidence_diagnosis_path.exists():
+            return emit_task(pkg, kind=TaskKind.EVIDENCE_DIAGNOSIS)
     scope_path = paths.explore_artifacts / "scope.json"
     query_plan_path = paths.explore_artifacts / "query_plan.json"
     landscape_path = paths.explore_artifacts / "landscape-0000.json"
@@ -94,6 +106,18 @@ def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
         if not landscape_path.exists():
             raise FileNotFoundError("landscape-0000.json is required for focus-synthesis task")
         task, task_path = build_focus_synthesis_task(paths, read_json(landscape_path))
+    elif kind == TaskKind.ASSESSMENT_CONTEXT:
+        focuses_path = paths.explore_artifacts / "focuses.json"
+        if not focuses_path.exists():
+            raise FileNotFoundError("focuses.json is required for assessment-context task")
+        task, task_path = build_assessment_context_task(paths, read_json(focuses_path))
+    elif kind == TaskKind.EVIDENCE_DIAGNOSIS:
+        context_path = paths.assess_artifacts / "assessment_context.json"
+        if not context_path.exists():
+            raise FileNotFoundError(
+                "assessment_context.json is required for evidence-diagnosis task"
+            )
+        task, task_path = build_evidence_diagnosis_task(paths, read_json(context_path))
     else:
         raise ValueError(f"Primitive task {kind.value} is not implemented yet")
     write_task(task, task_path)
@@ -189,12 +213,24 @@ def _write_candidate_artifact(
         artifact_path = paths.explore_artifacts / "focuses.json"
         write_json(artifact_path, focus_payload.model_dump(mode="json"))
         return artifact_path
+    if task.kind == TaskKind.ASSESSMENT_CONTEXT:
+        context_payload = AssessmentContextCandidatePayload.model_validate(candidate.payload)
+        artifact_path = paths.assess_artifacts / "assessment_context.json"
+        write_json(artifact_path, context_payload.model_dump(mode="json"))
+        return artifact_path
+    if task.kind == TaskKind.EVIDENCE_DIAGNOSIS:
+        diagnosis_payload = EvidenceDiagnosisCandidatePayload.model_validate(candidate.payload)
+        artifact_path = paths.assess_artifacts / "evidence_diagnosis.json"
+        write_json(artifact_path, diagnosis_payload.model_dump(mode="json"))
+        return artifact_path
     raise ValueError(f"No payload validator for {task.kind.value}")
 
 
 def gate_payload(pkg: str | Path, *, stage: str) -> dict[str, Any]:
     """Run a structural stage gate."""
     paths = ensure_loop_dirs(pkg)
+    if stage == "assess":
+        return _assess_gate_payload(paths)
     if stage != "explore":
         raise ValueError(f"Unsupported gate stage: {stage}")
     focuses_path = paths.explore_artifacts / "focuses.json"
@@ -206,6 +242,19 @@ def gate_payload(pkg: str | Path, *, stage: str) -> dict[str, Any]:
     status = "pass" if _has_selected_ready_focus(focuses) else "revise"
     payload = {"schema": "gaia.research_loop.gate.v1", "stage": stage, "status": status}
     write_json(paths.explore_artifacts / "explore_gate.json", payload)
+    return payload
+
+
+def _assess_gate_payload(paths: ResearchLoopPaths) -> dict[str, Any]:
+    diagnosis_path = paths.assess_artifacts / "evidence_diagnosis.json"
+    if not diagnosis_path.exists():
+        payload = {"schema": "gaia.research_loop.gate.v1", "stage": "assess", "status": "revise"}
+        write_json(paths.assess_artifacts / "assess_gate.json", payload)
+        return payload
+    diagnosis = read_json(diagnosis_path)
+    status = "pass" if _diagnosis_is_complete(diagnosis) else "revise"
+    payload = {"schema": "gaia.research_loop.gate.v1", "stage": "assess", "status": status}
+    write_json(paths.assess_artifacts / "assess_gate.json", payload)
     return payload
 
 
@@ -225,6 +274,33 @@ def _has_selected_ready_focus(focuses: dict[str, Any]) -> bool:
         if focus.get("ready_for_assess") is True and isinstance(refs, list) and refs:
             return True
     return False
+
+
+def _gate_passed(path: Path) -> bool:
+    return path.exists() and read_json(path).get("status") == "pass"
+
+
+def _diagnosis_is_complete(diagnosis: dict[str, Any]) -> bool:
+    evidence_items = diagnosis.get("evidence_items", [])
+    limitations = diagnosis.get("limitations", [])
+    gaps = diagnosis.get("gap_map", [])
+    next_tests = diagnosis.get("next_tests", [])
+    if not all(isinstance(value, list) and value for value in [evidence_items, limitations, gaps]):
+        return False
+    gap_ids = {
+        gap.get("gap_id")
+        for gap in gaps
+        if isinstance(gap, dict) and isinstance(gap.get("gap_id"), str)
+    }
+    for item in evidence_items:
+        if not isinstance(item, dict):
+            return False
+        refs = item.get("refs")
+        if not isinstance(refs, list) or not refs:
+            return False
+    if not isinstance(next_tests, list) or not next_tests:
+        return False
+    return all(isinstance(test, dict) and test.get("gap_id") in gap_ids for test in next_tests)
 
 
 def _record_validation_failure(

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -27,7 +27,12 @@ from gaia.research_loop.storage import (
     rebuild_state,
     write_json,
 )
-from gaia.research_loop.tasks import build_query_plan_task, build_scope_task, write_task
+from gaia.research_loop.tasks import (
+    build_query_plan_task,
+    build_scope_task,
+    build_search_execution_task,
+    write_task,
+)
 
 
 def status_payload(pkg: str | Path) -> dict[str, Any]:
@@ -53,9 +58,12 @@ def next_payload(pkg: str | Path) -> dict[str, Any]:
     if state.last_validation_error is not None:
         return _repair_task_payload(paths, state.last_validation_error)
     scope_path = paths.explore_artifacts / "scope.json"
-    if scope_path.exists():
+    query_plan_path = paths.explore_artifacts / "query_plan.json"
+    if not scope_path.exists():
+        return emit_task(pkg, kind=TaskKind.SCOPE)
+    if not query_plan_path.exists():
         return emit_task(pkg, kind=TaskKind.QUERY_PLAN)
-    return emit_task(pkg, kind=TaskKind.SCOPE)
+    return emit_task(pkg, kind=TaskKind.SEARCH_EXECUTION)
 
 
 def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
@@ -68,6 +76,11 @@ def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
         if not scope_path.exists():
             raise FileNotFoundError("scope.json is required for query-plan task")
         task, task_path = build_query_plan_task(paths, read_json(scope_path))
+    elif kind == TaskKind.SEARCH_EXECUTION:
+        query_plan_path = paths.explore_artifacts / "query_plan.json"
+        if not query_plan_path.exists():
+            raise FileNotFoundError("query_plan.json is required for search-execution task")
+        task, task_path = build_search_execution_task(paths, read_json(query_plan_path))
     else:
         raise ValueError(f"Primitive task {kind.value} is not implemented yet")
     write_task(task, task_path)

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -12,6 +12,7 @@ from gaia.research_loop.schemas import (
     AssessmentContextCandidatePayload,
     CandidateEnvelope,
     EvidenceDiagnosisCandidatePayload,
+    EvidenceRef,
     FocusSynthesisCandidatePayload,
     QueryPlanCandidatePayload,
     RepairContext,
@@ -66,6 +67,11 @@ def next_payload(pkg: str | Path) -> dict[str, Any]:
     if state.last_validation_error is not None:
         return _repair_task_payload(paths, state.last_validation_error)
     explore_gate_path = paths.explore_artifacts / "explore_gate.json"
+    focuses_path = paths.explore_artifacts / "focuses.json"
+    if not _gate_passed(explore_gate_path) and focuses_path.exists():
+        gate = gate_payload(pkg, stage="explore")
+        if gate.get("status") == "pass":
+            return next_payload(pkg)
     if _gate_passed(explore_gate_path):
         assessment_context_path = paths.assess_artifacts / "assessment_context.json"
         evidence_diagnosis_path = paths.assess_artifacts / "evidence_diagnosis.json"
@@ -73,20 +79,34 @@ def next_payload(pkg: str | Path) -> dict[str, Any]:
             return emit_task(pkg, kind=TaskKind.ASSESSMENT_CONTEXT)
         if not evidence_diagnosis_path.exists():
             return emit_task(pkg, kind=TaskKind.EVIDENCE_DIAGNOSIS)
+        assess_gate_path = paths.assess_artifacts / "assess_gate.json"
+        if not _gate_passed(assess_gate_path):
+            gate = gate_payload(pkg, stage="assess")
+            if gate.get("status") != "pass":
+                return emit_task(pkg, kind=TaskKind.EVIDENCE_DIAGNOSIS)
+        return _done_payload()
     scope_path = paths.explore_artifacts / "scope.json"
-    query_plan_path = paths.explore_artifacts / "query_plan.json"
-    landscape_path = paths.explore_artifacts / "landscape-0000.json"
-    focuses_path = paths.explore_artifacts / "focuses.json"
     if not scope_path.exists():
         return emit_task(pkg, kind=TaskKind.SCOPE)
-    if not query_plan_path.exists():
-        return emit_task(pkg, kind=TaskKind.QUERY_PLAN)
-    if landscape_path.exists() and not focuses_path.exists():
-        return emit_task(pkg, kind=TaskKind.FOCUS_SYNTHESIS)
-    return emit_task(pkg, kind=TaskKind.SEARCH_EXECUTION)
+    if not focuses_path.exists():
+        kind, round_number = _next_explore_task(paths)
+        return emit_task(pkg, kind=kind, round_number=round_number)
+    return emit_task(pkg, kind=TaskKind.SEARCH_EXECUTION, round_number=_next_round(paths))
 
 
-def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
+def _done_payload() -> dict[str, Any]:
+    return {
+        "recommended_action": "done",
+        "allowed_actions": ["done", "stop"],
+        "rationale": "Explore and Assess gates passed.",
+        "task_path": None,
+        "submit_command": None,
+    }
+
+
+def emit_task(
+    pkg: str | Path, *, kind: TaskKind, round_number: int | None = None
+) -> dict[str, Any]:
     """Emit one specific task envelope without consulting the full loop router."""
     paths = ensure_loop_dirs(pkg)
     if kind == TaskKind.SCOPE:
@@ -95,29 +115,58 @@ def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
         scope_path = paths.explore_artifacts / "scope.json"
         if not scope_path.exists():
             raise FileNotFoundError("scope.json is required for query-plan task")
-        task, task_path = build_query_plan_task(paths, read_json(scope_path))
+        selected_round = _next_round(paths) if round_number is None else round_number
+        task, task_path = build_query_plan_task(
+            paths,
+            read_json(scope_path),
+            round_number=selected_round,
+            prior_focus_synthesis=_latest_focus_synthesis(paths),
+        )
     elif kind == TaskKind.SEARCH_EXECUTION:
-        query_plan_path = paths.explore_artifacts / "query_plan.json"
+        selected_round = _latest_query_plan_round(paths) if round_number is None else round_number
+        query_plan_path = _query_plan_path(paths, selected_round)
         if not query_plan_path.exists():
-            raise FileNotFoundError("query_plan.json is required for search-execution task")
-        task, task_path = build_search_execution_task(paths, read_json(query_plan_path))
+            raise FileNotFoundError(f"{query_plan_path.name} is required for search-execution task")
+        task, task_path = build_search_execution_task(
+            paths,
+            read_json(query_plan_path),
+            round_number=selected_round,
+        )
     elif kind == TaskKind.FOCUS_SYNTHESIS:
-        landscape_path = paths.explore_artifacts / "landscape-0000.json"
+        selected_round = _latest_landscape_round(paths) if round_number is None else round_number
+        landscape_path = _landscape_path(paths, selected_round)
         if not landscape_path.exists():
-            raise FileNotFoundError("landscape-0000.json is required for focus-synthesis task")
-        task, task_path = build_focus_synthesis_task(paths, read_json(landscape_path))
+            raise FileNotFoundError(f"{landscape_path.name} is required for focus-synthesis task")
+        task, task_path = build_focus_synthesis_task(
+            paths,
+            _cumulative_landscape(paths, selected_round),
+            round_number=selected_round,
+        )
     elif kind == TaskKind.ASSESSMENT_CONTEXT:
         focuses_path = paths.explore_artifacts / "focuses.json"
         if not focuses_path.exists():
             raise FileNotFoundError("focuses.json is required for assessment-context task")
-        task, task_path = build_assessment_context_task(paths, read_json(focuses_path))
+        focuses = read_json(focuses_path)
+        task, task_path = build_assessment_context_task(
+            paths,
+            focuses,
+            evidence_context=_evidence_context_for_focuses(paths, focuses),
+        )
     elif kind == TaskKind.EVIDENCE_DIAGNOSIS:
         context_path = paths.assess_artifacts / "assessment_context.json"
         if not context_path.exists():
             raise FileNotFoundError(
                 "assessment_context.json is required for evidence-diagnosis task"
             )
-        task, task_path = build_evidence_diagnosis_task(paths, read_json(context_path))
+        assessment_context = read_json(context_path)
+        task, task_path = build_evidence_diagnosis_task(
+            paths,
+            assessment_context,
+            evidence_context=_evidence_context_for_refs(
+                paths,
+                assessment_context.get("evidence_refs", []),
+            ),
+        )
     else:
         raise ValueError(f"Primitive task {kind.value} is not implemented yet")
     write_task(task, task_path)
@@ -185,8 +234,15 @@ def _write_candidate_artifact(
         return artifact_path
     if task.kind == TaskKind.QUERY_PLAN:
         query_payload = QueryPlanCandidatePayload.model_validate(candidate.payload)
-        artifact_path = paths.explore_artifacts / "query_plan.json"
-        write_json(artifact_path, query_payload.model_dump(mode="json"))
+        _ensure_refs_allowed(
+            task,
+            [query.source_ref for query in query_payload.queries if query.source_ref is not None],
+        )
+        round_number = _round_from_task_id(task.task_id)
+        artifact_path = _query_plan_write_path(paths, round_number)
+        payload = query_payload.model_dump(mode="json")
+        write_json(artifact_path, payload)
+        write_json(paths.explore_artifacts / "query_plan.json", payload)
         return artifact_path
     if task.kind == TaskKind.SEARCH_EXECUTION:
         search_payload = SearchExecutionCandidatePayload.model_validate(candidate.payload)
@@ -198,28 +254,80 @@ def _write_candidate_artifact(
                 raise FileNotFoundError(f"Search result path does not exist: {raw_path}")
             raw_results.append((result.query, raw_path))
             manifest_results.append({"query": result.query, "path": str(raw_path)})
-        manifest_path = paths.explore_artifacts / "raw_search_manifest.json"
+        round_number = _round_from_task_id(task.task_id)
+        manifest_path = paths.explore_artifacts / f"raw_search_manifest-{round_number:04d}.json"
         write_json(manifest_path, {"results": manifest_results})
-        artifact_path = paths.explore_artifacts / "landscape-0000.json"
+        write_json(
+            paths.explore_artifacts / "raw_search_manifest.json", {"results": manifest_results}
+        )
+        artifact_path = _landscape_path(paths, round_number)
         landscape = build_landscape_from_raw_results(
             paths.pkg,
             raw_results=raw_results,
-            round_number=0,
+            round_number=round_number,
         )
         write_json(artifact_path, landscape)
         return artifact_path
     if task.kind == TaskKind.FOCUS_SYNTHESIS:
         focus_payload = FocusSynthesisCandidatePayload.model_validate(candidate.payload)
+        _ensure_refs_allowed(
+            task,
+            [ref for focus in focus_payload.focuses for ref in focus.evidence_refs],
+        )
+        round_number = _round_from_task_id(task.task_id)
+        payload = focus_payload.model_dump(mode="json")
+        round_path = paths.explore_artifacts / f"focus_synthesis-{round_number:04d}.json"
+        write_json(round_path, payload)
+        if candidate.selected_action == "needs_more_landscape":
+            artifact_path = paths.explore_artifacts / "explore_decision.json"
+            write_json(
+                artifact_path,
+                {
+                    "schema": "gaia.research_loop.artifact.v1",
+                    "stage": "explore",
+                    "action": "needs_more_landscape",
+                    "round": round_number,
+                    "next_round": round_number + 1,
+                    "focus_synthesis_path": str(round_path),
+                    "continue_rationale": focus_payload.continue_rationale,
+                    "next_queries": [
+                        query.model_dump(mode="json") for query in focus_payload.next_queries
+                    ],
+                },
+            )
+            return artifact_path
         artifact_path = paths.explore_artifacts / "focuses.json"
-        write_json(artifact_path, focus_payload.model_dump(mode="json"))
+        write_json(artifact_path, payload)
+        write_json(
+            paths.explore_artifacts / "explore_decision.json",
+            {
+                "schema": "gaia.research_loop.artifact.v1",
+                "stage": "explore",
+                "action": "submit_focuses",
+                "round": round_number,
+                "focuses_path": str(artifact_path),
+            },
+        )
         return artifact_path
     if task.kind == TaskKind.ASSESSMENT_CONTEXT:
         context_payload = AssessmentContextCandidatePayload.model_validate(candidate.payload)
+        _ensure_refs_allowed(
+            task,
+            [
+                *context_payload.evidence_refs,
+                *context_payload.supporting_refs,
+                *context_payload.opposing_refs,
+            ],
+        )
         artifact_path = paths.assess_artifacts / "assessment_context.json"
         write_json(artifact_path, context_payload.model_dump(mode="json"))
         return artifact_path
     if task.kind == TaskKind.EVIDENCE_DIAGNOSIS:
         diagnosis_payload = EvidenceDiagnosisCandidatePayload.model_validate(candidate.payload)
+        _ensure_refs_allowed(
+            task,
+            [ref for item in diagnosis_payload.evidence_items for ref in item.refs],
+        )
         artifact_path = paths.assess_artifacts / "evidence_diagnosis.json"
         write_json(artifact_path, diagnosis_payload.model_dump(mode="json"))
         return artifact_path
@@ -252,7 +360,9 @@ def _assess_gate_payload(paths: ResearchLoopPaths) -> dict[str, Any]:
         write_json(paths.assess_artifacts / "assess_gate.json", payload)
         return payload
     diagnosis = read_json(diagnosis_path)
-    status = "pass" if _diagnosis_is_complete(diagnosis) else "revise"
+    context_path = paths.assess_artifacts / "assessment_context.json"
+    context = read_json(context_path) if context_path.exists() else None
+    status = "pass" if _diagnosis_is_complete(diagnosis, context=context) else "revise"
     payload = {"schema": "gaia.research_loop.gate.v1", "stage": "assess", "status": status}
     write_json(paths.assess_artifacts / "assess_gate.json", payload)
     return payload
@@ -280,7 +390,13 @@ def _gate_passed(path: Path) -> bool:
     return path.exists() and read_json(path).get("status") == "pass"
 
 
-def _diagnosis_is_complete(diagnosis: dict[str, Any]) -> bool:
+def _diagnosis_is_complete(
+    diagnosis: dict[str, Any],
+    *,
+    context: dict[str, Any] | None = None,
+) -> bool:
+    if context is not None and diagnosis.get("focus_id") != context.get("focus_id"):
+        return False
     evidence_items = diagnosis.get("evidence_items", [])
     limitations = diagnosis.get("limitations", [])
     gaps = diagnosis.get("gap_map", [])
@@ -298,9 +414,265 @@ def _diagnosis_is_complete(diagnosis: dict[str, Any]) -> bool:
         refs = item.get("refs")
         if not isinstance(refs, list) or not refs:
             return False
+    if not _tensions_are_linked(diagnosis.get("contradictions_or_tensions", [])):
+        return False
     if not isinstance(next_tests, list) or not next_tests:
         return False
     return all(isinstance(test, dict) and test.get("gap_id") in gap_ids for test in next_tests)
+
+
+def _tensions_are_linked(tensions: Any) -> bool:
+    if not isinstance(tensions, list):
+        return False
+    for tension in tensions:
+        if not isinstance(tension, dict):
+            return False
+        linked: set[str] = set()
+        for field in ["evidence_item_ids", "evidence_ids", "claim_ids", "refs"]:
+            value = tension.get(field, [])
+            if isinstance(value, list):
+                linked.update(str(item) for item in value)
+        if len(linked) < 2:
+            return False
+    return True
+
+
+def _ensure_refs_allowed(task: ResearchLoopTask, refs: list[EvidenceRef]) -> None:
+    allowed = {(ref.kind, ref.id) for ref in task.allowed_refs}
+    for ref in refs:
+        if (ref.kind, ref.id) not in allowed:
+            raise ValueError(f"Reference {ref.kind}:{ref.id} is not allowed by task")
+
+
+def _next_explore_task(paths: ResearchLoopPaths) -> tuple[TaskKind, int]:
+    latest_query = _latest_round(paths, "query_plan")
+    latest_landscape = _latest_round(paths, "landscape")
+    latest_focus = _latest_round(paths, "focus_synthesis")
+    if latest_query is None:
+        return TaskKind.QUERY_PLAN, 0
+    if latest_landscape is None or latest_query > latest_landscape:
+        return TaskKind.SEARCH_EXECUTION, latest_query
+    if latest_focus is None or latest_landscape > latest_focus:
+        return TaskKind.FOCUS_SYNTHESIS, latest_landscape
+    decision_path = paths.explore_artifacts / "explore_decision.json"
+    if decision_path.exists():
+        decision = read_json(decision_path)
+        if decision.get("action") == "needs_more_landscape":
+            next_round = int(decision.get("next_round", latest_landscape + 1))
+            if latest_query < next_round:
+                return TaskKind.QUERY_PLAN, next_round
+            if latest_landscape < next_round:
+                return TaskKind.SEARCH_EXECUTION, next_round
+            return TaskKind.FOCUS_SYNTHESIS, next_round
+    return TaskKind.FOCUS_SYNTHESIS, latest_landscape
+
+
+def _next_round(paths: ResearchLoopPaths) -> int:
+    latest_landscape = _latest_landscape_round(paths)
+    decision_path = paths.explore_artifacts / "explore_decision.json"
+    if decision_path.exists():
+        decision = read_json(decision_path)
+        if decision.get("action") == "needs_more_landscape":
+            return int(decision.get("next_round", latest_landscape + 1))
+    return 0 if latest_landscape < 0 else latest_landscape + 1
+
+
+def _latest_query_plan_round(paths: ResearchLoopPaths) -> int:
+    return _latest_round(paths, "query_plan") or 0
+
+
+def _latest_landscape_round(paths: ResearchLoopPaths) -> int:
+    latest = _latest_round(paths, "landscape")
+    return -1 if latest is None else latest
+
+
+def _latest_focus_synthesis(paths: ResearchLoopPaths) -> dict[str, Any] | None:
+    latest = _latest_round(paths, "focus_synthesis")
+    if latest is None:
+        return None
+    return read_json(paths.explore_artifacts / f"focus_synthesis-{latest:04d}.json")
+
+
+def _query_plan_path(paths: ResearchLoopPaths, round_number: int) -> Path:
+    numbered = paths.explore_artifacts / f"query_plan-{round_number:04d}.json"
+    if numbered.exists() or round_number != 0:
+        return numbered
+    return paths.explore_artifacts / "query_plan.json"
+
+
+def _query_plan_write_path(paths: ResearchLoopPaths, round_number: int) -> Path:
+    return paths.explore_artifacts / f"query_plan-{round_number:04d}.json"
+
+
+def _landscape_path(paths: ResearchLoopPaths, round_number: int) -> Path:
+    return paths.explore_artifacts / f"landscape-{round_number:04d}.json"
+
+
+def _cumulative_landscape(paths: ResearchLoopPaths, round_number: int) -> dict[str, Any]:
+    landscape = dict(read_json(_landscape_path(paths, round_number)))
+    paper_leads: list[dict[str, Any]] = []
+    claim_leads: list[dict[str, Any]] = []
+    raw_results: list[dict[str, Any]] = []
+    evidence_snippets: list[dict[str, Any]] = []
+    seen_papers: set[str] = set()
+    seen_claims: set[str] = set()
+    seen_snippets: set[str] = set()
+    source_rounds: list[int] = []
+    for current_round in range(round_number + 1):
+        path = _landscape_path(paths, current_round)
+        if not path.exists():
+            continue
+        source_rounds.append(current_round)
+        current = read_json(path)
+        _append_unique_leads(
+            paper_leads,
+            current.get("paper_leads", []),
+            id_field="paper_id",
+            seen=seen_papers,
+        )
+        _append_unique_leads(
+            claim_leads,
+            current.get("claim_leads", []),
+            id_field="claim_id",
+            seen=seen_claims,
+            fallback_id_field="id",
+        )
+        raw_results.extend(
+            raw_result
+            for raw_result in current.get("raw_results", [])
+            if isinstance(raw_result, dict)
+        )
+        _append_unique_snippets(
+            evidence_snippets, current.get("evidence_snippets", []), seen_snippets
+        )
+    landscape["paper_leads"] = paper_leads
+    landscape["claim_leads"] = claim_leads
+    landscape["raw_results"] = raw_results
+    landscape["evidence_snippets"] = evidence_snippets
+    landscape["source_landscape_rounds"] = source_rounds
+    return landscape
+
+
+def _append_unique_leads(
+    target: list[dict[str, Any]],
+    source: Any,
+    *,
+    id_field: str,
+    seen: set[str],
+    fallback_id_field: str | None = None,
+) -> None:
+    if not isinstance(source, list):
+        return
+    for lead in source:
+        if not isinstance(lead, dict):
+            continue
+        lead_id = lead.get(id_field)
+        if not isinstance(lead_id, str) and fallback_id_field is not None:
+            lead_id = lead.get(fallback_id_field)
+        if not isinstance(lead_id, str) or lead_id in seen:
+            continue
+        seen.add(lead_id)
+        target.append(lead)
+
+
+def _append_unique_snippets(
+    target: list[dict[str, Any]],
+    source: Any,
+    seen: set[str],
+) -> None:
+    if not isinstance(source, list):
+        return
+    for snippet in source:
+        if not isinstance(snippet, dict):
+            continue
+        snippet_key = _snippet_key(snippet)
+        if snippet_key in seen:
+            continue
+        seen.add(snippet_key)
+        target.append(snippet)
+
+
+def _evidence_context_for_focuses(
+    paths: ResearchLoopPaths,
+    focuses: dict[str, Any],
+) -> list[dict[str, Any]]:
+    selected_focus = _selected_focus_from_focuses(focuses)
+    return _evidence_context_for_refs(paths, selected_focus.get("evidence_refs", []))
+
+
+def _selected_focus_from_focuses(focuses: dict[str, Any]) -> dict[str, Any]:
+    selected_ids: set[str] = set()
+    selection = focuses.get("selection")
+    if isinstance(selection, dict):
+        selected = selection.get("selected_focus_ids")
+        if isinstance(selected, list):
+            selected_ids = {item for item in selected if isinstance(item, str)}
+    for focus in focuses.get("focuses", []):
+        if isinstance(focus, dict) and focus.get("focus_id") in selected_ids:
+            return focus
+    return {}
+
+
+def _evidence_context_for_refs(
+    paths: ResearchLoopPaths,
+    refs: Any,
+) -> list[dict[str, Any]]:
+    paper_ids = {
+        ref.get("id")
+        for ref in refs
+        if isinstance(ref, dict) and ref.get("kind") == "paper" and isinstance(ref.get("id"), str)
+    }
+    if not paper_ids:
+        return []
+    context: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    latest = _latest_landscape_round(paths)
+    if latest < 0:
+        return context
+    for round_number in range(latest + 1):
+        path = _landscape_path(paths, round_number)
+        if not path.exists():
+            continue
+        landscape = read_json(path)
+        for snippet in landscape.get("evidence_snippets", []):
+            if not isinstance(snippet, dict) or snippet.get("paper_id") not in paper_ids:
+                continue
+            snippet_key = _snippet_key(snippet)
+            if snippet_key in seen:
+                continue
+            seen.add(snippet_key)
+            context.append(snippet)
+    return context
+
+
+def _snippet_key(snippet: dict[str, Any]) -> str:
+    node_id = snippet.get("lkm_node_id")
+    if isinstance(node_id, str) and node_id:
+        return node_id
+    return f"{snippet.get('paper_id')}::{snippet.get('content')}"
+
+
+def _latest_round(paths: ResearchLoopPaths, prefix: str) -> int | None:
+    rounds: list[int] = []
+    for path in paths.explore_artifacts.glob(f"{prefix}-[0-9][0-9][0-9][0-9].json"):
+        try:
+            rounds.append(int(path.stem.rsplit("-", maxsplit=1)[1]))
+        except (IndexError, ValueError):
+            continue
+    if (
+        prefix == "query_plan"
+        and not rounds
+        and (paths.explore_artifacts / "query_plan.json").exists()
+    ):
+        rounds.append(0)
+    return max(rounds) if rounds else None
+
+
+def _round_from_task_id(task_id: str) -> int:
+    try:
+        return int(task_id.rsplit("-", maxsplit=1)[1]) - 1
+    except (IndexError, ValueError) as exc:
+        raise ValueError(f"Task id does not include a round ordinal: {task_id}") from exc
 
 
 def _record_validation_failure(

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -1,0 +1,24 @@
+"""State-machine helpers for the Gaia research loop CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from gaia.research_loop.storage import ensure_loop_dirs, load_events, rebuild_state
+
+
+def status_payload(pkg: str | Path) -> dict[str, Any]:
+    """Return a JSON-compatible research-loop status payload."""
+    paths = ensure_loop_dirs(pkg)
+    state = rebuild_state(paths)
+    events = load_events(paths)
+    return {
+        "schema": state.schema_id,
+        "phase": state.phase,
+        "root": str(paths.root),
+        "latest_task_by_stage": state.latest_task_by_stage,
+        "latest_artifact_by_stage": state.latest_artifact_by_stage,
+        "event_count": len(events),
+        "recommended_next": "gaia-research-loop next",
+    }

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from gaia.research_loop.storage import ensure_loop_dirs, load_events, rebuild_state
+from gaia.research_loop.storage import (
+    append_event,
+    ensure_loop_dirs,
+    load_events,
+    read_json,
+    rebuild_state,
+)
+from gaia.research_loop.tasks import build_query_plan_task, build_scope_task, write_task
 
 
 def status_payload(pkg: str | Path) -> dict[str, Any]:
@@ -21,4 +28,29 @@ def status_payload(pkg: str | Path) -> dict[str, Any]:
         "latest_artifact_by_stage": state.latest_artifact_by_stage,
         "event_count": len(events),
         "recommended_next": "gaia-research-loop next",
+    }
+
+
+def next_payload(pkg: str | Path) -> dict[str, Any]:
+    """Emit the next recommended task envelope."""
+    paths = ensure_loop_dirs(pkg)
+    scope_path = paths.explore_artifacts / "scope.json"
+    if scope_path.exists():
+        task, task_path = build_query_plan_task(paths, read_json(scope_path))
+    else:
+        task, task_path = build_scope_task(paths)
+    write_task(task, task_path)
+    append_event(
+        paths,
+        event_type="task_emitted",
+        stage=task.stage,
+        data={"task_id": task.task_id, "kind": task.kind.value, "task_path": str(task_path)},
+    )
+    rebuild_state(paths)
+    return {
+        "recommended_action": task.recommended_action,
+        "allowed_actions": task.allowed_actions,
+        "task_path": str(task_path),
+        "submit_command": task.submit_command,
+        "rationale": task.objective,
     }

--- a/gaia/research_loop/engine.py
+++ b/gaia/research_loop/engine.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from gaia.research_loop.lkm_adapter import build_landscape_from_raw_results
 from gaia.research_loop.schemas import (
     CandidateEnvelope,
+    FocusSynthesisCandidatePayload,
     QueryPlanCandidatePayload,
     RepairContext,
     ResearchLoopTask,
@@ -30,6 +31,7 @@ from gaia.research_loop.storage import (
     write_json,
 )
 from gaia.research_loop.tasks import (
+    build_focus_synthesis_task,
     build_query_plan_task,
     build_scope_task,
     build_search_execution_task,
@@ -61,10 +63,14 @@ def next_payload(pkg: str | Path) -> dict[str, Any]:
         return _repair_task_payload(paths, state.last_validation_error)
     scope_path = paths.explore_artifacts / "scope.json"
     query_plan_path = paths.explore_artifacts / "query_plan.json"
+    landscape_path = paths.explore_artifacts / "landscape-0000.json"
+    focuses_path = paths.explore_artifacts / "focuses.json"
     if not scope_path.exists():
         return emit_task(pkg, kind=TaskKind.SCOPE)
     if not query_plan_path.exists():
         return emit_task(pkg, kind=TaskKind.QUERY_PLAN)
+    if landscape_path.exists() and not focuses_path.exists():
+        return emit_task(pkg, kind=TaskKind.FOCUS_SYNTHESIS)
     return emit_task(pkg, kind=TaskKind.SEARCH_EXECUTION)
 
 
@@ -83,6 +89,11 @@ def emit_task(pkg: str | Path, *, kind: TaskKind) -> dict[str, Any]:
         if not query_plan_path.exists():
             raise FileNotFoundError("query_plan.json is required for search-execution task")
         task, task_path = build_search_execution_task(paths, read_json(query_plan_path))
+    elif kind == TaskKind.FOCUS_SYNTHESIS:
+        landscape_path = paths.explore_artifacts / "landscape-0000.json"
+        if not landscape_path.exists():
+            raise FileNotFoundError("landscape-0000.json is required for focus-synthesis task")
+        task, task_path = build_focus_synthesis_task(paths, read_json(landscape_path))
     else:
         raise ValueError(f"Primitive task {kind.value} is not implemented yet")
     write_task(task, task_path)
@@ -173,7 +184,47 @@ def _write_candidate_artifact(
         )
         write_json(artifact_path, landscape)
         return artifact_path
+    if task.kind == TaskKind.FOCUS_SYNTHESIS:
+        focus_payload = FocusSynthesisCandidatePayload.model_validate(candidate.payload)
+        artifact_path = paths.explore_artifacts / "focuses.json"
+        write_json(artifact_path, focus_payload.model_dump(mode="json"))
+        return artifact_path
     raise ValueError(f"No payload validator for {task.kind.value}")
+
+
+def gate_payload(pkg: str | Path, *, stage: str) -> dict[str, Any]:
+    """Run a structural stage gate."""
+    paths = ensure_loop_dirs(pkg)
+    if stage != "explore":
+        raise ValueError(f"Unsupported gate stage: {stage}")
+    focuses_path = paths.explore_artifacts / "focuses.json"
+    if not focuses_path.exists():
+        payload = {"schema": "gaia.research_loop.gate.v1", "stage": stage, "status": "revise"}
+        write_json(paths.explore_artifacts / "explore_gate.json", payload)
+        return payload
+    focuses = read_json(focuses_path)
+    status = "pass" if _has_selected_ready_focus(focuses) else "revise"
+    payload = {"schema": "gaia.research_loop.gate.v1", "stage": stage, "status": status}
+    write_json(paths.explore_artifacts / "explore_gate.json", payload)
+    return payload
+
+
+def _has_selected_ready_focus(focuses: dict[str, Any]) -> bool:
+    selection = focuses.get("selection")
+    selected_ids = set()
+    if isinstance(selection, dict):
+        selected = selection.get("selected_focus_ids", [])
+        if isinstance(selected, list):
+            selected_ids = {item for item in selected if isinstance(item, str)}
+    for focus in focuses.get("focuses", []):
+        if not isinstance(focus, dict):
+            continue
+        if focus.get("focus_id") not in selected_ids:
+            continue
+        refs = focus.get("evidence_refs", [])
+        if focus.get("ready_for_assess") is True and isinstance(refs, list) and refs:
+            return True
+    return False
 
 
 def _record_validation_failure(

--- a/gaia/research_loop/lkm_adapter.py
+++ b/gaia/research_loop/lkm_adapter.py
@@ -19,12 +19,14 @@ def build_landscape_from_raw_results(
     """Build a research-loop landscape artifact from saved LKM search JSON."""
     batches: list[LandscapeBatch] = []
     raw_refs: list[dict[str, str]] = []
+    evidence_snippets: list[dict[str, Any]] = []
     for query, path in raw_results:
         payload = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             raise ValueError(f"Expected JSON object at {path}")
         batches.append(LandscapeBatch(search_results=payload, query=query, path=str(path)))
         raw_refs.append({"query": query, "path": str(path)})
+        evidence_snippets.extend(_evidence_snippets_from_search(payload, query=query))
 
     landscape = build_landscape(
         batches,
@@ -33,15 +35,77 @@ def build_landscape_from_raw_results(
         exploration_map=None,
     ).to_dict()
     paper_leads = landscape.get("paper_leads", [])
+    if isinstance(paper_leads, list):
+        paper_leads = _attach_snippets_to_paper_leads(paper_leads, evidence_snippets)
+    else:
+        paper_leads = []
     return {
         "schema": ARTIFACT_SCHEMA,
         "kind": "landscape",
         "round": round_number,
         "pkg": str(Path(pkg).resolve()),
         "raw_results": raw_refs,
-        "paper_leads": paper_leads if isinstance(paper_leads, list) else [],
+        "paper_leads": paper_leads,
+        "evidence_snippets": evidence_snippets,
         "coverage": {
-            "paper_count": len(paper_leads) if isinstance(paper_leads, list) else 0,
+            "paper_count": len(paper_leads),
+            "snippet_count": len(evidence_snippets),
         },
         "source_landscape": landscape,
     }
+
+
+def _evidence_snippets_from_search(payload: dict[str, Any], *, query: str) -> list[dict[str, Any]]:
+    snippets: list[dict[str, Any]] = []
+    results = payload.get("results", [])
+    if not isinstance(results, list):
+        return snippets
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        content = result.get("content")
+        source = result.get("source", {})
+        if not isinstance(content, str) or not content.strip() or not isinstance(source, dict):
+            continue
+        paper_id = source.get("paper_id")
+        if not isinstance(paper_id, str) or not paper_id:
+            continue
+        rank = result.get("rank", {})
+        snippets.append(
+            {
+                "paper_id": paper_id,
+                "paper_title": source.get("paper_title"),
+                "doi": source.get("doi"),
+                "lkm_node_id": result.get("id"),
+                "kind": result.get("kind"),
+                "role": source.get("role"),
+                "local_id": source.get("local_id"),
+                "query": query,
+                "rank_score": rank.get("score") if isinstance(rank, dict) else None,
+                "content": content,
+            }
+        )
+    return snippets
+
+
+def _attach_snippets_to_paper_leads(
+    paper_leads: list[Any],
+    evidence_snippets: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    snippets_by_paper: dict[str, list[dict[str, Any]]] = {}
+    for snippet in evidence_snippets:
+        paper_id = snippet.get("paper_id")
+        if isinstance(paper_id, str):
+            snippets_by_paper.setdefault(paper_id, []).append(snippet)
+
+    enriched: list[dict[str, Any]] = []
+    for lead in paper_leads:
+        if not isinstance(lead, dict):
+            continue
+        copy = dict(lead)
+        paper_id = copy.get("paper_id")
+        snippets = snippets_by_paper.get(paper_id, []) if isinstance(paper_id, str) else []
+        copy["evidence_snippets"] = snippets[:3]
+        copy["snippet_count"] = len(snippets)
+        enriched.append(copy)
+    return enriched

--- a/gaia/research_loop/lkm_adapter.py
+++ b/gaia/research_loop/lkm_adapter.py
@@ -1,0 +1,47 @@
+"""LKM-specific adapters for Gaia research loop artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from gaia.lkm_explorer.engine.landscape import LandscapeBatch, build_landscape
+from gaia.research_loop.schemas import ARTIFACT_SCHEMA
+
+
+def build_landscape_from_raw_results(
+    pkg: str | Path,
+    *,
+    raw_results: list[tuple[str, Path]],
+    round_number: int,
+) -> dict[str, Any]:
+    """Build a research-loop landscape artifact from saved LKM search JSON."""
+    batches: list[LandscapeBatch] = []
+    raw_refs: list[dict[str, str]] = []
+    for query, path in raw_results:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Expected JSON object at {path}")
+        batches.append(LandscapeBatch(search_results=payload, query=query, path=str(path)))
+        raw_refs.append({"query": query, "path": str(path)})
+
+    landscape = build_landscape(
+        batches,
+        materialized=set(),
+        materialized_paper_ids=set(),
+        exploration_map=None,
+    ).to_dict()
+    paper_leads = landscape.get("paper_leads", [])
+    return {
+        "schema": ARTIFACT_SCHEMA,
+        "kind": "landscape",
+        "round": round_number,
+        "pkg": str(Path(pkg).resolve()),
+        "raw_results": raw_refs,
+        "paper_leads": paper_leads if isinstance(paper_leads, list) else [],
+        "coverage": {
+            "paper_count": len(paper_leads) if isinstance(paper_leads, list) else 0,
+        },
+        "source_landscape": landscape,
+    }

--- a/gaia/research_loop/schemas.py
+++ b/gaia/research_loop/schemas.py
@@ -108,6 +108,37 @@ class CandidateEnvelope(BaseModel):
             raise ValueError("override_rationale is required when overriding recommendation")
 
 
+class ScopeCandidatePayload(BaseModel):
+    """Structured scope proposed by an agent or human."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    seed_question: str
+    domain_profile: str | None = None
+    scope_dimensions: dict[str, list[str]] = Field(default_factory=dict)
+    search_budget: int = 5
+
+
+class PlannedQuery(BaseModel):
+    """One planned LKM query."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    query: str
+    purpose: str
+    expected_evidence_family: str | None = None
+    source_ref: EvidenceRef | None = None
+
+
+class QueryPlanCandidatePayload(BaseModel):
+    """Agent-proposed query plan for the next landscape round."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    queries: list[PlannedQuery]
+    rationale: str
+
+
 class ResearchLoopEvent(BaseModel):
     """Append-only audit event for research loop activity."""
 

--- a/gaia/research_loop/schemas.py
+++ b/gaia/research_loop/schemas.py
@@ -1,0 +1,100 @@
+"""Schemas for the agent-facing Gaia research loop protocol."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TASK_SCHEMA: Literal["gaia.research_loop.task.v1"] = "gaia.research_loop.task.v1"
+CANDIDATE_SCHEMA: Literal["gaia.research_loop.candidate.v1"] = "gaia.research_loop.candidate.v1"
+ARTIFACT_SCHEMA = "gaia.research_loop.artifact.v1"
+GATE_SCHEMA = "gaia.research_loop.gate.v1"
+
+Stage = Literal["explore", "assess"]
+
+
+class TaskKind(StrEnum):
+    """Research loop task kinds."""
+
+    SCOPE = "scope"
+    QUERY_PLAN = "query_plan"
+    SEARCH_EXECUTION = "search_execution"
+    FOCUS_SYNTHESIS = "focus_synthesis"
+    EXPLORE_GATE = "explore_gate"
+    ASSESSMENT_CONTEXT = "assessment_context"
+    EVIDENCE_DIAGNOSIS = "evidence_diagnosis"
+    ASSESS_GATE = "assess_gate"
+
+
+class EvidenceRef(BaseModel):
+    """A grounded source reference that a task or candidate may cite."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    id: str
+    role: str | None = None
+
+
+class RepairContext(BaseModel):
+    """Validation failure context for retrying the same task."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    failed_candidate_path: str
+    errors: list[dict[str, Any]]
+    instruction: str
+    preserved_fields: dict[str, Any] = Field(default_factory=dict)
+
+
+class ResearchLoopTask(BaseModel):
+    """Self-contained task envelope emitted to an external agent."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_id: Literal["gaia.research_loop.task.v1"] = Field(default=TASK_SCHEMA, alias="schema")
+    task_id: str
+    stage: Stage
+    kind: TaskKind
+    objective: str
+    inputs: dict[str, Any]
+    instructions: list[str]
+    allowed_actions: list[str]
+    recommended_action: str
+    output_contract: dict[str, Any]
+    allowed_refs: list[EvidenceRef] = Field(default_factory=list)
+    minimal_example: dict[str, Any]
+    submit_command: str
+    validation: dict[str, Any] = Field(default_factory=dict)
+    repair_context: RepairContext | None = None
+
+
+class CandidateEnvelope(BaseModel):
+    """Candidate output submitted for a research loop task."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_id: Literal["gaia.research_loop.candidate.v1"] = Field(
+        default=CANDIDATE_SCHEMA,
+        alias="schema",
+    )
+    task_id: str
+    stage: Stage
+    kind: TaskKind
+    selected_action: str
+    override_rationale: str | None = None
+    payload: dict[str, Any]
+
+    def validate_against_actions(
+        self,
+        *,
+        recommended_action: str,
+        allowed_actions: list[str],
+    ) -> None:
+        """Validate action choice against the task recommendation."""
+        if self.selected_action not in allowed_actions:
+            raise ValueError(f"selected_action {self.selected_action!r} is not allowed")
+        if self.selected_action != recommended_action and not self.override_rationale:
+            raise ValueError("override_rationale is required when overriding recommendation")

--- a/gaia/research_loop/schemas.py
+++ b/gaia/research_loop/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Literal
 
@@ -11,8 +12,15 @@ TASK_SCHEMA: Literal["gaia.research_loop.task.v1"] = "gaia.research_loop.task.v1
 CANDIDATE_SCHEMA: Literal["gaia.research_loop.candidate.v1"] = "gaia.research_loop.candidate.v1"
 ARTIFACT_SCHEMA = "gaia.research_loop.artifact.v1"
 GATE_SCHEMA = "gaia.research_loop.gate.v1"
+EVENT_SCHEMA: Literal["gaia.research_loop.event.v1"] = "gaia.research_loop.event.v1"
+STATE_SCHEMA: Literal["gaia.research_loop.state.v1"] = "gaia.research_loop.state.v1"
 
 Stage = Literal["explore", "assess"]
+
+
+def utcnow() -> str:
+    """Return a compact UTC timestamp for artifacts and events."""
+    return datetime.now(tz=UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 class TaskKind(StrEnum):
@@ -98,3 +106,27 @@ class CandidateEnvelope(BaseModel):
             raise ValueError(f"selected_action {self.selected_action!r} is not allowed")
         if self.selected_action != recommended_action and not self.override_rationale:
             raise ValueError("override_rationale is required when overriding recommendation")
+
+
+class ResearchLoopEvent(BaseModel):
+    """Append-only audit event for research loop activity."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_id: Literal["gaia.research_loop.event.v1"] = Field(default=EVENT_SCHEMA, alias="schema")
+    created_at: str = Field(default_factory=utcnow)
+    event_type: str
+    stage: Stage | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ResearchLoopState(BaseModel):
+    """Rebuildable navigation state for a research loop package."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_id: Literal["gaia.research_loop.state.v1"] = Field(default=STATE_SCHEMA, alias="schema")
+    phase: str = "idle"
+    latest_task_by_stage: dict[str, str] = Field(default_factory=dict)
+    latest_artifact_by_stage: dict[str, str] = Field(default_factory=dict)
+    last_validation_error: dict[str, Any] | None = None

--- a/gaia/research_loop/schemas.py
+++ b/gaia/research_loop/schemas.py
@@ -186,6 +186,8 @@ class FocusSynthesisCandidatePayload(BaseModel):
 
     focuses: list[FocusRecord]
     selection: FocusSelection | None = None
+    next_queries: list[PlannedQuery] = Field(default_factory=list)
+    continue_rationale: str | None = None
 
 
 class AssessmentContextCandidatePayload(BaseModel):
@@ -195,6 +197,10 @@ class AssessmentContextCandidatePayload(BaseModel):
 
     focus_id: str
     evidence_refs: list[EvidenceRef] = Field(default_factory=list)
+    supporting_refs: list[EvidenceRef] = Field(default_factory=list)
+    opposing_refs: list[EvidenceRef] = Field(default_factory=list)
+    known_gaps: list[str] = Field(default_factory=list)
+    assessment_mode: str | None = None
 
 
 class EvidenceItem(BaseModel):
@@ -204,6 +210,10 @@ class EvidenceItem(BaseModel):
 
     id: str
     refs: list[EvidenceRef]
+    summary: str | None = None
+    claim: str | None = None
+    evidence_family: str | None = None
+    confidence_note: str | None = None
 
 
 class GapMapEntry(BaseModel):
@@ -231,10 +241,13 @@ class EvidenceDiagnosisCandidatePayload(BaseModel):
 
     focus_id: str
     evidence_items: list[EvidenceItem]
+    candidate_claims: list[dict[str, Any]] = Field(default_factory=list)
     contradictions_or_tensions: list[dict[str, Any]] = Field(default_factory=list)
     limitations: list[str]
+    missing_evidence: list[str] = Field(default_factory=list)
     gap_map: list[GapMapEntry]
     next_tests: list[NextTest]
+    confidence_notes: list[str] = Field(default_factory=list)
 
 
 class ResearchLoopEvent(BaseModel):

--- a/gaia/research_loop/schemas.py
+++ b/gaia/research_loop/schemas.py
@@ -139,6 +139,23 @@ class QueryPlanCandidatePayload(BaseModel):
     rationale: str
 
 
+class SearchResultPath(BaseModel):
+    """Raw search result path produced by a mechanical search execution task."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    query: str
+    path: str
+
+
+class SearchExecutionCandidatePayload(BaseModel):
+    """Submitted raw result paths after running planned LKM searches."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    results: list[SearchResultPath]
+
+
 class ResearchLoopEvent(BaseModel):
     """Append-only audit event for research loop activity."""
 

--- a/gaia/research_loop/schemas.py
+++ b/gaia/research_loop/schemas.py
@@ -156,6 +156,38 @@ class SearchExecutionCandidatePayload(BaseModel):
     results: list[SearchResultPath]
 
 
+class FocusRecord(BaseModel):
+    """One assessment focus synthesized from a landscape."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    focus_id: str
+    research_question: str
+    why_it_matters: str = ""
+    evidence_refs: list[EvidenceRef] = Field(default_factory=list)
+    coverage_status: str = "provisional"
+    ready_for_assess: bool = False
+    recommended_assess_mode: str | None = None
+
+
+class FocusSelection(BaseModel):
+    """Selected focuses for Explore -> Assess handoff."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    selected_focus_ids: list[str]
+    selection_rationale: str | None = None
+
+
+class FocusSynthesisCandidatePayload(BaseModel):
+    """Agent-synthesized focuses and optional selection."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    focuses: list[FocusRecord]
+    selection: FocusSelection | None = None
+
+
 class ResearchLoopEvent(BaseModel):
     """Append-only audit event for research loop activity."""
 

--- a/gaia/research_loop/schemas.py
+++ b/gaia/research_loop/schemas.py
@@ -188,6 +188,55 @@ class FocusSynthesisCandidatePayload(BaseModel):
     selection: FocusSelection | None = None
 
 
+class AssessmentContextCandidatePayload(BaseModel):
+    """Assessment context accepted or refined by an agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    focus_id: str
+    evidence_refs: list[EvidenceRef] = Field(default_factory=list)
+
+
+class EvidenceItem(BaseModel):
+    """One evidence row in an assessment diagnosis."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    refs: list[EvidenceRef]
+
+
+class GapMapEntry(BaseModel):
+    """One remaining assessment gap."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gap_id: str
+    description: str
+
+
+class NextTest(BaseModel):
+    """One proposed next test tied to a gap."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gap_id: str
+    test: str
+
+
+class EvidenceDiagnosisCandidatePayload(BaseModel):
+    """Agent-authored evidence diagnosis for one selected focus."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    focus_id: str
+    evidence_items: list[EvidenceItem]
+    contradictions_or_tensions: list[dict[str, Any]] = Field(default_factory=list)
+    limitations: list[str]
+    gap_map: list[GapMapEntry]
+    next_tests: list[NextTest]
+
+
 class ResearchLoopEvent(BaseModel):
     """Append-only audit event for research loop activity."""
 

--- a/gaia/research_loop/storage.py
+++ b/gaia/research_loop/storage.py
@@ -1,0 +1,131 @@
+"""Storage helpers for canonical research loop artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gaia.research_loop.schemas import ResearchLoopEvent, ResearchLoopState, Stage
+
+
+@dataclass(frozen=True)
+class ResearchLoopPaths:
+    """Canonical paths under ``<pkg>/.gaia/research_loop``."""
+
+    pkg: Path
+    root: Path
+    state: Path
+    events: Path
+    explore_tasks: Path
+    explore_candidates: Path
+    explore_artifacts: Path
+    assess_tasks: Path
+    assess_candidates: Path
+    assess_artifacts: Path
+
+
+def loop_paths(pkg: str | Path) -> ResearchLoopPaths:
+    """Return canonical research-loop paths for a package."""
+    pkg_path = Path(pkg).resolve()
+    root = pkg_path / ".gaia" / "research_loop"
+    return ResearchLoopPaths(
+        pkg=pkg_path,
+        root=root,
+        state=root / "state.json",
+        events=root / "events.jsonl",
+        explore_tasks=root / "explore" / "tasks",
+        explore_candidates=root / "explore" / "candidates",
+        explore_artifacts=root / "explore" / "artifacts",
+        assess_tasks=root / "assess" / "tasks",
+        assess_candidates=root / "assess" / "candidates",
+        assess_artifacts=root / "assess" / "artifacts",
+    )
+
+
+def ensure_loop_dirs(pkg: str | Path) -> ResearchLoopPaths:
+    """Create the canonical research-loop directory layout."""
+    paths = loop_paths(pkg)
+    for directory in [
+        paths.explore_tasks,
+        paths.explore_candidates,
+        paths.explore_artifacts,
+        paths.assess_tasks,
+        paths.assess_candidates,
+        paths.assess_artifacts,
+    ]:
+        directory.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write deterministic pretty JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    """Read a JSON object from disk."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object at {path}")
+    return payload
+
+
+def append_event(
+    paths: ResearchLoopPaths,
+    *,
+    event_type: str,
+    stage: Stage | None,
+    data: dict[str, Any],
+) -> ResearchLoopEvent:
+    """Append one JSONL audit event."""
+    event = ResearchLoopEvent(event_type=event_type, stage=stage, data=data)
+    paths.events.parent.mkdir(parents=True, exist_ok=True)
+    with paths.events.open("a", encoding="utf-8") as handle:
+        handle.write(event.model_dump_json(by_alias=True) + "\n")
+    return event
+
+
+def load_events(paths: ResearchLoopPaths) -> list[ResearchLoopEvent]:
+    """Load audit events from JSONL."""
+    if not paths.events.exists():
+        return []
+    return [
+        ResearchLoopEvent.model_validate_json(line)
+        for line in paths.events.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _latest_json_path(directory: Path) -> str | None:
+    matches = sorted(directory.glob("*.json"), key=lambda path: path.stat().st_mtime)
+    return str(matches[-1]) if matches else None
+
+
+def rebuild_state(paths: ResearchLoopPaths) -> ResearchLoopState:
+    """Rebuild navigation state from task and artifact files."""
+    state = ResearchLoopState(
+        latest_task_by_stage={
+            stage: path
+            for stage, path in {
+                "explore": _latest_json_path(paths.explore_tasks),
+                "assess": _latest_json_path(paths.assess_tasks),
+            }.items()
+            if path is not None
+        },
+        latest_artifact_by_stage={
+            stage: path
+            for stage, path in {
+                "explore": _latest_json_path(paths.explore_artifacts),
+                "assess": _latest_json_path(paths.assess_artifacts),
+            }.items()
+            if path is not None
+        },
+    )
+    write_json(paths.state, state.model_dump(mode="json", by_alias=True))
+    return state

--- a/gaia/research_loop/storage.py
+++ b/gaia/research_loop/storage.py
@@ -102,6 +102,28 @@ def load_events(paths: ResearchLoopPaths) -> list[ResearchLoopEvent]:
     ]
 
 
+def load_state(paths: ResearchLoopPaths) -> ResearchLoopState:
+    """Load state if present, otherwise rebuild it."""
+    if not paths.state.exists():
+        return rebuild_state(paths)
+    return ResearchLoopState.model_validate(read_json(paths.state))
+
+
+def find_task(paths: ResearchLoopPaths, task_id: str) -> Path:
+    """Find a task envelope by id across loop stages."""
+    for directory in [paths.explore_tasks, paths.assess_tasks]:
+        candidate = directory / f"{task_id}.json"
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"No task envelope found for {task_id}")
+
+
+def candidate_destination(paths: ResearchLoopPaths, stage: Stage, candidate_path: Path) -> Path:
+    """Return the canonical candidate copy path for a stage."""
+    directory = paths.explore_candidates if stage == "explore" else paths.assess_candidates
+    return directory / candidate_path.name
+
+
 def _latest_json_path(directory: Path) -> str | None:
     matches = sorted(directory.glob("*.json"), key=lambda path: path.stat().st_mtime)
     return str(matches[-1]) if matches else None

--- a/gaia/research_loop/tasks.py
+++ b/gaia/research_loop/tasks.py
@@ -1,0 +1,88 @@
+"""Task envelope builders for the Gaia research loop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from gaia.research_loop.schemas import (
+    EvidenceRef,
+    QueryPlanCandidatePayload,
+    ResearchLoopTask,
+    ScopeCandidatePayload,
+    TaskKind,
+)
+from gaia.research_loop.storage import ResearchLoopPaths, write_json
+
+
+def _task_path(paths: ResearchLoopPaths, task_id: str) -> Path:
+    return paths.explore_tasks / f"{task_id}.json"
+
+
+def build_scope_task(paths: ResearchLoopPaths) -> tuple[ResearchLoopTask, Path]:
+    """Build a task asking the agent to create a structured scope."""
+    task_id = "task-scope-0001"
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="explore",
+        kind=TaskKind.SCOPE,
+        objective="Turn the seed research question into a structured exploration scope.",
+        inputs={"pkg": str(paths.pkg)},
+        instructions=[
+            "Identify the seed question and any obvious scope dimensions.",
+            "Keep this lightweight; do not assess evidence yet.",
+        ],
+        allowed_actions=["submit_scope", "stop"],
+        recommended_action="submit_scope",
+        output_contract=ScopeCandidatePayload.model_json_schema(),
+        allowed_refs=[],
+        minimal_example={
+            "task_id": task_id,
+            "stage": "explore",
+            "kind": "scope",
+            "selected_action": "submit_scope",
+            "payload": {"seed_question": "example topic", "search_budget": 3},
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _task_path(paths, task_id)
+
+
+def build_query_plan_task(
+    paths: ResearchLoopPaths,
+    scope: dict[str, Any],
+) -> tuple[ResearchLoopTask, Path]:
+    """Build a task asking the agent to plan the next LKM searches."""
+    task_id = "task-query-plan-0001"
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        objective="Plan the next LKM searches from the current scope and coverage.",
+        inputs={"scope": scope},
+        instructions=[
+            "Propose a small set of LKM search queries.",
+            "Prefer breadth-first coverage over deep paper analysis.",
+        ],
+        allowed_actions=["submit_query_plan", "stop"],
+        recommended_action="submit_query_plan",
+        output_contract=QueryPlanCandidatePayload.model_json_schema(),
+        allowed_refs=[EvidenceRef(kind="scope", id="scope")],
+        minimal_example={
+            "task_id": task_id,
+            "stage": "explore",
+            "kind": "query_plan",
+            "selected_action": "submit_query_plan",
+            "payload": {
+                "queries": [{"query": "example query", "purpose": "cover one evidence family"}],
+                "rationale": "Tiny shape example only.",
+            },
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _task_path(paths, task_id)
+
+
+def write_task(task: ResearchLoopTask, path: Path) -> None:
+    """Write a task envelope to disk."""
+    write_json(path, task.model_dump(mode="json", by_alias=True))

--- a/gaia/research_loop/tasks.py
+++ b/gaia/research_loop/tasks.py
@@ -106,7 +106,10 @@ def build_search_execution_task(
         if not isinstance(query, str) or not query.strip():
             continue
         output_path = paths.explore_artifacts / f"raw-search-0001-{index}.json"
-        command = f"gaia search lkm knowledge {quote(query)} --json > {quote(str(output_path))}"
+        command = (
+            "gaia search lkm knowledge "
+            f"{quote(query)} --format gaia-json --out {quote(str(output_path))}"
+        )
         commands.append(
             {
                 "query": query,

--- a/gaia/research_loop/tasks.py
+++ b/gaia/research_loop/tasks.py
@@ -7,6 +7,8 @@ from shlex import quote
 from typing import Any
 
 from gaia.research_loop.schemas import (
+    AssessmentContextCandidatePayload,
+    EvidenceDiagnosisCandidatePayload,
     EvidenceRef,
     FocusSynthesisCandidatePayload,
     QueryPlanCandidatePayload,
@@ -20,6 +22,10 @@ from gaia.research_loop.storage import ResearchLoopPaths, write_json
 
 def _task_path(paths: ResearchLoopPaths, task_id: str) -> Path:
     return paths.explore_tasks / f"{task_id}.json"
+
+
+def _assess_task_path(paths: ResearchLoopPaths, task_id: str) -> Path:
+    return paths.assess_tasks / f"{task_id}.json"
 
 
 def build_scope_task(paths: ResearchLoopPaths) -> tuple[ResearchLoopTask, Path]:
@@ -177,6 +183,81 @@ def build_focus_synthesis_task(
     return task, _task_path(paths, task_id)
 
 
+def build_assessment_context_task(
+    paths: ResearchLoopPaths,
+    focuses: dict[str, Any],
+) -> tuple[ResearchLoopTask, Path]:
+    """Build an assessment-context task from selected Explore focuses."""
+    task_id = "task-assessment-context-0001"
+    selected_focus = _selected_focus(focuses)
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="assess",
+        kind=TaskKind.ASSESSMENT_CONTEXT,
+        objective="Package the selected focus for evidence diagnosis.",
+        inputs={"focus": selected_focus, "focuses": focuses},
+        instructions=[
+            "Preserve the selected focus id.",
+            "Carry forward only evidence refs grounded by the selected focus.",
+        ],
+        allowed_actions=["submit_assessment_context", "stop"],
+        recommended_action="submit_assessment_context",
+        output_contract=AssessmentContextCandidatePayload.model_json_schema(),
+        allowed_refs=_refs_from_focus(selected_focus),
+        minimal_example={
+            "task_id": task_id,
+            "stage": "assess",
+            "kind": "assessment_context",
+            "selected_action": "submit_assessment_context",
+            "payload": {"focus_id": "focus-example", "evidence_refs": []},
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _assess_task_path(paths, task_id)
+
+
+def build_evidence_diagnosis_task(
+    paths: ResearchLoopPaths,
+    assessment_context: dict[str, Any],
+) -> tuple[ResearchLoopTask, Path]:
+    """Build an evidence-diagnosis task from an assessment context."""
+    task_id = "task-evidence-diagnosis-0001"
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="assess",
+        kind=TaskKind.EVIDENCE_DIAGNOSIS,
+        objective="Diagnose the evidence, tensions, limitations, gaps, and next tests.",
+        inputs={"assessment_context": assessment_context},
+        instructions=[
+            "Ground every evidence item in allowed refs.",
+            "Tie each next test to a gap id.",
+        ],
+        allowed_actions=["submit_evidence_diagnosis", "stop"],
+        recommended_action="submit_evidence_diagnosis",
+        output_contract=EvidenceDiagnosisCandidatePayload.model_json_schema(),
+        allowed_refs=[
+            EvidenceRef.model_validate(ref)
+            for ref in assessment_context.get("evidence_refs", [])
+            if isinstance(ref, dict)
+        ],
+        minimal_example={
+            "task_id": task_id,
+            "stage": "assess",
+            "kind": "evidence_diagnosis",
+            "selected_action": "submit_evidence_diagnosis",
+            "payload": {
+                "focus_id": "focus-example",
+                "evidence_items": [{"id": "e1", "refs": []}],
+                "limitations": ["Example limitation."],
+                "gap_map": [{"gap_id": "g1", "description": "Example gap."}],
+                "next_tests": [{"gap_id": "g1", "test": "Example test."}],
+            },
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _assess_task_path(paths, task_id)
+
+
 def _paper_refs_from_landscape(landscape: dict[str, Any]) -> list[EvidenceRef]:
     refs: list[EvidenceRef] = []
     for lead in landscape.get("paper_leads", []):
@@ -185,6 +266,27 @@ def _paper_refs_from_landscape(landscape: dict[str, Any]) -> list[EvidenceRef]:
         paper_id = lead.get("paper_id")
         if isinstance(paper_id, str) and paper_id:
             refs.append(EvidenceRef(kind="paper", id=paper_id))
+    return refs
+
+
+def _selected_focus(focuses: dict[str, Any]) -> dict[str, Any]:
+    selected_ids: set[str] = set()
+    selection = focuses.get("selection")
+    if isinstance(selection, dict):
+        selected = selection.get("selected_focus_ids")
+        if isinstance(selected, list):
+            selected_ids = {item for item in selected if isinstance(item, str)}
+    for focus in focuses.get("focuses", []):
+        if isinstance(focus, dict) and focus.get("focus_id") in selected_ids:
+            return focus
+    return {}
+
+
+def _refs_from_focus(focus: dict[str, Any]) -> list[EvidenceRef]:
+    refs: list[EvidenceRef] = []
+    for ref in focus.get("evidence_refs", []):
+        if isinstance(ref, dict):
+            refs.append(EvidenceRef.model_validate(ref))
     return refs
 
 

--- a/gaia/research_loop/tasks.py
+++ b/gaia/research_loop/tasks.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from gaia.research_loop.schemas import (
     EvidenceRef,
+    FocusSynthesisCandidatePayload,
     QueryPlanCandidatePayload,
     ResearchLoopTask,
     ScopeCandidatePayload,
@@ -133,6 +134,58 @@ def build_search_execution_task(
         submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
     )
     return task, _task_path(paths, task_id)
+
+
+def build_focus_synthesis_task(
+    paths: ResearchLoopPaths,
+    landscape: dict[str, Any],
+) -> tuple[ResearchLoopTask, Path]:
+    """Build a semantic task for synthesizing assessment focuses."""
+    task_id = "task-focus-synthesis-0001"
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="explore",
+        kind=TaskKind.FOCUS_SYNTHESIS,
+        objective="Synthesize assessment focuses from the current landscape.",
+        inputs={"landscape": landscape},
+        instructions=[
+            "Generate research questions, not paper clusters.",
+            "Ground every evidence ref in the allowed refs.",
+            "Select ready focuses only when they have enough refs for assessment.",
+        ],
+        allowed_actions=["submit_focuses", "needs_more_landscape", "stop"],
+        recommended_action="submit_focuses",
+        output_contract=FocusSynthesisCandidatePayload.model_json_schema(),
+        allowed_refs=_paper_refs_from_landscape(landscape),
+        minimal_example={
+            "task_id": task_id,
+            "stage": "explore",
+            "kind": "focus_synthesis",
+            "selected_action": "submit_focuses",
+            "payload": {
+                "focuses": [
+                    {
+                        "focus_id": "focus-example",
+                        "research_question": "Example question?",
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ]
+            },
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _task_path(paths, task_id)
+
+
+def _paper_refs_from_landscape(landscape: dict[str, Any]) -> list[EvidenceRef]:
+    refs: list[EvidenceRef] = []
+    for lead in landscape.get("paper_leads", []):
+        if not isinstance(lead, dict):
+            continue
+        paper_id = lead.get("paper_id")
+        if isinstance(paper_id, str) and paper_id:
+            refs.append(EvidenceRef(kind="paper", id=paper_id))
+    return refs
 
 
 def write_task(task: ResearchLoopTask, path: Path) -> None:

--- a/gaia/research_loop/tasks.py
+++ b/gaia/research_loop/tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from shlex import quote
 from typing import Any
 
 from gaia.research_loop.schemas import (
@@ -10,6 +11,7 @@ from gaia.research_loop.schemas import (
     QueryPlanCandidatePayload,
     ResearchLoopTask,
     ScopeCandidatePayload,
+    SearchExecutionCandidatePayload,
     TaskKind,
 )
 from gaia.research_loop.storage import ResearchLoopPaths, write_json
@@ -77,6 +79,56 @@ def build_query_plan_task(
                 "queries": [{"query": "example query", "purpose": "cover one evidence family"}],
                 "rationale": "Tiny shape example only.",
             },
+        },
+        submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
+    )
+    return task, _task_path(paths, task_id)
+
+
+def build_search_execution_task(
+    paths: ResearchLoopPaths,
+    query_plan: dict[str, Any],
+) -> tuple[ResearchLoopTask, Path]:
+    """Build a mechanical task for running planned LKM searches."""
+    task_id = "task-search-execution-0001"
+    commands: list[dict[str, str]] = []
+    for index, item in enumerate(query_plan.get("queries", [])):
+        if not isinstance(item, dict):
+            continue
+        query = item.get("query")
+        if not isinstance(query, str) or not query.strip():
+            continue
+        output_path = paths.explore_artifacts / f"raw-search-0001-{index}.json"
+        command = f"gaia search lkm knowledge {quote(query)} --json > {quote(str(output_path))}"
+        commands.append(
+            {
+                "query": query,
+                "command": command,
+                "output_path": str(output_path),
+            }
+        )
+
+    task = ResearchLoopTask(
+        task_id=task_id,
+        stage="explore",
+        kind=TaskKind.SEARCH_EXECUTION,
+        objective="Run the planned LKM searches and submit raw JSON result paths.",
+        inputs={"query_plan": query_plan, "commands": commands},
+        instructions=[
+            "Run each command exactly as written.",
+            "Do not summarize or transform the raw LKM JSON.",
+            "Submit the output paths after all commands finish.",
+        ],
+        allowed_actions=["submit_search_results", "stop"],
+        recommended_action="submit_search_results",
+        output_contract=SearchExecutionCandidatePayload.model_json_schema(),
+        allowed_refs=[EvidenceRef(kind="query_plan", id="query_plan")],
+        minimal_example={
+            "task_id": task_id,
+            "stage": "explore",
+            "kind": "search_execution",
+            "selected_action": "submit_search_results",
+            "payload": {"results": [{"query": "example query", "path": "/tmp/raw-search.json"}]},
         },
         submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
     )

--- a/gaia/research_loop/tasks.py
+++ b/gaia/research_loop/tasks.py
@@ -60,15 +60,21 @@ def build_scope_task(paths: ResearchLoopPaths) -> tuple[ResearchLoopTask, Path]:
 def build_query_plan_task(
     paths: ResearchLoopPaths,
     scope: dict[str, Any],
+    *,
+    round_number: int = 0,
+    prior_focus_synthesis: dict[str, Any] | None = None,
 ) -> tuple[ResearchLoopTask, Path]:
     """Build a task asking the agent to plan the next LKM searches."""
-    task_id = "task-query-plan-0001"
+    task_id = f"task-query-plan-{round_number + 1:04d}"
+    inputs: dict[str, Any] = {"scope": scope, "round": round_number}
+    if prior_focus_synthesis is not None:
+        inputs["prior_focus_synthesis"] = prior_focus_synthesis
     task = ResearchLoopTask(
         task_id=task_id,
         stage="explore",
         kind=TaskKind.QUERY_PLAN,
         objective="Plan the next LKM searches from the current scope and coverage.",
-        inputs={"scope": scope},
+        inputs=inputs,
         instructions=[
             "Propose a small set of LKM search queries.",
             "Prefer breadth-first coverage over deep paper analysis.",
@@ -95,9 +101,11 @@ def build_query_plan_task(
 def build_search_execution_task(
     paths: ResearchLoopPaths,
     query_plan: dict[str, Any],
+    *,
+    round_number: int = 0,
 ) -> tuple[ResearchLoopTask, Path]:
     """Build a mechanical task for running planned LKM searches."""
-    task_id = "task-search-execution-0001"
+    task_id = f"task-search-execution-{round_number + 1:04d}"
     commands: list[dict[str, str]] = []
     for index, item in enumerate(query_plan.get("queries", [])):
         if not isinstance(item, dict):
@@ -105,7 +113,7 @@ def build_search_execution_task(
         query = item.get("query")
         if not isinstance(query, str) or not query.strip():
             continue
-        output_path = paths.explore_artifacts / f"raw-search-0001-{index}.json"
+        output_path = paths.explore_artifacts / f"raw-search-{round_number + 1:04d}-{index}.json"
         command = (
             "gaia search lkm knowledge "
             f"{quote(query)} --format gaia-json --out {quote(str(output_path))}"
@@ -123,7 +131,7 @@ def build_search_execution_task(
         stage="explore",
         kind=TaskKind.SEARCH_EXECUTION,
         objective="Run the planned LKM searches and submit raw JSON result paths.",
-        inputs={"query_plan": query_plan, "commands": commands},
+        inputs={"query_plan": query_plan, "round": round_number, "commands": commands},
         instructions=[
             "Run each command exactly as written.",
             "Do not summarize or transform the raw LKM JSON.",
@@ -148,17 +156,20 @@ def build_search_execution_task(
 def build_focus_synthesis_task(
     paths: ResearchLoopPaths,
     landscape: dict[str, Any],
+    *,
+    round_number: int = 0,
 ) -> tuple[ResearchLoopTask, Path]:
     """Build a semantic task for synthesizing assessment focuses."""
-    task_id = "task-focus-synthesis-0001"
+    task_id = f"task-focus-synthesis-{round_number + 1:04d}"
     task = ResearchLoopTask(
         task_id=task_id,
         stage="explore",
         kind=TaskKind.FOCUS_SYNTHESIS,
-        objective="Synthesize assessment focuses from the current landscape.",
-        inputs={"landscape": landscape},
+        objective="Synthesize assessment focuses from the cumulative landscape through this round.",
+        inputs={"landscape": landscape, "round": round_number},
         instructions=[
             "Generate research questions, not paper clusters.",
+            "Use the cumulative landscape to preserve cross-round evidence context.",
             "Ground every evidence ref in the allowed refs.",
             "Select ready focuses only when they have enough refs for assessment.",
         ],
@@ -189,19 +200,26 @@ def build_focus_synthesis_task(
 def build_assessment_context_task(
     paths: ResearchLoopPaths,
     focuses: dict[str, Any],
+    *,
+    evidence_context: list[dict[str, Any]] | None = None,
 ) -> tuple[ResearchLoopTask, Path]:
     """Build an assessment-context task from selected Explore focuses."""
     task_id = "task-assessment-context-0001"
     selected_focus = _selected_focus(focuses)
+    inputs: dict[str, Any] = {"focus": selected_focus, "focuses": focuses}
+    if evidence_context is not None:
+        inputs["evidence_context"] = evidence_context
     task = ResearchLoopTask(
         task_id=task_id,
         stage="assess",
         kind=TaskKind.ASSESSMENT_CONTEXT,
         objective="Package the selected focus for evidence diagnosis.",
-        inputs={"focus": selected_focus, "focuses": focuses},
+        inputs=inputs,
         instructions=[
             "Preserve the selected focus id.",
             "Carry forward only evidence refs grounded by the selected focus.",
+            "Read evidence_context snippets before assigning support, opposition, or gaps.",
+            "Separate supporting refs, opposing refs, known gaps, and assessment mode when known.",
         ],
         allowed_actions=["submit_assessment_context", "stop"],
         recommended_action="submit_assessment_context",
@@ -212,7 +230,14 @@ def build_assessment_context_task(
             "stage": "assess",
             "kind": "assessment_context",
             "selected_action": "submit_assessment_context",
-            "payload": {"focus_id": "focus-example", "evidence_refs": []},
+            "payload": {
+                "focus_id": "focus-example",
+                "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                "supporting_refs": [{"kind": "paper", "id": "P1"}],
+                "opposing_refs": [],
+                "known_gaps": ["Example gap."],
+                "assessment_mode": "evidence_diagnosis",
+            },
         },
         submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",
     )
@@ -222,18 +247,28 @@ def build_assessment_context_task(
 def build_evidence_diagnosis_task(
     paths: ResearchLoopPaths,
     assessment_context: dict[str, Any],
+    *,
+    evidence_context: list[dict[str, Any]] | None = None,
 ) -> tuple[ResearchLoopTask, Path]:
     """Build an evidence-diagnosis task from an assessment context."""
     task_id = "task-evidence-diagnosis-0001"
+    inputs: dict[str, Any] = {"assessment_context": assessment_context}
+    if evidence_context is not None:
+        inputs["evidence_context"] = evidence_context
     task = ResearchLoopTask(
         task_id=task_id,
         stage="assess",
         kind=TaskKind.EVIDENCE_DIAGNOSIS,
         objective="Diagnose the evidence, tensions, limitations, gaps, and next tests.",
-        inputs={"assessment_context": assessment_context},
+        inputs=inputs,
         instructions=[
             "Ground every evidence item in allowed refs.",
+            "Use evidence_context snippets as the primary content to analyze.",
             "Tie each next test to a gap id.",
+            "Preserve the assessment context focus id.",
+            "When listing a contradiction or tension, link at least two evidence items or claims.",
+            "Use limitations, missing_evidence, and confidence_notes "
+            "to explain residual uncertainty.",
         ],
         allowed_actions=["submit_evidence_diagnosis", "stop"],
         recommended_action="submit_evidence_diagnosis",
@@ -250,10 +285,19 @@ def build_evidence_diagnosis_task(
             "selected_action": "submit_evidence_diagnosis",
             "payload": {
                 "focus_id": "focus-example",
-                "evidence_items": [{"id": "e1", "refs": []}],
+                "evidence_items": [
+                    {
+                        "id": "e1",
+                        "refs": [{"kind": "paper", "id": "P1"}],
+                        "summary": "Example evidence item.",
+                    }
+                ],
+                "candidate_claims": [{"id": "c1", "claim": "Example candidate claim."}],
                 "limitations": ["Example limitation."],
+                "missing_evidence": ["Example missing evidence."],
                 "gap_map": [{"gap_id": "g1", "description": "Example gap."}],
                 "next_tests": [{"gap_id": "g1", "test": "Example test."}],
+                "confidence_notes": ["Example confidence note."],
             },
         },
         submit_command=f"gaia-research-loop submit {paths.pkg} <candidate.json>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ markers = [
 [project.scripts]
 gaia = "gaia.cli.main:app"
 gaia-lkm-explore = "gaia.lkm_explorer.client.cli:app"
+gaia-research-loop = "gaia.research_loop.cli:app"
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -12,6 +12,7 @@ from gaia.lkm_explorer.engine.artifacts import (
     build_exploration_artifact,
     build_focus_context_artifact,
     build_focuses_artifact,
+    build_focuses_artifact_from_candidates,
     build_gate_report,
     build_scope_artifact,
     collect_landscape_grounding_refs,
@@ -257,7 +258,127 @@ def test_build_focus_context_artifact_records_grounded_packet(tmp_path: Path) ->
     ]
     assert artifact["queries"][0]["query"] == "aspirin primary prevention"
     assert artifact["existing_focuses"] == []
+    assert artifact["allowed_evidence_refs"] == [
+        {
+            "kind": "paper",
+            "id": "P1",
+            "round": 0,
+            "path": ".gaia/exploration/landscape-0.json",
+            "title": "Benefit trial",
+        },
+        {
+            "kind": "lkm_node",
+            "id": "lkm:benefit",
+            "round": 0,
+            "path": ".gaia/exploration/landscape-0.json",
+            "paper_id": "P1",
+            "title": "Benefit trial",
+        },
+    ]
+    assert artifact["output_contract"]["format"] == "json"
+    assert "CandidateFocuses" in artifact["output_contract"]["json_schema"]["title"]
+    assert (
+        "Every evidence_refs[].id must appear in allowed_evidence_refs."
+        in artifact["output_contract"]["rules"]
+    )
     assert "Propose only focuses grounded in evidence refs." in artifact["instructions"]
+
+
+def test_build_focuses_artifact_from_candidates_accepts_grounded_llm_focus(
+    tmp_path: Path,
+) -> None:
+    context_path = tmp_path / ".gaia" / "exploration" / "focus_context.json"
+    context = {
+        "kind": "focus_synthesis_context",
+        "inputs": {"scope": ".gaia/exploration/scope.json"},
+        "landscape_rounds": [
+            {
+                "round": 0,
+                "path": ".gaia/exploration/landscape-0.json",
+                "purpose": "broad_initial_survey",
+                "paper_leads": 2,
+            }
+        ],
+        "paper_leads": [
+            {"paper_id": "P1", "lkm_node_ids": ["lkm:1"]},
+            {"paper_id": "P2", "lkm_node_ids": ["lkm:2"]},
+        ],
+    }
+    candidates = {
+        "focuses": [
+            {
+                "id": "focus_net_benefit",
+                "kind": "benefit_harm_tension",
+                "question": "Does aspirin primary prevention have net clinical benefit?",
+                "status": "ready_for_assess",
+                "coverage": {
+                    "status": "ready_for_assess",
+                    "evidence_families": ["randomized_trial", "meta_analysis"],
+                    "missing_dimensions": [],
+                },
+                "evidence_refs": [
+                    {"kind": "paper", "id": "P1", "role": "benefit"},
+                    {"kind": "lkm_node", "id": "lkm:2", "role": "harm"},
+                ],
+                "candidate_claims": [],
+                "next_landscape_queries": [],
+            }
+        ]
+    }
+
+    artifact = build_focuses_artifact_from_candidates(
+        tmp_path,
+        context_path=context_path,
+        context=context,
+        candidates=candidates,
+        map_round=3,
+        generation="llm",
+    )
+
+    focus = artifact["focuses"][0]
+    assert artifact["schema"] == SOP_SCHEMA_V2
+    assert artifact["inputs"]["focus_context"] == ".gaia/exploration/focus_context.json"
+    assert artifact["inputs"]["landscape_rounds"][0]["round"] == 0
+    assert artifact["provenance"]["generation"] == "llm"
+    assert focus["level"] == "focus"
+    assert focus["recommended_next"] == "assess"
+    assert focus["text"] == focus["question"]
+    assert focus["provenance"]["focus_context"] == ".gaia/exploration/focus_context.json"
+    assert focus["provenance"]["grounded_ref_count"] == 2
+    assert focus["evidence_refs"] == candidates["focuses"][0]["evidence_refs"]
+
+
+def test_build_focuses_artifact_from_candidates_rejects_ungrounded_refs(
+    tmp_path: Path,
+) -> None:
+    context = {
+        "paper_leads": [{"paper_id": "P1", "lkm_node_ids": ["lkm:1"]}],
+        "landscape_rounds": [],
+    }
+    candidates = {
+        "focuses": [
+            {
+                "id": "focus_bad",
+                "kind": "unsupported_tension",
+                "question": "Is this grounded?",
+                "status": "ready_for_assess",
+                "coverage": {"status": "ready_for_assess"},
+                "evidence_refs": [{"kind": "paper", "id": "P2"}],
+                "candidate_claims": [],
+                "next_landscape_queries": [],
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="ungrounded evidence refs"):
+        build_focuses_artifact_from_candidates(
+            tmp_path,
+            context_path=tmp_path / ".gaia" / "exploration" / "focus_context.json",
+            context=context,
+            candidates=candidates,
+            map_round=0,
+            generation="llm",
+        )
 
 
 def test_build_exploration_artifact_records_present_and_missing_sidecars(tmp_path: Path) -> None:

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -510,6 +510,60 @@ def test_build_gate_report_requires_v2_coverage_budget_record() -> None:
     assert report["checks"]["coverage_budget_recorded"]["status"] == "fail"
 
 
+def test_build_gate_report_accepts_v2_landscape_rounds_as_provenance() -> None:
+    artifact = {
+        "schema": SOP_SCHEMA_V2,
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-1.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": ".gaia/ir.json",
+            "beliefs": ".gaia/beliefs.json",
+            "rounds": None,
+        },
+        "landscape_rounds": [
+            {
+                "round": 0,
+                "path": ".gaia/exploration/landscape-0.json",
+                "purpose": "broad_initial_survey",
+            },
+            {
+                "round": 1,
+                "path": ".gaia/exploration/landscape-1.json",
+                "purpose": "focus_gap_followup",
+            },
+        ],
+        "audit": {
+            "coverage": {
+                "paper_level_gaps": [],
+                "claim_level_gaps": [],
+                "budget_exhaustion": "not_evaluated",
+            }
+        },
+    }
+    focuses = {
+        "schema": SOP_SCHEMA_V2,
+        "focuses": [
+            {
+                "id": "focus_1",
+                "status": "ready_for_assess",
+                "question": "Should this paper cluster enter assessment?",
+                "coverage": {"status": "ready_for_assess"},
+                "provenance": {},
+                "evidence_refs": [{"kind": "paper", "id": "P1"}],
+            }
+        ],
+    }
+
+    report = build_gate_report(artifact, focuses, grounding_refs={"P1"})
+
+    assert report["verdict"] == "pass"
+    assert report["checks"]["rounds_present"]["status"] == "pass"
+
+
 def test_build_gate_report_revises_when_warning_artifacts_are_missing() -> None:
     artifact = {
         "schema": SOP_SCHEMA,

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -12,6 +12,7 @@ from gaia.lkm_explorer.engine.artifacts import (
     build_focuses_artifact,
     build_gate_report,
     build_scope_artifact,
+    landscape_round_paths,
     latest_landscape_path,
     parse_dimensions,
     rel_artifact_path,
@@ -49,6 +50,13 @@ def test_latest_landscape_path_returns_highest_sorted(tmp_path: Path) -> None:
         (exp / name).write_text("{}", encoding="utf-8")
 
     assert latest_landscape_path(tmp_path) == exp / "landscape-10.json"
+    assert landscape_round_paths(tmp_path) == [
+        exp / "landscape-0.json",
+        exp / "landscape-1.json",
+        exp / "landscape-2.json",
+        exp / "landscape-9.json",
+        exp / "landscape-10.json",
+    ]
 
 
 def test_rel_artifact_path_prefers_package_relative_paths(tmp_path: Path) -> None:
@@ -123,13 +131,26 @@ def test_build_exploration_artifact_records_present_and_missing_sidecars(tmp_pat
     exp.mkdir(parents=True)
     (exp / "scope.json").write_text("{}", encoding="utf-8")
     (exp / "landscape-0.json").write_text("{}", encoding="utf-8")
+    (exp / "landscape-1.json").write_text("{}", encoding="utf-8")
     (exp / "map.json").write_text("{}", encoding="utf-8")
 
     artifact = build_exploration_artifact(tmp_path, map_round=0, map_version=1)
 
     assert artifact["kind"] == "lkm_exploration"
     assert artifact["artifacts"]["scope"] == ".gaia/exploration/scope.json"
-    assert artifact["artifacts"]["landscape"] == ".gaia/exploration/landscape-0.json"
+    assert artifact["artifacts"]["landscape"] == ".gaia/exploration/landscape-1.json"
+    assert artifact["landscape_rounds"] == [
+        {
+            "round": 0,
+            "path": ".gaia/exploration/landscape-0.json",
+            "purpose": "broad_initial_survey",
+        },
+        {
+            "round": 1,
+            "path": ".gaia/exploration/landscape-1.json",
+            "purpose": "focus_gap_followup",
+        },
+    ]
     assert artifact["artifacts"]["focuses"] is None
     assert "missing focuses.json" in artifact["audit"]["known_limitations"]
     assert artifact["audit"]["allowed_next_steps"] == ["gate"]

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -126,6 +126,66 @@ def test_build_focuses_artifact_uses_landscape_paper_leads(tmp_path: Path) -> No
     ]
 
 
+def test_build_focuses_artifact_aggregates_landscape_rounds(tmp_path: Path) -> None:
+    round_0 = {
+        "kind": "exploration_landscape",
+        "paper_leads": [
+            {
+                "paper_id": "P1",
+                "title": "Benefit trial",
+                "queries": ["aspirin benefit"],
+                "lkm_node_ids": ["lkm:benefit"],
+            }
+        ],
+    }
+    round_1 = {
+        "kind": "exploration_landscape",
+        "paper_leads": [
+            {
+                "paper_id": "P2",
+                "title": "Bleeding trial",
+                "queries": ["aspirin bleeding"],
+                "lkm_node_ids": ["lkm:harm"],
+            }
+        ],
+    }
+
+    artifact = build_focuses_artifact(
+        tmp_path,
+        scope_path=tmp_path / ".gaia" / "exploration" / "scope.json",
+        landscape_path=tmp_path / ".gaia" / "exploration" / "landscape-1.json",
+        landscape=round_1,
+        landscape_rounds=[
+            (tmp_path / ".gaia" / "exploration" / "landscape-0.json", round_0),
+            (tmp_path / ".gaia" / "exploration" / "landscape-1.json", round_1),
+        ],
+        map_round=1,
+    )
+
+    focus = artifact["focuses"][0]
+    assert artifact["inputs"]["landscape"] == ".gaia/exploration/landscape-1.json"
+    assert artifact["inputs"]["landscape_rounds"] == [
+        {
+            "round": 0,
+            "path": ".gaia/exploration/landscape-0.json",
+            "paper_leads": 1,
+        },
+        {
+            "round": 1,
+            "path": ".gaia/exploration/landscape-1.json",
+            "paper_leads": 1,
+        },
+    ]
+    assert focus["evidence_refs"] == [
+        {"kind": "paper", "id": "P1"},
+        {"kind": "lkm_node", "id": "lkm:benefit"},
+        {"kind": "paper", "id": "P2"},
+        {"kind": "lkm_node", "id": "lkm:harm"},
+    ]
+    assert focus["provenance"]["paper_ids"] == ["P1", "P2"]
+    assert focus["provenance"]["queries"] == ["aspirin benefit", "aspirin bleeding"]
+
+
 def test_build_exploration_artifact_records_present_and_missing_sidecars(tmp_path: Path) -> None:
     exp = tmp_path / ".gaia" / "exploration"
     exp.mkdir(parents=True)

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -14,6 +14,7 @@ from gaia.lkm_explorer.engine.artifacts import (
     build_focuses_artifact,
     build_gate_report,
     build_scope_artifact,
+    collect_landscape_grounding_refs,
     landscape_round_paths,
     latest_landscape_path,
     parse_dimensions,
@@ -116,11 +117,17 @@ def test_build_focuses_artifact_uses_landscape_paper_leads(tmp_path: Path) -> No
         map_round=0,
     )
 
+    assert artifact["schema"] == SOP_SCHEMA_V2
     assert artifact["kind"] == "exploration_focuses"
     assert artifact["focuses"]
     focus = artifact["focuses"][0]
     assert focus["kind"] == "paper_lead_cluster"
+    assert focus["level"] == "focus"
+    assert focus["status"] == "ready_for_assess"
+    assert focus["question"].startswith("Assess the paper-lead cluster")
     assert focus["recommended_next"] == "assess"
+    assert focus["coverage"]["status"] == "ready_for_assess"
+    assert focus["coverage"]["grounded_ref_count"] == 3
     assert focus["evidence_refs"] == [
         {"kind": "paper", "id": "P1"},
         {"kind": "lkm_node", "id": "lkm:1"},
@@ -279,9 +286,91 @@ def test_build_exploration_artifact_records_present_and_missing_sidecars(tmp_pat
         },
     ]
     assert artifact["artifacts"]["focuses"] is None
+    assert artifact["artifacts"]["focus_context"] is None
+    assert artifact["schema"] == SOP_SCHEMA_V2
+    assert artifact["focus_statuses"] == []
+    assert artifact["audit"]["coverage"]["budget_exhaustion"] == "not_evaluated"
+    assert artifact["audit"]["coverage"]["paper_level_gaps"] == []
+    assert artifact["audit"]["coverage"]["claim_level_gaps"] == [
+        "compiled IR missing",
+        "beliefs sidecar missing",
+    ]
     assert "missing focuses.json" in artifact["audit"]["known_limitations"]
     assert artifact["audit"]["allowed_next_steps"] == ["gate"]
     assert "gaia-evidence assess" in artifact["interface"]["assess"]["command"]
+    assert artifact["interface"]["assess"]["focus_commands"] == []
+
+
+def test_build_exploration_artifact_records_focus_statuses_and_assess_commands(
+    tmp_path: Path,
+) -> None:
+    exp = tmp_path / ".gaia" / "exploration"
+    exp.mkdir(parents=True)
+    (exp / "scope.json").write_text("{}", encoding="utf-8")
+    (exp / "landscape-0.json").write_text("{}", encoding="utf-8")
+    (exp / "map.json").write_text("{}", encoding="utf-8")
+    focuses = {
+        "schema": SOP_SCHEMA_V2,
+        "focuses": [
+            {
+                "id": "focus_1",
+                "status": "ready_for_assess",
+                "question": "What is the net clinical benefit?",
+                "coverage": {"status": "ready_for_assess"},
+                "provenance": {},
+                "evidence_refs": [{"kind": "paper", "id": "P1"}],
+            },
+            {
+                "id": "focus_2",
+                "status": "needs_more_landscape",
+                "question": "What is missing in older adults?",
+                "coverage": {"missing_dimensions": ["older adults"]},
+                "next_landscape_queries": ["aspirin primary prevention older adults"],
+                "evidence_refs": [],
+            },
+        ],
+    }
+
+    artifact = build_exploration_artifact(
+        tmp_path,
+        map_round=2,
+        map_version=1,
+        focuses=focuses,
+    )
+
+    assert artifact["focus_statuses"] == [
+        {
+            "id": "focus_1",
+            "status": "ready_for_assess",
+            "recommended_next": "assess",
+            "evidence_refs": 1,
+        },
+        {
+            "id": "focus_2",
+            "status": "needs_more_landscape",
+            "recommended_next": "landscape",
+            "evidence_refs": 0,
+        },
+    ]
+    assert artifact["interface"]["assess"]["focus_commands"] == [
+        "gaia-evidence assess --exploration .gaia/exploration/artifact.json --focus focus_1"
+    ]
+
+
+def test_collect_landscape_grounding_refs_indexes_all_round_refs() -> None:
+    refs = collect_landscape_grounding_refs(
+        [
+            {
+                "paper_leads": [
+                    {"paper_id": "P1", "lkm_node_ids": ["lkm:1", "lkm:2"]},
+                    {"paper_id": "P2", "lkm_node_ids": []},
+                ]
+            },
+            {"paper_leads": [{"paper_id": "P3", "lkm_node_ids": ["lkm:3"]}]},
+        ]
+    )
+
+    assert refs == {"P1", "P2", "P3", "lkm:1", "lkm:2", "lkm:3"}
 
 
 def test_build_gate_report_blocks_without_focuses() -> None:
@@ -330,16 +419,95 @@ def test_build_gate_report_passes_with_supported_schema_and_backed_focus() -> No
         "focuses": [
             {
                 "id": "focus_1",
+                "status": "ready_for_assess",
+                "question": "Should this paper cluster enter assessment?",
+                "coverage": {"status": "ready_for_assess"},
+                "provenance": {},
                 "recommended_next": "assess",
                 "evidence_refs": [{"kind": "paper", "id": "P1"}],
             }
         ],
     }
 
-    report = build_gate_report(artifact, focuses)
+    report = build_gate_report(artifact, focuses, grounding_refs={"P1"})
 
     assert report["verdict"] == "pass"
+    assert report["checks"]["ready_focuses_have_contract"]["status"] == "pass"
+    assert report["checks"]["ready_focus_refs_grounded"]["status"] == "pass"
+    assert report["checks"]["coverage_budget_recorded"]["status"] == "skip"
     assert report["audit"]["allowed_next_steps"] == ["assess"]
+
+
+def test_build_gate_report_blocks_ungrounded_ready_focus() -> None:
+    artifact = {
+        "schema": SOP_SCHEMA_V2,
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": ".gaia/ir.json",
+            "beliefs": ".gaia/beliefs.json",
+            "rounds": ".gaia/exploration/rounds.jsonl",
+        },
+    }
+    focuses = {
+        "schema": SOP_SCHEMA_V2,
+        "focuses": [
+            {
+                "id": "focus_1",
+                "status": "ready_for_assess",
+                "question": "Should this paper cluster enter assessment?",
+                "coverage": {"status": "ready_for_assess"},
+                "provenance": {},
+                "evidence_refs": [{"kind": "paper", "id": "P2"}],
+            }
+        ],
+    }
+
+    report = build_gate_report(artifact, focuses, grounding_refs={"P1"})
+
+    assert report["verdict"] == "block"
+    assert report["checks"]["ready_focus_refs_grounded"]["status"] == "fail"
+    assert report["validation"]["ungrounded_refs"] == ["P2"]
+
+
+def test_build_gate_report_requires_v2_coverage_budget_record() -> None:
+    artifact = {
+        "schema": SOP_SCHEMA_V2,
+        "kind": "lkm_exploration",
+        "artifacts": {
+            "scope": ".gaia/exploration/scope.json",
+            "landscape": ".gaia/exploration/landscape-0.json",
+            "focuses": ".gaia/exploration/focuses.json",
+            "map": ".gaia/exploration/map.json",
+            "artifact": ".gaia/exploration/artifact.json",
+            "gaia_ir": ".gaia/ir.json",
+            "beliefs": ".gaia/beliefs.json",
+            "rounds": ".gaia/exploration/rounds.jsonl",
+        },
+        "audit": {"coverage": {}},
+    }
+    focuses = {
+        "schema": SOP_SCHEMA_V2,
+        "focuses": [
+            {
+                "id": "focus_1",
+                "status": "ready_for_assess",
+                "question": "Should this paper cluster enter assessment?",
+                "coverage": {"status": "ready_for_assess"},
+                "provenance": {},
+                "evidence_refs": [{"kind": "paper", "id": "P1"}],
+            }
+        ],
+    }
+
+    report = build_gate_report(artifact, focuses, grounding_refs={"P1"})
+
+    assert report["verdict"] == "block"
+    assert report["checks"]["coverage_budget_recorded"]["status"] == "fail"
 
 
 def test_build_gate_report_revises_when_warning_artifacts_are_missing() -> None:
@@ -362,6 +530,10 @@ def test_build_gate_report_revises_when_warning_artifacts_are_missing() -> None:
         "focuses": [
             {
                 "id": "focus_1",
+                "status": "ready_for_assess",
+                "question": "Should this paper cluster enter assessment?",
+                "coverage": {"status": "ready_for_assess"},
+                "provenance": {},
                 "recommended_next": "assess",
                 "evidence_refs": [{"kind": "paper", "id": "P1"}],
             }

--- a/tests/lkm_explorer/test_artifacts.py
+++ b/tests/lkm_explorer/test_artifacts.py
@@ -7,8 +7,10 @@ import pytest
 
 from gaia.lkm_explorer.engine.artifacts import (
     SOP_SCHEMA,
+    SOP_SCHEMA_V2,
     artifact_id,
     build_exploration_artifact,
+    build_focus_context_artifact,
     build_focuses_artifact,
     build_gate_report,
     build_scope_artifact,
@@ -184,6 +186,71 @@ def test_build_focuses_artifact_aggregates_landscape_rounds(tmp_path: Path) -> N
     ]
     assert focus["provenance"]["paper_ids"] == ["P1", "P2"]
     assert focus["provenance"]["queries"] == ["aspirin benefit", "aspirin bleeding"]
+
+
+def test_build_focus_context_artifact_records_grounded_packet(tmp_path: Path) -> None:
+    landscape_path = tmp_path / ".gaia" / "exploration" / "landscape-0.json"
+    landscape = {
+        "kind": "exploration_landscape",
+        "queries": [
+            {
+                "index": 0,
+                "query": "aspirin primary prevention",
+                "raw_results": 2,
+                "paper_leads": 1,
+            }
+        ],
+        "paper_leads": [
+            {
+                "paper_id": "P1",
+                "title": "Benefit trial",
+                "doi": "10.1/demo",
+                "index_id": "bohrium",
+                "best_rank": 0.1,
+                "queries": ["aspirin primary prevention"],
+                "lkm_node_ids": ["lkm:benefit"],
+            }
+        ],
+    }
+    scope = {"kind": "exploration_scope", "inputs": {"seeds": ["aspirin"]}}
+
+    artifact = build_focus_context_artifact(
+        tmp_path,
+        scope_path=tmp_path / ".gaia" / "exploration" / "scope.json",
+        scope=scope,
+        landscape_rounds=[(landscape_path, landscape)],
+        existing_focuses_path=None,
+        existing_focuses=None,
+        map_round=0,
+    )
+
+    assert artifact["schema"] == SOP_SCHEMA_V2
+    assert artifact["kind"] == "focus_synthesis_context"
+    assert artifact["scope"] == scope
+    assert artifact["landscape_rounds"] == [
+        {
+            "round": 0,
+            "path": ".gaia/exploration/landscape-0.json",
+            "purpose": "broad_initial_survey",
+            "paper_leads": 1,
+        }
+    ]
+    assert artifact["paper_leads"] == [
+        {
+            "round": 0,
+            "path": ".gaia/exploration/landscape-0.json",
+            "paper_id": "P1",
+            "title": "Benefit trial",
+            "doi": "10.1/demo",
+            "index_id": "bohrium",
+            "best_rank": 0.1,
+            "queries": ["aspirin primary prevention"],
+            "lkm_node_ids": ["lkm:benefit"],
+        }
+    ]
+    assert artifact["queries"][0]["query"] == "aspirin primary prevention"
+    assert artifact["existing_focuses"] == []
+    assert "Propose only focuses grounded in evidence refs." in artifact["instructions"]
 
 
 def test_build_exploration_artifact_records_present_and_missing_sidecars(tmp_path: Path) -> None:

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -701,11 +701,16 @@ def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):
     payload = json.loads(
         (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(encoding="utf-8")
     )
+    assert payload["schema"] == "gaia.sop.artifact.v2"
     assert payload["kind"] == "exploration_focuses"
     assert [row["round"] for row in payload["inputs"]["landscape_rounds"]] == [0, 1]
     assert payload["focuses"]
     focus = payload["focuses"][0]
     assert focus["kind"] == "paper_lead_cluster"
+    assert focus["level"] == "focus"
+    assert focus["status"] == "ready_for_assess"
+    assert focus["question"]
+    assert focus["coverage"]["status"] == "ready_for_assess"
     assert focus["recommended_next"] == "assess"
     assert focus["evidence_refs"]
 
@@ -766,7 +771,12 @@ def test_explore_artifact_writes_handoff_envelope(galileo_pkg: Path):
     assert payload["artifacts"]["scope"] == ".gaia/exploration/scope.json"
     assert payload["artifacts"]["focuses"] == ".gaia/exploration/focuses.json"
     assert payload["artifacts"]["artifact"] == ".gaia/exploration/artifact.json"
+    assert payload["focus_statuses"][0]["status"] == "ready_for_assess"
     assert payload["interface"]["assess"]["command"].startswith("gaia-evidence assess")
+    assert payload["interface"]["assess"]["focus_commands"]
+    assert payload["interface"]["assess"]["focus_commands"][0].endswith(
+        f"--focus {payload['focus_statuses'][0]['id']}"
+    )
 
 
 def test_explore_gate_blocks_without_focuses(galileo_pkg: Path):
@@ -808,6 +818,7 @@ def test_explore_gate_passes_with_complete_assessable_artifacts(galileo_pkg: Pat
         (galileo_pkg / ".gaia" / "exploration" / "gate_report.json").read_text(encoding="utf-8")
     )
     assert payload["verdict"] == "pass"
+    assert payload["checks"]["ready_focus_refs_grounded"]["status"] == "pass"
     assert payload["audit"]["allowed_next_steps"] == ["assess"]
 
 

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -735,7 +736,146 @@ def test_explore_focus_context_writes_grounded_packet(galileo_pkg: Path):
     assert payload["landscape_rounds"][0]["round"] == 0
     assert payload["paper_leads"]
     assert payload["queries"]
+    assert payload["allowed_evidence_refs"]
+    assert payload["output_contract"]["format"] == "json"
     assert "Propose only focuses grounded in evidence refs." in payload["instructions"]
+
+
+def test_explore_focuses_accepts_candidate_focuses_file(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    runner.invoke(app, ["scope", str(galileo_pkg)])
+    runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
+    runner.invoke(app, ["focus-context", str(galileo_pkg)])
+    context_path = galileo_pkg / ".gaia" / "exploration" / "focus_context.json"
+    context = json.loads(context_path.read_text(encoding="utf-8"))
+    ref = context["allowed_evidence_refs"][0]
+    candidates_path = galileo_pkg / ".gaia" / "exploration" / "focus_candidates.json"
+    candidates_path.write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "id": "focus_free_fall_core_question",
+                        "kind": "model_family_tension",
+                        "question": "Which falling-body model family should be assessed first?",
+                        "status": "ready_for_assess",
+                        "coverage": {
+                            "status": "ready_for_assess",
+                            "evidence_families": ["paper_lead"],
+                            "missing_dimensions": [],
+                        },
+                        "evidence_refs": [
+                            {"kind": ref["kind"], "id": ref["id"], "role": "seed evidence"}
+                        ],
+                        "candidate_claims": [],
+                        "next_landscape_queries": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "focuses",
+            str(galileo_pkg),
+            "--from-context",
+            str(context_path),
+            "--candidate-focuses",
+            str(candidates_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(encoding="utf-8")
+    )
+    assert payload["provenance"]["generation"] == "candidate_file"
+    assert payload["focuses"][0]["id"] == "focus_free_fall_core_question"
+    assert payload["focuses"][0]["provenance"]["focus_context"] == (
+        ".gaia/exploration/focus_context.json"
+    )
+
+
+def test_explore_focuses_runs_llm_command_against_focus_context(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    runner.invoke(app, ["scope", str(galileo_pkg)])
+    runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
+    runner.invoke(app, ["focus-context", str(galileo_pkg)])
+    script = galileo_pkg / "fake_focus_llm.py"
+    script.write_text(
+        """
+import json
+import sys
+
+context = json.load(sys.stdin)
+ref = context["allowed_evidence_refs"][0]
+json.dump({
+    "focuses": [{
+        "id": "focus_generated_by_command",
+        "kind": "llm_synthesized_focus",
+        "question": "What focused assessment should be run first?",
+        "status": "ready_for_assess",
+        "coverage": {
+            "status": "ready_for_assess",
+            "evidence_families": ["paper_lead"],
+            "missing_dimensions": []
+        },
+        "evidence_refs": [{"kind": ref["kind"], "id": ref["id"], "role": "grounding"}],
+        "candidate_claims": [],
+        "next_landscape_queries": []
+    }]
+}, sys.stdout)
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "focuses",
+            str(galileo_pkg),
+            "--llm-command",
+            f"{sys.executable} {script}",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(encoding="utf-8")
+    )
+    assert payload["provenance"]["generation"] == "llm_command"
+    assert payload["focuses"][0]["id"] == "focus_generated_by_command"
+
+
+def test_explore_focuses_rejects_invalid_candidate_schema(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    runner.invoke(app, ["scope", str(galileo_pkg)])
+    runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
+    runner.invoke(app, ["focus-context", str(galileo_pkg)])
+    candidates_path = galileo_pkg / ".gaia" / "exploration" / "focus_candidates.json"
+    candidates_path.write_text(
+        json.dumps({"focuses": [{"id": "missing_fields"}]}), encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        app,
+        ["focuses", str(galileo_pkg), "--candidate-focuses", str(candidates_path)],
+    )
+
+    assert result.exit_code == 2
+    assert "candidate focuses do not match schema" in result.output
 
 
 def test_explore_focuses_requires_landscape(galileo_pkg: Path):

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -677,15 +677,31 @@ def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):
         ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)],
     )
     assert landscape_result.exit_code == 0, landscape_result.output
+    landscape_round_1 = runner.invoke(
+        app,
+        [
+            "landscape",
+            str(galileo_pkg),
+            "--search-json",
+            str(_FIXTURE),
+            "--query",
+            "falling bodies followup",
+            "--out",
+            str(galileo_pkg / ".gaia" / "exploration" / "landscape-1.json"),
+        ],
+    )
+    assert landscape_round_1.exit_code == 0, landscape_round_1.output
 
     result = runner.invoke(app, ["focuses", str(galileo_pkg)])
 
     assert result.exit_code == 0, result.output
     assert "Focuses:" in result.output
+    assert "2 landscape round(s)" in result.output
     payload = json.loads(
         (galileo_pkg / ".gaia" / "exploration" / "focuses.json").read_text(encoding="utf-8")
     )
     assert payload["kind"] == "exploration_focuses"
+    assert [row["round"] for row in payload["inputs"]["landscape_rounds"]] == [0, 1]
     assert payload["focuses"]
     focus = payload["focuses"][0]
     assert focus["kind"] == "paper_lead_cluster"

--- a/tests/lkm_explorer/test_cli_explore.py
+++ b/tests/lkm_explorer/test_cli_explore.py
@@ -470,6 +470,7 @@ def test_explore_help_lists_all_verbs():
         "scope",
         "observe",
         "landscape",
+        "focus-context",
         "focuses",
         "artifact",
         "gate",
@@ -707,6 +708,29 @@ def test_explore_focuses_writes_focuses_from_landscape(galileo_pkg: Path):
     assert focus["kind"] == "paper_lead_cluster"
     assert focus["recommended_next"] == "assess"
     assert focus["evidence_refs"]
+
+
+def test_explore_focus_context_writes_grounded_packet(galileo_pkg: Path):
+    runner.invoke(
+        app,
+        ["init", str(galileo_pkg), "--seed", _galileo_qid("aristotle_model")],
+    )
+    runner.invoke(app, ["scope", str(galileo_pkg)])
+    runner.invoke(app, ["landscape", str(galileo_pkg), "--search-json", str(_FIXTURE)])
+
+    result = runner.invoke(app, ["focus-context", str(galileo_pkg), "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "Focus context:" in result.output
+    payload = json.loads(
+        (galileo_pkg / ".gaia" / "exploration" / "focus_context.json").read_text(encoding="utf-8")
+    )
+    assert payload["kind"] == "focus_synthesis_context"
+    assert payload["scope"]["kind"] == "exploration_scope"
+    assert payload["landscape_rounds"][0]["round"] == 0
+    assert payload["paper_leads"]
+    assert payload["queries"]
+    assert "Propose only focuses grounded in evidence refs." in payload["instructions"]
 
 
 def test_explore_focuses_requires_landscape(galileo_pkg: Path):

--- a/tests/research_loop/__init__.py
+++ b/tests/research_loop/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Gaia research loop protocol."""

--- a/tests/research_loop/test_assess_gate.py
+++ b/tests/research_loop/test_assess_gate.py
@@ -37,10 +37,179 @@ def test_next_after_explore_gate_emits_assessment_context(tmp_path: Path) -> Non
     assert task["kind"] == "assessment_context"
 
 
+def test_next_auto_gates_ready_focus_and_enters_assess(tmp_path: Path) -> None:
+    runner = CliRunner()
+    explore = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    explore.mkdir(parents=True)
+    (explore / "focuses.json").write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "focus_id": "focus-net-benefit",
+                        "research_question": "Does benefit outweigh bleeding risk?",
+                        "ready_for_assess": True,
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ],
+                "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["stage"] == "assess"
+    assert task["kind"] == "assessment_context"
+    assert (explore / "explore_gate.json").exists()
+
+
+def test_task_assessment_context_primitive_uses_selected_focus(tmp_path: Path) -> None:
+    runner = CliRunner()
+    explore = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    explore.mkdir(parents=True)
+    (explore / "focuses.json").write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "focus_id": "focus-net-benefit",
+                        "research_question": "Does benefit outweigh bleeding risk?",
+                        "ready_for_assess": True,
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ],
+                "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "assessment-context", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["stage"] == "assess"
+    assert task["kind"] == "assessment_context"
+    assert task["inputs"]["focus"]["focus_id"] == "focus-net-benefit"
+
+
+def test_task_assessment_context_includes_selected_ref_snippets(tmp_path: Path) -> None:
+    runner = CliRunner()
+    explore = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    explore.mkdir(parents=True)
+    (explore / "focuses.json").write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "focus_id": "focus-net-benefit",
+                        "research_question": "Does benefit outweigh bleeding risk?",
+                        "ready_for_assess": True,
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ],
+                "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (explore / "landscape-0000.json").write_text(
+        json.dumps(
+            {
+                "kind": "landscape",
+                "paper_leads": [{"paper_id": "P1"}],
+                "evidence_snippets": [
+                    {
+                        "paper_id": "P1",
+                        "lkm_node_id": "lkm:claim-1",
+                        "kind": "claim",
+                        "content": "Aspirin increased major bleeding without clear net benefit.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "assessment-context", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    task = json.loads(Path(json.loads(result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    assert task["inputs"]["evidence_context"][0]["content"].startswith("Aspirin increased")
+
+
+def test_task_evidence_diagnosis_primitive_uses_assessment_context(tmp_path: Path) -> None:
+    runner = CliRunner()
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    assess.mkdir(parents=True)
+    (assess / "assessment_context.json").write_text(
+        json.dumps(
+            {"focus_id": "focus-net-benefit", "evidence_refs": [{"kind": "paper", "id": "P1"}]}
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "evidence-diagnosis", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["stage"] == "assess"
+    assert task["kind"] == "evidence_diagnosis"
+    assert task["allowed_refs"] == [{"kind": "paper", "id": "P1", "role": None}]
+
+
+def test_task_evidence_diagnosis_includes_assessment_ref_snippets(tmp_path: Path) -> None:
+    runner = CliRunner()
+    explore = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    explore.mkdir(parents=True)
+    assess.mkdir(parents=True)
+    (explore / "landscape-0000.json").write_text(
+        json.dumps(
+            {
+                "kind": "landscape",
+                "evidence_snippets": [
+                    {
+                        "paper_id": "P1",
+                        "lkm_node_id": "lkm:claim-1",
+                        "kind": "claim",
+                        "content": "Aspirin reduced events but increased bleeding.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (assess / "assessment_context.json").write_text(
+        json.dumps(
+            {"focus_id": "focus-net-benefit", "evidence_refs": [{"kind": "paper", "id": "P1"}]}
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "evidence-diagnosis", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    task = json.loads(Path(json.loads(result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    assert task["inputs"]["evidence_context"][0]["content"].startswith("Aspirin reduced")
+
+
 def test_assess_gate_passes_grounded_evidence_diagnosis(tmp_path: Path) -> None:
     runner = CliRunner()
     assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
     assess.mkdir(parents=True)
+    (assess / "assessment_context.json").write_text(
+        json.dumps(
+            {"focus_id": "focus-net-benefit", "evidence_refs": [{"kind": "paper", "id": "P1"}]}
+        ),
+        encoding="utf-8",
+    )
     (assess / "evidence_diagnosis.json").write_text(
         json.dumps(
             {
@@ -59,3 +228,140 @@ def test_assess_gate_passes_grounded_evidence_diagnosis(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert json.loads(result.stdout)["status"] == "pass"
+
+
+def test_next_auto_gates_complete_assess_and_returns_done(tmp_path: Path) -> None:
+    runner = CliRunner()
+    explore = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    explore.mkdir(parents=True)
+    assess.mkdir(parents=True)
+    (explore / "explore_gate.json").write_text(json.dumps({"status": "pass"}), encoding="utf-8")
+    (assess / "assessment_context.json").write_text(
+        json.dumps(
+            {"focus_id": "focus-net-benefit", "evidence_refs": [{"kind": "paper", "id": "P1"}]}
+        ),
+        encoding="utf-8",
+    )
+    (assess / "evidence_diagnosis.json").write_text(
+        json.dumps(
+            {
+                "focus_id": "focus-net-benefit",
+                "evidence_items": [{"id": "e1", "refs": [{"kind": "paper", "id": "P1"}]}],
+                "limitations": ["Sparse example."],
+                "gap_map": [{"gap_id": "g1", "description": "Need subgroup evidence."}],
+                "next_tests": [{"gap_id": "g1", "test": "Search subgroup RCTs."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    payload = json.loads(result.stdout)
+    assert payload["recommended_action"] == "done"
+    assert payload["rationale"] == "Explore and Assess gates passed."
+    assert (assess / "assess_gate.json").exists()
+
+
+def test_assess_gate_revises_when_focus_id_is_not_preserved(tmp_path: Path) -> None:
+    runner = CliRunner()
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    assess.mkdir(parents=True)
+    (assess / "assessment_context.json").write_text(
+        json.dumps(
+            {"focus_id": "focus-net-benefit", "evidence_refs": [{"kind": "paper", "id": "P1"}]}
+        ),
+        encoding="utf-8",
+    )
+    (assess / "evidence_diagnosis.json").write_text(
+        json.dumps(
+            {
+                "focus_id": "different-focus",
+                "evidence_items": [{"id": "e1", "refs": [{"kind": "paper", "id": "P1"}]}],
+                "limitations": ["Sparse example."],
+                "gap_map": [{"gap_id": "g1", "description": "Need subgroup evidence."}],
+                "next_tests": [{"gap_id": "g1", "test": "Search subgroup RCTs."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["gate", str(tmp_path), "--stage", "assess", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["status"] == "revise"
+
+
+def test_assess_gate_revises_when_tension_lacks_two_links(tmp_path: Path) -> None:
+    runner = CliRunner()
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    assess.mkdir(parents=True)
+    (assess / "assessment_context.json").write_text(
+        json.dumps(
+            {"focus_id": "focus-net-benefit", "evidence_refs": [{"kind": "paper", "id": "P1"}]}
+        ),
+        encoding="utf-8",
+    )
+    (assess / "evidence_diagnosis.json").write_text(
+        json.dumps(
+            {
+                "focus_id": "focus-net-benefit",
+                "evidence_items": [{"id": "e1", "refs": [{"kind": "paper", "id": "P1"}]}],
+                "contradictions_or_tensions": [
+                    {
+                        "id": "t1",
+                        "summary": "Only one linked evidence item.",
+                        "evidence_item_ids": ["e1"],
+                    }
+                ],
+                "limitations": ["Sparse example."],
+                "gap_map": [{"gap_id": "g1", "description": "Need subgroup evidence."}],
+                "next_tests": [{"gap_id": "g1", "test": "Search subgroup RCTs."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["gate", str(tmp_path), "--stage", "assess", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["status"] == "revise"
+
+
+def test_evidence_diagnosis_rejects_ungrounded_refs(tmp_path: Path) -> None:
+    runner = CliRunner()
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    assess.mkdir(parents=True)
+    (assess / "assessment_context.json").write_text(
+        json.dumps(
+            {"focus_id": "focus-net-benefit", "evidence_refs": [{"kind": "paper", "id": "P1"}]}
+        ),
+        encoding="utf-8",
+    )
+    next_result = runner.invoke(app, ["task", "evidence-diagnosis", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    candidate = tmp_path / "diagnosis-ungrounded.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "assess",
+                "kind": "evidence_diagnosis",
+                "selected_action": "submit_evidence_diagnosis",
+                "payload": {
+                    "focus_id": "focus-net-benefit",
+                    "evidence_items": [{"id": "e1", "refs": [{"kind": "paper", "id": "P2"}]}],
+                    "limitations": ["Sparse example."],
+                    "gap_map": [{"gap_id": "g1", "description": "Need subgroup evidence."}],
+                    "next_tests": [{"gap_id": "g1", "test": "Search subgroup RCTs."}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(candidate), "--json"])
+
+    assert submit.exit_code == 1
+    assert "not allowed by task" in submit.stdout

--- a/tests/research_loop/test_assess_gate.py
+++ b/tests/research_loop/test_assess_gate.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_next_after_explore_gate_emits_assessment_context(tmp_path: Path) -> None:
+    runner = CliRunner()
+    explore = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    explore.mkdir(parents=True)
+    (explore / "focuses.json").write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "focus_id": "focus-net-benefit",
+                        "research_question": "Does benefit outweigh bleeding risk?",
+                        "ready_for_assess": True,
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ],
+                "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (explore / "explore_gate.json").write_text(json.dumps({"status": "pass"}), encoding="utf-8")
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    task = json.loads(Path(json.loads(result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    assert task["stage"] == "assess"
+    assert task["kind"] == "assessment_context"
+
+
+def test_assess_gate_passes_grounded_evidence_diagnosis(tmp_path: Path) -> None:
+    runner = CliRunner()
+    assess = tmp_path / ".gaia" / "research_loop" / "assess" / "artifacts"
+    assess.mkdir(parents=True)
+    (assess / "evidence_diagnosis.json").write_text(
+        json.dumps(
+            {
+                "focus_id": "focus-net-benefit",
+                "evidence_items": [{"id": "e1", "refs": [{"kind": "paper", "id": "P1"}]}],
+                "contradictions_or_tensions": [],
+                "limitations": ["Sparse example."],
+                "gap_map": [{"gap_id": "g1", "description": "Need subgroup evidence."}],
+                "next_tests": [{"gap_id": "g1", "test": "Search subgroup RCTs."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["gate", str(tmp_path), "--stage", "assess", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["status"] == "pass"

--- a/tests/research_loop/test_cli_status.py
+++ b/tests/research_loop/test_cli_status.py
@@ -25,3 +25,13 @@ def test_status_human_output_names_next_command(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "Research loop: idle" in result.stdout
     assert "Next: gaia-research-loop next" in result.stdout
+
+
+def test_research_loop_skill_exists_and_is_thin() -> None:
+    path = Path("gaia/_skills/gaia-research-loop/SKILL.md")
+
+    text = path.read_text(encoding="utf-8")
+
+    assert "gaia-research-loop next" in text
+    assert "output_contract" in text
+    assert "Do not hardcode" in text

--- a/tests/research_loop/test_cli_status.py
+++ b/tests/research_loop/test_cli_status.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_status_initializes_empty_loop(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["status", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    assert '"phase": "idle"' in result.stdout
+    assert (tmp_path / ".gaia" / "research_loop" / "state.json").exists()
+
+
+def test_status_human_output_names_next_command(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["status", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Research loop: idle" in result.stdout
+    assert "Next: gaia-research-loop next" in result.stdout

--- a/tests/research_loop/test_explore_gate.py
+++ b/tests/research_loop/test_explore_gate.py
@@ -26,7 +26,7 @@ def test_focus_synthesis_candidate_writes_focuses(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    next_result = runner.invoke(app, ["task", "focus-synthesis", str(tmp_path), "--json"])
     task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
     assert task["kind"] == "focus_synthesis"
     candidate = tmp_path / "focuses.json"
@@ -65,6 +65,46 @@ def test_focus_synthesis_candidate_writes_focuses(tmp_path: Path) -> None:
     assert focuses["focuses"][0]["focus_id"] == "focus-net-benefit"
 
 
+def test_focus_synthesis_rejects_ungrounded_refs(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "landscape-0000.json").write_text(
+        json.dumps({"kind": "landscape", "paper_leads": [{"paper_id": "P1"}]}),
+        encoding="utf-8",
+    )
+    next_result = runner.invoke(app, ["task", "focus-synthesis", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    candidate = tmp_path / "focuses-ungrounded.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "focus_synthesis",
+                "selected_action": "submit_focuses",
+                "payload": {
+                    "focuses": [
+                        {
+                            "focus_id": "focus-net-benefit",
+                            "research_question": "Does benefit outweigh bleeding risk?",
+                            "evidence_refs": [{"kind": "paper", "id": "P2"}],
+                            "ready_for_assess": True,
+                        }
+                    ],
+                    "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(candidate), "--json"])
+
+    assert submit.exit_code == 1
+    assert "not allowed by task" in submit.stdout
+
+
 def test_gate_passes_when_selected_focus_ready(tmp_path: Path) -> None:
     runner = CliRunner()
     artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
@@ -90,3 +130,206 @@ def test_gate_passes_when_selected_focus_ready(tmp_path: Path) -> None:
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["status"] == "pass"
+
+
+def test_needs_more_landscape_routes_to_next_query_round(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "scope.json").write_text(
+        json.dumps({"seed_question": "aspirin", "search_budget": 2}), encoding="utf-8"
+    )
+    (artifacts / "query_plan.json").write_text(
+        json.dumps(
+            {
+                "queries": [{"query": "aspirin primary prevention", "purpose": "broad"}],
+                "rationale": "Round 0.",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifacts / "query_plan-0000.json").write_text(
+        (artifacts / "query_plan.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (artifacts / "landscape-0000.json").write_text(
+        json.dumps({"kind": "landscape", "paper_leads": [{"paper_id": "P1"}]}),
+        encoding="utf-8",
+    )
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    candidate = tmp_path / "focus-needs-more.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "focus_synthesis",
+                "selected_action": "needs_more_landscape",
+                "override_rationale": "Need subgroup coverage before assessment.",
+                "payload": {
+                    "focuses": [
+                        {
+                            "focus_id": "focus-diabetes",
+                            "research_question": "Does aspirin help diabetes patients?",
+                            "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                            "coverage_status": "needs_more_landscape",
+                            "ready_for_assess": False,
+                        }
+                    ],
+                    "next_queries": [
+                        {
+                            "query": "aspirin primary prevention diabetes bleeding",
+                            "purpose": "diabetes subgroup",
+                        }
+                    ],
+                    "continue_rationale": "Diabetes subgroup is under-covered.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(candidate), "--json"])
+    assert submit.exit_code == 0
+
+    second_next = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    payload = json.loads(second_next.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert payload["recommended_action"] == "submit_query_plan"
+    assert task["task_id"] == "task-query-plan-0002"
+    assert task["inputs"]["round"] == 1
+    assert task["inputs"]["prior_focus_synthesis"]["next_queries"][0]["query"].startswith(
+        "aspirin primary prevention diabetes"
+    )
+
+
+def test_second_round_search_writes_numbered_landscape(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "query_plan-0001.json").write_text(
+        json.dumps(
+            {
+                "queries": [{"query": "free fall", "purpose": "fixture"}],
+                "rationale": "Round 1.",
+            }
+        ),
+        encoding="utf-8",
+    )
+    next_result = runner.invoke(app, ["task", "search-execution", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    raw_path = Path("tests/lkm_explorer/fixtures/lkm_search_free_fall.json").resolve()
+    candidate = tmp_path / "search-results-round-1.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "search_execution",
+                "selected_action": "submit_search_results",
+                "payload": {"results": [{"query": "free fall", "path": str(raw_path)}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(candidate), "--json"])
+
+    assert submit.exit_code == 0
+    assert (artifacts / "landscape-0001.json").exists()
+    assert (artifacts / "raw_search_manifest-0001.json").exists()
+
+
+def test_second_round_focus_synthesis_can_use_cumulative_landscape_refs(
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "landscape-0000.json").write_text(
+        json.dumps({"kind": "landscape", "paper_leads": [{"paper_id": "P0"}]}),
+        encoding="utf-8",
+    )
+    (artifacts / "landscape-0001.json").write_text(
+        json.dumps({"kind": "landscape", "paper_leads": [{"paper_id": "P1"}]}),
+        encoding="utf-8",
+    )
+
+    next_result = runner.invoke(app, ["task", "focus-synthesis", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    candidate = tmp_path / "focuses-round-1.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "focus_synthesis",
+                "selected_action": "submit_focuses",
+                "payload": {
+                    "focuses": [
+                        {
+                            "focus_id": "focus-cross-round",
+                            "research_question": "What focus needs both rounds?",
+                            "evidence_refs": [
+                                {"kind": "paper", "id": "P0"},
+                                {"kind": "paper", "id": "P1"},
+                            ],
+                            "ready_for_assess": True,
+                        }
+                    ],
+                    "selection": {"selected_focus_ids": ["focus-cross-round"]},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(candidate), "--json"])
+
+    assert submit.exit_code == 0
+    allowed_refs = {(ref["kind"], ref["id"]) for ref in task["allowed_refs"]}
+    assert allowed_refs == {("paper", "P0"), ("paper", "P1")}
+
+
+def test_first_round_query_plan_writes_numbered_artifact_and_alias(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    scope_candidate = tmp_path / "scope.json"
+    scope_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-scope-0001",
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {"seed_question": "free fall", "search_budget": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner.invoke(app, ["submit", str(tmp_path), str(scope_candidate), "--json"])
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    query_candidate = tmp_path / "query-plan.json"
+    query_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-query-plan-0001",
+                "stage": "explore",
+                "kind": "query_plan",
+                "selected_action": "submit_query_plan",
+                "payload": {
+                    "queries": [{"query": "free fall", "purpose": "fixture"}],
+                    "rationale": "Round 0.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(query_candidate), "--json"])
+
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    assert submit.exit_code == 0
+    assert (artifacts / "query_plan-0000.json").exists()
+    assert (artifacts / "query_plan.json").exists()

--- a/tests/research_loop/test_explore_gate.py
+++ b/tests/research_loop/test_explore_gate.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_focus_synthesis_candidate_writes_focuses(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "scope.json").write_text(
+        json.dumps({"seed_question": "aspirin"}), encoding="utf-8"
+    )
+    (artifacts / "query_plan.json").write_text(json.dumps({"queries": []}), encoding="utf-8")
+    (artifacts / "landscape-0000.json").write_text(
+        json.dumps(
+            {
+                "kind": "landscape",
+                "paper_leads": [{"paper_id": "P1", "title": "Aspirin trial"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "focus_synthesis"
+    candidate = tmp_path / "focuses.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "focus_synthesis",
+                "selected_action": "submit_focuses",
+                "payload": {
+                    "focuses": [
+                        {
+                            "focus_id": "focus-net-benefit",
+                            "research_question": "Does benefit outweigh bleeding risk?",
+                            "why_it_matters": "It determines clinical recommendation.",
+                            "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                            "coverage_status": "ready_for_assess",
+                            "ready_for_assess": True,
+                            "recommended_assess_mode": "evidence_table",
+                        }
+                    ],
+                    "selection": {
+                        "selected_focus_ids": ["focus-net-benefit"],
+                        "selection_rationale": "Ready and grounded.",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    submit = runner.invoke(app, ["submit", str(tmp_path), str(candidate), "--json"])
+    assert submit.exit_code == 0
+    focuses = json.loads((artifacts / "focuses.json").read_text(encoding="utf-8"))
+    assert focuses["focuses"][0]["focus_id"] == "focus-net-benefit"
+
+
+def test_gate_passes_when_selected_focus_ready(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "focuses.json").write_text(
+        json.dumps(
+            {
+                "focuses": [
+                    {
+                        "focus_id": "focus-net-benefit",
+                        "ready_for_assess": True,
+                        "evidence_refs": [{"kind": "paper", "id": "P1"}],
+                    }
+                ],
+                "selection": {"selected_focus_ids": ["focus-net-benefit"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["gate", str(tmp_path), "--stage", "explore", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "pass"

--- a/tests/research_loop/test_lkm_adapter.py
+++ b/tests/research_loop/test_lkm_adapter.py
@@ -19,3 +19,22 @@ def test_build_landscape_from_raw_results_extracts_paper_leads(tmp_path: Path) -
     assert artifact["round"] == 0
     assert artifact["raw_results"][0]["query"] == "free fall"
     assert isinstance(artifact["paper_leads"], list)
+
+
+def test_build_landscape_from_raw_results_exposes_retrieved_content_snippets(
+    tmp_path: Path,
+) -> None:
+    fixture = Path("tests/lkm_explorer/fixtures/lkm_search_free_fall.json")
+
+    artifact = build_landscape_from_raw_results(
+        pkg=tmp_path,
+        raw_results=[("free fall", fixture)],
+        round_number=0,
+    )
+
+    snippets = artifact["evidence_snippets"]
+    assert snippets
+    assert snippets[0]["content"].startswith("The kinematic maps mark free fall")
+    assert snippets[0]["paper_id"] == "813135328909983744"
+    assert snippets[0]["query"] == "free fall"
+    assert any(lead.get("evidence_snippets") for lead in artifact["paper_leads"])

--- a/tests/research_loop/test_lkm_adapter.py
+++ b/tests/research_loop/test_lkm_adapter.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gaia.research_loop.lkm_adapter import build_landscape_from_raw_results
+
+
+def test_build_landscape_from_raw_results_extracts_paper_leads(tmp_path: Path) -> None:
+    fixture = Path("tests/lkm_explorer/fixtures/lkm_search_free_fall.json")
+
+    artifact = build_landscape_from_raw_results(
+        pkg=tmp_path,
+        raw_results=[("free fall", fixture)],
+        round_number=0,
+    )
+
+    assert artifact["schema"] == "gaia.research_loop.artifact.v1"
+    assert artifact["kind"] == "landscape"
+    assert artifact["round"] == 0
+    assert artifact["raw_results"][0]["query"] == "free fall"
+    assert isinstance(artifact["paper_leads"], list)

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -138,3 +138,50 @@ def test_submit_invalid_candidate_records_repair_context(tmp_path: Path) -> None
     )
     assert repair_task["repair_context"]["failed_candidate_path"].endswith("bad.json")
     assert "seed_question" in json.dumps(repair_task["repair_context"]["errors"])
+
+
+def test_next_after_query_plan_emits_search_execution(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    scope_candidate = tmp_path / "scope.json"
+    scope_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-scope-0001",
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {"seed_question": "aspirin primary prevention", "search_budget": 2},
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner.invoke(app, ["submit", str(tmp_path), str(scope_candidate), "--json"])
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    query_candidate = tmp_path / "query-plan.json"
+    query_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-query-plan-0001",
+                "stage": "explore",
+                "kind": "query_plan",
+                "selected_action": "submit_query_plan",
+                "payload": {
+                    "queries": [
+                        {"query": "aspirin primary prevention bleeding", "purpose": "harms"}
+                    ],
+                    "rationale": "Need harm evidence.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner.invoke(app, ["submit", str(tmp_path), str(query_candidate), "--json"])
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "search_execution"
+    assert "gaia search lkm knowledge" in task["inputs"]["commands"][0]["command"]
+    assert task["inputs"]["commands"][0]["output_path"].endswith(".json")

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -185,3 +185,65 @@ def test_next_after_query_plan_emits_search_execution(tmp_path: Path) -> None:
     assert task["kind"] == "search_execution"
     assert "gaia search lkm knowledge" in task["inputs"]["commands"][0]["command"]
     assert task["inputs"]["commands"][0]["output_path"].endswith(".json")
+
+
+def test_submit_search_execution_writes_manifest_and_landscape(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    scope_candidate = tmp_path / "scope.json"
+    scope_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-scope-0001",
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {"seed_question": "free fall", "search_budget": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner.invoke(app, ["submit", str(tmp_path), str(scope_candidate), "--json"])
+    runner.invoke(app, ["next", str(tmp_path), "--json"])
+    query_candidate = tmp_path / "query-plan.json"
+    query_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": "task-query-plan-0001",
+                "stage": "explore",
+                "kind": "query_plan",
+                "selected_action": "submit_query_plan",
+                "payload": {
+                    "queries": [{"query": "free fall", "purpose": "fixture"}],
+                    "rationale": "Use saved fixture.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner.invoke(app, ["submit", str(tmp_path), str(query_candidate), "--json"])
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task = json.loads(Path(json.loads(next_result.stdout)["task_path"]).read_text(encoding="utf-8"))
+    raw_path = Path("tests/lkm_explorer/fixtures/lkm_search_free_fall.json").resolve()
+    search_candidate = tmp_path / "search-results.json"
+    search_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "search_execution",
+                "selected_action": "submit_search_results",
+                "payload": {"results": [{"query": "free fall", "path": str(raw_path)}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["submit", str(tmp_path), str(search_candidate), "--json"])
+
+    assert result.exit_code == 0
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    assert (artifacts / "raw_search_manifest.json").exists()
+    landscape = json.loads((artifacts / "landscape-0000.json").read_text(encoding="utf-8"))
+    assert landscape["kind"] == "landscape"
+    assert landscape["raw_results"][0]["query"] == "free fall"

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -41,3 +41,34 @@ def test_next_emits_query_plan_after_scope_artifact(tmp_path: Path) -> None:
     task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
     assert task["kind"] == "query_plan"
     assert "Plan the next LKM searches" in task["objective"]
+
+
+def test_task_scope_primitive_writes_scope_task(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["task", "scope", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["recommended_action"] == "submit_scope"
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "scope"
+    assert task["submit_command"].startswith("gaia-research-loop submit")
+
+
+def test_task_query_plan_primitive_uses_existing_scope(tmp_path: Path) -> None:
+    runner = CliRunner()
+    scope_dir = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "scope.json").write_text(
+        json.dumps({"seed_question": "aspirin primary prevention"}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "query-plan", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "query_plan"
+    assert task["inputs"]["scope"]["seed_question"] == "aspirin primary prevention"

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -74,6 +74,64 @@ def test_task_query_plan_primitive_uses_existing_scope(tmp_path: Path) -> None:
     assert task["inputs"]["scope"]["seed_question"] == "aspirin primary prevention"
 
 
+def test_task_help_lists_all_loop_primitives() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["task", "--help"])
+
+    assert result.exit_code == 0
+    for command in [
+        "scope",
+        "query-plan",
+        "search-execution",
+        "focus-synthesis",
+        "assessment-context",
+        "evidence-diagnosis",
+    ]:
+        assert command in result.stdout
+
+
+def test_task_search_execution_primitive_uses_existing_query_plan(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "query_plan.json").write_text(
+        json.dumps(
+            {
+                "queries": [{"query": "aspirin primary prevention bleeding", "purpose": "harms"}],
+                "rationale": "Need harm evidence.",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "search-execution", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "search_execution"
+    assert "--format gaia-json --out" in task["inputs"]["commands"][0]["command"]
+
+
+def test_task_focus_synthesis_primitive_uses_existing_landscape(tmp_path: Path) -> None:
+    runner = CliRunner()
+    artifacts = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "landscape-0000.json").write_text(
+        json.dumps({"kind": "landscape", "paper_leads": [{"paper_id": "P1"}]}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["task", "focus-synthesis", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "focus_synthesis"
+    assert task["allowed_refs"] == [{"kind": "paper", "id": "P1", "role": None}]
+
+
 def test_submit_scope_writes_scope_artifact(tmp_path: Path) -> None:
     runner = CliRunner()
     next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gaia.research_loop.cli import app
+
+
+def test_next_emits_scope_task_for_empty_loop(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["recommended_action"] == "submit_scope"
+    task_path = Path(payload["task_path"])
+    assert task_path.exists()
+    task = json.loads(task_path.read_text(encoding="utf-8"))
+    assert task["kind"] == "scope"
+    assert task["output_contract"]["title"] == "ScopeCandidatePayload"
+    assert task["submit_command"].startswith("gaia-research-loop submit")
+
+
+def test_next_emits_query_plan_after_scope_artifact(tmp_path: Path) -> None:
+    runner = CliRunner()
+    scope_dir = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts"
+    scope_dir.mkdir(parents=True)
+    (scope_dir / "scope.json").write_text(
+        json.dumps({"kind": "scope", "seed_question": "aspirin primary prevention"}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["recommended_action"] == "submit_query_plan"
+    task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
+    assert task["kind"] == "query_plan"
+    assert "Plan the next LKM searches" in task["objective"]

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -247,3 +247,57 @@ def test_submit_search_execution_writes_manifest_and_landscape(tmp_path: Path) -
     landscape = json.loads((artifacts / "landscape-0000.json").read_text(encoding="utf-8"))
     assert landscape["kind"] == "landscape"
     assert landscape["raw_results"][0]["query"] == "free fall"
+
+
+def test_e2e_loop_reaches_search_execution_task(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    status = runner.invoke(app, ["status", str(tmp_path), "--json"])
+    first_next = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    scope_task = json.loads(
+        Path(json.loads(first_next.stdout)["task_path"]).read_text(encoding="utf-8")
+    )
+    scope_candidate = tmp_path / "scope-candidate.json"
+    scope_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": scope_task["task_id"],
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {"seed_question": "aspirin primary prevention", "search_budget": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    submit_scope = runner.invoke(app, ["submit", str(tmp_path), str(scope_candidate), "--json"])
+    query_next = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    query_task = json.loads(
+        Path(json.loads(query_next.stdout)["task_path"]).read_text(encoding="utf-8")
+    )
+    query_candidate = tmp_path / "query-candidate.json"
+    query_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": query_task["task_id"],
+                "stage": "explore",
+                "kind": "query_plan",
+                "selected_action": "submit_query_plan",
+                "payload": {
+                    "queries": [{"query": "aspirin primary prevention", "purpose": "broad"}],
+                    "rationale": "Initial broad search.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    submit_query = runner.invoke(app, ["submit", str(tmp_path), str(query_candidate), "--json"])
+    search_next = runner.invoke(app, ["next", str(tmp_path), "--json"])
+
+    assert status.exit_code == 0
+    assert submit_scope.exit_code == 0
+    assert submit_query.exit_code == 0
+    search_task = json.loads(
+        Path(json.loads(search_next.stdout)["task_path"]).read_text(encoding="utf-8")
+    )
+    assert search_task["kind"] == "search_execution"

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -72,3 +72,69 @@ def test_task_query_plan_primitive_uses_existing_scope(tmp_path: Path) -> None:
     task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
     assert task["kind"] == "query_plan"
     assert task["inputs"]["scope"]["seed_question"] == "aspirin primary prevention"
+
+
+def test_submit_scope_writes_scope_artifact(tmp_path: Path) -> None:
+    runner = CliRunner()
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task_path = Path(json.loads(next_result.stdout)["task_path"])
+    task = json.loads(task_path.read_text(encoding="utf-8"))
+    candidate_path = tmp_path / "scope-candidate.json"
+    candidate_path.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {
+                    "seed_question": "aspirin primary prevention",
+                    "domain_profile": "clinical",
+                    "scope_dimensions": {"outcome": ["MI", "major bleeding"]},
+                    "search_budget": 4,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["submit", str(tmp_path), str(candidate_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "accepted"
+    scope_artifact = tmp_path / ".gaia" / "research_loop" / "explore" / "artifacts" / "scope.json"
+    assert (
+        json.loads(scope_artifact.read_text(encoding="utf-8"))["seed_question"]
+        == "aspirin primary prevention"
+    )
+
+
+def test_submit_invalid_candidate_records_repair_context(tmp_path: Path) -> None:
+    runner = CliRunner()
+    next_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    task_path = Path(json.loads(next_result.stdout)["task_path"])
+    task = json.loads(task_path.read_text(encoding="utf-8"))
+    bad_candidate = tmp_path / "bad.json"
+    bad_candidate.write_text(
+        json.dumps(
+            {
+                "task_id": task["task_id"],
+                "stage": "explore",
+                "kind": "scope",
+                "selected_action": "submit_scope",
+                "payload": {"search_budget": 4},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["submit", str(tmp_path), str(bad_candidate), "--json"])
+    assert result.exit_code == 1
+
+    repair_result = runner.invoke(app, ["next", str(tmp_path), "--json"])
+    repair_task = json.loads(
+        Path(json.loads(repair_result.stdout)["task_path"]).read_text(encoding="utf-8")
+    )
+    assert repair_task["repair_context"]["failed_candidate_path"].endswith("bad.json")
+    assert "seed_question" in json.dumps(repair_task["repair_context"]["errors"])

--- a/tests/research_loop/test_next_submit.py
+++ b/tests/research_loop/test_next_submit.py
@@ -184,6 +184,9 @@ def test_next_after_query_plan_emits_search_execution(tmp_path: Path) -> None:
     task = json.loads(Path(payload["task_path"]).read_text(encoding="utf-8"))
     assert task["kind"] == "search_execution"
     assert "gaia search lkm knowledge" in task["inputs"]["commands"][0]["command"]
+    assert "--format gaia-json" in task["inputs"]["commands"][0]["command"]
+    assert "--out" in task["inputs"]["commands"][0]["command"]
+    assert ">" not in task["inputs"]["commands"][0]["command"]
     assert task["inputs"]["commands"][0]["output_path"].endswith(".json")
 
 

--- a/tests/research_loop/test_schemas.py
+++ b/tests/research_loop/test_schemas.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gaia.research_loop.schemas import (
+    CandidateEnvelope,
+    EvidenceRef,
+    ResearchLoopTask,
+    TaskKind,
+)
+
+
+def test_task_embeds_contract_and_minimal_example() -> None:
+    task = ResearchLoopTask(
+        task_id="task-query-plan-1",
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        objective="Plan the next LKM searches.",
+        inputs={"scope": {"seed": "aspirin primary prevention"}},
+        instructions=["Return two focused queries."],
+        allowed_actions=["submit_query_plan", "stop"],
+        recommended_action="submit_query_plan",
+        output_contract={"type": "object", "required": ["queries"]},
+        allowed_refs=[EvidenceRef(kind="scope", id="scope-1")],
+        minimal_example={"queries": [{"query": "example query", "purpose": "shape only"}]},
+        submit_command="gaia-research-loop submit /tmp/pkg candidate.json",
+    )
+
+    assert task.model_dump(by_alias=True)["schema"] == "gaia.research_loop.task.v1"
+    assert task.stage == "explore"
+    assert task.kind == TaskKind.QUERY_PLAN
+    assert task.repair_context is None
+
+
+def test_candidate_selected_action_must_be_allowed_or_recommended() -> None:
+    candidate = CandidateEnvelope(
+        task_id="task-query-plan-1",
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        selected_action="stop",
+        override_rationale="Budget exhausted.",
+        payload={"reason": "No more searches."},
+    )
+
+    candidate.validate_against_actions(
+        recommended_action="submit_query_plan",
+        allowed_actions=["submit_query_plan", "stop"],
+    )
+
+
+def test_candidate_override_requires_rationale() -> None:
+    candidate = CandidateEnvelope(
+        task_id="task-query-plan-1",
+        stage="explore",
+        kind=TaskKind.QUERY_PLAN,
+        selected_action="stop",
+        payload={"reason": "No more searches."},
+    )
+
+    with pytest.raises(ValueError, match="override_rationale"):
+        candidate.validate_against_actions(
+            recommended_action="submit_query_plan",
+            allowed_actions=["submit_query_plan", "stop"],
+        )
+
+
+def test_extra_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResearchLoopTask.model_validate(
+            {
+                "task_id": "task-query-plan-1",
+                "stage": "explore",
+                "kind": TaskKind.QUERY_PLAN,
+                "objective": "Plan.",
+                "inputs": {},
+                "instructions": [],
+                "allowed_actions": ["submit_query_plan"],
+                "recommended_action": "submit_query_plan",
+                "output_contract": {},
+                "allowed_refs": [],
+                "minimal_example": {},
+                "submit_command": "gaia-research-loop submit /tmp/pkg candidate.json",
+                "unexpected": True,
+            }
+        )

--- a/tests/research_loop/test_storage.py
+++ b/tests/research_loop/test_storage.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gaia.research_loop.storage import (
+    append_event,
+    ensure_loop_dirs,
+    load_events,
+    rebuild_state,
+    write_json,
+)
+
+
+def test_ensure_loop_dirs_creates_canonical_layout(tmp_path: Path) -> None:
+    paths = ensure_loop_dirs(tmp_path)
+
+    assert paths.root == tmp_path / ".gaia" / "research_loop"
+    for stage in ["explore", "assess"]:
+        for leaf in ["tasks", "candidates", "artifacts"]:
+            assert (paths.root / stage / leaf).is_dir()
+
+
+def test_append_event_writes_jsonl(tmp_path: Path) -> None:
+    paths = ensure_loop_dirs(tmp_path)
+    append_event(paths, event_type="task_emitted", stage="explore", data={"task_id": "t1"})
+
+    events = load_events(paths)
+    assert len(events) == 1
+    assert events[0].event_type == "task_emitted"
+    assert events[0].stage == "explore"
+    assert events[0].data == {"task_id": "t1"}
+
+
+def test_rebuild_state_indexes_latest_task_and_artifact(tmp_path: Path) -> None:
+    paths = ensure_loop_dirs(tmp_path)
+    write_json(paths.explore_tasks / "task-1.json", {"task_id": "task-1", "kind": "scope"})
+    write_json(paths.explore_artifacts / "scope.json", {"kind": "scope", "id": "scope-1"})
+
+    state = rebuild_state(paths)
+
+    assert state.schema_id == "gaia.research_loop.state.v1"
+    assert state.latest_task_by_stage["explore"].endswith("task-1.json")
+    assert state.latest_artifact_by_stage["explore"].endswith("scope.json")


### PR DESCRIPTION
## Summary
- Complete the agent-facing Explore -> Assess loop with primitive task commands for search execution, focus synthesis, assessment context, and evidence diagnosis.
- Support iterative landscape rounds, cumulative focus synthesis refs, validated evidence refs, and automatic explore/assess gate routing.
- Carry retrieved LKM snippets into assessment context and diagnosis so Assess is grounded in actual search content.

## Test Plan
- `uv run pytest tests/research_loop -q`
- `uv run ruff check gaia/research_loop tests/research_loop`
- `uv run ruff format --check gaia/research_loop tests/research_loop`
- `uv run mypy gaia/research_loop tests/research_loop`
