### PR TITLE
docs(research): clarify split acceptance scope

### DIFF
--- a/docs/plans/2026-06-13-research-report-workflow-parity-migration.md
+++ b/docs/plans/2026-06-13-research-report-workflow-parity-migration.md
@@ -1,0 +1,208 @@
+# Research Report Workflow Parity Migration Plan
+
+> **Status:** Current implementation plan for the next `gaia-research` split
+> milestone.
+>
+> **Parent spec:**
+> [Research Module Split Acceptance](../specs/2026-06-13-research-module-split-acceptance.md)
+>
+> **Scope:** Move the existing Gaia upper report workflow into `gaia-research`
+> with parity. Do not implement graph-session expansion in this plan.
+
+## 1. Goal
+
+Make `gaia-research` own the current topic-to-report workflow that previously
+lived across Gaia-core research and `gaia-lkm-explore` surfaces.
+
+The target user flow is:
+
+```bash
+gaia research report \
+  --topic "aspirin primary prevention cardiovascular disease" \
+  --workspace ./runs/aspirin-fast-report \
+  --profile fast \
+  --json
+```
+
+The standalone equivalent is:
+
+```bash
+gaia-research report \
+  --topic "aspirin primary prevention cardiovascular disease" \
+  --workspace ./runs/aspirin-fast-report \
+  --profile fast \
+  --json
+```
+
+## 2. Non-Goals
+
+This plan does not implement:
+
+- large graph-session expansion;
+- O(N) graph-session performance guarantees;
+- indefinite pause/resume research memory;
+- new deep/broad expansion strategies;
+- LKM writeback;
+- public registry publication.
+
+It may preserve artifact hooks for those later capabilities, but they are not
+acceptance criteria for this milestone.
+
+## 3. Work Packages
+
+### M0. Documentation Correction
+
+Deliverables:
+
+- add the canonical split acceptance spec;
+- add this parity migration plan;
+- mark older research-action and LKM-explore specs as historical/prior art;
+- update `gaia-research` README and execution record so the bridge milestone is
+  not described as completed research-module split.
+
+Verification:
+
+- no document still claims the review/report runner bridge is the completed
+  research split;
+- the current scope says report workflow parity only;
+- graph-session expansion is marked future work.
+
+### M0b. Documentation Ownership Migration
+
+Deliverables:
+
+- create `gaia-research/docs/foundations/` as the durable workflow design home;
+- record in `gaia-research/README.md` or `gaia-research/AGENTS.md` that
+  foundations docs must be updated in the same PR as code changes that alter
+  workflow semantics, artifact schemas, CLI behavior, or engine boundaries;
+- inventory Gaia-core research docs that should move or be rewritten into
+  `gaia-research/docs/foundations/`;
+- leave Gaia-core copies as historical pointers or deprecation/migration
+  documents only;
+- do not copy old Gaia docs verbatim into `gaia-research`; rewrite them against
+  the current ownership boundary.
+
+Verification:
+
+- `gaia-research/docs/foundations/README.md` exists;
+- `gaia-research/README.md` or `gaia-research/AGENTS.md` documents the update
+  rule;
+- Gaia-core specs point to the canonical split acceptance spec and do not claim
+  ownership of current workflow design;
+- future implementation plans treat documentation migration as part of report
+  workflow parity, not as cleanup after the fact.
+
+### M1. Gaia-Core Deprecation Inventory
+
+Deliverables:
+
+- inventory all Gaia-core upper workflow entry points:
+  - `gaia research ...`;
+  - `gaia-lkm-explore ...`;
+  - docs that describe `gaia-lkm-explore` as canonical;
+- classify each command as `handoff`, `deprecated alias`, or `remove after
+  parity`.
+
+Verification:
+
+- test coverage lists every CLI surface that must change;
+- `gaia search lkm` is explicitly excluded from deprecation because it is a
+  primitive.
+
+### M2. Port Report Workflow Engine Surface
+
+Deliverables:
+
+- create `gaia-research` engine modules for report workflow state and
+  transitions;
+- port the deterministic utilities needed from `gaia.lkm_explorer`:
+  - landscape aggregation;
+  - paper lead deduplication;
+  - focus candidate extraction;
+  - artifact provenance normalization;
+- keep Gaia core imports behind declared public surfaces or subprocess
+  adapters.
+
+Verification:
+
+- unit tests cover each deterministic transition;
+- source-boundary tests still prove Gaia core does not import
+  `gaia_research`;
+- migrated artifacts write under `.gaia/research/**`, not
+  `.gaia/exploration/**`.
+
+### M3. Implement Topic-Driven Report Workflow
+
+Deliverables:
+
+- implement an engine function that starts from a topic and workspace;
+- create or validate the working Gaia package/workspace;
+- call Gaia LKM search as a primitive;
+- produce landscape, field-map, focus, assessment, materialization-decision, and
+  report artifacts;
+- reuse the existing report rendering path where parity requires it.
+
+Verification:
+
+- a fixture topic produces all expected artifacts;
+- the report cites the landscape/focus/assessment artifacts used;
+- no stable Gaia source is written without an explicit materialization decision.
+
+### M4. Rename User Command To `report`
+
+Deliverables:
+
+- add `gaia-research report`;
+- add `gaia research report` through plugin handoff;
+- keep `review` only as a deprecated compatibility alias if needed;
+- update human-readable output to say `report completed`, not `review run
+  completed`.
+
+Verification:
+
+- standalone CLI tests call `report`;
+- Gaia plugin tests call `gaia research report`;
+- compatibility tests cover the alias only if it is retained;
+- README examples use `report`.
+
+### M5. Deprecate Gaia-Core Upper Workflow Surfaces
+
+Deliverables:
+
+- mark `gaia-lkm-explore` deprecated after `gaia-research report` covers the
+  parity workflow;
+- ensure Gaia-core `gaia research` hands off to `gaia-research` for report;
+- update Gaia docs to point users to `gaia-research`.
+
+Verification:
+
+- CLI help text points to `gaia-research`;
+- tests prove `gaia search lkm` still works as a core primitive;
+- tests prove upper workflow commands do not silently keep running Gaia-core
+  implementations.
+
+### M6. Cross-Repo Parity Audit
+
+Deliverables:
+
+- add a repeatable audit script that installs Gaia core and `gaia-research`;
+- run a topic-driven report workflow through the Gaia plugin command;
+- compare expected artifact presence and status with the legacy workflow.
+
+Verification:
+
+- CI runs the audit;
+- audit output includes run id, status, artifact paths, report path, and event
+  count;
+- failure to find the `gaia-research` handoff fails hard.
+
+## 4. Completion Criteria
+
+The milestone is complete when:
+
+- `gaia-research report --topic ...` works from a clean install;
+- `gaia research report --topic ...` works through Gaia plugin handoff;
+- Gaia-core upper workflow surfaces are deprecated or handed off;
+- `gaia-lkm-explore` is no longer documented as canonical;
+- cross-repo CI proves the report workflow from topic to report;
+- documentation separates this parity milestone from future graph-session work.

