### PR TITLE
feat(pkg): materialize LKM search results

### DIFF
--- a/docs/reference/cli/pkg.md
+++ b/docs/reference/cli/pkg.md
@@ -6,6 +6,8 @@ Install, publish, and bootstrap packages.
 gaia pkg add <package>            Install a registered package from the registry
 gaia pkg add --lkm-index <id> --lkm-paper <paper-id>
                                   Materialize an LKM paper as a local package
+gaia pkg add --lkm-search-json <path>
+                                  Materialize LKM search claim/question results
 gaia pkg add lkm:<index>:paper:<paper-id>
                                   Materialize a canonical LKM paper source ref
 gaia pkg add-import --from <m>    Insert a sibling/module import into a package file
@@ -16,7 +18,7 @@ gaia pkg scaffold --target <p>    Bootstrap a fresh -gaia package directory layo
 
 | Verb | Purpose |
 |---|---|
-| `add` | Resolve a registry entry to a SHA-pinned git URL, add as dependency, optionally cache `dep_beliefs/<name>.json`; also accepts LKM paper source refs/flags, materializes the paper graph as a project-local Gaia package, compiles it, and adds it as an editable dependency |
+| `add` | Resolve a registry entry to a SHA-pinned git URL, add as dependency, optionally cache `dep_beliefs/<name>.json`; also accepts LKM source refs/flags, materializes LKM paper graphs or search variables as project-local Gaia packages, compiles them, and adds them as editable dependencies |
 | `add-import` | Insert an idempotent `from <module> import <names>` line into `__init__.py` or another package source file |
 | `add-module` | Create `src/<import_name>/<module>.py` with an optional docstring, optional seeded DSL imports, and a literal empty `__all__` |
 | `register` | Submit a package to the registry: emit Package/Versions/Deps TOML, exports/premises/holes/bridges/beliefs JSON, and (optionally) push + open a registry PR |
@@ -33,12 +35,24 @@ and canonical source refs:
 
 ```text
 gaia pkg add --lkm-index bohrium --lkm-paper 811827932371615744
+gaia pkg add --lkm-search-json /tmp/lkm-search.json
 gaia pkg add lkm:bohrium:paper:811827932371615744
 gaia pkg add lkm:paper:811827932371615744
 ```
 
 The short `lkm:paper:<id>` form is a default-index compatibility alias; Gaia
-emits canonical refs with the explicit index id. The paper form fetches
+emits canonical refs with the explicit index id.
+
+`--lkm-search-json` consumes the normalized `gaia-json` envelope produced by
+`gaia search lkm ... --format gaia-json` and materializes claim/question results
+shallowly. Each retrieved LKM variable becomes a generated `claim(...)` or
+`question(...)` in a local LKM-backed dependency package, with metadata preserving
+the query text, search result id, retrieval score, LKM provider id,
+`source_package`, `local_id`, paper id/title, and DOI. This is intentionally a
+search-result landing step: it does not fetch reasoning chains or the full paper
+graph.
+
+The paper form fetches
 `/papers/graph`, writes a generated Gaia package under
 `.gaia/lkm_packages/<package-name>/`, compiles it so dependency manifests exist,
 and runs `uv add --editable <generated-package>`.
@@ -59,9 +73,10 @@ Downstream source can import generated claims directly, for example:
 from lkm_bohrium_controlling_phase_and_morphology_811827932371615744 import conclusion_1
 ```
 
-`gaia pkg add` still does not install standalone LKM claim nodes. Use
-`gaia search lkm reasoning --claim-id <claim-id>` to resolve a claim to its
-backing paper, then add the paper package.
+`gaia pkg add --lkm-claim <claim-id>` still does not fetch standalone LKM claim
+content by id. Use a normalized LKM search JSON file when you already have the
+claim/question payload, or use `gaia search lkm reasoning --claim-id <claim-id>`
+to inspect a claim's reasoning chain before adding the backing paper package.
 
 LKM index URLs are resolver configuration, not package names. `bohrium` is the
 built-in index id for `https://open.bohrium.com/openapi/v1/lkm`; custom indexes

