### PR TITLE
docs(research): narrow split plan to Goal A

### DIFF
--- a/docs/specs/2026-06-11-research-repo-split-plan.md
+++ b/docs/specs/2026-06-11-research-repo-split-plan.md
@@ -18,27 +18,35 @@ Completion checklist:
 Implementation plan:
 [Research Repo Split Implementation Plan](../superpowers/plans/2026-06-12-research-repo-split-implementation.md).
 
-## Product Goal and Mode Contract
+## Goal A: Repo Split and Gaia Connection
 
-The split is not complete if it merely moves the current `gaia research run`
-code into another repository. The new repository must support two usage modes
-through one shared research kernel:
+The current delivery goal is **Goal A**: split Gaia's research implementation
+into an independent `gaia-research` repository and keep it connected to Gaia
+through public core APIs, plugin entry points, contract CI, and a migrated
+review-run workflow.
 
-1. **Review run mode**: product- and skill-facing evidence synthesis. A caller
-   gives a topic/profile, the workflow performs broad LKM exploration, field-map
-   induction, focus selection, evidence assessment, and sectioned report
-   writing. The intended interactive target is tens to hundreds of papers in a
-   3-5 minute window when provider/search latency permits it.
-2. **Graph session mode**: agent-framework-facing graph expansion. A caller can
-   keep extending a research graph to thousands or tens of thousands of durable
-   nodes and relations, pause, inspect, resume, and continue from the frontier.
-   It may never request a final prose report. Normal continuation must process
-   only newly added frontier/input records, so runtime is proportional to the
-   explored area for that step rather than repeatedly growing a superlinear
-   whole-graph pass.
+Goal A is not the same as delivering every future research capability. In
+particular, large-scale graph sessions are now tracked as a follow-up capability
+in [#767](https://github.com/SiliconEinstein/Gaia/issues/767). Goal A should
+not be considered incomplete merely because graph-session execution has not
+been implemented. It should only avoid architectural choices that would make
+that follow-up hard or impossible.
 
-The two modes share providers, schemas, provenance, evidence references, and
-promotion discipline. They differ in orchestration defaults:
+Goal A includes:
+
+1. **Repository extraction**: `gaia-research` exists as its own git repository,
+   with migrated code, tests, docs, package metadata, and skill assets.
+2. **Gaia connection**: Gaia core exposes the public surfaces research needs,
+   and `gaia research` delegates through a plugin when `gaia-research` is
+   installed.
+3. **Review-run parity**: the current package-native review-run workflow keeps
+   working from the new repo, with SDK/CLI/skill smoke tests proving observable
+   state, events, checkpoints, and report paths.
+4. **Future graph compatibility**: `.gaia/research/**` ownership, SDK layering,
+   and promotion discipline leave room for #767 without requiring a second
+   canonical research protocol.
+
+The future capability roadmap remains:
 
 | Concern | Review run mode | Graph session mode |
 | --- | --- | --- |
@@ -48,10 +56,10 @@ promotion discipline. They differ in orchestration defaults:
 | State updates | Run state, events, artifacts, report | Append-only graph/session log plus checkpoints |
 | Gaia source writes | Explicit sync/promotion gates only | Explicit sync/promotion gates only |
 
-PR #755 is the implementation body for the first mode. The closed PR #726
-`gaia-research-loop` branch is **not** revived as a second canonical workflow,
-but its task envelope, candidate validation, repair, and gate lessons are input
-to the graph-session SDK and disk contract under `.gaia/research/**`.
+PR #755 is the implementation body for the review-run path that Goal A migrates.
+The closed PR #726 `gaia-research-loop` branch is **not** revived as a second
+canonical workflow. Its task-envelope, candidate-validation, repair, and gate
+lessons are now background for #767.
 
 ## 0. Current State and Feasibility
 
@@ -104,7 +112,7 @@ distributions — the current size does not justify that):
 ```
 gaia-research/
   src/gaia_research/
-    engine/        # pure library: shared kernel, run orchestration, graph sessions,
+    engine/        # pure library: shared kernel, review-run orchestration,
                    # landscape, assessment, report, stop, sync; zero typer imports
     contracts/     # pydantic models for disk artifacts, events, graph records,
                    # task envelopes, provider I/O, and schema-versioned files
@@ -122,9 +130,12 @@ gaia-research/
   `events.ndjson`, manifest, trace, benchmark) transfers to the research repo
   and is explicitly versioned — downstream UIs depend only on that contract
   plus the SDK, never on internal modules.
-- Review runs and graph sessions are both engine concepts. The CLI and skill
-  surfaces call the same SDK that product backends and agent frameworks call;
-  they are not separate implementations.
+- Review runs are the Goal A engine concept. The CLI and skill surfaces call
+  the same SDK that product backends call; they are not separate
+  implementations.
+- Graph sessions are a reserved follow-up capability (#767). The repository
+  layout should leave a natural place for them, but Goal A does not implement
+  `.gaia/research/sessions/**`.
 
 ### 2.1 Shared Kernel
 
@@ -143,7 +154,8 @@ Mode-specific orchestration is thin:
 - Review run mode wires the kernel into the PR #755 sequence:
   `query_plan -> broad_search -> field_map -> focus -> selected_evidence ->
   assess -> stop -> report`.
-- Graph session mode wires the kernel into an incremental loop:
+- Graph-session mode is tracked in #767 and should later wire the kernel into
+  an incremental loop:
   `frontier_batch -> search/materialize/analyze -> node_edge_delta ->
   field_map_delta -> focus_policy -> checkpoint/continue`.
 
@@ -163,28 +175,17 @@ new canonical `.gaia/research_loop/**` tree.
     analysis/
     trace/
     final_report.md
-  sessions/<session-id>/
-    state.json
-    events.ndjson
-    frontier.jsonl
-    nodes.jsonl
-    edges.jsonl
-    focuses.jsonl
-    obligations.jsonl
-    field_map.json
-    checkpoints/
 ```
 
 Every JSON/JSONL record carries `schema_version`. `events.ndjson` is the audit
 spine. The compact `state.json` files are indexes and UI summaries; they must be
 rebuildable from append-only records plus artifacts.
 
-Graph-session continuation reads the current frontier cursor and the newly
-accepted frontier/input batch. It may update derived indexes such as
-`field_map.json`, but it must not require a full historical node/edge scan
-during normal continuation. Full rebuild is an explicit maintenance operation.
+The `.gaia/research/sessions/**` namespace is reserved for #767. Goal A should
+not introduce any canonical `.gaia/research_loop/**` state or any graph-session
+state shape that conflicts with the #767 follow-up issue.
 
-### 2.3 Agent Task Contract
+### 2.3 Future Agent Task Contract
 
 PR #726's strongest idea is a self-contained task envelope:
 
@@ -192,7 +193,8 @@ PR #726's strongest idea is a self-contained task envelope:
 task envelope -> agent candidate -> validation -> artifact/delta -> next task
 ```
 
-In the split repo this becomes an SDK contract, not a second CLI product:
+In the future graph-session work this should become an SDK contract, not a
+second CLI product:
 
 - task envelopes are versioned records under `.gaia/research/**`;
 - candidates are validated against allowed refs and task kind;
@@ -202,7 +204,8 @@ In the split repo this becomes an SDK contract, not a second CLI product:
   or promote.
 
 This lets an external agent framework use Gaia Research as a deterministic
-protocol kernel while keeping semantic judgment in the agent.
+protocol kernel while keeping semantic judgment in the agent. This section is a
+handoff to #767, not a Goal A implementation requirement.
 
 ## 3. Refactors in the Gaia Core Repo (R1–R6, in order)
 
@@ -292,11 +295,6 @@ run = client.run_review(topic=..., profile="review")
 state = client.read_state(run.run_id)            # typed RunState (pydantic)
 for ev in client.iter_events(run.run_id):        # typed event stream
     ...
-
-session = client.open_session(topic=..., mode="graph")
-task = client.next_task(session.session_id)
-result = client.submit_candidate(session.session_id, candidate)
-client.resume_session(session.session_id)
 ```
 
 - Freeze the dict contracts of `state.json` / `events.ndjson` / artifacts into
@@ -304,10 +302,11 @@ client.resume_session(session.session_id)
   models).
 - The ports in `orchestrator_ports.py` become the documented extension point
   (custom analysis/search providers).
-- Expose both high-level mode methods (`run_review`, `open_session`,
-  `resume_session`) and primitive methods (`build_landscape`, `assess_focus`,
-  `write_report`, `next_task`, `submit_candidate`) so product backends and
-  agent frameworks do not shell out to the CLI.
+- Expose high-level review-run methods (`run_review`, state/event readers) and
+  review primitives (`build_landscape`, `assess_focus`, `write_report`) so
+  product backends do not shell out to the CLI. Graph-session SDK methods
+  (`open_session`, `next_task`, `submit_candidate`, `resume_session`) belong to
+  #767.
 
 **S3. Provider layering**: litellm goes behind the `gaia-research[llm]` extra;
 the command/checkpoint providers are built-in and dependency-free. Fix the
@@ -320,13 +319,12 @@ compatibility off the schema version. Fixing finding 3 (all failure paths write
 `status: failed` plus a `run.failed` event) is a precondition for this contract
 being trustworthy.
 
-The contract document must separately cover:
+The Goal A contract document must cover:
 
 - review-run state/events/checkpoints/report artifacts;
-- graph-session frontier/node/edge/focus/obligation records;
-- task-envelope/candidate/repair records absorbed from PR #726;
-- rebuild semantics for state indexes;
-- explicit full-rebuild vs normal incremental continuation.
+- rebuild semantics for review-run state summaries;
+- explicit ownership of `.gaia/research/**`, including a reservation that
+  `.gaia/research/sessions/**` is deferred to #767.
 
 **S5. Dual CLI entry**: console script `gaia-research` (standalone) plus the
 `gaia.cli_plugins` entry point (preserving the `gaia research ...` muscle
@@ -351,9 +349,8 @@ installed distributions (reusable entry-point group, e.g. `gaia.skills`).
 - `gaia research doctor` / `gaia-research doctor` checks package shape,
   `.gaia/research` writability, LKM credentials, provider/model config,
   profiles, run/session paths, and schema compatibility.
-- Built-in profiles cover `quick`, `review`, and `deep` for review-run mode,
-  plus at least one graph-session profile that favors frontier continuity over
-  final report writing.
+- Built-in profiles cover `quick`, `review`, and `deep` for review-run mode.
+  Graph-session profiles belong to #767.
 - Docs show short commands and SDK calls, not long flag recipes.
 - CLI output and SDK return values make state, events, checkpoints,
   intermediate artifacts, and final report paths obvious.
@@ -371,22 +368,22 @@ the latest compatible 0.6 release and the 0.7.0 removal candidate before Gaia
 core removes bundled research. Replicate core's alpha/beta/rc/stable
 four-channel `workflow_dispatch` release process.
 
-## 5. Migration Order (canonical phases 0-7)
+## 5. Migration Order (canonical Goal A phases 0-6)
 
 The phase numbers below are canonical across this plan, the acceptance
-checklist, and the implementation plan. Earlier five-phase summaries are
-superseded by this map.
+checklist, and the implementation plan. Earlier maps that included
+graph-session implementation as a split-completion phase are superseded by this
+Goal A map.
 
 | Phase | Content | Output |
 |-------|---------|--------|
 | 0 | Make monorepo research movable by landing PR #755 and closing or owning high-risk #761/#764 blockers. | Research still lives in the monorepo, but the implementation is extraction-ready. |
 | 1 | Extract Gaia core public APIs used by research: LKM client/readiness, authoring batch mode, materialization, packaging, inquiry-state contract, CLI plugin hook. | Gaia core exposes stable downstream surfaces without requiring research to import CLI-private modules. |
 | 2 | Bootstrap the `gaia-research` repository and preserve/import history, including PR #726 as historical/spec input only. | New repo exists with package metadata, migrated code/tests/docs/skills, and no canonical `.gaia/research_loop/**` writes. |
-| 3 | Build shared `gaia-research` contracts and SDK. | Review-run and graph-session contracts are typed, versioned, and SDK-accessible. |
+| 3 | Build Goal A `gaia-research` review-run contracts and SDK. | Review-run contracts are typed, versioned, and SDK-accessible; graph-session contract work is linked to #767. |
 | 4 | Re-enable review-run mode in the new repo. | Product/skill smoke tests produce observable state/events/report paths. |
-| 5 | Implement graph-session mode. | Incremental continuation, pause/resume, node/edge/focus/field-map records pass instrumented tests. |
-| 6 | Product readiness, packaged skills, profiles, and doctor. | #762 acceptance checks pass and short happy paths are documented. |
-| 7 | Contract CI, release, and Gaia core removal. | `gaia-research` passes downstream contract CI against the 0.7.0 removal candidate; Gaia core no longer owns research implementation. |
+| 5 | Product readiness, packaged skills, profiles, and doctor. | #762 acceptance checks pass and short happy paths are documented. |
+| 6 | Contract CI, release, and Gaia core removal. | `gaia-research` passes downstream contract CI against the 0.7.0 removal candidate; Gaia core no longer owns research implementation. |
 
 ## 6. Risks and Decision Points
 
@@ -404,10 +401,10 @@ superseded by this map.
    `.gaia/research/runs/<id>/state.json` sees stable paths through the
    transition and after extraction; only the `schema_version` field is added —
    backward compatible.
-5. **Graph-session scalability**: long sessions can become unusable if normal
-   continuation rescans all historical records. Mitigation: append-only records,
-   frontier cursors, delta indexes, and explicit full-rebuild operations in the
-   disk contract and tests.
+5. **Graph-session scalability is a separate capability risk**: #767 must later
+   prove append-only records, frontier cursors, delta indexes, and explicit
+   full-rebuild operations. Goal A mitigates only by preserving extension points
+   and not creating a conflicting protocol.
 6. **When the split is not worth it**: if research iteration stays tightly
    synchronized with core (every core change drags a research change), two
    repos turn one PR into two. Current evidence (PR #755 is almost purely
@@ -424,7 +421,8 @@ cover them:
 | [#764](https://github.com/SiliconEinstein/Gaia/issues/764) | Candidate relations silently skipped during research sync; `claim_refs` validation holes; missing compile gate after authored writes | S1 (skip diagnostics, packet validation) + R1 (compile gate in the public authoring API) | 0–1 | Closed before the phase-2 repo bootstrap |
 | [#761](https://github.com/SiliconEinstein/Gaia/issues/761) | PR #755 review follow-ups: engine/CLI orchestration extraction, multi-focus checkpoint semantics, CLI override sentinels, report failure/concurrency, citation dedup, typed retry contracts | S1 (engine extraction, checkpoints, overrides) + S2 (report rendering consolidation) + S3 (retry contracts) | 0–4 | Core-owned blockers closed before phase 2; research-side remainder re-homed before phase 7 removal |
 | [#745](https://github.com/SiliconEinstein/Gaia/issues/745) | Fast/batch author mode for agent research workflows | R1 (the public `gaia.engine.authoring` API ships batch writes + single validation pass as a first-class mode, not a research-side workaround) | 1 | Closed by the R1 extraction PR |
-| [#762](https://github.com/SiliconEinstein/Gaia/issues/762) | New-user readiness for package-native research workflows: doctor, profiles, short commands, observable outputs | S8 (doctor/readiness, profile docs/tests) | 6 | Closed before publishing gaia-research 0.1.0 |
+| [#762](https://github.com/SiliconEinstein/Gaia/issues/762) | New-user readiness for package-native research workflows: doctor, profiles, short commands, observable outputs | S8 (doctor/readiness, profile docs/tests) | 5 | Closed before publishing gaia-research 0.1.0 |
+| [#767](https://github.com/SiliconEinstein/Gaia/issues/767) | Future large-scale graph-session design and linear-continuation contract | Follow-up issue outside Goal A | Post-Goal A | Must not block Goal A; must be referenced when implementing `.gaia/research/sessions/**` |
 
 Related but closed/experimental:
 PR #726 contributes task-envelope, candidate-validation, repair-context, and

--- a/docs/specs/2026-06-12-research-repo-split-acceptance-checklist.md
+++ b/docs/specs/2026-06-12-research-repo-split-acceptance-checklist.md
@@ -10,9 +10,16 @@
 > Implementation plan:
 > [Research Repo Split Implementation Plan](../superpowers/plans/2026-06-12-research-repo-split-implementation.md).
 
-This checklist defines the evidence required before the research split can be
-called complete. It is intentionally stricter than "the code moved": every item
-must be proven by files, tests, commands, PR/issue state, or runtime artifacts.
+This checklist defines the evidence required before **Goal A** can be called
+complete: the research repo split, Gaia connection, review-run parity, and
+release/removal gates. It is intentionally stricter than "the code moved":
+every item must be proven by files, tests, commands, PR/issue state, or runtime
+artifacts.
+
+Large-scale graph-session execution is tracked separately in
+[#767](https://github.com/SiliconEinstein/Gaia/issues/767). Goal A should not
+be blocked on implementing graph sessions; it should only preserve a clean
+extension path for that follow-up.
 
 ## 1. Completion Requirements
 
@@ -22,10 +29,10 @@ must be proven by files, tests, commands, PR/issue state, or runtime artifacts.
 | A2 | Gaia core no longer owns research implementation code after the removal phase. | Core release branch lacks `gaia/engine/research/**`, `gaia/cli/commands/research*.py`, and bundled research skill code; `gaia research` resolves via plugin or prints an install hint. |
 | A3 | Dependency direction is one-way: `gaia-research -> gaia core`. | Import check in both repos proves Gaia core does not import `gaia_research`; contract CI installs `gaia-research` as a downstream package. |
 | A4 | Review run mode supports product/skill use for evidence-backed reports. | SDK/CLI/skill smoke test creates a package-local run, performs mocked explore/assessment/report phases, and emits observable state/events/report paths. |
-| A5 | Graph session mode supports resumable long-running expansion without requiring a final report. | SDK/CLI smoke test opens a session, submits multiple frontier batches, writes nodes/edges/focus/field-map records, pauses, resumes, and continues without report generation. |
-| A6 | Normal graph-session continuation is incremental. | Performance/complexity regression test proves continuation reads the new frontier/input batch and cursor/index files, not all historical node/edge records. |
-| A7 | `.gaia/research/**` is the only canonical research namespace. | Tests assert review runs and graph sessions write under `.gaia/research/**`; docs and code do not create canonical `.gaia/research_loop/**` state. |
-| A8 | Research artifacts and graph-session records are not automatically stable Gaia source. | Promotion tests show source writes require explicit sync/promotion calls; default run/session steps leave `src/<pkg>/` unchanged unless a sync gate is requested. |
+| A5 | Large-scale graph-session work is explicitly re-homed outside Goal A. | #767 exists, is linked from the split docs, and contains the follow-up design notes for linear continuation, session state, and verifiers. |
+| A6 | Goal A preserves a future graph-session extension path without implementing it. | Docs and code reserve `.gaia/research/sessions/**` for future work, do not create canonical `.gaia/research_loop/**` state, and do not require Gaia core internals for future session state. |
+| A7 | `.gaia/research/**` is the only canonical research namespace. | Tests assert review runs write under `.gaia/research/**`; docs and code do not create canonical `.gaia/research_loop/**` state, and future graph sessions are reserved for `.gaia/research/sessions/**` via #767. |
+| A8 | Research artifacts are not automatically stable Gaia source. | Promotion/sync tests show source writes require explicit sync/promotion calls; default review-run artifact generation leaves stable claims/relations unchanged unless a sync gate is requested. |
 | A9 | #745, #761, #762, and #764 are closed or re-homed with release-blocking owners. | Issue tracker links from release checklist; phase gates in PR descriptions; no open silent-skip or batch-author correctness gap remains unowned. |
 | A10 | New-user readiness is first-class. | `gaia-research doctor` / `gaia research doctor` tests cover missing credentials, missing provider config, invalid package shape, profile resolution, and output paths without leaking secrets. |
 
@@ -53,9 +60,14 @@ The release checklist must include one mocked CI run and one manually recorded
 live or staging run. The live/staging record may use a small topic, but it must
 exercise real provider/search configuration and produce a final report path.
 
-## 3. Graph Session Mode Acceptance
+## 3. Graph Session Follow-up Handoff
 
-Graph session mode is accepted only when all of these pass:
+Graph session mode is not a Goal A acceptance target. The implementation
+direction and verifier sketch are captured in
+[#767](https://github.com/SiliconEinstein/Gaia/issues/767), and future work
+should use that issue as the starting point.
+
+The follow-up issue currently carries these intended checks:
 
 | Check | Evidence command or artifact | Failure condition |
 | --- | --- | --- |
@@ -64,11 +76,11 @@ Graph session mode is accepted only when all of these pass:
 | Pause/resume | `tests/session/test_pause_resume.py::test_resume_continues_from_saved_cursor` | Resume reprocesses already accepted frontier records or requires a final report artifact. |
 | Field map delta | `tests/session/test_field_map_delta.py::test_field_map_updates_from_delta_records` | Normal continuation scans all historical nodes/edges to update the field map. |
 | Task contract | `tests/session/test_task_contract.py::test_candidate_validation_produces_repair_context` | Invalid candidate advances the session, lacks repair context, or creates a second protocol namespace. |
-| Promotion boundary | `tests/session/test_promotion_boundary.py::test_session_records_do_not_write_gaia_source_by_default` | Opening or continuing a session writes stable `claim(...)`, `derive(...)`, or `contradict(...)` without explicit promotion. |
+| Promotion boundary | `tests/session/test_promotion_boundary.py::test_stable_promotion_requires_explicit_gate` | Opening or continuing a session writes stable `claim(...)`, `derive(...)`, or `contradict(...)` without explicit promotion. |
 
-The key complexity check must use an instrumented storage adapter. It should
-seed a session with a large historical log, then submit a small frontier batch
-and assert that normal continuation reads only:
+The future complexity check should use an instrumented storage adapter. It
+should seed a session with a large historical log, then submit a small frontier
+batch and assert that normal continuation reads only:
 
 ```text
 state.json
@@ -77,9 +89,13 @@ the new frontier/input batch
 the necessary delta index files
 ```
 
-It must fail if continuation opens every historical node/edge record in
+It should fail if continuation opens every historical node/edge record in
 `nodes.jsonl` or `edges.jsonl`. Full rebuild commands may scan history, but
 they must be named and tested separately.
+
+For Goal A, the acceptance evidence is only that this work is re-homed to #767
+and that the split does not introduce a conflicting namespace, dependency
+direction, or promotion model.
 
 ## 4. Core Repo Acceptance
 
@@ -110,11 +126,10 @@ run gaia research --help through the plugin path
 | Phase 0 to Phase 1 | PR #755 landed or superseded; #761 high-risk follow-ups either fixed or listed in gaia-research tracker with owners. |
 | Phase 1 to Phase 2 | Public LKM/readiness, authoring batch mode for #745, materialization, package-installer, inquiry-state, and CLI-plugin surfaces exist; #764 relation skip/validation/compile gate is closed; materialization collision fix is present. |
 | Phase 2 to Phase 3 | New repo bootstrapped; PR #726 lessons imported as historical/spec input only; no canonical `.gaia/research_loop/**` writes. |
-| Phase 3 to Phase 4 | Shared review-run and graph-session contracts are typed, versioned, SDK-accessible, and use `.gaia/research/**`. |
+| Phase 3 to Phase 4 | Review-run contracts are typed, versioned, SDK-accessible, and use `.gaia/research/**`; graph-session contract work is linked to #767. |
 | Phase 4 to Phase 5 | Review-run SDK/CLI/skill smoke tests create package-local runs and observable state/events/report artifacts. |
-| Phase 5 to Phase 6 | Graph-session contract tests pass, including pause/resume, candidate repair, promotion boundary, and instrumented incremental-continuation read-set checks. |
-| Phase 6 to Phase 7 | #762 doctor/profile/readiness acceptance checks pass; packaged skill registration works through the external research distribution. |
-| Phase 7 removal | Gaia core has downstream contract CI against the `gaia-lang 0.7.0` removal candidate; open research-side issues are transferred or closed with forwarding links. |
+| Phase 5 to Phase 6 | #762 doctor/profile/readiness acceptance checks pass; packaged skill registration works through the external research distribution. |
+| Phase 6 removal | Gaia core has downstream contract CI against the `gaia-lang 0.7.0` removal candidate; open research-side issues are transferred or closed with forwarding links. |
 
 If any issue remains open past its phase gate, the release checklist must name
 the new owner repo, blocking label, and exact acceptance test that will close it.
@@ -128,10 +143,10 @@ Before marking the split goal complete, run this audit against current state:
 2. Inspect `pyproject.toml` and package metadata in both repositories.
 3. Run core contract CI or the local equivalent.
 4. Run gaia-research unit, contract, SDK, CLI, and skill smoke tests.
-5. Run the graph-session incremental continuation test with an instrumented
-   storage adapter.
+5. Confirm #767 remains linked as the post-Goal A graph-session follow-up and
+   no Goal A code/docs conflict with it.
 6. Run or inspect one product-style review run that produces a report.
-7. Inspect GitHub issue state for #745, #761, #762, and #764.
+7. Inspect GitHub issue state for #745, #761, #762, #764, and #767.
 8. Inspect docs for accidental canonical `.gaia/research_loop/**` state.
 9. Confirm no completion claim relies only on intent, partial migration, or
    narrow tests that do not cover the original objective.

--- a/docs/specs/2026-06-12-research-repo-split-execution-record.md
+++ b/docs/specs/2026-06-12-research-repo-split-execution-record.md
@@ -8,25 +8,34 @@
 
 ## 1. Fixed Goal
 
-Split Gaia's research module into a new git repository while preserving and
-making first-class two usage modes:
+**Current goal: Goal A.** Split Gaia's research module into a new git
+repository and keep it connected to Gaia through public core APIs, plugin entry
+points, contract CI, and migrated review-run parity.
 
-1. **Review run mode**: product/skill-facing workflow that explores, assesses,
-   and writes an evidence-backed report for tens to hundreds of papers within a
-   short interactive window.
-2. **Graph session mode**: agent-framework-facing workflow that can keep
-   expanding a research graph to thousands or tens of thousands of nodes, with
-   runtime proportional to the newly explored area, durable node/relation/focus
-   records, and pause/resume support. A final report is optional.
+Goal A includes:
+
+1. A standalone `gaia-research` repository with migrated implementation,
+   tests, docs, package metadata, and skill assets.
+2. Public Gaia core surfaces needed by research, with dependency direction
+   `gaia-research -> gaia core`.
+3. `gaia research` connected back through plugin entry points when
+   `gaia-research` is installed.
+4. Review-run parity for the current package-native evidence-report workflow.
+5. Clear `.gaia/research/**` namespace ownership.
+
+Large-scale graph-session execution is a follow-up capability tracked in
+[#767](https://github.com/SiliconEinstein/Gaia/issues/767). It must not block
+Goal A. Goal A should only preserve extension points and avoid conflicting
+protocol choices.
 
 The split must incorporate the current Gaia research PRs and issues, especially
 PR #755, PR #763, the lessons from closed PR #726, and issues #745, #761, #762,
-and #764.
+and #764. Issue #767 is the graph-session follow-up handoff.
 
 ## 2. Non-Negotiable Invariants
 
-- Do not let "move PR #755 to another repo" replace the broader goal. The new
-  repo must support both short review runs and long graph sessions.
+- Do not let "move PR #755 to another repo" replace Goal A. The new repo must
+  be a connected, tested downstream package, not a code dump.
 - Do not create two parallel canonical research protocols. Lessons from the old
   `gaia-research-loop` task-envelope design may be absorbed, but the target
   on-disk contract should be unified under `.gaia/research/**`.
@@ -36,9 +45,8 @@ and #764.
   Gaia core; Gaia core must not depend on research.
 - Preserve package-native promotion discipline: research artifacts and graph
   session records are not automatically stable Gaia source.
-- Long graph-session operations must be incremental. Normal continuation should
-  process only new frontier/input batches, not recompute the whole graph each
-  turn.
+- Do not implement or partially specify `.gaia/research/sessions/**` inside
+  Goal A unless that work explicitly moves into the #767 follow-up scope.
 
 ## 3. Evidence Sources To Recheck
 
@@ -54,6 +62,7 @@ and #764.
 | Issue #761 | PR #755 follow-up robustness and refactor list | Checked 2026-06-12 |
 | Issue #762 | New-user product readiness for research workflows | Checked 2026-06-12 |
 | Issue #764 | Candidate relation sync correctness hole | Checked 2026-06-12 |
+| Issue #767 | Large-scale graph-session design follow-up | Created 2026-06-12 |
 
 Recheck this table whenever more than one day has passed, a PR is updated, or
 the implementation phase changes.
@@ -66,8 +75,8 @@ to section 7.
 ### V1. Goal Verifier
 
 - Does the step serve the new `gaia-research` repo split?
-- Does it preserve both Review Run Mode and Graph Session Mode?
-- Does it avoid prematurely optimizing only for final reports?
+- Does it preserve review-run parity and Gaia connection?
+- Does it avoid pulling #767 graph-session implementation back into Goal A?
 - Does it mention the relevant PR/issue constraints when they apply?
 
 ### V2. Architecture Verifier
@@ -77,12 +86,12 @@ to section 7.
 - Is `.gaia/research/**` the unified research artifact/session namespace?
 - Are package promotion and formal Gaia source writes still explicit gates?
 
-### V3. Long-Run Graph Verifier
+### V3. Graph Follow-up Boundary Verifier
 
-- Is graph-session state append-only or otherwise resumable?
-- Does continuation process only newly added frontier/input records?
-- Are node, edge, focus, obligation, and evidence references durable?
-- Can a run be paused, inspected, rebuilt from logs, and resumed?
+- Is large-scale graph-session work linked to #767 when mentioned?
+- Does Goal A avoid creating canonical `.gaia/research_loop/**` state?
+- Does Goal A reserve, but not prematurely define, `.gaia/research/sessions/**`?
+- Does the split preserve public extension points needed by future sessions?
 
 ### V4. Product/Skill Verifier
 
@@ -105,17 +114,20 @@ to section 7.
 
 Stop and re-check the fixed goal if any of these happen:
 
-- The design mentions report writing but not graph-session continuation.
+- The design expands from repo split/review-run parity into implementing
+  graph-session mechanics without explicitly moving into #767.
 - The implementation adds new `.gaia/research_loop/**` canonical state.
 - The split plan relies on private CLI modules as stable cross-repo APIs.
 - A correctness issue is deferred without a target repo, phase, or acceptance
   criterion.
-- A proposed graph expansion step requires scanning all historical nodes during
-  normal continuation.
 - Product/skill usage requires long command recipes rather than profiles,
   config, SDK calls, or a doctor command.
 
 ## 6. Decision Log
+
+Rows before the 2026-06-12 Goal A narrowing are historical context. The active
+goal and phase map are the Goal A definitions in sections 1-5; graph-session
+execution is re-homed to #767.
 
 | Date | Decision | Rationale | Verifier |
 | --- | --- | --- | --- |
@@ -123,7 +135,8 @@ Stop and re-check the fixed goal if any of these happen:
 | 2026-06-12 | Absorb PR #726 task-envelope lessons into `.gaia/research/**` rather than preserving `.gaia/research_loop/**`. | The task/candidate/gate pattern helps agent frameworks, but a second canonical namespace would split state and confuse migration. | V2, V3 |
 | 2026-06-12 | Make `gaia-research` a single shared kernel with two first-class modes: review runs and graph sessions. | The product skill path and long-running agent-framework path share providers, refs, provenance, and promotion discipline, but need different orchestration defaults and disk records. | V1-V4 |
 | 2026-06-12 | Add a completion acceptance checklist before implementation begins. | The split needs evidence-based gates for repository extraction, product review runs, graph-session incrementality, pause/resume, and issue closure rather than relying on implementation intent. | V1-V5 |
-| 2026-06-12 | Add a phase-by-phase implementation plan only after the dual-mode contract and acceptance evidence were explicit. | Implementation work now has ordered gates for monorepo hardening, core public APIs, repo bootstrap, review run, graph session, doctor/readiness, CI, and core removal. | V1-V5 |
+| 2026-06-12 | Add a phase-by-phase implementation plan only after the dual-mode contract and acceptance evidence were explicit. | This was the pre-Goal-A-narrowing phase map; it has since been superseded by the Goal A 0-6 map and #767 graph-session follow-up. | V1-V5 |
+| 2026-06-12 | Narrow the active goal to Goal A and re-home large-scale graph sessions to #767. | Repo extraction/connection and graph-session scalability are both large goals. Keeping graph execution inside split acceptance would make PR scope and completion evidence drift. | V1, V3 |
 
 ## 7. Checkpoint Log
 
@@ -132,8 +145,8 @@ Stop and re-check the fixed goal if any of these happen:
 | 2026-06-12 | Initial discovery over PRs, issues, and worktrees | V1, V2, V5 | Current split plan is viable but under-specifies long graph-session mode. | Amend split plan with dual-mode architecture and graph-session contract. |
 | 2026-06-12 | Add execution record and drift-control loop | V1-V5 | Process guardrails are now explicit and should be updated before each major step. | Use this record before editing the companion split plan. |
 | 2026-06-12 | Amend split plan with product goal, dual-mode architecture, unified disk contract, graph-session incremental contract, SDK shape, #762 release gate, and PR #726 absorption rule | V1-V5 | Split plan now states that moving PR #755 alone is insufficient; `.gaia/research/**` remains unified; graph sessions require frontier cursors and no normal full-history scan; #745/#761/#762/#764 all have phase gates. | Add acceptance checks/tests for graph-session contract and product doctor/readiness in the implementation plan. |
-| 2026-06-12 | Add acceptance checklist for split completion evidence, review-run smoke tests, graph-session incremental tests, core API gates, and issue phase gates | V1-V5 | Completion now has requirement-by-requirement proof targets, including instrumented storage checks for graph-session continuation and doctor/readiness checks for product usage. | Use the checklist as the handoff for writing detailed implementation tasks or bootstrapping the new repo. |
-| 2026-06-12 | Add implementation plan with phases 0-7 and concrete evidence commands | V1-V5 | Plan covers PR #755 hardening, #764/#761 fixes, #745 core authoring API, new repo bootstrap, SDK contracts, review-run mode, graph-session O(N) tests, #762 doctor/readiness, contract CI, and Gaia core removal. | Use the implementation plan to execute Phase 0 in a clean worktree or delegate phase tasks to subagents with verifier checkpoints. |
+| 2026-06-12 | Add acceptance checklist for split completion evidence, review-run smoke tests, graph-session incremental tests, core API gates, and issue phase gates | V1-V5 | This was the pre-Goal-A-narrowing checklist; graph-session incremental tests are now re-homed to #767. | Use the Goal A checklist as the handoff for writing detailed implementation tasks or bootstrapping the new repo. |
+| 2026-06-12 | Add implementation plan with phases 0-7 and concrete evidence commands | V1-V5 | This was the pre-Goal-A-narrowing implementation plan; it is now superseded by the Goal A 0-6 plan. | Use the Goal A implementation plan to continue from public core surfaces, skill plugin discovery, repo bootstrap, and review-run parity gates. |
 | 2026-06-12 | Execute Phase 0 slice for #764 on branch `codex/research-actions-pkg-contract`; pushed commit `55046adb` (`fix(research): surface relation sync skips`). | V1, V5 | Explicit non-claim `claim_refs` are rejected during assessment validation, inferred non-claim package refs produce visible sync skip reasons, and CLI sync summaries now surface `candidate_relations_skipped`. Verified with `uv run pytest tests/gaia/test_research_assessment.py -q`, `uv run pytest tests/cli/test_research.py -q -k candidate_relation`, targeted `ruff`, targeted `mypy`, and `git diff --check`. This is a #764 hardening slice, not split completion. | Continue Phase 0 with the remaining #761/#764 gates, then move to Phase 1 public core APIs only after the verifier table still passes. |
 | 2026-06-12 | Execute second Phase 0 slice for #764 on branch `codex/research-actions-pkg-contract`; pushed commit `177a8755` (`fix(research): reject unparseable sync writes`). | V1, V5 | Research sync now parse-checks `authored/__init__.py` after source writes, restores the prior authored source on parse failure, exposes `ResearchSyncSourceError`, and has CLI exit-2 handling without traceback. Verified with `uv run pytest tests/gaia/test_research_artifacts.py tests/gaia/test_research_assessment.py -q`, `uv run pytest tests/cli/test_research.py -q -k "candidate_relation or unparseable_sync_source or schema_errors"`, targeted `ruff`, targeted `mypy`, and `git diff --check`. This closes another #764 correctness hole while leaving broader repo split work open. | Re-run PR #755 CI/review state, then continue Phase 0 #761 items or move only the completed #764 slice forward for review. |
 | 2026-06-12 | Execute Phase 0 slice for #761 on branch `codex/research-actions-pkg-contract`; pushed commit `4cd5b21f` (`refactor(research): share assessment review rendering`). | V1, V5 | Sync no longer carries a separate review-to-markdown renderer. Package-authored assessment review notes now use the report renderer path, cover abstract, key points, summary, sections, evidence table, limitations, and next queries, and strip reader-facing unresolved internal refs. Verified with `uv run pytest tests/gaia/test_research_artifacts.py tests/gaia/test_research_report.py -q`, `uv run pytest tests/cli/test_research.py -q -k "accepts_analysis_json_with_review or unparseable_sync_source or candidate_relation"`, targeted `ruff`, targeted `mypy`, and `git diff --check`. This addresses the #761 rendering-consolidation slice only. | Check PR #755 CI/review threads, then decide whether to continue remaining #761 robustness items or split remaining follow-ups into smaller PRs. |
@@ -152,7 +165,8 @@ Stop and re-check the fixed goal if any of these happen:
 | 2026-06-12 | Execute first Phase 1.2 slice for public Gaia core authoring APIs on branch `codex/research-actions-pkg-contract`. | V1, V2, V5 | Added `gaia.engine.authoring` with public `ProposedAuthorOp`, `run_author_batch`, structured batch result types, and compatibility exports for the stable authored-submodule/write helpers used by research. Batch authoring writes operations in order, supports later operations referencing earlier labels, runs one final `postwrite_check`, and rolls back source files on later prewrite/postwrite failure. `gaia.cli.commands.author._proposed_op` now re-exports the engine model, and `gaia.engine.research.sync` imports authoring helpers through the public engine facade instead of directly importing `gaia.cli.commands.author._*`. Verified red-green with `tests/gaia/test_authoring_api.py` (initial failure: `ModuleNotFoundError: No module named 'gaia.engine.authoring'`), then fixed an import-cycle caught by `uv run pytest tests/cli/author -q`. Final local evidence: `uv run pytest tests/gaia/test_authoring_api.py tests/gaia/test_research_artifacts.py tests/gaia/test_research_assessment.py -q` (21 passed), `uv run pytest tests/cli/author -q` (343 passed), `uv run pytest tests/cli/test_research.py -q -k "sync or candidate_relation or unparseable_sync_source"` (3 passed, 58 deselected), targeted `ruff`, targeted `mypy`, `uv run ruff format --check ...`, and `git diff --check`. This is not full #745 closure: the remaining work is to move more CLI author implementation/helpers behind the public engine API and wire CLI verbs onto the public batch/write surface where appropriate. | Commit and push this code slice, re-check PR #755/#763 CI, then continue Phase 1.2 or move to public LKM client depending on the next highest coupling blocker. |
 | 2026-06-12 | Execute Phase 1.1 slice for public Gaia core LKM client/index/error APIs on branch `codex/research-actions-pkg-contract`. | V1, V2, V4, V5 | Added `gaia.lkm.client` and `gaia.lkm.indexes` as public import surfaces for LKM access, index normalization, and typed error handling. CLI-private `gaia.cli.commands.search.lkm._client` and `_indexes` now compatibility re-export the public modules, while CLI `_shared.run_request` translates `LKMPermissionError` and `LKMNotFoundError` into CLI exit codes. The public error surface includes `LKMCredentialError`, `NoAccessKeyError`, `LKMTransportError`, `LKMPermissionError`, `LKMNotFoundError`, and envelope `LKMError`, so downstream `gaia-research` can distinguish transport, permission, not-found, credential, and business-envelope failures without importing Typer or CLI modules. Verified red-green with `tests/gaia/test_lkm_client.py` (initial failure: `ModuleNotFoundError: No module named 'gaia.lkm'`), then fixed an import-cycle by moving index helpers to `gaia.lkm.indexes`. Fresh local evidence: `uv run pytest tests/gaia/test_lkm_client.py tests/cli/search/test_lkm_auth.py tests/cli/search/test_lkm_verbs.py -q` (99 passed), `uv run pytest tests/cli/search/test_lkm_package_e2e.py tests/gaia/test_materialize_api.py -q` (24 passed), targeted `ruff`, targeted `mypy`, `uv run ruff format --check ...`, and `git diff --check`. This is a public client/error slice only; public credential/readiness APIs remain a separate Phase 1.1 slice. | Commit and push this code slice, update PR #755 evidence, then continue Phase 1.1 credential/readiness or Phase 1 plugin entry points based on the highest remaining extraction blocker. |
 | 2026-06-12 | Follow up on PR #755 wheel-smoke failure after the public LKM client slice. | V1, V2, V5 | Remote `gh pr checks 755` showed build and commit-lint passing, `Run tests` passing, but the wheel smoke step failed because the built wheel omitted the new `gaia.lkm` package (`ModuleNotFoundError: No module named 'gaia.lkm'` during installed `gaia --help`). Added `gaia.lkm*` to setuptools package discovery, added a packaging contract test for the public LKM namespace, and extended the wheel-smoke facade import list to include `gaia.lkm`. Verified the red test first with `uv run pytest tests/test_alpha0_packaging.py -q` (failed on missing `gaia.lkm*`), then final local evidence: `uv run pytest tests/test_alpha0_packaging.py tests/gaia/test_lkm_client.py tests/cli/search/test_lkm_auth.py tests/cli/search/test_lkm_verbs.py -q` (101 passed), `uv run pytest tests/cli/search/test_lkm_package_e2e.py tests/gaia/test_materialize_api.py -q` (24 passed), targeted `ruff`, targeted `mypy`, YAML parse for `.github/actions/wheel-smoke/action.yml`, `git diff --check`, `uv build --wheel --out-dir /tmp/gaia-lkm-wheel-check-c2e066e0`, zipfile check for `gaia/lkm/{__init__,client,indexes}.py`, and direct `import gaia.lkm` from the built wheel path. | Commit and push the wheel packaging fix, then re-check PR #755 remote CI until build, commit-lint, and test are all green. |
-| 2026-06-12 | Address PR #763 review findings after PR #755 merged into main. | V1, V2, V5 | Made the implementation plan's 0-7 phase map canonical across the split plan and acceptance checklist; changed `gaia-research` dependency guidance to `gaia-lang>=0.6,<0.8` with explicit contract CI against the 0.7.0 removal candidate; added the missing `tests/gaia/test_research_orchestrator.py` import path; replaced stale `tests/cli/test_author.py` and `gaia/engine/packaging/installer.py` references with current `tests/cli/author` and `gaia/engine/packaging.py` paths. | Re-run doc consistency greps and push the #763 review-fix commit. |
+| 2026-06-12 | Address PR #763 review findings after PR #755 merged into main. | V1, V2, V5 | Made the then-current 0-7 phase map consistent across the split plan and acceptance checklist; that map is now superseded by Goal A 0-6. Also changed `gaia-research` dependency guidance to `gaia-lang>=0.6,<0.8`, added the missing `tests/gaia/test_research_orchestrator.py` import path, and replaced stale path references. | Re-run doc consistency greps and push the #763 review-fix commit. |
+| 2026-06-12 | Create #767 and realign split docs around Goal A. | V1, V3, V5 | Large-scale graph-session implementation notes now live in #767. Goal A docs should require repo split, Gaia connection, review-run parity, readiness, contract CI, and core removal; they should not require graph-session execution or O(N) tests. | Continue Goal A execution from public core surfaces, skill plugin discovery, repo bootstrap, and review-run parity gates. |
 
 ## 8. Process Learnings and PR Operating Rules
 
@@ -212,8 +226,9 @@ before new research behavior:
 3. Update and merge the split-plan PR as the stable acceptance baseline.
 4. Add the missing skill plugin discovery surface, such as `gaia.skills`, before
    moving bundled research skills out of Gaia core.
-5. Write the graph-session contract design as its own spec/PR before
-   implementing `.gaia/research/sessions/**`.
+5. Treat #767 as the graph-session design handoff; do not implement
+   `.gaia/research/sessions/**` as part of Goal A unless the goal is explicitly
+   expanded again.
 
 ### 8.4 Design Gate Discipline
 
@@ -224,9 +239,9 @@ before new research behavior:
 - If a design gate is waiting on user approval, record the blocked item clearly
   and stop changing code for that slice. Continue only with read-only review or
   unrelated already-approved work.
-- The graph-session disk contract remains such a design-gated item because it
-  determines the O(N) continuation verifier, pause/resume semantics, repair
-  context, and promotion boundary.
+- The graph-session disk contract remains such a design-gated item in #767
+  because it determines the O(N) continuation verifier, pause/resume semantics,
+  repair context, and promotion boundary.
 
 ### 8.5 Worktree Hygiene
 

--- a/docs/superpowers/plans/2026-06-12-research-repo-split-implementation.md
+++ b/docs/superpowers/plans/2026-06-12-research-repo-split-implementation.md
@@ -2,9 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Split Gaia's research module into an independent `gaia-research` repository with first-class review-run and graph-session modes.
+**Goal:** Complete Goal A: split Gaia's research module into an independent
+`gaia-research` repository, connect it back to Gaia through public APIs and
+plugin entry points, and preserve review-run parity.
 
-**Architecture:** Gaia core keeps public language/package/search/authoring/materialization primitives and plugin hooks. `gaia-research` owns the shared research kernel, versioned `.gaia/research/**` contracts, SDK, providers, CLI, skill assets, review-run orchestration, and long-running graph-session orchestration. Contract CI proves the one-way dependency `gaia-research -> gaia core`.
+**Architecture:** Gaia core keeps public language/package/search/authoring/materialization primitives and plugin hooks. `gaia-research` owns the shared research kernel, versioned `.gaia/research/**` review-run contracts, SDK, providers, CLI, skill assets, and review-run orchestration. Contract CI proves the one-way dependency `gaia-research -> gaia core`. Large-scale graph-session execution is a post-Goal A follow-up tracked in #767.
 
 **Tech Stack:** Python 3.12, uv, Typer, Pydantic v2, pytest, ruff, mypy strict, GitHub Actions, Gaia package/check tooling, optional LiteLLM behind a `llm` extra.
 
@@ -27,11 +29,10 @@ the execution record.
 | 0 | Make monorepo research movable by closing correctness/coupling blockers. | PR #755 landed/superseded; #761 high-risk items owned; #764 closed or fixed before bootstrap. |
 | 1 | Extract Gaia core public APIs used by research. | Public LKM, authoring, materialization, inquiry, credentials, plugin surfaces exist and pass contract tests. |
 | 2 | Bootstrap `gaia-research` repo and preserve/import history. | New repo has package metadata, migrated code/tests/docs/skills, and no canonical `.gaia/research_loop/**` writes. |
-| 3 | Build `gaia-research` shared contracts and SDK. | Review-run and graph-session contracts are typed and SDK-accessible. |
+| 3 | Build Goal A `gaia-research` contracts and SDK. | Review-run contracts are typed and SDK-accessible; graph-session work is linked to #767. |
 | 4 | Re-enable review-run mode in the new repo. | Product/skill smoke tests produce observable state/events/report paths. |
-| 5 | Implement graph-session mode. | Incremental continuation, pause/resume, node/edge/focus/field-map records pass instrumented tests. |
-| 6 | Product readiness, skills, and doctor. | #762 acceptance checks pass and short happy paths are documented. |
-| 7 | Contract CI, release, and Gaia core removal. | Core installs downstream `gaia-research`, plugin path works, core no longer owns research implementation. |
+| 5 | Product readiness, skills, and doctor. | #762 acceptance checks pass and short happy paths are documented. |
+| 6 | Contract CI, release, and Gaia core removal. | Core installs downstream `gaia-research`, plugin path works, core no longer owns research implementation. |
 
 ## Phase 0: Make Monorepo Research Movable
 
@@ -436,98 +437,7 @@ CLI output for core handles.
 **Acceptance evidence:** Product/skill path is usable without copying long PR
 commands.
 
-## Phase 5: Graph Session Mode
-
-**Files likely created or modified in `gaia-research`:**
-
-- `src/gaia_research/engine/session.py`
-- `src/gaia_research/engine/frontier.py`
-- `src/gaia_research/engine/session_storage.py`
-- `src/gaia_research/engine/field_map_delta.py`
-- `src/gaia_research/engine/task_protocol.py`
-- `src/gaia_research/cli/session.py`
-- `tests/session/`
-
-### Task 5.1: Session Storage and Append-Only Records
-
-- [ ] Implement `.gaia/research/sessions/<session-id>/` storage:
-
-  ```text
-  state.json
-  events.ndjson
-  frontier.jsonl
-  nodes.jsonl
-  edges.jsonl
-  focuses.jsonl
-  obligations.jsonl
-  field_map.json
-  checkpoints/
-  ```
-
-- [ ] Add cursor/index files required for normal continuation.
-- [ ] Run:
-
-  ```bash
-  uv run pytest tests/session/test_session_state_contract.py tests/session/test_frontier_append.py -q
-  uv run ruff check src/gaia_research/engine/session*.py src/gaia_research/engine/frontier.py tests/session
-  uv run mypy src/gaia_research/engine/session.py src/gaia_research/engine/frontier.py
-  ```
-
-**Acceptance evidence:** Checklist A5 and A7 pass.
-
-### Task 5.2: Incremental Continuation Complexity Gate
-
-- [ ] Add an instrumented storage adapter that records every file open/read.
-- [ ] Seed a session with a large historical node/edge log.
-- [ ] Submit a small new frontier batch.
-- [ ] Assert normal continuation reads only:
-
-  ```text
-  state.json
-  cursor/index files
-  new frontier/input batch
-  delta index files
-  ```
-
-- [ ] Add a separate full-rebuild command/test that is allowed to scan history.
-- [ ] Run:
-
-  ```bash
-  uv run pytest tests/session/test_incremental_continuation.py -q
-  uv run pytest tests/session/test_full_rebuild.py -q
-  ```
-
-**Acceptance evidence:** Checklist A6 is proven by test, not by code review.
-
-### Task 5.3: Task Envelope, Candidate Repair, Pause/Resume
-
-- [ ] Implement versioned task envelopes and candidate validation from PR #726
-  lessons under `.gaia/research/**`.
-- [ ] Reject invalid candidates without advancing the session.
-- [ ] Produce repair context for the same task.
-- [ ] Implement pause/resume from saved cursor without requiring a report.
-- [ ] Run:
-
-  ```bash
-  uv run pytest tests/session/test_task_contract.py tests/session/test_pause_resume.py -q
-  ```
-
-**Acceptance evidence:** Agent framework integration can use deterministic
-tasks while semantic judgment remains outside Gaia Research.
-
-### Task 5.4: Promotion Boundary
-
-- [ ] Ensure session continuation writes graph-session records only by default.
-- [ ] Add explicit promotion/sync methods and tests for writing Gaia source.
-- [ ] Run:
-
-  ```bash
-  uv run pytest tests/session/test_promotion_boundary.py -q
-  ```
-
-**Acceptance evidence:** Checklist A8 passes for long graph sessions.
-
-## Phase 6: Product Readiness and Doctor
+## Phase 5: Product Readiness and Doctor
 
 **Files likely created or modified in `gaia-research`:**
 
@@ -539,13 +449,14 @@ tasks while semantic judgment remains outside Gaia Research.
 - `tests/doctor/`
 - `tests/profiles/`
 
-### Task 6.1: Doctor Command (#762)
+### Task 5.1: Doctor Command (#762)
 
 - [ ] Implement `gaia-research doctor <pkg>`.
 - [ ] Through plugin path, expose `gaia research doctor <pkg>`.
 - [ ] Check package shape, `.gaia/research` writability, LKM credential
-  readiness, provider/model config, profile resolution, run/session paths, and
-  schema compatibility.
+  readiness, provider/model config, profile resolution, review-run paths,
+  schema compatibility, and the absence of conflicting `.gaia/research_loop/**`
+  canonical state.
 - [ ] Redact secrets from all output.
 - [ ] Run:
 
@@ -556,15 +467,14 @@ tasks while semantic judgment remains outside Gaia Research.
 
 **Acceptance evidence:** #762 doctor/readiness checks pass.
 
-### Task 6.2: Profiles and Docs
+### Task 5.2: Profiles and Docs
 
-- [ ] Define `quick`, `review`, `deep`, and one graph-session profile.
+- [ ] Define `quick`, `review`, and `deep` review-run profiles.
 - [ ] Document short commands:
 
   ```bash
   gaia-research doctor "$PKG"
   gaia-research run-review "$PKG" --topic "..." --profile quick
-  gaia-research session open "$PKG" --topic "..." --profile graph
   ```
 
 - [ ] Add docs smoke tests for command examples where feasible.
@@ -577,7 +487,18 @@ tasks while semantic judgment remains outside Gaia Research.
 
 **Acceptance evidence:** Product and skill users do not need long flag recipes.
 
-## Phase 7: Contract CI, Release, and Core Removal
+### Task 5.3: Graph Session Follow-up Link
+
+- [ ] Link #767 from the `gaia-research` roadmap or docs.
+- [ ] State that `.gaia/research/sessions/**` is reserved for future
+  graph-session work and is not implemented by Goal A.
+- [ ] Confirm no Goal A docs or commands require users to run graph-session
+  flows.
+
+**Acceptance evidence:** Checklist A5 and A6 pass through explicit re-homing and
+non-conflict evidence, not through graph-session implementation.
+
+## Phase 6: Contract CI, Release, and Core Removal
 
 **Files likely modified across repos:**
 
@@ -589,7 +510,7 @@ tasks while semantic judgment remains outside Gaia Research.
 - `gaia-research/README.md`
 - `gaia-research/docs/release.md`
 
-### Task 7.1: Downstream Contract CI
+### Task 6.1: Downstream Contract CI
 
 - [ ] Add Gaia core workflow that installs candidate Gaia core and compatible
   `gaia-research`.
@@ -603,7 +524,7 @@ tasks while semantic judgment remains outside Gaia Research.
 
 **Acceptance evidence:** Checklist A3 and core removal gate pass.
 
-### Task 7.2: Remove Research Implementation From Gaia Core
+### Task 6.2: Remove Research Implementation From Gaia Core
 
 - [ ] Delete core-owned research implementation after `gaia-research` release
   candidate is available:
@@ -626,10 +547,10 @@ tasks while semantic judgment remains outside Gaia Research.
 
 **Acceptance evidence:** Checklist A2 passes.
 
-### Task 7.3: Final Completion Audit
+### Task 6.3: Final Completion Audit
 
 - [ ] Run the acceptance checklist section 6 audit against current state.
-- [ ] Inspect GitHub issue state for #745, #761, #762, and #764.
+- [ ] Inspect GitHub issue state for #745, #761, #762, #764, and #767.
 - [ ] Confirm every completion requirement A1-A10 has direct evidence.
 - [ ] Only then mark the long-running goal complete.
 
@@ -638,9 +559,10 @@ artifact paths for every requirement.
 
 ## Self-Review Notes
 
-- This plan covers both short review runs and long graph sessions.
+- This plan covers Goal A: repo split, Gaia connection, and review-run parity.
+- Large-scale graph sessions are re-homed to #767 and must not block Goal A.
 - It keeps `.gaia/research/**` as the only canonical research namespace.
 - It assigns #745, #761, #762, and #764 to phase gates.
-- It requires an instrumented storage test for the O(N) continuation claim.
-- It separates full rebuild from normal continuation.
+- It links the future O(N) continuation claim to #767 rather than making it a
+  split-completion requirement.
 - It leaves stable Gaia source writes behind explicit promotion/sync gates.


### PR DESCRIPTION
## Summary

- Narrow the active research split docs to Goal A: repo split, Gaia connection, review-run parity, readiness, contract CI, and core removal.
- Re-home large-scale graph-session execution to #767 instead of making it a split-completion requirement.
- Replace the previous 0-7 phase map with a Goal A 0-6 map and update the acceptance checklist/execution record accordingly.

## Verification

- `git diff --check`
- `rg -n "must support both|Graph Session Mode|graph-session mode supports|normal graph-session continuation|Phase 5: Graph|This plan covers both|A5 and A7 pass|A6 is proven by test|canonical 0-7|0-7 phase map canonical" docs/specs/2026-06-11-research-repo-split-plan.md docs/specs/2026-06-12-research-repo-split-acceptance-checklist.md docs/specs/2026-06-12-research-repo-split-execution-record.md docs/superpowers/plans/2026-06-12-research-repo-split-implementation.md`

## Notes

This PR intentionally does not close #767. That issue is now the follow-up home for graph-session design and eventual implementation.