--- a/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
+++ b/docs/specs/2026-05-25-gaia-lkm-explore-assess-design.md
@@ -2,7 +2,13 @@
 
 > **状态：** Experimental / historical reference。
 >
-> **当前实现锚点：**
+> **当前 canonical 验收标准：**
+> [Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+>
+> **当前执行计划：**
+> [Research Report Workflow Parity Migration Plan](../plans/2026-06-13-research-report-workflow-parity-migration.md)
+>
+> **Prior-art context：**
 > [Research Actions Package-Native Overview](2026-06-01-research-actions-package-native-overview.md)
 > 和
 > [Research Actions Implementation Roadmap](2026-06-01-research-actions-implementation-roadmap.md).

--- a/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
+++ b/docs/specs/2026-05-26-lkm-explore-artifact-mvp-design.md
@@ -2,7 +2,13 @@
 
 > **状态：** Experimental / historical reference。
 >
-> **当前实现锚点：**
+> **当前 canonical 验收标准：**
+> [Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+>
+> **当前执行计划：**
+> [Research Report Workflow Parity Migration Plan](../plans/2026-06-13-research-report-workflow-parity-migration.md)
+>
+> **Prior-art context：**
 > [Research Actions Package-Native Overview](2026-06-01-research-actions-package-native-overview.md)
 > 和
 > [Research Actions Implementation Roadmap](2026-06-01-research-actions-implementation-roadmap.md).

--- a/docs/specs/2026-05-27-lkm-explore-iterative-landscape-design.md
+++ b/docs/specs/2026-05-27-lkm-explore-iterative-landscape-design.md
@@ -2,7 +2,13 @@
 
 > **状态：** Experimental / historical reference。
 >
-> **当前实现锚点：**
+> **当前 canonical 验收标准：**
+> [Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+>
+> **当前执行计划：**
+> [Research Report Workflow Parity Migration Plan](../plans/2026-06-13-research-report-workflow-parity-migration.md)
+>
+> **Prior-art context：**
 > [Research Actions Package-Native Overview](2026-06-01-research-actions-package-native-overview.md)
 > 和
 > [Research Actions Implementation Roadmap](2026-06-01-research-actions-implementation-roadmap.md).

--- a/docs/specs/2026-06-01-research-actions-implementation-roadmap.md
+++ b/docs/specs/2026-06-01-research-actions-implementation-roadmap.md
@@ -1,10 +1,17 @@
 # Research Actions Implementation Roadmap
 
-> **状态：** package-native research actions 的 canonical implementation roadmap。
+> **状态：** Historical / prior-art roadmap。它记录 Gaia-core package-native
+> research actions 的实现切片，但不再是当前 canonical migration plan。
 >
 > **日期：** 2026-06-01
 >
-> **Canonical overview：**
+> **当前 canonical 验收标准：**
+> [Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+>
+> **当前执行计划：**
+> [Research Report Workflow Parity Migration Plan](../plans/2026-06-13-research-report-workflow-parity-migration.md)
+>
+> **Prior-art overview：**
 > [Research Actions Package-Native Overview](2026-06-01-research-actions-package-native-overview.md)
 >
 > **迁移说明：**
@@ -15,6 +22,10 @@
 
 ## 1. 实现原则
 
+> **2026-06-13 correction:** 本 roadmap 不再定义当前 implementation plan。
+> 当前工作只迁移现有 report workflow parity 到 `gaia-research`；graph-session
+> expansion 是下一步，不进入本轮验收。
+
 `gaia research` 应该按小切片实现。每个切片都必须保留 overview 中的硬性不变量：
 
 - 不创建平行 focus registry；
@@ -23,7 +34,7 @@
 - `gaia build check` 仍然是 package structural validation path；
 - early Explore 保持 breadth-first，默认 pull budget 为 0。
 
-当前实现已经越过早期 trace-only 计划。canonical behavior 是：
+本文当时记录的 package-native behavior 是：
 
 - `explore` / `expand` 默认写 landscape trace、同步 inquiry hypotheses /
   obligations，并把浅层 search items 物化成本地 source package；
@@ -179,13 +190,14 @@ Required work:
 - document or implement a read-only import path from `.gaia/exploration/` to
   `.gaia/research/` provenance;
 - mark `gaia-lkm-explore` as deprecated compatibility surface;
-- update docs and skills so `gaia research` is the only canonical workflow;
+- update docs and skills so the replacement workflow is owned by
+  `gaia-research`, with Gaia core providing only primitives and plugin handoff;
 - keep useful deterministic utilities only when they write package-native artifacts.
 
 Validation:
 
-- at least one real LKM-backed live run completes with `gaia research` and does not call
-  the old entry point;
+- at least one real LKM-backed live run completes through the replacement
+  `gaia-research` workflow and does not call the old entry point;
 - old `.gaia/exploration/` artifacts are never treated as canonical semantic state;
 - deprecation docs include replacement commands.
 

--- a/docs/specs/2026-06-01-research-actions-knowledge-model.md
+++ b/docs/specs/2026-06-01-research-actions-knowledge-model.md
@@ -1,13 +1,22 @@
 # Research Actions Knowledge Model
 
-> **状态：** package-native research actions 的 canonical knowledge-model note。
+> **状态：** Historical / prior-art knowledge-model note。它仍可用于理解
+> focus、obligation、assessment relation 和 stable Gaia source 的分层，但不再是
+> 当前 canonical split target。
 >
 > **日期：** 2026-06-01
 >
-> **Canonical overview：**
+> **当前 canonical 验收标准：**
+> [Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+>
+> **Prior-art overview：**
 > [Research Actions Package-Native Overview](2026-06-01-research-actions-package-native-overview.md)
 
 ## 1. 为什么需要这份说明
+
+> **2026-06-13 correction:** 本文的概念分层仍然有效；实现 ownership 已经改变。
+> 上层 research workflow 应迁到 `gaia-research`，Gaia core 只保留 primitives 和
+> stable package semantics。
 
 `gaia research` 的核心风险不是命令怎么拼，而是把不同层级的研究对象混成一种
 `claim(...)`。这会让 open question、process obligation、assessment judgment 和 stable

--- a/docs/specs/2026-06-01-research-actions-migration-notes.md
+++ b/docs/specs/2026-06-01-research-actions-migration-notes.md
@@ -1,10 +1,18 @@
 # Research Actions Migration Notes
 
-> **状态：** package-native research actions 设计的 canonical migration companion。
+> **状态：** Historical / prior-art migration notes。它记录从
+> `gaia-lkm-explore` 到 package-native research actions 的迁移经验，但不再是当前
+> canonical migration companion。
 >
 > **日期：** 2026-06-01
 >
-> **Canonical overview：**
+> **当前 canonical 验收标准：**
+> [Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+>
+> **当前执行计划：**
+> [Research Report Workflow Parity Migration Plan](../plans/2026-06-13-research-report-workflow-parity-migration.md)
+>
+> **Prior-art overview：**
 > [Research Actions Package-Native Overview](2026-06-01-research-actions-package-native-overview.md)
 >
 > **Roadmap：**
@@ -12,14 +20,20 @@
 
 ## 1. 文档状态图
 
-当前实现锚点是 package-native `gaia research` 设计。旧 exploration 文档仍然有参考价值，
-但不是 implementation contract。
+> **2026-06-13 correction:** 当前实现锚点已经变成
+> `gaia-research` report workflow parity migration。本文中的 package-native
+> `gaia research` 设计只作为 prior art；不要把它当作本轮完成标准。
+
+当前实现锚点是 `gaia-research` report workflow parity migration。旧 package-native
+research actions 和 exploration 文档仍然有参考价值，但不是 implementation contract。
 
 | 文档或分支 | 状态 | 可以用于 | 不要作为 |
 | --- | --- | --- | --- |
-| `2026-06-01-research-actions-package-native-overview.md` | canonical | 架构锚点 | 迁移细节日志 |
-| `2026-06-01-research-actions-knowledge-model.md` | canonical | focus / obligation / assessment relation 分层 | 迁移计划 |
-| `2026-06-01-research-actions-implementation-roadmap.md` | canonical | 实现切片和验证 | 架构长篇论证 |
+| `2026-06-13-research-module-split-acceptance.md` | canonical | split 验收标准、ownership 边界、本轮 scope | 具体任务清单 |
+| `../plans/2026-06-13-research-report-workflow-parity-migration.md` | canonical current plan | report workflow parity migration | graph-session 扩展计划 |
+| `2026-06-01-research-actions-package-native-overview.md` | historical / prior art | package-native artifact / promotion policy 经验 | 当前 split target |
+| `2026-06-01-research-actions-knowledge-model.md` | historical / prior art | focus / obligation / assessment relation 分层 | 当前迁移计划 |
+| `2026-06-01-research-actions-implementation-roadmap.md` | historical / prior art | 旧实现切片和验证经验 | 当前 roadmap |
 | `2026-05-25-gaia-lkm-explore-assess-design.md` | experimental / historical | 早期 Explore / Assess 拆分思路 | 当前 contract |
 | `2026-05-26-lkm-explore-artifact-mvp-design.md` | experimental / historical | artifact MVP 经验 | 当前 artifact schema |
 | `2026-05-27-lkm-explore-iterative-landscape-design.md` | experimental / historical | iterative landscape 经验 | 当前实现计划 |
@@ -104,8 +118,10 @@ PR #726 不应该成为 canonical architecture：
 
 ## 5. 后续文档规则
 
-新的实现 PR 如果需要引用历史文档，应该先链接 canonical overview，再把历史文档作为
-reference material。不要再把新需求加到 historical specs 里。
+新的实现 PR 如果需要引用历史文档，应该先链接
+[Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+和当前 plan，再把历史文档作为 reference material。不要再把新需求加到 historical
+specs 里。
 
 ## 6. 共存期 Artifact 规则
 

--- a/docs/specs/2026-06-01-research-actions-package-native-overview.md
+++ b/docs/specs/2026-06-01-research-actions-package-native-overview.md
@@ -1,8 +1,15 @@
 # Gaia Research Actions Package-Native Overview
 
-> **状态：** `gaia research` 方向的 canonical overview。
+> **状态：** Historical / prior-art overview。它记录 package-native research
+> actions 的设计经验，但不再是当前 canonical split target。
 >
 > **日期：** 2026-06-01
+>
+> **当前 canonical 验收标准：**
+> [Research Module Split Acceptance](2026-06-13-research-module-split-acceptance.md)
+>
+> **当前执行计划：**
+> [Research Report Workflow Parity Migration Plan](../plans/2026-06-13-research-report-workflow-parity-migration.md)
 >
 > **实现路线图：**
 > [Research Actions Implementation Roadmap](2026-06-01-research-actions-implementation-roadmap.md)
@@ -15,6 +22,11 @@
 
 ## 1. 核心判断
 
+> **2026-06-13 correction:** 本文仍可作为 package-native artifact 和
+> promotion policy 的 prior art，但它把 `gaia research` 描述成 Gaia core 内的
+> canonical product surface。当前 split 边界已改为：Gaia core 保留 primitives，
+> `gaia-research` owns upper research workflows。
+
 Research Loop 不应该成为 Gaia package 旁边的第二套长期系统。它应该成为
 package-native 的 research action layer：
 
@@ -25,7 +37,7 @@ gaia research = Gaia primitives 之上的薄编排层
 LLM / agent = 研究判断层，不维护平行状态系统
 ```
 
-canonical user / agent surface 是：
+当时设想的 user / agent surface 是：
 
 ```bash
 gaia research explore ...
@@ -33,9 +45,12 @@ gaia research assess ...
 gaia research propose ...
 ```
 
-旧 `gaia-lkm-explore` 可以作为实验入口或兼容参考存在，但不能作为当前实现锚点。
+2026-06-13 以后，这些上层 workflow surface 应迁到 `gaia-research`，当前本轮只实现
+report workflow parity。旧 `gaia-lkm-explore` 可以作为实验入口或兼容参考存在，但
+不能作为当前实现锚点。
 `gaia-research-loop` skill 可以作为 agent guide / prompt template collection 维护；
-它必须调用 `gaia research` contracts 和 CLI primitives，不能成为另一套 canonical API。
+它必须调用 `gaia-research` contracts 和 Gaia CLI primitives，不能成为另一套
+canonical API。
 
 ## 2. Package-Native 状态
 

--- a/docs/specs/2026-06-13-research-module-split-acceptance.md
+++ b/docs/specs/2026-06-13-research-module-split-acceptance.md
@@ -1,0 +1,160 @@
+# Research Module Split Acceptance
+
+> **Status:** Canonical acceptance boundary for the `gaia-research` split.
+>
+> **Date:** 2026-06-13
+>
+> **Current implementation focus:** report workflow parity migration. Large
+> graph-session expansion is explicitly future work.
+>
+> **Supersedes as canonical target:**
+> [Research Actions Package-Native Overview](2026-06-01-research-actions-package-native-overview.md),
+> [Research Actions Implementation Roadmap](2026-06-01-research-actions-implementation-roadmap.md),
+> and [Research Actions Migration Notes](2026-06-01-research-actions-migration-notes.md).
+
+## 1. Correction
+
+The first `gaia-research` milestone split out a review/report runner, a package
+local `.gaia/research/runs/**` envelope, and the Gaia CLI plugin handoff. That
+milestone is useful, but it is not the completed research module split.
+
+The completed split means Gaia core stops owning the upper research workflow.
+`gaia-research` owns the workflow that starts from a research topic and drives
+the current report path through landscape, field-map, focus, assessment,
+materialization decisions, and report generation.
+
+## 2. Ownership Boundary
+
+Gaia core owns primitives:
+
+- `gaia search lkm` and the LKM client/auth/docs substrate;
+- `gaia add`;
+- `gaia inquiry`;
+- `gaia author`;
+- package scaffolding, materialization, build, check, infer, and render;
+- public Python surfaces needed by downstream workflow packages.
+
+`gaia-research` owns research workflows:
+
+- the replacement for `gaia research ...` upper-level workflow commands;
+- the replacement for `gaia-lkm-explore ...`;
+- topic-driven report workflows;
+- landscape, field map, focus selection, assessment artifacts,
+  materialization/promotion policy, and report orchestration;
+- session state and agent-facing JSON artifacts under `.gaia/research/**`.
+
+`gaia search lkm` is not part of the upper workflow split. It remains a Gaia
+core primitive that `gaia-research` can call through a public interface.
+
+## 3. Current Iteration Scope
+
+This iteration focuses on moving the existing Gaia report workflow behavior into
+`gaia-research` with parity. It must not expand into the future graph-session
+work.
+
+In scope:
+
+- deprecate Gaia-core upper research workflow CLIs after replacements exist;
+- deprecate `gaia-lkm-explore` as a product workflow surface;
+- port or wrap the existing deterministic `gaia.lkm_explorer` workflow pieces
+  needed for current report generation;
+- expose a `gaia-research` engine API and CLI for report workflows;
+- make `gaia research report ...` the user-facing command name;
+- keep compatibility aliases only when needed for migration;
+- verify parity against current Gaia report workflow behavior.
+
+Out of scope for this iteration:
+
+- thousands or tens of thousands of node graph sessions;
+- O(N) large-scale expansion optimization;
+- long-running graph-session memory beyond what current report parity needs;
+- deep/broad continuous expansion policies;
+- LKM writeback or public registry publication.
+
+## 4. Report Workflow Contract
+
+The current parity target is:
+
+```text
+topic
+  -> landscape
+  -> field map
+  -> focus selection
+  -> assess/report-ready artifact
+  -> materialization decision
+  -> report
+```
+
+The workflow may use Gaia core primitives, but the orchestration belongs in
+`gaia-research`. The CLI must be a thin adapter over engine calls, not the place
+where workflow state and transitions live.
+
+The first-class engine API should be shaped around durable workflow state:
+
+```python
+run_report_workflow(topic, workspace, policy)
+resume_report_workflow(run_id, workspace)
+```
+
+The exact Python names may change during implementation, but the boundary must
+not: product CLIs, Gaia plugin handoff, and external agent skills should all call
+the same engine workflow.
+
+## 5. Artifact Boundary
+
+`gaia-research` writes agent-facing workflow artifacts under:
+
+```text
+<package-or-workspace>/.gaia/research/
+  runs/<run-id>/
+  landscape/
+  field_map/
+  focuses/
+  assessments/
+  materialization/
+  reports/
+```
+
+The exact layout can be refined by implementation, but the semantic rule is
+fixed:
+
+- raw search hits and paper leads remain research artifacts;
+- candidate nodes and candidate relations remain research artifacts;
+- obligations live in Gaia inquiry state when accepted as process work;
+- stable truth-bearing content only enters Gaia source through an explicit
+  materialization or promotion step;
+- report output must cite the artifacts and Gaia package state it used.
+
+## 6. Deprecation Acceptance
+
+Gaia core is acceptable only when the upper workflow surfaces tell users and
+agents to use `gaia-research`:
+
+- `gaia-lkm-explore --help` is deprecated or removed after parity replacement;
+- old Gaia-core `gaia research` workflow commands are deprecated or handed off
+  to the installed `gaia-research` plugin;
+- Gaia docs no longer present `gaia-lkm-explore` as the canonical research
+  workflow;
+- CI verifies the replacement through `gaia-research`, not through a hidden
+  Gaia-core implementation path.
+
+## 7. Parity Acceptance
+
+This iteration is complete when the current report workflow can be run from
+`gaia-research` and produces equivalent user-visible artifacts to the Gaia-core
+workflow it replaces.
+
+Required evidence:
+
+- a topic-driven report command in `gaia-research`;
+- engine-level tests for each deterministic transition;
+- CLI tests for standalone `gaia-research report`;
+- Gaia plugin tests for `gaia research report`;
+- migration/deprecation tests in Gaia core;
+- cross-repo smoke that installs Gaia core plus `gaia-research` and runs the
+  report workflow;
+- docs that describe `gaia-research` as the report workflow owner and Gaia core
+  as primitive owner.
+
+The bridge milestone remains useful evidence, but it is not sufficient evidence
+for this acceptance target.


### PR DESCRIPTION
## Summary
- add canonical research module split acceptance spec
- add report workflow parity migration plan, including documentation ownership migration
- mark older research action and lkm-explore specs as historical/prior art

## Verification
- git diff --check in Gaia docs worktree

This is a docs-only correction that makes the current scope explicit: report workflow parity migration only; graph-session expansion is future work.