--- a/gaia/cli/commands/add.py
+++ b/gaia/cli/commands/add.py
@@ -14,6 +14,7 @@ from gaia.cli._registry import DEFAULT_REGISTRY, fetch_file_optional, resolve_pa
 from gaia.cli.commands.pkg.lkm_materialize import (
     MaterializedLKMPackage,
     materialize_lkm_paper_package,
+    materialize_lkm_search_packages,
 )
 from gaia.cli.commands.search.lkm._indexes import (
     DEFAULT_LKM_INDEX_ID,
@@ -47,7 +48,7 @@ def add_command(
         DEFAULT_LKM_INDEX_ID,
         "--lkm-index",
         "--lkm-server",
-        help="Configured LKM index id for --lkm-paper / --lkm-claim.",
+        help="Configured LKM index id for LKM-backed package materialization.",
     ),
     lkm_paper: str | None = typer.Option(
         None,
@@ -58,6 +59,14 @@ def add_command(
         None,
         "--lkm-claim",
         help="Resolve this LKM claim id to its backing paper package.",
+    ),
+    lkm_search_json: str | None = typer.Option(
+        None,
+        "--lkm-search-json",
+        help=(
+            "Materialize claim/question variables from a normalized "
+            "`gaia search lkm --format gaia-json` output file."
+        ),
     ),
     target: str = typer.Option(
         ".",
@@ -82,7 +91,10 @@ def add_command(
 
     LKM paper refs/flags fetch the paper graph, generate a local Gaia package
     under ``.gaia/lkm_packages/``, compile it, and add it as an editable
-    dependency with ``uv add --editable``.
+    dependency with ``uv add --editable``. ``--lkm-search-json`` consumes
+    normalized LKM search output and shallowly materializes claim/question
+    variables as Gaia package dependencies without fetching reasoning chains or
+    whole paper graphs.
 
     ``--version`` pins a specific release; omit to take the latest
     registered version.
@@ -94,9 +106,16 @@ def add_command(
         gaia pkg add galileo-falling-bodies-gaia
         gaia pkg add mendel-v0-5-gaia --version 0.1.0
         gaia pkg add --lkm-index bohrium --lkm-paper 811827932371615744
+        gaia pkg add --lkm-search-json /tmp/lkm-search.json
         gaia pkg add lkm:bohrium:paper:811827932371615744
     """
     try:
+        _validate_lkm_search_json_inputs(
+            package,
+            lkm_paper=lkm_paper,
+            lkm_claim=lkm_claim,
+            lkm_search_json=lkm_search_json,
+        )
         lkm_ref = _resolve_lkm_source_ref(
             package,
             lkm_index=lkm_index,
@@ -112,6 +131,13 @@ def add_command(
     # "run from inside the package" behavior by walking up to the nearest root.
     package_root = _resolve_package_root(target)
 
+    if lkm_search_json is not None:
+        _handle_lkm_search_json_add(
+            Path(lkm_search_json),
+            package_root=package_root,
+            index_id=lkm_index,
+        )
+        return
     if lkm_ref is not None:
         _handle_lkm_source_add(lkm_ref, package_root=package_root)
         return
@@ -172,6 +198,22 @@ class LKMSourceRef:
     def ref(self) -> str:
         """Return the canonical LKM source ref."""
         return f"lkm:{self.index_id}:{self.kind}:{self.provider_id}"
+
+
+def _validate_lkm_search_json_inputs(
+    package: str | None,
+    *,
+    lkm_paper: str | None,
+    lkm_claim: str | None,
+    lkm_search_json: str | None,
+) -> None:
+    if lkm_search_json is None:
+        return
+    if package is not None or lkm_paper is not None or lkm_claim is not None:
+        raise GaiaPackagingError(
+            "pass --lkm-search-json by itself; do not combine it with PACKAGE, "
+            "--lkm-paper, or --lkm-claim."
+        )
 
 
 def _resolve_lkm_source_ref(
@@ -242,6 +284,80 @@ def _handle_lkm_source_add(ref: LKMSourceRef, *, package_root: Path | None) -> N
         err=True,
     )
     raise typer.Exit(1)
+
+
+def _handle_lkm_search_json_add(
+    path: Path,
+    *,
+    package_root: Path | None,
+    index_id: str,
+) -> None:
+    if package_root is None:
+        typer.echo(
+            "Error: --lkm-search-json needs a target Gaia knowledge package. "
+            "Run it inside the package that should depend on these LKM search "
+            "variables, or point --target at it.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise GaiaPackagingError("LKM search JSON root must be an object.")
+        materialized = materialize_lkm_search_packages(
+            payload,
+            project_root=package_root,
+            index_id=normalize_lkm_index_id(index_id) or index_id,
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        typer.echo(f"Error: failed to read LKM search JSON {path}: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    except GaiaPackagingError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    if not materialized.packages:
+        typer.echo(
+            "Error: no claim/question variables with paper provenance were "
+            "found in the LKM search JSON.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    for package in materialized.packages:
+        try:
+            result = _run_uv(["uv", "add", "--editable", str(package.root)], cwd=package_root)
+        except GaiaPackagingError as exc:
+            _echo_lkm_uv_add_failure(package, str(exc))
+            raise typer.Exit(1) from exc
+        if result.returncode != 0:
+            stderr = result.stderr.strip() or result.stdout.strip()
+            _echo_lkm_uv_add_failure(package, stderr or "uv exited with a non-zero status")
+            raise typer.Exit(1)
+
+    package_word = "package" if len(materialized.packages) == 1 else "packages"
+    typer.echo(f"Materialized {len(materialized.packages)} LKM search {package_word}")
+    for package in materialized.packages:
+        typer.echo(f"Package: {package.dist_name}")
+        typer.echo(f"Path: {package.root}")
+        typer.echo(
+            "Contents: "
+            f"{package.claim_count} claims, "
+            f"{package.question_count} questions, "
+            f"{package.dependency_count} depends_on scaffold dependencies"
+        )
+        if package.regenerated_existing:
+            typer.echo(
+                "Warning: regenerated an existing LKM package; review downstream imports "
+                "if generated symbols changed.",
+                err=True,
+            )
+    if materialized.skipped_result_count:
+        typer.echo(
+            f"Note: skipped {materialized.skipped_result_count} search result(s) "
+            "that were not claim/question variables with paper provenance."
+        )
+    typer.echo("Added editable LKM search dependency with uv.")
 
 
 def _handle_lkm_paper_add(ref: LKMSourceRef, *, package_root: Path | None) -> None:

--- a/gaia/cli/commands/pkg/lkm_materialize.py
+++ b/gaia/cli/commands/pkg/lkm_materialize.py
@@ -6,7 +6,7 @@ import json
 import keyword
 import re
 import unicodedata
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +44,14 @@ class MaterializedLKMPackage:
 
 
 @dataclass(frozen=True)
+class MaterializedLKMSearchPackages:
+    """Generated local Gaia packages backed by one LKM search envelope."""
+
+    packages: list[MaterializedLKMPackage]
+    skipped_result_count: int
+
+
+@dataclass(frozen=True)
 class _DependencyStatements:
     statements: list[str]
     skipped_factor_count: int
@@ -58,6 +66,7 @@ class _Node:
     title: str | None
     local_id: str | None
     role: str | None
+    search_metadata: dict[str, Any] = field(default_factory=dict)
 
 
 def materialize_lkm_paper_package(
@@ -67,6 +76,7 @@ def materialize_lkm_paper_package(
     index_id: str,
     paper_id: str,
     storage_root: Path | None = None,
+    allow_paper_fallback: bool = True,
 ) -> MaterializedLKMPackage:
     """Write, compile, and return a local Gaia package for an LKM paper graph."""
     item = _select_paper_item(payload, paper_id=paper_id)
@@ -86,7 +96,12 @@ def materialize_lkm_paper_package(
     src.mkdir(parents=True, exist_ok=True)
     (root / ".gaia").mkdir(exist_ok=True)
 
-    nodes = _collect_nodes(item, paper=paper, paper_id=resolved_paper_id)
+    nodes = _collect_nodes(
+        item,
+        paper=paper,
+        paper_id=resolved_paper_id,
+        allow_paper_fallback=allow_paper_fallback,
+    )
     dependency_result = _dependency_statements(
         item,
         nodes=nodes,
@@ -154,6 +169,86 @@ def materialize_lkm_paper_package(
     )
 
 
+def materialize_lkm_search_packages(
+    payload: dict[str, Any],
+    *,
+    project_root: Path,
+    index_id: str,
+    storage_root: Path | None = None,
+) -> MaterializedLKMSearchPackages:
+    """Write shallow local Gaia packages from normalized LKM search results.
+
+    This materializes only retrieved LKM variable nodes (claims/questions) as
+    source claims/questions. It deliberately does not fetch paper graphs or
+    reasoning chains; callers can upgrade specific nodes later with
+    ``gaia pkg add --lkm-paper`` once assessment needs deeper structure.
+    """
+    query = payload.get("query") if isinstance(payload.get("query"), dict) else {}
+    query_text = _text(query.get("text")) if isinstance(query, dict) else None
+    effective_index_id = (
+        _text(query.get("index_id")) if isinstance(query, dict) else None
+    ) or index_id
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise GaiaPackagingError("LKM search JSON must include a `results` list.")
+
+    skipped = 0
+    by_paper: dict[str, dict[str, Any]] = {}
+    for result in results:
+        if not isinstance(result, dict):
+            skipped += 1
+            continue
+        source = result.get("source") if isinstance(result.get("source"), dict) else {}
+        paper_id = _text(source.get("paper_id")) if isinstance(source, dict) else None
+        source_package = _text(source.get("source_package")) if isinstance(source, dict) else None
+        if paper_id is None:
+            paper_id = _paper_id_from_source_package(source_package)
+        if paper_id is None:
+            skipped += 1
+            continue
+        variable = _search_result_variable(
+            result,
+            query_text=query_text,
+            source_package=source_package,
+        )
+        if variable is None:
+            skipped += 1
+            continue
+        item = by_paper.get(paper_id)
+        if item is None:
+            paper_title = _text(source.get("paper_title")) if isinstance(source, dict) else None
+            doi = _text(source.get("doi")) if isinstance(source, dict) else None
+            item = {
+                "paper": _clean_dict(
+                    {
+                        "id": paper_id,
+                        "package_id": source_package or f"paper:{paper_id}",
+                        "en_title": paper_title,
+                        "doi": doi,
+                    }
+                ),
+                "variables": [],
+                "factors": [],
+                "motivations": [],
+            }
+            by_paper[paper_id] = item
+        item["variables"].append(variable)
+
+    packages: list[MaterializedLKMPackage] = []
+    for paper_id, item in by_paper.items():
+        packages.append(
+            materialize_lkm_paper_package(
+                item,
+                project_root=project_root,
+                index_id=effective_index_id,
+                paper_id=paper_id,
+                storage_root=storage_root,
+                allow_paper_fallback=False,
+            )
+        )
+    return MaterializedLKMSearchPackages(packages=packages, skipped_result_count=skipped)
+
+
 def _select_paper_item(payload: dict[str, Any], *, paper_id: str) -> dict[str, Any]:
     data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
     papers = data.get("papers") if isinstance(data, dict) else None
@@ -206,11 +301,18 @@ def _paper_id(paper: dict[str, Any]) -> str | None:
     return None
 
 
+def _paper_id_from_source_package(source_package: str | None) -> str | None:
+    if source_package and source_package.startswith("paper:"):
+        return source_package.split(":", 1)[1]
+    return None
+
+
 def _collect_nodes(
     item: dict[str, Any],
     *,
     paper: dict[str, Any],
     paper_id: str,
+    allow_paper_fallback: bool = True,
 ) -> list[_Node]:
     nodes: list[_Node] = []
     seen_ids: set[str] = set()
@@ -245,10 +347,11 @@ def _collect_nodes(
                 title=_text(raw.get("title")),
                 local_id=_text(raw.get("local_id")),
                 role=_text(raw.get("role")),
+                search_metadata=_dict(raw.get("_gaia_search")),
             )
         )
 
-    if any(node.type == "claim" for node in nodes):
+    if any(node.type == "claim" for node in nodes) or not allow_paper_fallback:
         return nodes
 
     fallback_content = _fallback_claim_content(paper)
@@ -270,6 +373,70 @@ def _collect_nodes(
             ),
         )
     return nodes
+
+
+def _search_result_variable(
+    result: dict[str, Any],
+    *,
+    query_text: str | None,
+    source_package: str | None,
+) -> dict[str, Any] | None:
+    variable_type = _search_result_variable_type(result)
+    if variable_type not in {"claim", "question"}:
+        return None
+    source = result.get("source") if isinstance(result.get("source"), dict) else {}
+    raw_value = result.get("raw")
+    raw = raw_value if isinstance(raw_value, dict) else {}
+    payload_value = raw.get("payload")
+    raw_payload = payload_value if isinstance(payload_value, dict) else {}
+    variable = dict(raw_payload)
+    provider_id = _text(source.get("provider_id")) if isinstance(source, dict) else None
+    result_id = _text(result.get("id"))
+    rank = result.get("rank") if isinstance(result.get("rank"), dict) else {}
+    rank_score = rank.get("score") if isinstance(rank, dict) else None
+    if provider_id is None:
+        provider_id = _text(variable.get("global_id")) or _text(variable.get("id"))
+    if provider_id is None:
+        provider_id = result_id
+    content = _text(result.get("content")) or _text(variable.get("content"))
+    if content is None:
+        return None
+    variable["type"] = variable_type
+    variable["content"] = content
+    if provider_id is not None:
+        variable.setdefault("global_id", provider_id)
+    variable.setdefault("title", _text(result.get("title")))
+    if isinstance(source, dict):
+        variable.setdefault("local_id", _text(source.get("local_id")))
+        variable.setdefault("role", _text(source.get("role")))
+    variable["_gaia_search"] = _clean_dict(
+        {
+            "query_text": query_text,
+            "search_result_id": result_id,
+            "rank_score": rank_score if isinstance(rank_score, int | float) else None,
+            "source_package": source_package,
+            "provider_result_kind": _text(result.get("kind")),
+        }
+    )
+    return variable
+
+
+def _search_result_variable_type(result: dict[str, Any]) -> str | None:
+    kind = _text(result.get("kind"))
+    if kind in {"claim", "question"}:
+        return kind
+    gaia = result.get("gaia") if isinstance(result.get("gaia"), dict) else {}
+    object_kind = _text(gaia.get("object_kind")) if isinstance(gaia, dict) else None
+    if object_kind in {"claim", "question"}:
+        return object_kind
+    raw_value = result.get("raw")
+    raw = raw_value if isinstance(raw_value, dict) else {}
+    payload_value = raw.get("payload")
+    raw_payload = payload_value if isinstance(payload_value, dict) else {}
+    raw_type = _text(raw_payload.get("type")) if isinstance(raw_payload, dict) else None
+    if raw_type in {"claim", "question"}:
+        return raw_type
+    return None
 
 
 def _raw_lkm_nodes(item: dict[str, Any]) -> list[dict[str, Any]]:
@@ -411,6 +578,7 @@ def _module_text(
             "node_id": node.provider_id,
             "local_id": node.local_id,
             "role": node.role,
+            **node.search_metadata,
         }
         ctor = "question" if node.type == "question" else "claim"
         blocks.append(
@@ -573,6 +741,12 @@ def _list(value: Any) -> list[Any]:
     return []
 
 
+def _dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
 def _text(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
@@ -610,4 +784,9 @@ def _clean_dict(value: dict[str, Any]) -> dict[str, Any]:
     return {key: item for key, item in value.items() if item is not None}
 
 
-__all__ = ["MaterializedLKMPackage", "materialize_lkm_paper_package"]
+__all__ = [
+    "MaterializedLKMPackage",
+    "MaterializedLKMSearchPackages",
+    "materialize_lkm_paper_package",
+    "materialize_lkm_search_packages",
+]

--- a/tests/cli/search/test_lkm_package_e2e.py
+++ b/tests/cli/search/test_lkm_package_e2e.py
@@ -86,6 +86,79 @@ def _paper_graph_payload() -> dict[str, Any]:
     }
 
 
+def _knowledge_search_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "query": {
+            "text": "alpha FAPbI3 phase purity",
+            "provider": "lkm",
+            "kind": "knowledge",
+            "index_id": "bohrium",
+        },
+        "results": [
+            {
+                "id": "lkm:bohrium:gcn_phase",
+                "provider": "lkm",
+                "kind": "claim",
+                "title": "Annealing improves alpha-phase purity",
+                "content": "Annealing at 120 C improves alpha-phase purity.",
+                "rank": {"score": 0.91, "score_kind": "retrieval"},
+                "gaia": {"object_kind": "claim", "qid": None},
+                "source": {
+                    "provider_id": "gcn_phase",
+                    "index_id": "bohrium",
+                    "source_package": "paper:811827932371615744",
+                    "paper_id": "811827932371615744",
+                    "paper_title": "Controlling phase and morphology",
+                    "doi": "10.1016/j.jpcs.2021.110374",
+                    "local_id": "paper:811827932371615744::conclusion_1",
+                    "role": "conclusion",
+                    "has_reasoning": True,
+                },
+                "raw": {
+                    "provider": "lkm",
+                    "payload": {
+                        "content": "Annealing at 120 C improves alpha-phase purity.",
+                        "global_id": "gcn_phase",
+                        "local_id": "paper:811827932371615744::conclusion_1",
+                        "title": "Annealing improves alpha-phase purity",
+                        "type": "claim",
+                    },
+                },
+            },
+            {
+                "id": "lkm:bohrium:gq_phase",
+                "provider": "lkm",
+                "kind": "question",
+                "title": "Which phase conversion pathway dominates?",
+                "content": "Which phase conversion pathway dominates?",
+                "rank": {"score": 0.73, "score_kind": "retrieval"},
+                "gaia": {"object_kind": "question", "qid": None},
+                "source": {
+                    "provider_id": "gq_phase",
+                    "index_id": "bohrium",
+                    "source_package": "paper:811827932371615744",
+                    "paper_id": "811827932371615744",
+                    "paper_title": "Controlling phase and morphology",
+                    "doi": "10.1016/j.jpcs.2021.110374",
+                    "local_id": "paper:811827932371615744::Q1",
+                    "role": "subproblem",
+                },
+                "raw": {
+                    "provider": "lkm",
+                    "payload": {
+                        "content": "Which phase conversion pathway dominates?",
+                        "global_id": "gq_phase",
+                        "local_id": "paper:811827932371615744::Q1",
+                        "title": "Which phase conversion pathway dominates?",
+                        "type": "question",
+                    },
+                },
+            },
+        ],
+    }
+
+
 def _write_consumer_package(
     root: Path,
     *,
@@ -219,6 +292,32 @@ def test_materialized_lkm_package_can_be_imported_and_referenced(tmp_path: Path)
     qids = {item["id"] for item in ir["knowledges"]}
     assert "referenced_lkm_claim" in labels
     assert any(qid.startswith(f"lkm:{materialized.import_name}::") for qid in qids)
+
+
+def test_materialize_lkm_search_variables_creates_shallow_paper_package(
+    tmp_path: Path,
+) -> None:
+    from gaia.cli.commands.pkg.lkm_materialize import materialize_lkm_search_packages
+
+    materialized = materialize_lkm_search_packages(
+        _knowledge_search_payload(),
+        project_root=tmp_path,
+        index_id="bohrium",
+    )
+
+    assert len(materialized.packages) == 1
+    package = materialized.packages[0]
+    assert package.source_ref == "lkm:bohrium:paper:811827932371615744"
+    assert package.claim_count == 1
+    assert package.question_count == 1
+    assert package.dependency_count == 0
+
+    generated_source = (package.root / "src" / package.import_name / "__init__.py").read_text()
+    assert "Annealing at 120 C improves alpha-phase purity." in generated_source
+    assert "Which phase conversion pathway dominates?" in generated_source
+    assert "'query_text': 'alpha FAPbI3 phase purity'" in generated_source
+    assert "'search_result_id': 'lkm:bohrium:gcn_phase'" in generated_source
+    assert "'source_package': 'paper:811827932371615744'" in generated_source
 
 
 def test_materialized_lkm_package_can_be_imported_from_uv_sources(
@@ -364,6 +463,41 @@ def test_pkg_add_lkm_paper_materializes_and_adds_editable_dependency(
     materialized_root = Path(uv_args[3])
     assert materialized_root.exists()
     assert (materialized_root / ".gaia" / "manifests" / "premises.json").exists()
+
+
+def test_pkg_add_lkm_search_json_materializes_shallow_dependencies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gaia.cli.commands.add as add_mod
+
+    consumer = tmp_path / "consumer"
+    _write_empty_gaia_package(consumer)
+    search_json = tmp_path / "search.json"
+    search_json.write_text(json.dumps(_knowledge_search_payload()), encoding="utf-8")
+
+    uv_calls: list[tuple[list[str], Path | None]] = []
+
+    def fake_run_uv(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        uv_calls.append((args, kwargs.get("cwd")))
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(add_mod, "_run_uv", fake_run_uv)
+    monkeypatch.chdir(consumer)
+
+    result = runner.invoke(
+        app,
+        ["pkg", "add", "--lkm-search-json", str(search_json)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Materialized 1 LKM search package" in result.output
+    assert "1 claims, 1 questions, 0 depends_on scaffold dependencies" in result.output
+    assert len(uv_calls) == 1
+    uv_args, uv_cwd = uv_calls[0]
+    assert uv_args[:3] == ["uv", "add", "--editable"]
+    assert uv_cwd == consumer
+    assert Path(uv_args[3]).exists()
 
 
 def test_pkg_add_lkm_paper_warns_when_response_has_no_paper_id(


### PR DESCRIPTION
## Summary
- add gaia pkg add --lkm-search-json for shallow materialization of normalized LKM search claim/question results
- generate local LKM-backed dependency packages preserving query/result/source metadata without fetching chains or full paper graphs
- document the search-result landing behavior and cover it with CLI/materializer tests

## Verification
- uv run pytest tests/cli/test_add.py tests/cli/search/test_lkm_package_e2e.py -q
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy gaia/cli/commands/add.py gaia/cli/commands/pkg/lkm_materialize.py tests/cli/search/test_lkm_package_e2e.py
- uv run pytest -m "pr_gate and not slow" -q