### PR TITLE
feat(pkg): add local package dependencies

### DIFF
--- a/docs/reference/cli/pkg.md
+++ b/docs/reference/cli/pkg.md
@@ -4,6 +4,7 @@ Install, publish, and bootstrap packages.
 
 ```text
 gaia pkg add <package>            Install a registered package from the registry
+gaia pkg add --local <path>       Add a local Gaia package dependency
 gaia pkg add --lkm-index <id> --lkm-paper <paper-id>
                                   Materialize an LKM paper as a local package
 gaia pkg add --lkm-index <id> --lkm-claim <claim-id>
@@ -20,7 +21,7 @@ gaia pkg scaffold --target <p>    Bootstrap a fresh -gaia package directory layo
 
 | Verb | Purpose |
 |---|---|
-| `add` | Resolve a registry entry to a SHA-pinned git URL, add as dependency, optionally cache `dep_beliefs/<name>.json`; also accepts LKM paper source refs/flags, materializes the paper graph as a project-local Gaia package, compiles it, and adds it as an editable dependency |
+| `add` | Resolve a registry entry to a SHA-pinned git URL, add as dependency, optionally cache `dep_beliefs/<name>.json`; add an existing local Gaia package with `--local`; also accepts LKM paper source refs/flags, materializes the paper graph as a project-local Gaia package, compiles it, and adds it as a local dependency |
 | `add-import` | Insert an idempotent `from <module> import <names>` line into `__init__.py` or another package source file |
 | `add-module` | Create `src/<import_name>/<module>.py` with an optional docstring, optional seeded DSL imports, and a literal empty `__all__` |
 | `register` | Submit a package to the registry: emit Package/Versions/Deps TOML, exports/premises/holes/bridges/beliefs JSON, and (optionally) push + open a registry PR |
@@ -31,6 +32,18 @@ The historical flat verbs map to grouped paths where applicable
 `add-import`, `add-module`, and `scaffold` verbs are v0.5 additions. See
 [CLI Commands](../../for-users/cli-commands.md) for workflow examples and
 use `gaia pkg <verb> --help` for the executable option surface.
+
+For local Gaia packages, use `--local`:
+
+```text
+gaia pkg add --local .gaia/lkm_packages/<package-name>
+```
+
+The local path must already be a Gaia knowledge package. Internally, Gaia asks
+`uv` to install it as an editable local dependency, but the public contract is
+"add this local package". Generated source packages from future research or LKM
+adapters should be written as Gaia packages first, then attached with `--local`
+instead of teaching `pkg add` source-specific search schemas.
 
 For LKM search results, `gaia pkg add` accepts both the friendly action form
 and canonical source refs:

--- a/gaia/cli/commands/add.py
+++ b/gaia/cli/commands/add.py
@@ -61,6 +61,11 @@ def add_command(
         "--lkm-claim",
         help="Resolve this LKM claim id to its backing paper package.",
     ),
+    local: str | None = typer.Option(
+        None,
+        "--local",
+        help="Add this local Gaia package directory as a dependency.",
+    ),
     target: str = typer.Option(
         ".",
         "--target",
@@ -72,7 +77,7 @@ def add_command(
         ),
     ),
 ) -> None:
-    """Install a registered or LKM-backed Gaia knowledge package.
+    """Install a registered, LKM-backed, or local Gaia knowledge package.
 
     Resolves ``<package>`` against the gaia registry (default:
     ``SiliconEinstein/gaia-registry`` on GitHub), runs ``uv add`` on the
@@ -86,6 +91,11 @@ def add_command(
     under ``.gaia/lkm_packages/``, compile it, and add it as an editable
     dependency with ``uv add --editable``.
 
+    ``--local <path>`` adds an existing local Gaia package directory as a local
+    dependency. This keeps ``gaia pkg add`` package-centric: upstream research
+    adapters can generate partial or full source packages, then add those
+    packages through the same local package contract.
+
     ``--version`` pins a specific release; omit to take the latest
     registered version.
 
@@ -95,11 +105,19 @@ def add_command(
 
         gaia pkg add galileo-falling-bodies-gaia
         gaia pkg add mendel-v0-5-gaia --version 0.1.0
+        gaia pkg add --local .gaia/lkm_packages/generated-source-package
         gaia pkg add --lkm-index bohrium --lkm-paper 811827932371615744
         gaia pkg add --lkm-index bohrium --lkm-claim gcn_579430355a0e4bbd
         gaia pkg add lkm:bohrium:paper:811827932371615744
     """
     try:
+        _validate_local_source_args(
+            package,
+            version=version,
+            local=local,
+            lkm_paper=lkm_paper,
+            lkm_claim=lkm_claim,
+        )
         lkm_ref = _resolve_lkm_source_ref(
             package,
             lkm_index=lkm_index,
@@ -115,6 +133,9 @@ def add_command(
     # "run from inside the package" behavior by walking up to the nearest root.
     package_root = _resolve_package_root(target)
 
+    if local is not None:
+        _handle_local_package_add(Path(local), package_root=package_root)
+        return
     if lkm_ref is not None:
         _handle_lkm_source_add(lkm_ref, package_root=package_root)
         return
@@ -177,6 +198,23 @@ class LKMSourceRef:
         return f"lkm:{self.index_id}:{self.kind}:{self.provider_id}"
 
 
+def _validate_local_source_args(
+    package: str | None,
+    *,
+    version: str | None,
+    local: str | None,
+    lkm_paper: str | None,
+    lkm_claim: str | None,
+) -> None:
+    if local is None:
+        return
+    if package is not None or version is not None or lkm_paper is not None or lkm_claim is not None:
+        raise GaiaPackagingError(
+            "pass --local by itself with only --target; it cannot be combined "
+            "with PACKAGE, --version, --lkm-paper, or --lkm-claim."
+        )
+
+
 def _resolve_lkm_source_ref(
     package: str | None,
     *,
@@ -229,6 +267,42 @@ def _make_lkm_ref(index_id: str, kind: str, provider_id: str) -> LKMSourceRef:
         kind=kind,
         provider_id=normalized_provider_id,
     )
+
+
+def _handle_local_package_add(local: Path, *, package_root: Path | None) -> None:
+    if package_root is None:
+        typer.echo(
+            "Error: --local needs a target Gaia knowledge package. Run it inside "
+            "the consumer package, or point --target at that package.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    local_root = _resolve_package_root(str(local))
+    if local_root is None:
+        typer.echo(
+            f"Error: --local path is not a Gaia knowledge package: {local.resolve()}",
+            err=True,
+        )
+        raise typer.Exit(1)
+    if local_root == package_root:
+        typer.echo(
+            "Error: --local cannot add the target package to itself.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    try:
+        result = _run_uv(["uv", "add", "--editable", str(local_root)], cwd=package_root)
+    except GaiaPackagingError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        typer.echo(f"Error: uv add failed: {stderr}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo(f"Added local Gaia package: {local_root}")
 
 
 def _handle_lkm_source_add(ref: LKMSourceRef, *, package_root: Path | None) -> None:

--- a/gaia/cli/commands/add.py
+++ b/gaia/cli/commands/add.py
@@ -278,10 +278,13 @@ def _handle_local_package_add(local: Path, *, package_root: Path | None) -> None
         )
         raise typer.Exit(1)
 
-    local_root = _resolve_package_root(str(local))
+    local_candidate = local if local.is_absolute() else package_root / local
+    local_root = _resolve_package_root(str(local_candidate))
+    if local_root is None and not local.is_absolute():
+        local_root = _resolve_package_root(str(local))
     if local_root is None:
         typer.echo(
-            f"Error: --local path is not a Gaia knowledge package: {local.resolve()}",
+            f"Error: --local path is not a Gaia knowledge package: {local_candidate.resolve()}",
             err=True,
         )
         raise typer.Exit(1)

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -153,6 +153,38 @@ def test_add_local_gaia_package_as_editable_dependency(mock_uv, tmp_path, monkey
     assert f"Added local Gaia package: {dependency.resolve()}" in result.output
 
 
+@patch("gaia.cli.commands.add._run_uv")
+def test_add_local_relative_path_resolves_from_target_package(mock_uv, tmp_path, monkeypatch):
+    """Relative --local paths resolve from the target package root."""
+    consumer = tmp_path / "consumer-gaia"
+    dependency = consumer / ".gaia" / "lkm_packages" / "source-paper-gaia"
+    consumer.mkdir()
+    dependency.mkdir(parents=True)
+    _write_gaia_package_root(consumer)
+    _write_gaia_package_root(dependency)
+    monkeypatch.chdir(tmp_path)
+    mock_uv.return_value = MagicMock(returncode=0)
+
+    result = runner.invoke(
+        app,
+        [
+            "pkg",
+            "add",
+            "--target",
+            "consumer-gaia",
+            "--local",
+            ".gaia/lkm_packages/source-paper-gaia",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_uv.assert_called_once_with(
+        ["uv", "add", "--editable", str(dependency.resolve())],
+        cwd=consumer.resolve(),
+    )
+    assert f"Added local Gaia package: {dependency.resolve()}" in result.output
+
+
 def test_add_local_requires_local_gaia_package(tmp_path, monkeypatch):
     """Gaia pkg add --local rejects paths that are not Gaia knowledge packages."""
     consumer = tmp_path / "consumer-gaia"

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -128,6 +128,59 @@ def test_add_rejects_conflicting_lkm_inputs_before_registry_lookup():
     assert "pass either PACKAGE or LKM flags" in result.output
 
 
+@patch("gaia.cli.commands.add._run_uv")
+def test_add_local_gaia_package_as_editable_dependency(mock_uv, tmp_path, monkeypatch):
+    """Gaia pkg add --local installs a local Gaia package into the target package."""
+    consumer = tmp_path / "consumer-gaia"
+    dependency = tmp_path / "source-paper-gaia"
+    consumer.mkdir()
+    dependency.mkdir()
+    _write_gaia_package_root(consumer)
+    _write_gaia_package_root(dependency)
+    monkeypatch.chdir(tmp_path)
+    mock_uv.return_value = MagicMock(returncode=0)
+
+    result = runner.invoke(
+        app,
+        ["pkg", "add", "--target", str(consumer), "--local", str(dependency)],
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_uv.assert_called_once_with(
+        ["uv", "add", "--editable", str(dependency.resolve())],
+        cwd=consumer.resolve(),
+    )
+    assert f"Added local Gaia package: {dependency.resolve()}" in result.output
+
+
+def test_add_local_requires_local_gaia_package(tmp_path, monkeypatch):
+    """Gaia pkg add --local rejects paths that are not Gaia knowledge packages."""
+    consumer = tmp_path / "consumer-gaia"
+    not_package = tmp_path / "not-package"
+    consumer.mkdir()
+    not_package.mkdir()
+    _write_gaia_package_root(consumer)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["pkg", "add", "--target", str(consumer), "--local", str(not_package)],
+    )
+
+    assert result.exit_code == 1
+    assert "not a Gaia knowledge package" in result.output
+
+
+def test_add_local_rejects_package_argument():
+    result = runner.invoke(
+        app,
+        ["pkg", "add", "galileo-falling-bodies-gaia", "--local", "./dep"],
+    )
+
+    assert result.exit_code == 4
+    assert "pass --local by itself" in result.output
+
+
 def test_add_rejects_malformed_lkm_ref():
     result = runner.invoke(app, ["pkg", "add", "lkm:bohrium:dataset:123"])
     assert result.exit_code == 4


### PR DESCRIPTION
## Summary
- add `gaia pkg add --local <path>` for attaching an existing local Gaia knowledge package to a target package
- keep `editable` as an internal uv implementation detail via `uv add --editable`
- document the package-centric contract so search/LKM adapters can generate Gaia packages first, then attach them with `--local`

This replaces the abandoned #739 direction: `gaia pkg add` remains a package-manager verb and does not consume search JSON schemas.

## Verification
- `uv run pytest tests/cli/test_add.py::test_add_local_gaia_package_as_editable_dependency tests/cli/test_add.py::test_add_local_requires_local_gaia_package tests/cli/test_add.py::test_add_local_rejects_package_argument -q`
- `uv run pytest tests/cli/test_add.py -q`
- `uv run gaia pkg add --help`
- `uv run ruff check gaia/cli/commands/add.py tests/cli/test_add.py`
- `uv run ruff format --check gaia/cli/commands/add.py tests/cli/test_add.py`
- `uv run mypy gaia/cli/commands/add.py tests/cli/test_add.py`
- `uv run pytest -m "pr_gate and not slow" -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`